### PR TITLE
docs: fix typo 'applicaiton' in index.mdx

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -16,7 +16,7 @@ Thermion is divided into two packages:
 
 With this structure, the Flutter-specific components are not coupled to the Dart components, meaning Thermion can be used for rendering in both Flutter and non-Flutter applications.
 
-For example, Thermion ships with examples for rendering with Dart only (no Flutter) with a CLI/headless application on MacOS, and with a Javascript/WASM/HTML applicaiton in browsers.
+For example, Thermion ships with examples for rendering with Dart only (no Flutter) with a CLI/headless application on MacOS, and with a Javascript/WASM/HTML application in browsers.
 
 `thermion_flutter` exports `thermion_dart`, so if you are working with a Flutter application, you will only need to import `thermion_fluttter`.
 


### PR DESCRIPTION
Heya @nmfisher,

Good to see you're still actively building stuff!

Was just skimming the docs and spotted this minor typo. This PR takes care of that.

If I notice anything else small as I read more, I'll make sure to accumulate them into a single PR next time.
