### PR TITLE
docs: correct link to windows page in quickstart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-07-04
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`thermion_dart` - `v0.1.1+5`](#thermion_dart---v0115)
+ - [`thermion_flutter_web` - `v0.0.1+9`](#thermion_flutter_web---v0019)
+ - [`thermion_flutter` - `v0.1.1+10`](#thermion_flutter---v01110)
+ - [`thermion_flutter_platform_interface` - `v0.1.0+9`](#thermion_flutter_platform_interface---v0109)
+ - [`thermion_flutter_ffi` - `v0.1.0+9`](#thermion_flutter_ffi---v0109)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `thermion_flutter_web` - `v0.0.1+9`
+ - `thermion_flutter` - `v0.1.1+10`
+ - `thermion_flutter_platform_interface` - `v0.1.0+9`
+ - `thermion_flutter_ffi` - `v0.1.0+9`
+
+---
+
+#### `thermion_dart` - `v0.1.1+5`
+
+ - Bump "thermion_dart" to `0.1.1+5`.
+
+
 ## 2024-07-02
 
 ### Changes

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -40,7 +40,7 @@ and change the minimum deployment target to 13.0:
 </Accordion>
 
 <Accordion title="Click to open Windows instructions">
-See the [/windows](/Windows) page for steps needed to build on Windows.
+See the [/windows](/windows) page for steps needed to build on Windows.
 </Accordion>
 
 

--- a/thermion_dart/CHANGELOG.md
+++ b/thermion_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+5
+
+ - Bump "thermion_dart" to `0.1.1+5`.
+
 ## 0.1.1+4
 
  - **FIX**: defer creating image entity/material/etc until actually requested.

--- a/thermion_dart/pubspec.yaml
+++ b/thermion_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: thermion_dart
 description: 3D rendering toolkit for Dart.
-version: 0.1.1+4
+version: 0.1.1+5
 homepage: https://thermion.dev
 repository: https://github.com/nmfisher/thermion
 

--- a/thermion_flutter/thermion_flutter/CHANGELOG.md
+++ b/thermion_flutter/thermion_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+10
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+9
 
  - Update a dependency to the latest release.

--- a/thermion_flutter/thermion_flutter/pubspec.yaml
+++ b/thermion_flutter/thermion_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: thermion_flutter
 description: Flutter plugin for 3D rendering with the Thermion toolkit.
-version: 0.1.1+9
+version: 0.1.1+10
 homepage: https://thermion.dev
 repository: https://github.com/nmfisher/thermion
 
@@ -17,10 +17,10 @@ dependencies:
   plugin_platform_interface: ^2.0.0
   ffi: ^2.1.2
   animation_tools_dart: ^0.0.4
-  thermion_dart: ^0.1.1+4
-  thermion_flutter_platform_interface: ^0.1.0+8
-  thermion_flutter_ffi: ^0.1.0+8
-  thermion_flutter_web: ^0.0.1+8
+  thermion_dart: ^0.1.1+5
+  thermion_flutter_platform_interface: ^0.1.0+9
+  thermion_flutter_ffi: ^0.1.0+9
+  thermion_flutter_web: ^0.0.1+9
   logging: ^1.2.0
 
 dev_dependencies:

--- a/thermion_flutter/thermion_flutter_ffi/CHANGELOG.md
+++ b/thermion_flutter/thermion_flutter_ffi/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+9
+
+ - Update a dependency to the latest release.
+
 ## 0.1.0+8
 
  - Update a dependency to the latest release.

--- a/thermion_flutter/thermion_flutter_ffi/pubspec.yaml
+++ b/thermion_flutter/thermion_flutter_ffi/pubspec.yaml
@@ -1,7 +1,7 @@
 name: thermion_flutter_ffi
 description: An FFI interface for the thermion_flutter plugin (all platforms except web).
 repository: https://github.com/nmfisher/thermion_flutter/thermion_flutter
-version: 0.1.0+8
+version: 0.1.0+9
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
@@ -22,8 +22,8 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.0
-  thermion_flutter_platform_interface: ^0.1.0+8
-  thermion_dart: ^0.1.1+4
+  thermion_flutter_platform_interface: ^0.1.0+9
+  thermion_dart: ^0.1.1+5
 
 dev_dependencies:
   flutter_test:

--- a/thermion_flutter/thermion_flutter_platform_interface/CHANGELOG.md
+++ b/thermion_flutter/thermion_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+9
+
+ - Update a dependency to the latest release.
+
 ## 0.1.0+8
 
  - Update a dependency to the latest release.

--- a/thermion_flutter/thermion_flutter_platform_interface/pubspec.yaml
+++ b/thermion_flutter/thermion_flutter_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: thermion_flutter_platform_interface
 description: A common platform interface for the thermion_flutter plugin.
 repository: https://github.com/nmfisher/thermion_flutter/thermion_flutter
-version: 0.1.0+8
+version: 0.1.0+9
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.0
-  thermion_dart: ^0.1.1+4
+  thermion_dart: ^0.1.1+5
 
 dev_dependencies:
   flutter_test:

--- a/thermion_flutter/thermion_flutter_web/CHANGELOG.md
+++ b/thermion_flutter/thermion_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+9
+
+ - Update a dependency to the latest release.
+
 ## 0.0.1+8
 
  - Update a dependency to the latest release.

--- a/thermion_flutter/thermion_flutter_web/pubspec.yaml
+++ b/thermion_flutter/thermion_flutter_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: thermion_flutter_web
 description: A web platform interface for the thermion_flutter plugin.
 repository: https://github.com/nmfisher/thermion_flutter/thermion_flutter
-version: 0.0.1+8
+version: 0.0.1+9
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
@@ -20,8 +20,8 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.0
   web: ^0.5.1
-  thermion_dart: ^0.1.1+4
-  thermion_flutter_platform_interface: ^0.1.0+8
+  thermion_dart: ^0.1.1+5
+  thermion_flutter_platform_interface: ^0.1.0+9
   flutter_web_plugins:
     sdk: flutter
 


### PR DESCRIPTION
The link was still broken (oops), changed "W" in windows to lowercase