### PR TITLE
Expose in-place geometry POSITION buffer updates (VertexBuffer::setBufferAt) via thermion_dart

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -2371,6 +2371,14 @@ external Aabb3 SceneAsset_getBoundingBox(
 );
 
 @ffi.Native<
+    ffi.Pointer<TVertexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<
     ffi.Pointer<TRenderTicker> Function(
         ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
 external ffi.Pointer<TRenderTicker> RenderTicker_create(

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:animation_tools_dart/animation_tools_dart.dart';
 import 'package:logging/logging.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_material.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_vertex_buffer.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 import 'package:vector_math/vector_math_64.dart' as v64;
 
@@ -854,5 +855,14 @@ class FFIAsset extends ThermionAsset {
   @override
   Future<bool> containsChild(ThermionEntity entity) async {
     return (await getChildEntities()).contains(entity);
+  }
+  
+  @override
+  VertexBuffer? getVertexBuffer({int primitiveIndex = 0}) {
+    final vbPtr = SceneAsset_getVertexBuffer(asset, primitiveIndex);
+    if (vbPtr == nullptr) {
+      return null;
+    }
+    return FFIVertexBuffer(vbPtr, FilamentApp.instance!.engine);
   }
 }

--- a/thermion_dart/lib/src/filament/src/interface/asset.dart
+++ b/thermion_dart/lib/src/filament/src/interface/asset.dart
@@ -407,4 +407,20 @@ abstract class ThermionAsset {
   Future<int> getPrimitiveCount({ThermionEntity? entity}) async {
     throw UnimplementedError();
   }
+
+  ///
+  ///
+  ///
+  /// Returns the underlying [VertexBuffer] for this asset, if available.
+  ///
+  /// For geometry assets this exposes the backing Filament vertex buffer so you
+  /// can update data via [VertexBuffer.setBufferAt].
+  ///
+  /// [primitiveIndex] is reserved for future use. Geometry assets currently
+  /// only support a single primitive, so it is ignored.
+  ///
+  /// Returns null if this asset type does not expose a vertex buffer.
+  VertexBuffer? getVertexBuffer({int primitiveIndex = 0}) {
+    throw UnimplementedError();
+  }
 }

--- a/thermion_dart/native/include/c_api/TSceneAsset.h
+++ b/thermion_dart/native/include/c_api/TSceneAsset.h
@@ -40,6 +40,7 @@ extern "C"
     EMSCRIPTEN_KEEPALIVE size_t SceneAsset_getInstanceCount(TSceneAsset *tSceneAsset);
     EMSCRIPTEN_KEEPALIVE TSceneAsset * SceneAsset_createInstance(TSceneAsset *asset, TMaterialInstance **materialInstances, int materialInstanceCount);
     EMSCRIPTEN_KEEPALIVE Aabb3 SceneAsset_getBoundingBox(TSceneAsset *asset);
+    EMSCRIPTEN_KEEPALIVE TVertexBuffer *SceneAsset_getVertexBuffer(TSceneAsset *tSceneAsset, int primitiveIndex);
         
 #ifdef __cplusplus
 }

--- a/thermion_dart/native/src/c_api/TSceneAsset.cpp
+++ b/thermion_dart/native/src/c_api/TSceneAsset.cpp
@@ -228,6 +228,16 @@ extern "C"
         return Aabb3{box.center().x, box.center().y, box.center().z, box.extent().x, box.extent().y, box.extent().z};
     }
 
+    EMSCRIPTEN_KEEPALIVE TVertexBuffer *SceneAsset_getVertexBuffer(TSceneAsset *tSceneAsset, int primitiveIndex) {
+        auto *asset = reinterpret_cast<SceneAsset*>(tSceneAsset);
+        if (asset->getType() == SceneAsset::SceneAssetType::Geometry) {
+            auto geometrySceneAsset = reinterpret_cast<GeometrySceneAsset *>(asset);
+            auto *vertexBuffer = geometrySceneAsset->getVertexBuffer();
+            return reinterpret_cast<TVertexBuffer *>(vertexBuffer);
+        }
+        return nullptr;
+    }
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds a minimal API to update an existing geometry asset’s vertex positions in-place, instead of destroying/recreating geometry each update. The intent is to enable efficient dynamic meshes.


  - Native C API:
      - SceneAsset_updatePositionBuffer(TEngine*, TSceneAsset*, float* positions, uint32_t numFloats) updates buffer slot 0 (POSITION) on geometry assets after validating type and vertexCount * 3.
      - Memory is copied into heap-owned storage and freed via the BufferDescriptor callback.
  - Render-thread proxy:
      - SceneAsset_updatePositionBufferRenderThread(...) enqueues the update on the render thread and returns a success/failure boolean via callback.
  - Dart API:
      - FilamentApp.updateGeometryPositions(ThermionAsset asset, Float32List positions)
      - FFIFilamentApp implementation forwards to the render-thread API and throws if the native update fails.

  Notes

  - This is intentionally “positions-only” and targets the existing geometry layout where POSITION is in buffer slot 0.
  - I’m not a C++ expert; a proper C++/Filament review would be appreciated, especially around render-thread usage, memory/lifetime, and callback conventions.
