### PR TITLE
fix: return camera frustum in camera space 

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
@@ -81,7 +81,7 @@ class FFICamera extends Camera<Pointer<TCamera>> {
   @override
   Future setTransform(Matrix4 transform) async {
     var entity = Camera_getEntity(camera);
-    FilamentApp.instance!.transformManager.setTransform(entity,transform);
+    FilamentApp.instance!.transformManager.setTransform(entity, transform);
   }
 
   @override
@@ -190,12 +190,59 @@ class FFICamera extends Camera<Pointer<TCamera>> {
     Camera_getFrustum(camera, out.address);
 
     var frustum = Frustum();
-    frustum.plane0.setFromComponents(out[0], out[1], out[2], out[3]);
-    frustum.plane1.setFromComponents(out[4], out[5], out[6], out[7]);
-    frustum.plane2.setFromComponents(out[8], out[9], out[10], out[11]);
-    frustum.plane3.setFromComponents(out[12], out[13], out[14], out[15]);
-    frustum.plane4.setFromComponents(out[16], out[17], out[18], out[19]);
-    frustum.plane5.setFromComponents(out[20], out[21], out[22], out[23]);
+
+    // Filament returns the frustum in world space
+    // Transform planes to camera space using (V^-1)^T = modelMatrix^T
+    final transformMatrix = await getViewMatrix();
+    transformMatrix.invert();
+
+    // Transform each plane from world space to camera space
+    for (int i = 0; i < 6; i++) {
+      int idx = i * 4;
+
+      // Extract plane as Vector4 (nx, ny, nz, d)
+      var planeWorld =
+          Vector4(out[idx], out[idx + 1], out[idx + 2], out[idx + 3]);
+
+      // Transform plane to camera space: plane_camera = (V^-1)^T * plane_world
+      var planeCamera = transformMatrix.transform(planeWorld);
+
+      // Normalize the plane
+      var normalLength =
+          Vector3(planeCamera.x, planeCamera.y, planeCamera.z).length;
+      if (normalLength > 0) {
+        planeCamera = planeCamera / normalLength;
+      }
+
+      // Set the transformed plane
+      switch (i) {
+        case 0:
+          frustum.plane0.setFromComponents(
+              planeCamera.x, planeCamera.y, planeCamera.z, planeCamera.w);
+          break;
+        case 1:
+          frustum.plane1.setFromComponents(
+              planeCamera.x, planeCamera.y, planeCamera.z, planeCamera.w);
+          break;
+        case 2:
+          frustum.plane2.setFromComponents(
+              planeCamera.x, planeCamera.y, planeCamera.z, planeCamera.w);
+          break;
+        case 3:
+          frustum.plane3.setFromComponents(
+              planeCamera.x, planeCamera.y, planeCamera.z, planeCamera.w);
+          break;
+        case 4:
+          frustum.plane4.setFromComponents(
+              planeCamera.x, planeCamera.y, planeCamera.z, planeCamera.w);
+          break;
+        case 5:
+          frustum.plane5.setFromComponents(
+              planeCamera.x, planeCamera.y, planeCamera.z, planeCamera.w);
+          break;
+      }
+    }
+
     if (FILAMENT_WASM) {
       //stackRestore(stackPtr);
       out.free();

--- a/thermion_dart/lib/src/filament/src/interface/camera.dart
+++ b/thermion_dart/lib/src/filament/src/interface/camera.dart
@@ -119,6 +119,8 @@ abstract class Camera<T> extends NativeHandle {
   
   Future<double> getHorizontalFieldOfView();
   Future<double> getVerticalFieldOfView();
+  
+  // Returns the view frustum of the camera in camera space.
   Future<Frustum> getFrustum();
 
   Future destroy();


### PR DESCRIPTION
Filament returns frustum in world space but our API provides this in camera space  