### PR TITLE
fix: Resolve VK_ERROR_OUT_OF_HOST_MEMORY crash on Windows by releasing command buffer resources

### DIFF
--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -241,7 +241,7 @@ class ThermionVulkanContext::Impl {
             auto bundle = _platform->getSwapChainBundle(_platform->current);
             VkImage swapchainImage = bundle.colors[_platform->currentColorIndex];
 
-            VkResult result = bluevk::vkResetCommandBuffer(blitCommandBuffer, 0); 
+            VkResult result = bluevk::vkResetCommandBuffer(blitCommandBuffer, VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT);
 
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to allocate command buffer: " << result << std::endl;


### PR DESCRIPTION
This PR fixes a crash that occurred after approximately 5 minutes of runtime on Windows. The application would terminate with Failed to begin command buffer: -1 (VK_ERROR_OUT_OF_HOST_MEMORY).

Root Cause:
The BlitFromSwapchain method runs every frame to synchronize the Vulkan and D3D textures. Previously, vkResetCommandBuffer was called with the default 0 flag. This instructed the driver to reset the command buffer state but retain the allocated memory within the pool. My guess is that over thousands of frames, this retention led to memory fragmentation or exhaustion of the host-side memory pool, causing the driver to fail new allocations.