### PR TITLE
Native-assets build error on Windows when targeting Android

### DIFF
--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -176,9 +176,17 @@ void main(List<String> args) async {
           Architecture.ia32 => "i686-linux-android",
           _ => throw FormatException('Invalid')
         };
-        var ndkRoot = File(config.cCompiler.compiler!.path).parent.parent.path;
+          
+        var compilerPath = config.cCompiler.compiler!.path;
+        
+        if(Platform.isWindows && compilerPath.startsWith("/")) {
+          compilerPath = compilerPath.substring(1);
+        }
+        
+        var ndkRoot = File(compilerPath).parent.parent.uri.toFilePath(windows:true);
+
         var stlPath =
-            File("$ndkRoot/sysroot/usr/lib/${archExtension}/libc++_shared.so");
+            File([ndkRoot, "sysroot", "usr", "lib", archExtension, "libc++_shared.so"].join(Platform.pathSeparator));
         output.addAsset(NativeCodeAsset(
             package: "thermion_dart",
             name: "libc++_shared.so",


### PR DESCRIPTION
When targeting Android, we need to copy the NDK version of `libc++_shared.so` to the build output directory to bundle with the app. 

On Windows, the NDK path provided by `native-assets` is ill-formatted with a leading slash. This PR removes this slash when building on Windows and targeting Android.

Should fix #61.