### PR TITLE
Add example files that can be parsed by pub.dev

### DIFF
--- a/thermion_dart/example/README.md
+++ b/thermion_dart/example/README.md
@@ -1,0 +1,1 @@
+For an example with both pure Dart and Flutter, see the [example repository](https://github.com/nmfisher/thermion_examples).

--- a/thermion_flutter/thermion_flutter/example/README.md
+++ b/thermion_flutter/thermion_flutter/example/README.md
@@ -1,0 +1,96 @@
+For a more thorough example with both Flutter and pure Dart, see the [example repository](https://github.com/nmfisher/thermion_examples).
+
+[flutter/quickstart/lib/main.dart](https://github.com/nmfisher/thermion_examples/blob/master/flutter/quickstart/lib/main.dart)
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:thermion_flutter/thermion_flutter.dart';
+
+import 'package:vector_math/vector_math_64.dart' as v;
+import 'dart:math';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key, required this.title});
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  bool _loaded = false;
+  ThermionViewer? _thermionViewer;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Future _load() async {
+    var viewer = await ThermionFlutterPlugin.createViewer();
+    _thermionViewer = viewer;
+    _thermionViewer!.loadSkybox("assets/default_env_skybox.ktx");
+    _thermionViewer!.loadGlb("assets/cube.glb");
+
+    _thermionViewer!.setCameraPosition(0, 1, 10);
+    _thermionViewer!.setCameraRotation(
+        v.Quaternion.axisAngle(v.Vector3(1, 0, 0), -30 / 180 * pi) *
+            v.Quaternion.axisAngle(v.Vector3(0, 1, 0), 15 / 180 * pi));
+    _thermionViewer!.addLight(LightType.SUN, 7500, 50000, 0, 0, 0, 1, -1, -1);
+    _thermionViewer!.setRendering(true);
+    _loaded = true;
+
+    setState(() {});
+  }
+
+  Future _unload() async {
+    var viewer = _thermionViewer!;
+    _thermionViewer = null;
+    setState(() {});
+    await viewer.dispose();
+    _loaded = false;
+    setState(() {});
+  }
+
+  Widget _loadButton() {
+    return Center(
+        child: ElevatedButton(child: const Text("Load"), onPressed: _load));
+  }
+
+  Widget _unloadButton() {
+    return Center(
+        child: ElevatedButton(child: const Text("Unload"), onPressed: _unload));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(children: [
+      if (_thermionViewer != null)
+        Positioned.fill(child: ThermionWidget(viewer: _thermionViewer!)),
+      if (!_loaded) _loadButton(),
+      if (_loaded) _unloadButton(),
+    ]);
+  }
+}
+```
+


### PR DESCRIPTION
This adds simple `README.md` files to the `exapmle/` directories of `thermion_dart` and `thermion_flutter`.

For the Flutter package I copied the quickstart, but for Dart I just referenced the example repository. We should perhaps add an example directly to the `README` as well, but I'm not sure what that would be.

This PR is a part of issue #38.