### PR TITLE
fix: windows used different vulkan devices

### DIFF
--- a/examples/dart/cli_windows/bin/cli_windows.dart
+++ b/examples/dart/cli_windows/bin/cli_windows.dart
@@ -1,20 +1,15 @@
-import 'dart:ffi';
 import 'dart:io';
 import 'dart:math';
-import 'package:ffi/ffi.dart';
-import 'package:thermion_dart/src/viewer/src/ffi/src/ffi_filament_app.dart';
-import 'package:thermion_dart/src/viewer/src/ffi/src/thermion_viewer_ffi.dart';
-import 'package:thermion_dart/src/viewer/src/ffi/src/thermion_dart.g.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/thermion_dart.dart';
-import 'package:vector_math/vector_math_64.dart';
 import 'package:cli_windows/thermion_window.g.dart';
 
 void main(List<String> arguments) async {
   var hwnd = create_thermion_window(500, 500, 0, 0);
   update();
-  await FFIFilamentApp.create();
-  var viewer = ThermionViewerFFI(
-    loadAssetFromUri: (path) async => File(path.replaceAll("file://", "")).readAsBytesSync());
+  final config = FFIFilamentConfig(loadResource: (path) async => File(path.replaceAll("file://", "")).readAsBytesSync());
+  await FFIFilamentApp.create(config: config);
+  var viewer = ThermionViewerFFI();
 
   await viewer.initialized;
   var swapChain = await FilamentApp.instance!.createSwapChain(Pointer<Void>.fromAddress(hwnd));

--- a/examples/dart/cli_windows/hook/build.dart
+++ b/examples/dart/cli_windows/hook/build.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:path/path.dart' as path;
 
@@ -8,7 +9,7 @@ void main(List<String> args) async {
       ..level = Level.ALL
       ..onRecord.listen((record) => print(
           record.message + "\n"));
-  await build(args, (input, output) async {
+  await build(args, (BuildInput input, BuildOutputBuilder output) async {
     final cbuilder = CBuilder.library(
       name: input.packageName,
       language: Language.cpp,

--- a/examples/dart/cli_windows/pubspec.yaml
+++ b/examples/dart/cli_windows/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
     path: ../../../thermion_dart
   ffi: ^2.1.3
   vector_math: ^2.1.4
-  native_toolchain_c: ^0.9.0
-  native_assets_cli: ^0.12.0
+  native_toolchain_c: ^0.17.4
+  hooks: ^1.0.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/thermion_dart/native/include/windows/vulkan/d3d_context.h
+++ b/thermion_dart/native/include/windows/vulkan/d3d_context.h
@@ -7,20 +7,36 @@
 #include <d3d11_1.h>
 #include <dxgi1_2.h>  
 #include <d3d11_4.h>
+
 #include <Windows.h>
 #include <wrl.h>
+#include <wrl/client.h>
+
 
 namespace thermion::windows::d3d { 
 
     class DLL_EXPORT D3DContext {
         public:
-            D3DContext();
+            D3DContext(const uint8_t *vulkanLUID); 
             ~D3DContext();
             void Flush();
             std::unique_ptr<D3DTexture> CreateTexture(uint32_t width, uint32_t height);
+            
+            bool IsValid() {
+                return _D3D11Device;
+            }
+
+            void ImportSemaphore(HANDLE handle);
+            
+            void SetWaitForSemaphore(uint64_t value);
 
         private:
             ID3D11DeviceContext* _D3D11DeviceContext = nullptr;
             ID3D11Device* _D3D11Device = nullptr;
+            Microsoft::WRL::ComPtr<ID3D11Device5> _D3D11Device5;
+            Microsoft::WRL::ComPtr<ID3D11DeviceContext4> _D3D11DeviceContext4;
+            Microsoft::WRL::ComPtr<ID3D11Fence> _sharedFence;
+
+
     };
 }

--- a/thermion_dart/native/include/windows/vulkan/vulkan_context.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_context.h
@@ -38,6 +38,8 @@ namespace thermion::windows::vulkan {
         filament::backend::VulkanPlatform *GetPlatform();
       
         void BlitFromSwapchain();
+
+        void* GetSharedContext();
       
         void readPixelsFromImage(
           uint32_t width,

--- a/thermion_dart/native/include/windows/vulkan/vulkan_context.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_context.h
@@ -49,6 +49,7 @@ namespace thermion::windows::vulkan {
     private:
         class Impl; 
         std::unique_ptr<Impl> pImpl;
+        
     };
 
 }

--- a/thermion_dart/native/include/windows/vulkan/vulkan_utils.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_utils.h
@@ -55,7 +55,7 @@ void readVkImageToBitmap(
     const char* outputPath
 );
 
-VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevice, VkDevice *device);
+VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevice, VkDevice *device, uint32_t* queueFamilyIndex);
 
 void createDeviceWithGraphicsQueue(VkPhysicalDevice physicalDevice, uint32_t& queueFamilyIndex, VkDevice* device);
 void fillImageWithColor(

--- a/thermion_dart/native/src/windows/vulkan/d3d_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/d3d_context.cpp
@@ -4,7 +4,7 @@
 namespace thermion::windows::d3d
 {
 
-    D3DContext::D3DContext()
+    D3DContext::D3DContext(const uint8_t *vulkanLUID)
     {
         IDXGIAdapter *adapter_ = nullptr;
 
@@ -24,11 +24,35 @@ namespace thermion::windows::d3d
             std::cout << "Failed to create DXGI 1.1 factory" << std::endl;
             return;
         }
-        dxgi->EnumAdapters(0, &adapter_);
+
+         // Find the adapter matching the Vulkan LUID passed above
+        UINT i = 0;
+        IDXGIAdapter* currAdapter = nullptr;
+        bool found = false;
+
+        while (dxgi->EnumAdapters(i, &currAdapter) != DXGI_ERROR_NOT_FOUND) {
+            DXGI_ADAPTER_DESC desc;
+            currAdapter->GetDesc(&desc);
+
+            //std::wcout << "Checking D3D adapter LUID" << desc.AdapterLuid << std::endl;
+
+            // Compare the 8 bytes of LUID
+            // LUID structure in Windows is exactly 8 bytes (DWORD + LONG)
+            if (memcmp(&desc.AdapterLuid, vulkanLUID, 8) == 0) {
+                adapter_ = currAdapter;
+                std::wcout << L"[INFO] Found matching D3D adapter: " << desc.Description << std::endl;
+                found = true;
+                break;
+            }
+            currAdapter->Release();
+            i++;
+        }
+    
         dxgi->Release();
-        if (!adapter_)
-        {
-            std::cout << "Failed to locate default D3D adapter" << std::endl;
+
+        
+        if (!found || !adapter_) {
+            std::cout << "[ERROR] Could not find D3D adapter matching Vulkan device LUID!" << std::endl;
             return;
         }
 
@@ -66,6 +90,18 @@ namespace thermion::windows::d3d
         std::cout << "Direct3D Feature Level: "
                   << (((unsigned)level) >> 12) << "_"
                   << ((((unsigned)level) >> 8) & 0xf) << std::endl;
+
+        hr = _D3D11Device->QueryInterface(__uuidof(ID3D11Device5), (void**)&_D3D11Device5);
+
+        if (FAILED(hr)) {
+            std::cout << "Failed to query ID3D11Device5 (Windows 10 Creator's Update required)" << std::endl;
+            return;
+        }
+
+        // Query for ID3D11DeviceContext4
+        hr = _D3D11DeviceContext->QueryInterface(__uuidof(ID3D11DeviceContext4), (void**)&_D3D11DeviceContext4);
+
+        adapter_->Release();
     }
 
     D3DContext::~D3DContext() { 
@@ -151,6 +187,25 @@ namespace thermion::windows::d3d
     void D3DContext::Flush()
     {
         _D3D11DeviceContext->Flush();
+    }
+
+    void D3DContext::ImportSemaphore(HANDLE handle)
+    {
+        if (!_D3D11Device5) return;
+
+        // Open the shared fence from Vulkan
+        HRESULT hr = _D3D11Device5->OpenSharedFence(handle, __uuidof(ID3D11Fence), (void**)&_sharedFence);
+        if (FAILED(hr)) {
+            std::cout << "Failed to open shared fence from Vulkan" << std::endl;
+        }
+    }
+
+    void D3DContext::SetWaitForSemaphore(uint64_t value) {
+        if (_D3D11DeviceContext4 && _sharedFence) {
+            // Instruct the GPU to wait until the fence reaches 'value'
+            // This is a GPU-side wait, it does not block the CPU.
+            _D3D11DeviceContext4->Wait(_sharedFence.Get(), value);
+        }
     }
 
 }

--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -46,22 +46,32 @@ class ThermionVulkanContext::Impl {
             }
             bluevk::bindInstance(instance);
 
-            result = createLogicalDevice(instance, &physicalDevice, &device);
+            uint32_t queueFamilyIndex = 0;
+            result = createLogicalDevice(instance, &physicalDevice, &device, &queueFamilyIndex);
             if (result != VK_SUCCESS)
             {
                 std::cout << "[ERROR] Failed to create logical device! Error: " << VkResultToString(result) << std::endl;
                 vkDestroyInstance(instance, nullptr);
                 return;
             }
+            _sharedContext.instance = instance;
+            _sharedContext.physicalDevice = physicalDevice;
+            _sharedContext.logicalDevice = device;
+            _sharedContext.graphicsQueueFamilyIndex = queueFamilyIndex;
+            _sharedContext.graphicsQueueIndex = 0;
+            _sharedContext.debugUtilsSupported = false;
+            _sharedContext.debugMarkersSupported = false;
+            _sharedContext.multiviewSupported = false;
 
-            uint32_t queueFamilyIndex;
-            
-            createDeviceWithGraphicsQueue(physicalDevice,queueFamilyIndex, &device);
-            
+            std::cout << "[INFO] Vulkan logical device created with queue family index "
+                      << queueFamilyIndex << std::endl;
+
             CommandResources cmdResources = createCommandResources(device, physicalDevice);
 
             commandPool = cmdResources.commandPool;
             queue = cmdResources.queue;
+            std::cout << "[INFO] Vulkan command resources using queue family index "
+                      << cmdResources.queueFamilyIndex << std::endl;
 
             VkPhysicalDeviceExternalImageFormatInfo externFormatInfo = {
                 .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO,
@@ -536,6 +546,10 @@ class ThermionVulkanContext::Impl {
         filament::backend::VulkanPlatform *GetPlatform() { 
             return _platform.get();
         }
+
+        void* GetSharedContext() {
+            return &_sharedContext;
+        }
     private:
         VkInstance instance = VK_NULL_HANDLE;
         VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
@@ -549,6 +563,7 @@ class ThermionVulkanContext::Impl {
         std::vector<std::unique_ptr<thermion::windows::vulkan::VulkanTexture>> _vulkanTextures;
         
         std::unique_ptr<TVulkanPlatform> _platform;
+        filament::backend::VulkanPlatform::VulkanSharedContext _sharedContext{};
 };
 
 HANDLE ThermionVulkanContext::CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top) {
@@ -565,6 +580,10 @@ void ThermionVulkanContext::Flush() {
 
 filament::backend::VulkanPlatform *ThermionVulkanContext::GetPlatform() { 
 return pImpl->GetPlatform();
+}
+
+void* ThermionVulkanContext::GetSharedContext() {
+    return pImpl->GetSharedContext();
 }
 
 void ThermionVulkanContext::BlitFromSwapchain() {

--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -76,15 +76,17 @@ class ThermionVulkanContext::Impl {
             VkPhysicalDeviceExternalImageFormatInfo externFormatInfo = {
                 .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO,
                 .pNext = nullptr,
-                .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT};
+                .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT
+            };
+
 
             VkPhysicalDeviceImageFormatInfo2 formatInfo = {
                 .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2,
                 .pNext = &externFormatInfo,
                 .format = VK_FORMAT_R8G8B8A8_UNORM,
                 .type = VK_IMAGE_TYPE_2D,
-                .tiling = VK_IMAGE_TILING_OPTIMAL,                                      // Changed to LINEAR for VM compatibility
-                .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, // Simplified usage flags
+                .tiling = VK_IMAGE_TILING_OPTIMAL,                                      
+                .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 
                 .flags = 0
             };
 
@@ -110,7 +112,57 @@ class ThermionVulkanContext::Impl {
 
             _platform = std::make_unique<TVulkanPlatform>();
 
-            _d3dContext = std::make_unique<thermion::windows::d3d::D3DContext>();
+            VkPhysicalDeviceIDProperties idProps{};
+            idProps.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+            idProps.pNext = nullptr;
+
+            VkPhysicalDeviceProperties2 props{};
+            props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+            props.pNext = &idProps;
+
+            // requires Vulkan instance version 1.1+ OR VK_KHR_get_physical_device_properties2 
+            bluevk::vkGetPhysicalDeviceProperties2(physicalDevice, &props);
+
+            if (idProps.deviceLUIDValid == VK_TRUE) {
+                Log("Using Vulkan Device LUID %d", idProps.deviceLUID);
+                _d3dContext = std::make_unique<thermion::windows::d3d::D3DContext>(idProps.deviceLUID);
+            } 
+
+            if(!_d3dContext || !_d3dContext->IsValid()) {
+                ERROR("Could not resolve Vulkan Device LUID");
+                return;
+            }
+
+            // Command buffer allocation
+            VkCommandBufferAllocateInfo cmdBufInfo{};
+            cmdBufInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            cmdBufInfo.commandPool = commandPool;
+            cmdBufInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            cmdBufInfo.commandBufferCount = 1;
+
+            vkAllocateCommandBuffers(device, &cmdBufInfo, &blitCommandBuffer);
+
+            createSyncObjects();
+
+            VkSemaphoreGetWin32HandleInfoKHR handleInfo{};
+            handleInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR;
+            handleInfo.semaphore = sharedSemaphore;
+            handleInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
+
+            HANDLE semaphoreHandle = NULL;
+
+            auto fpGetSemaphoreWin32Handle = (PFN_vkGetSemaphoreWin32HandleKHR)vkGetDeviceProcAddr(device, "vkGetSemaphoreWin32HandleKHR");
+            if (fpGetSemaphoreWin32Handle) {
+                fpGetSemaphoreWin32Handle(device, &handleInfo, &semaphoreHandle);
+            } else { 
+                ERROR("Failed to resolve vkGetSemaphoreWin32HandleKHR");
+            }
+
+            if(semaphoreHandle == VK_NULL_HANDLE) {
+                ERROR("Failed to create Vulkan semaphore");
+            } else {
+                _d3dContext->ImportSemaphore(semaphoreHandle);
+            }
 
         }
 
@@ -178,8 +230,6 @@ class ThermionVulkanContext::Impl {
                 return;
             }
 
-            
-
             auto&& vkTexture = _vulkanTextures.back();
             auto image = vkTexture->GetImage();
 
@@ -190,15 +240,9 @@ class ThermionVulkanContext::Impl {
 
             auto bundle = _platform->getSwapChainBundle(_platform->current);
             VkImage swapchainImage = bundle.colors[_platform->currentColorIndex];
-            // Command buffer allocation
-            VkCommandBufferAllocateInfo cmdBufInfo{};
-            cmdBufInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-            cmdBufInfo.commandPool = commandPool;
-            cmdBufInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-            cmdBufInfo.commandBufferCount = 1;
 
-            VkCommandBuffer cmd;
-            VkResult result = bluevk::vkAllocateCommandBuffers(device, &cmdBufInfo, &cmd);
+            VkResult result = bluevk::vkResetCommandBuffer(blitCommandBuffer, 0); 
+
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to allocate command buffer: " << result << std::endl;
                 return;
@@ -209,7 +253,7 @@ class ThermionVulkanContext::Impl {
             beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
             beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
             
-            result = bluevk::vkBeginCommandBuffer(cmd, &beginInfo);
+            result = bluevk::vkBeginCommandBuffer(blitCommandBuffer, &beginInfo);
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to begin command buffer: " << result << std::endl;
                 return;
@@ -251,9 +295,9 @@ class ThermionVulkanContext::Impl {
             // Pre-blit barriers
             VkImageMemoryBarrier preBlitBarriers[] = {srcBarrier, dstBarrier};
             vkCmdPipelineBarrier(
-                cmd,
-                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,  // Changed from TRANSFER_BIT for better sync
-                VK_PIPELINE_STAGE_TRANSFER_BIT,
+                blitCommandBuffer,
+                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 
+                VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
                 0,
                 0, nullptr,
                 0, nullptr,
@@ -275,11 +319,11 @@ class ThermionVulkanContext::Impl {
 
             // Perform blit with validation
             bluevk::vkCmdBlitImage(
-                cmd,
+                blitCommandBuffer,
                 swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                 image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                 1, &blit,
-                VK_FILTER_NEAREST  // Changed to NEAREST for debugging
+                VK_FILTER_NEAREST 
             );
 
             // Post-transition barriers
@@ -298,9 +342,9 @@ class ThermionVulkanContext::Impl {
             // Post-blit barriers
             VkImageMemoryBarrier postBlitBarriers[] = {srcBarrier, dstBarrier};
             bluevk::vkCmdPipelineBarrier(
-                cmd,
+                blitCommandBuffer,
                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,  // Changed for better sync
+                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 
                 0,
                 0, nullptr,
                 0, nullptr,
@@ -308,49 +352,41 @@ class ThermionVulkanContext::Impl {
             );
 
             // End command buffer
-            result = bluevk::vkEndCommandBuffer(cmd);
+            result = bluevk::vkEndCommandBuffer(blitCommandBuffer);
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to end command buffer: " << result << std::endl;
                 return;
             }
 
-            // Create fence for synchronization
-            // VkFenceCreateInfo fenceInfo{};
-            // fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-            
-            // VkFence fence;
-            // result = bluevk::vkCreateFence(device, &fenceInfo, nullptr, &fence);
-            // if (result != VK_SUCCESS) {
-            //     std::cout << "Failed to create fence: " << result << std::endl;
-            //     return;
-            // }
+            uint64_t signalValue = ++currentSemaphoreValue;
 
-            // // Submit with fence
+            // 2. Setup Timeline Submit Info
+            VkTimelineSemaphoreSubmitInfo timelineInfo{};
+            timelineInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
+            timelineInfo.signalSemaphoreValueCount = 1;
+            timelineInfo.pSignalSemaphoreValues = &signalValue;
+
+            // 3. Setup Standard Submit Info
             VkSubmitInfo submitInfo{};
             submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            submitInfo.pNext = &timelineInfo; // Chain the timeline info
             submitInfo.commandBufferCount = 1;
-            submitInfo.pCommandBuffers = &cmd;
+            submitInfo.pCommandBuffers = &blitCommandBuffer;
+            
+            // Define the semaphore to signal
+            submitInfo.signalSemaphoreCount = 1;
+            submitInfo.pSignalSemaphores = &sharedSemaphore;
 
-            result = bluevk::vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE); //fence);
+            result = bluevk::vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE);
+
+            _d3dContext->SetWaitForSemaphore(signalValue);
+
+
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to submit queue: " << result << std::endl;
                 // bluevk::vkDestroyFence(device, fence, nullptr);
                 return;
             }
-
-            // // Wait for fence with timeout
-            // result = bluevk::vkWaitForFences(device, 1, &fence, VK_TRUE, 5000000000); // 5 second timeout
-            // if (result != VK_SUCCESS) {
-            //     std::cout << "Failed to wait for fence: " << result << std::endl;
-            //     vkDestroyFence(device, fence, nullptr);
-            //     return;
-            // }
-
-            // std::cout << "Blit operation completed successfully" << std::endl;
-
-            // // Cleanup
-            // bluevk::vkDestroyFence(device, fence, nullptr);
-            // bluevk::vkFreeCommandBuffers(device, commandPool, 1, &cmd);
         }
 
         void readPixelsFromImage(
@@ -550,13 +586,18 @@ class ThermionVulkanContext::Impl {
         void* GetSharedContext() {
             return &_sharedContext;
         }
+    
     private:
         VkInstance instance = VK_NULL_HANDLE;
         VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
         VkDevice device = VK_NULL_HANDLE;
         VkCommandPool commandPool = VK_NULL_HANDLE;
+        VkCommandBuffer blitCommandBuffer = VK_NULL_HANDLE; 
         VkQueue queue = VK_NULL_HANDLE;
-    
+
+        VkSemaphore sharedSemaphore = VK_NULL_HANDLE;
+        uint64_t currentSemaphoreValue = 0;
+        
         std::unique_ptr<thermion::windows::d3d::D3DContext> _d3dContext;
     
         std::vector<std::unique_ptr<thermion::windows::d3d::D3DTexture>> _d3dTextures;
@@ -564,6 +605,29 @@ class ThermionVulkanContext::Impl {
         
         std::unique_ptr<TVulkanPlatform> _platform;
         filament::backend::VulkanPlatform::VulkanSharedContext _sharedContext{};
+
+        void createSyncObjects() {
+            VkExportSemaphoreCreateInfo exportInfo{};
+            exportInfo.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO;
+            // D3D12_FENCE is the handle type that maps to ID3D11Fence
+            exportInfo.handleTypes = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
+
+            VkSemaphoreTypeCreateInfo timelineInfo{};
+            timelineInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
+            timelineInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+            timelineInfo.initialValue = 0;
+            timelineInfo.pNext = &exportInfo;
+
+            VkSemaphoreCreateInfo semaphoreInfo{};
+            semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+            semaphoreInfo.pNext = &timelineInfo;
+
+            VkResult result = bluevk::vkCreateSemaphore(device, &semaphoreInfo, nullptr, &sharedSemaphore);
+            if (result != VK_SUCCESS) {
+                std::cout << "Failed to create shared semaphore: " << result << std::endl;
+            }
+        }
+
 };
 
 HANDLE ThermionVulkanContext::CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top) {

--- a/thermion_dart/native/src/windows/vulkan/vulkan_platform.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_platform.cpp
@@ -24,8 +24,8 @@
 namespace thermion::windows::vulkan {
  
 TVulkanPlatform::TVulkanPlatform() {
-  _customization.gpu.index = 0;
-  TRACE("Set GPU index to 1");
+  _customization.gpu.index = -1;
+  TRACE("Using default Vulkan GPU selection");
 }
        
 TVulkanPlatform::~TVulkanPlatform() {

--- a/thermion_dart/native/src/windows/vulkan/vulkan_utils.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_utils.cpp
@@ -576,7 +576,10 @@ VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevi
     std::vector<const char *> deviceExtensions = {
         VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
         VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
-        VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+        VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,
+        VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME, };
 
     float queuePriority = 1.0f;
     VkDeviceQueueCreateInfo queueCreateInfo = {};

--- a/thermion_dart/native/src/windows/vulkan/vulkan_utils.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_utils.cpp
@@ -558,7 +558,7 @@ void readVkImageToBitmap(
 }
 
 // Consolidated function for creating logical device
-VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevice, VkDevice *device)
+VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevice, VkDevice *device, uint32_t* queueFamilyIndex)
 {
     uint32_t deviceCount = 0;
     bluevk::vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
@@ -571,15 +571,17 @@ VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevi
     }
 
     *physicalDevice = physicalDevices[0];
+    *queueFamilyIndex = findGraphicsQueueFamily(*physicalDevice);
 
     std::vector<const char *> deviceExtensions = {
         VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
-        VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME};
+        VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
+        VK_KHR_SWAPCHAIN_EXTENSION_NAME};
 
     float queuePriority = 1.0f;
     VkDeviceQueueCreateInfo queueCreateInfo = {};
     queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    queueCreateInfo.queueFamilyIndex = 0;
+    queueCreateInfo.queueFamilyIndex = *queueFamilyIndex;
     queueCreateInfo.queueCount = 1;
     queueCreateInfo.pQueuePriorities = &queuePriority;
 

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal_native_texture.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal_native_texture.dart
@@ -247,7 +247,6 @@ class _ThermionTextureWidgetState extends State<ThermionWidgetInternal> {
 
   @override
   Widget build(BuildContext context) {
-    print("NATIVE");
     if (_texture == null) {
       return widget.initial ?? Container(color: Colors.red);
     }

--- a/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
+++ b/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
@@ -175,8 +175,7 @@ namespace thermion::tflutter::windows
       {
         _context = new thermion::windows::vulkan::ThermionVulkanContext();
       }
-      // result->Success(flutter::EncodableValue((int64_t)_context->GetSharedContext()));
-      result->Success(flutter::EncodableValue((int64_t) nullptr));
+      result->Success(flutter::EncodableValue((int64_t)_context->GetSharedContext()));
     }
     else if (methodCall.method_name() == "createTexture")
     {


### PR DESCRIPTION
Problem

  - On Windows Vulkan, Filament and the interop blit path were using different Vulkan devices/queues.
  - This caused VK_ERROR_DEVICE_LOST on submit.
  - Repro: Intel i7‑1265U (iGPU only).

  Fix

  - Build a VulkanSharedContext and pass it to Filament so both paths share the same VkInstance/VkDevice/queue family.
  - Enable VK_KHR_swapchain on the shared device (required by Filament).
  - Stop forcing a GPU index when sharing a context to avoid Filament’s precondition failure.

review request

  - I’m not a graphics engineer and would appreciate a careful review, especially around Vulkan queue usage and device selection.

Cheers!
