### PR TITLE
Implement widget-based overlays

### DIFF
--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -65,7 +65,7 @@ outputDirectory : ${outputDirectory.path}
         .listSync(recursive: true)
         .whereType<File>()
         .map((f) => f.path)
-        .where((f) => !(f.contains("CMakeLists") || f.contains("main.cpp")))
+        .where((f) => !(f.contains("CMakeLists") || f.contains("main.cpp") || f.contains("build")))
         .toList();
 
     if (targetOS != OS.windows) {

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -95,9 +95,8 @@ outputDirectory : ${outputDirectory.path}
       "filament",
       "backend",
       "filameshio",
-      if (targetOS != OS.iOS) "filamat",
+	if (targetOS == OS.linux) "filamat_combined" else if (targetOS != OS.iOS) "filamat",
       if (targetOS == OS.linux) "shaders",
-      //"geometry",
       "utils",
       "filabridge",
       "gltfio_core",
@@ -118,7 +117,7 @@ outputDirectory : ${outputDirectory.path}
       "uberarchive",
       "zstd",
       //"mikktspace",
-      "geometry",
+      if (targetOS == OS.linux) "geometry_combined" else "geometry",
       if (targetOS == OS.macOS && buildMode == BuildMode.debug) ...["matdbg", "fgviewer"]
     ];
 

--- a/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
@@ -41,8 +41,11 @@ class EdgeDetectionView extends FFIView {
   final ThermionEntity _fullscreenQuadEntity;
   final FFITextureSampler _edgeSampler;
 
-  // Silhouette texture to sample (set externally)
-  final Texture silhouetteTexture;
+  // Silhouette texture to sample (mutable for resize support)
+  Texture _silhouetteTexture;
+
+  /// The silhouette texture being sampled for edge detection
+  Texture get silhouetteTexture => _silhouetteTexture;
 
   EdgeDetectionView._(
     super.view,
@@ -57,8 +60,8 @@ class EdgeDetectionView extends FFIView {
     required FFIIndexBuffer quadIB,
     required ThermionEntity fullscreenQuadEntity,
     required FFITextureSampler edgeSampler,
-    required this.silhouetteTexture
-  })  : 
+    required Texture silhouetteTexture,
+  })  : _silhouetteTexture = silhouetteTexture,
         _edgeMaterial = material,
         _edgeScene = scene,
         _skybox = skybox,
@@ -239,6 +242,13 @@ class EdgeDetectionView extends FFIView {
     await _updateEdgeMaterialParams();
   }
 
+  /// Update the silhouette texture reference (called when SilhouetteView resizes)
+  Future<void> updateSilhouetteTexture(Texture newTexture) async {
+    _silhouetteTexture = newTexture;
+    await _updateEdgeMaterialParams();
+    _logger.info("Updated silhouette texture reference");
+  }
+
   /// Update viewport size.
   @override
   Future setViewport(int width, int height) async {
@@ -287,7 +297,7 @@ class EdgeDetectionView extends FFIView {
     // Set silhouette texture
     await _edgeMaterialInstance.setParameterTexture(
       'silhouette',
-      silhouetteTexture! as FFITexture,
+      _silhouetteTexture as FFITexture,
       _edgeSampler,
     );
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -48,7 +48,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
   final Pointer<TRenderManager> renderManager;
 
   final Pointer<TMaterialProvider> ubershaderMaterialProvider;
-  
+
   final Pointer<TNameComponentManager> nameComponentManager;
 
   late final Future<Uint8List> Function(String uri) _loadResource;
@@ -138,7 +138,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     );
 
     await withVoidCallback((requestId, cb) =>
-        RenderManager_addAnimationManagerRenderThread(renderManager, animationManager, requestId, cb));
+        RenderManager_addAnimationManagerRenderThread(
+            renderManager, animationManager, requestId, cb));
 
     FilamentApp.instance = FFIFilamentApp(
         engine,
@@ -211,8 +212,14 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
         }
       }
 
-      await withVoidCallback((requestId, cb) => RenderManager_setRenderableRenderThread(
-          renderManager, swapChain.getNativeHandle(), viewsPtr, numRenderable, requestId, cb));
+      await withVoidCallback((requestId, cb) =>
+          RenderManager_setRenderableRenderThread(
+              renderManager,
+              swapChain.getNativeHandle(),
+              viewsPtr,
+              numRenderable,
+              requestId,
+              cb));
       _logger.finest("Updated render order, $numRenderable renderable views");
     }
   }
@@ -285,7 +292,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
   Future destroySwapChain(SwapChain swapChain) async {
     _logger.info("Destroying swapchain");
     await withVoidCallback((requestId, cb) =>
-        RenderManager_removeSwapChainRenderThread(renderManager, swapChain.getNativeHandle(), requestId, cb));
+        RenderManager_removeSwapChainRenderThread(
+            renderManager, swapChain.getNativeHandle(), requestId, cb));
     await withVoidCallback((requestId, callback) {
       Engine_destroySwapChainRenderThread(
           engine, swapChain.getNativeHandle(), requestId, callback);
@@ -369,7 +377,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
             TextureUsage.TEXTURE_USAGE_BLIT_SRC
           },
           textureFormat: TextureFormat.RGBA8) as FFITexture;
-      _logger.finest("Created ${width}x${height} color texture (TextureFormat.RGBA8)");
+      _logger.finest(
+          "Created ${width}x${height} color texture (TextureFormat.RGBA8)");
     }
     if (depth == null) {
       _logger.finest("No depth texture provided");
@@ -380,7 +389,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
             TextureUsage.TEXTURE_USAGE_BLIT_SRC,
           },
           textureFormat: TextureFormat.DEPTH32F) as FFITexture;
-      _logger.finest("Created ${width}x${height} depth texture (TextureFormat.DEPTH32F)");
+      _logger.finest(
+          "Created ${width}x${height} depth texture (TextureFormat.DEPTH32F)");
     }
     final renderTarget = await withPointerCallback<TRenderTarget>((cb) {
       RenderTarget_createRenderThread(
@@ -661,6 +671,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     _swapChains[swapChain]!
         .sort((a, b) => a.renderOrder.compareTo(b.renderOrder));
     await updateRenderOrder();
+    _logger.info("Registered swapchain with view");
   }
 
   ///
@@ -723,9 +734,9 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     final frameTimeInNanos = DateTime.now().microsecond * 1000000;
 
     await withVoidCallback((requestId, cb) {
-      RenderManager_renderRenderThread(renderManager, frameTimeInNanos, requestId, cb);
+      RenderManager_renderRenderThread(
+          renderManager, frameTimeInNanos, requestId, cb);
     });
-    
   }
 
   ///
@@ -837,10 +848,11 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
           "Added ${views.length} views (from ${_swapChains.length} swapchains)");
     }
 
-    for(final view in views) {
+    for (final view in views) {
       final vp = await view.getViewport();
-      if(vp.width == 0 || vp.height == 0) {
-        throw Exception("Invalid viewport : ${vp.width}x${vp.height} for ${view.getNativeHandle()}");
+      if (vp.width == 0 || vp.height == 0) {
+        throw Exception(
+            "Invalid viewport : ${vp.width}x${vp.height} for ${view.getNativeHandle()}");
       }
     }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -496,6 +496,9 @@ class FFIView extends View<Pointer<TView>> {
     final camera = await getCamera();
     await _highlightOverlayManager!.setCamera(camera);
 
+    await app.updateRenderOrder();
+
+
     _logger.info("Highlight overlay enabled");
     return true;
   }

--- a/thermion_dart/lib/src/filament/src/implementation/highlight_overlay_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/highlight_overlay_manager.dart
@@ -41,6 +41,7 @@ class HighlightOverlayManager {
       width: actualWidth,
       height: actualHeight,
     );
+    await silhouetteView.setBlendMode(BlendMode.transparent);
 
     // Create edge detection view (second pass)
     final edgeDetectionView = await EdgeDetectionView.create(
@@ -49,6 +50,12 @@ class HighlightOverlayManager {
       height: actualHeight,
       silhouetteTexture: silhouetteView.colorTexture,
     );
+
+    // Wire up texture resize callback so EdgeDetectionView gets notified
+    // when SilhouetteView resizes its render target
+    silhouetteView.onTextureResized = (newTexture) async {
+      await edgeDetectionView.updateSilhouetteTexture(newTexture);
+    };
 
     final manager = HighlightOverlayManager._(
       app,
@@ -66,7 +73,6 @@ class HighlightOverlayManager {
   /// Set the camera for the silhouette view.
   Future<void> setCamera(Camera camera) async {
     await silhouetteView.setCamera(camera);
-    await overlayView.setCamera(camera);
   }
 
   /// Update viewport size for both views.

--- a/thermion_dart/lib/src/filament/src/implementation/silhouette_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/silhouette_view.dart
@@ -21,8 +21,8 @@ class _SilhouetteComponent {
 
 /// Manages the first (silhouette) rendering pass for highlighted entities.
 ///
-/// Renders highlighted entities as white silhouettes to a standalone texture/render target. 
-/// 
+/// Renders highlighted entities as white silhouettes to a standalone texture/render target.
+///
 /// This texture is passed to the edge detection pass.
 ///
 class SilhouetteView extends FFIView {
@@ -31,10 +31,17 @@ class SilhouetteView extends FFIView {
   // Material (owned by this class)
   final FFIMaterial _silhouetteMaterial;
 
-  // Render target resources
-  final FFITexture _colorTexture;
-  final FFITexture _depthTexture;
-  final FFIRenderTarget _renderTarget;
+  // Render target resources (mutable for resize support)
+  FFITexture _colorTexture;
+  FFITexture _depthTexture;
+  FFIRenderTarget _renderTarget;
+
+  // Track current texture dimensions
+  int _textureWidth = 0;
+  int _textureHeight = 0;
+
+  // Callback to notify when texture changes (for EdgeDetectionView)
+  Future<void> Function(Texture)? onTextureResized;
 
   // Scene resources (separate from parent's scene)
   final FFIScene _silhouetteScene;
@@ -52,8 +59,7 @@ class SilhouetteView extends FFIView {
     required FFIRenderTarget renderTarget,
     required FFIScene scene,
     required Skybox skybox,
-  })  : 
-        _silhouetteMaterial = material,
+  })  : _silhouetteMaterial = material,
         _colorTexture = colorTexture,
         _depthTexture = depthTexture,
         _renderTarget = renderTarget,
@@ -99,7 +105,8 @@ class SilhouetteView extends FFIView {
 
     // Create scene with black skybox to clear render target
     final silhouetteScene = await app.createScene() as FFIScene;
-    final skybox = await app.createColoredSkybox(r: 0.0, g: 0.0, b: 0.0, a: 1.0);
+    final skybox =
+        await app.createColoredSkybox(r: 0.0, g: 0.0, b: 0.0, a: 1.0);
     await silhouetteScene.setSkybox(skybox);
 
     // Create the SilhouetteView with all resources
@@ -114,6 +121,10 @@ class SilhouetteView extends FFIView {
       skybox: skybox,
     );
 
+    // Initialize texture dimensions to prevent resize on first setViewport
+    silhouetteView._textureWidth = width;
+    silhouetteView._textureHeight = height;
+
     // Configure this view
     await silhouetteView.setScene(silhouetteScene);
     await silhouetteView.setViewport(width, height);
@@ -122,6 +133,69 @@ class SilhouetteView extends FFIView {
     await silhouetteView.setShadowsEnabled(false);
 
     return silhouetteView;
+  }
+
+  @override
+  Future setViewport(int width, int height) async {
+    _logger.info("setViewport $width x $height (current texture: ${_textureWidth}x${_textureHeight})");
+    await super.setViewport(width, height);
+
+    // Resize if dimensions are valid and different from current texture size
+    if (width > 0 && height > 0 &&
+        (width != _textureWidth || height != _textureHeight)) {
+      await _resizeRenderTarget(width, height);
+    }
+  }
+
+  Future _resizeRenderTarget(int width, int height) async {
+    _logger.info("Resizing render target from ${_textureWidth}x${_textureHeight} to ${width}x${height}");
+
+    // Store old resources for cleanup
+    final oldColorTexture = _colorTexture;
+    final oldDepthTexture = _depthTexture;
+    final oldRenderTarget = _renderTarget;
+
+    // Create new textures
+    _colorTexture = await app.createTexture(
+      width,
+      height,
+      flags: {
+        TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
+        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+      },
+      textureFormat: TextureFormat.RGBA8,
+    ) as FFITexture;
+
+    _depthTexture = await app.createTexture(
+      width,
+      height,
+      flags: {TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT},
+      textureFormat: TextureFormat.DEPTH32F,
+    ) as FFITexture;
+
+    _renderTarget = await app.createRenderTarget(
+      width,
+      height,
+      color: _colorTexture,
+      depth: _depthTexture,
+    ) as FFIRenderTarget;
+
+    // Set new render target on view
+    await setRenderTarget(_renderTarget);
+
+    // Update tracked dimensions
+    _textureWidth = width;
+    _textureHeight = height;
+
+    // Notify listeners (EdgeDetectionView needs new texture reference)
+    await onTextureResized?.call(_colorTexture);
+
+    // Destroy old resources
+    await oldRenderTarget.destroy();
+    await oldColorTexture.dispose();
+    await oldDepthTexture.dispose();
+
+    _logger.info("Render target resized successfully");
   }
 
   /// The color texture containing white silhouettes (for edge detection sampling).
@@ -156,10 +230,8 @@ class SilhouetteView extends FFIView {
   @override
   View? getOverlayView() => throw Exception();
 
-
   @override
   bool hasHighlights() => _components.isNotEmpty;
-
 
   /// Add a highlight for the given entity.
   Future<void> addHighlight({

--- a/thermion_dart/native/include/ThermionWin32.h
+++ b/thermion_dart/native/include/ThermionWin32.h
@@ -36,4 +36,5 @@
 #pragma comment(lib, "vulkan-1.lib")
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "mikktspace.lib")
  

--- a/thermion_dart/native/include/windows/vulkan/d3d_context.h
+++ b/thermion_dart/native/include/windows/vulkan/d3d_context.h
@@ -26,9 +26,6 @@ namespace thermion::windows::d3d {
                 return _D3D11Device;
             }
 
-            void ImportSemaphore(HANDLE handle);
-            
-            void SetWaitForSemaphore(uint64_t value);
 
         private:
             ID3D11DeviceContext* _D3D11DeviceContext = nullptr;

--- a/thermion_dart/native/include/windows/vulkan/vulkan_context.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_context.h
@@ -29,8 +29,10 @@ namespace thermion::windows::vulkan {
         ThermionVulkanContext();
         ~ThermionVulkanContext();
         
-        HANDLE CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top);        
-        
+        HANDLE CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top);
+
+        VkImage GetVulkanImageForSurface(HANDLE d3dTextureHandle);
+
         void DestroyRenderingSurface(HANDLE handle);
                 
         void Flush();

--- a/thermion_dart/native/include/windows/vulkan/vulkan_context.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_context.h
@@ -39,7 +39,7 @@ namespace thermion::windows::vulkan {
       
         filament::backend::VulkanPlatform *GetPlatform();
       
-        void BlitFromSwapchain();
+        void BlitFromSwapchain(HANDLE d3dTextureHandle);
 
         void* GetSharedContext();
       

--- a/thermion_dart/native/include/windows/vulkan/vulkan_texture.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_texture.h
@@ -12,14 +12,23 @@ typedef void *HANDLE;
 
 class DLL_EXPORT VulkanTexture {
     public:
+        // Constructor for D3D-interop textures (doesn't own memory)
         VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, HANDLE d3dTextureHandle);
+
+        // Constructor for pure Vulkan textures (owns memory)
+        VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, bool ownsMemory);
+
         ~VulkanTexture();
 
-        HANDLE GetD3DTextureHandle() { 
+        HANDLE GetD3DTextureHandle() {
             return _d3dTextureHandle;
         }
 
+        // Factory method for D3D-interop textures
         static std::unique_ptr<VulkanTexture> create(VkDevice device, VkPhysicalDevice physicalDevice, uint32_t width, uint32_t height, HANDLE d3dTextureHandle);
+
+        // Factory method for pure Vulkan textures (render target backing)
+        static std::unique_ptr<VulkanTexture> createPure(VkDevice device, VkPhysicalDevice physicalDevice, uint32_t width, uint32_t height);
 
         VkImage GetImage() {
             return _image;
@@ -30,7 +39,8 @@ class DLL_EXPORT VulkanTexture {
         VkDeviceMemory _imageMemory = VK_NULL_HANDLE;
         uint32_t _width = 0;
         uint32_t _height = 0;
-        HANDLE _d3dTextureHandle;
+        HANDLE _d3dTextureHandle = nullptr;
+        bool _ownsMemory = false;
 };
 
 }

--- a/thermion_dart/native/src/windows/vulkan/d3d_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/d3d_context.cpp
@@ -189,23 +189,5 @@ namespace thermion::windows::d3d
         _D3D11DeviceContext->Flush();
     }
 
-    void D3DContext::ImportSemaphore(HANDLE handle)
-    {
-        if (!_D3D11Device5) return;
-
-        // Open the shared fence from Vulkan
-        HRESULT hr = _D3D11Device5->OpenSharedFence(handle, __uuidof(ID3D11Fence), (void**)&_sharedFence);
-        if (FAILED(hr)) {
-            std::cout << "Failed to open shared fence from Vulkan" << std::endl;
-        }
-    }
-
-    void D3DContext::SetWaitForSemaphore(uint64_t value) {
-        if (_D3D11DeviceContext4 && _sharedFence) {
-            // Instruct the GPU to wait until the fence reaches 'value'
-            // This is a GPU-side wait, it does not block the CPU.
-            _D3D11DeviceContext4->Wait(_sharedFence.Get(), value);
-        }
-    }
 
 }

--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -30,7 +30,8 @@ class ThermionVulkanContext::Impl {
     public:
 
         ~Impl() {
-            std::cerr << "ThermionVulkanContext destructor " << _vulkanTextures.size() << " Vulkan textures / " << _d3dTextures.size() << " D3D textures remain" << std::endl;
+            std::cerr << "ThermionVulkanContext destructor " << _vulkanTextures.size() << " Vulkan textures / "
+                      << _d3dTextures.size() << " D3D textures / " << _renderTargetTextures.size() << " render targets remain" << std::endl;
             _d3dContext = std::nullptr_t();
         }
         
@@ -167,10 +168,17 @@ class ThermionVulkanContext::Impl {
         }
 
         HANDLE CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top) {
-            
+
             Log("Creating Vulkan texture %dx%d", width, height);
 
-            // creates the D3D texture
+            // 1. Create pure Vulkan texture for render target (returned to Flutter as hardware texture ID)
+            auto renderTargetTexture = VulkanTexture::createPure(device, physicalDevice, width, height);
+            if(!renderTargetTexture) {
+                ERROR("Failed to create pure Vulkan render target texture");
+                return NULL;
+            }
+
+            // 2. Create D3D texture and D3D-interop Vulkan texture (for Flutter display)
             auto d3dTexture = _d3dContext->CreateTexture(width, height);
             auto d3dTextureHandle = d3dTexture->GetTextureHandle();
             auto vkTexture = VulkanTexture::create(device, physicalDevice, width, height, d3dTextureHandle);
@@ -179,10 +187,7 @@ class ThermionVulkanContext::Impl {
                 return NULL;
             }
 
-            // fillImageWithColor(device, commandPool, queue, image, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED,  // Current image layout
-            //     { width, height, 1 }, // Image extent
-            //     0.0f, 1.0f, 0.0f, 1.0f);    // Red color (RGBA))
-            
+            _renderTargetTextures.push_back(std::move(renderTargetTexture));
             _d3dTextures.push_back(std::move(d3dTexture));
             _vulkanTextures.push_back(std::move(vkTexture));
             return d3dTextureHandle;
@@ -190,27 +195,30 @@ class ThermionVulkanContext::Impl {
     
         void DestroyRenderingSurface(HANDLE handle) {
             std::cerr << "Destroying rendering surface " << handle << std::endl;
-            auto vulkanNewEnd = std::remove_if(_vulkanTextures.begin(), _vulkanTextures.end(), [=](auto&& vkTexture) {
-                return vkTexture->GetD3DTextureHandle() == handle;
-            });
-            
-            if (vulkanNewEnd != _vulkanTextures.end()) {
-                _vulkanTextures.erase(vulkanNewEnd, _vulkanTextures.end());
-            } else { 
-                std::cerr << "Vulkan texture not found?" << std::endl;
-            }
-            
-            auto d3dNewEnd = std::remove_if(_d3dTextures.begin(), _d3dTextures.end(), [=](auto&& d3dTexture) {
-                return d3dTexture->GetTextureHandle() == handle;
-            });
-            
-            if (d3dNewEnd != _d3dTextures.end()) {
-                _d3dTextures.erase(d3dNewEnd, _d3dTextures.end());
-            } else { 
-                std::cerr << "D3D texture not found?" << std::endl;
-            }
-            std::cerr << "Rendering surface destroyed, " << _vulkanTextures.size() << " Vulkan textures / " << _d3dTextures.size() << " D3D textures remain" << std::endl;
 
+            // Find index of the D3D texture with this handle and remove from all three vectors
+            for (size_t i = 0; i < _d3dTextures.size(); i++) {
+                if (_d3dTextures[i]->GetTextureHandle() == handle) {
+                    _renderTargetTextures.erase(_renderTargetTextures.begin() + i);
+                    _vulkanTextures.erase(_vulkanTextures.begin() + i);
+                    _d3dTextures.erase(_d3dTextures.begin() + i);
+                    std::cerr << "Rendering surface destroyed, " << _vulkanTextures.size() << " Vulkan textures / "
+                              << _d3dTextures.size() << " D3D textures / " << _renderTargetTextures.size() << " render targets remain" << std::endl;
+                    return;
+                }
+            }
+            std::cerr << "D3D texture not found for handle " << handle << std::endl;
+        }
+
+        VkImage GetVulkanImageForSurface(HANDLE handle) {
+            // Find the index of the D3D texture with this handle and return the corresponding render target VkImage
+            for (size_t i = 0; i < _d3dTextures.size(); i++) {
+                if (_d3dTextures[i]->GetTextureHandle() == handle) {
+                    // Return the corresponding render target texture's VkImage (not the D3D-interop one)
+                    return _renderTargetTextures[i]->GetImage();
+                }
+            }
+            return VK_NULL_HANDLE;
         }
 
         void Flush() {
@@ -218,33 +226,27 @@ class ThermionVulkanContext::Impl {
         }
 
         void BlitFromSwapchain() {
-            
-            std::lock_guard lock(_platform->mutex);
-            if(!_platform->current) {
-                ERROR("No platform");
+            // Blit from render target texture to D3D-interop texture for Flutter display
+            if (_renderTargetTextures.empty() || _vulkanTextures.empty() || _d3dTextures.empty()) {
+                ERROR("No textures available for blit");
                 return;
             }
 
-            if(_d3dTextures.size() == 0) {
-                ERROR("No D3D textures");
-                return;
-            }
+            // Source: pure Vulkan render target texture
+            auto&& renderTarget = _renderTargetTextures.back();
+            auto srcImage = renderTarget->GetImage();
 
+            // Destination: D3D-interop texture
             auto&& vkTexture = _vulkanTextures.back();
-            auto image = vkTexture->GetImage();
+            auto dstImage = vkTexture->GetImage();
 
-            auto&& texture = _d3dTextures.back();
+            auto&& d3dTexture = _d3dTextures.back();
+            auto width = d3dTexture->GetWidth();
+            auto height = d3dTexture->GetHeight();
 
-            auto height = texture->GetHeight();
-            auto width = texture->GetWidth();
-
-            auto bundle = _platform->getSwapChainBundle(_platform->current);
-            VkImage swapchainImage = bundle.colors[_platform->currentColorIndex];
-
-            VkResult result = bluevk::vkResetCommandBuffer(blitCommandBuffer, 0); 
-
+            VkResult result = bluevk::vkResetCommandBuffer(blitCommandBuffer, 0);
             if (result != VK_SUCCESS) {
-                std::cout << "Failed to allocate command buffer: " << result << std::endl;
+                std::cout << "Failed to reset command buffer: " << result << std::endl;
                 return;
             }
 
@@ -252,30 +254,26 @@ class ThermionVulkanContext::Impl {
             VkCommandBufferBeginInfo beginInfo{};
             beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
             beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-            
+
             result = bluevk::vkBeginCommandBuffer(blitCommandBuffer, &beginInfo);
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to begin command buffer: " << result << std::endl;
                 return;
             }
 
-            // std::cout << "Starting blit operation..." << std::endl;
-            
-            // Pre-transition barriers
+            // Source barrier: render target texture (COLOR_ATTACHMENT_OPTIMAL -> TRANSFER_SRC_OPTIMAL)
             VkImageMemoryBarrier srcBarrier{};
             srcBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            srcBarrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+            srcBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
             srcBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-            srcBarrier.oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+            srcBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
             srcBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
             srcBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             srcBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            srcBarrier.image = swapchainImage;
-            srcBarrier.subresourceRange = {
-                VK_IMAGE_ASPECT_COLOR_BIT,
-                0, 1, 0, 1
-            };
+            srcBarrier.image = srcImage;
+            srcBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
+            // Destination barrier: D3D-interop texture (UNDEFINED -> TRANSFER_DST_OPTIMAL)
             VkImageMemoryBarrier dstBarrier{};
             dstBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
             dstBarrier.srcAccessMask = 0;
@@ -284,27 +282,22 @@ class ThermionVulkanContext::Impl {
             dstBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            dstBarrier.image = image;
-            dstBarrier.subresourceRange = {
-                VK_IMAGE_ASPECT_COLOR_BIT,
-                0, 1, 0, 1
-            };
-
-            // std::cout << "Transitioning images to transfer layouts..." << std::endl;
+            dstBarrier.image = dstImage;
+            dstBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
             // Pre-blit barriers
             VkImageMemoryBarrier preBlitBarriers[] = {srcBarrier, dstBarrier};
             vkCmdPipelineBarrier(
                 blitCommandBuffer,
-                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 
-                VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT,
                 0,
                 0, nullptr,
                 0, nullptr,
                 2, preBlitBarriers
             );
 
-            // Define blit region with bounds checking
+            // Define blit region
             VkImageBlit blit{};
             blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
             blit.srcOffsets[0] = {0, 0, 0};
@@ -313,38 +306,33 @@ class ThermionVulkanContext::Impl {
             blit.dstOffsets[0] = {0, 0, 0};
             blit.dstOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
 
-            // std::cout << "Executing blit command..." << std::endl;
-            // std::cout << "Source dimensions: " << width << "x" << height << std::endl;
-            // std::cout << "Destination dimensions: " << width << "x" << height << std::endl;
-
-            // Perform blit with validation
+            // Perform blit (handles RGBA->BGRA format conversion automatically)
             bluevk::vkCmdBlitImage(
                 blitCommandBuffer,
-                swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                srcImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                 1, &blit,
-                VK_FILTER_NEAREST 
+                VK_FILTER_NEAREST
             );
 
-            // Post-transition barriers
+            // Post-blit barriers
+            // Source: transition back to COLOR_ATTACHMENT_OPTIMAL for next render
             srcBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-            srcBarrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+            srcBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
             srcBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-            srcBarrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+            srcBarrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
+            // Destination: transition to SHADER_READ_ONLY_OPTIMAL for D3D sampling
             dstBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             dstBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
             dstBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             dstBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-            // std::cout << "Transitioning images back to original layouts..." << std::endl;
-
-            // Post-blit barriers
             VkImageMemoryBarrier postBlitBarriers[] = {srcBarrier, dstBarrier};
             bluevk::vkCmdPipelineBarrier(
                 blitCommandBuffer,
                 VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 
+                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                 0,
                 0, nullptr,
                 0, nullptr,
@@ -360,20 +348,18 @@ class ThermionVulkanContext::Impl {
 
             uint64_t signalValue = ++currentSemaphoreValue;
 
-            // 2. Setup Timeline Submit Info
+            // Setup Timeline Submit Info
             VkTimelineSemaphoreSubmitInfo timelineInfo{};
             timelineInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
             timelineInfo.signalSemaphoreValueCount = 1;
             timelineInfo.pSignalSemaphoreValues = &signalValue;
 
-            // 3. Setup Standard Submit Info
+            // Setup Standard Submit Info
             VkSubmitInfo submitInfo{};
             submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-            submitInfo.pNext = &timelineInfo; // Chain the timeline info
+            submitInfo.pNext = &timelineInfo;
             submitInfo.commandBufferCount = 1;
             submitInfo.pCommandBuffers = &blitCommandBuffer;
-            
-            // Define the semaphore to signal
             submitInfo.signalSemaphoreCount = 1;
             submitInfo.pSignalSemaphores = &sharedSemaphore;
 
@@ -381,10 +367,8 @@ class ThermionVulkanContext::Impl {
 
             _d3dContext->SetWaitForSemaphore(signalValue);
 
-
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to submit queue: " << result << std::endl;
-                // bluevk::vkDestroyFence(device, fence, nullptr);
                 return;
             }
         }
@@ -602,6 +586,7 @@ class ThermionVulkanContext::Impl {
     
         std::vector<std::unique_ptr<thermion::windows::d3d::D3DTexture>> _d3dTextures;
         std::vector<std::unique_ptr<thermion::windows::vulkan::VulkanTexture>> _vulkanTextures;
+        std::vector<std::unique_ptr<thermion::windows::vulkan::VulkanTexture>> _renderTargetTextures;  // Pure Vulkan textures for render targets
         
         std::unique_ptr<TVulkanPlatform> _platform;
         filament::backend::VulkanPlatform::VulkanSharedContext _sharedContext{};
@@ -633,7 +618,11 @@ class ThermionVulkanContext::Impl {
 HANDLE ThermionVulkanContext::CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top) {
     return pImpl->CreateRenderingSurface(width, height, left, top);
 }
-  
+
+VkImage ThermionVulkanContext::GetVulkanImageForSurface(HANDLE handle) {
+    return pImpl->GetVulkanImageForSurface(handle);
+}
+
 void ThermionVulkanContext::DestroyRenderingSurface(HANDLE handle) {
     pImpl->DestroyRenderingSurface(handle);
 }

--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -225,24 +225,30 @@ class ThermionVulkanContext::Impl {
             // ?? what to do here
         }
 
-        void BlitFromSwapchain() {
-            // Blit from render target texture to D3D-interop texture for Flutter display
-            if (_renderTargetTextures.empty() || _vulkanTextures.empty() || _d3dTextures.empty()) {
-                ERROR("No textures available for blit");
+        void BlitFromSwapchain(HANDLE d3dTextureHandle) {
+            // Find the texture index for this handle
+            size_t textureIndex = SIZE_MAX;
+            for (size_t i = 0; i < _d3dTextures.size(); i++) {
+                if (_d3dTextures[i]->GetTextureHandle() == d3dTextureHandle) {
+                    textureIndex = i;
+                    break;
+                }
+            }
+
+            if (textureIndex == SIZE_MAX) {
+                ERROR("BlitFromSwapchain: texture handle not found");
                 return;
             }
 
-            // Source: pure Vulkan render target texture
-            auto&& renderTarget = _renderTargetTextures.back();
-            auto srcImage = renderTarget->GetImage();
+            if (textureIndex >= _renderTargetTextures.size() || textureIndex >= _vulkanTextures.size()) {
+                ERROR("BlitFromSwapchain: texture index out of bounds");
+                return;
+            }
 
-            // Destination: D3D-interop texture
-            auto&& vkTexture = _vulkanTextures.back();
-            auto dstImage = vkTexture->GetImage();
-
-            auto&& d3dTexture = _d3dTextures.back();
-            auto width = d3dTexture->GetWidth();
-            auto height = d3dTexture->GetHeight();
+            auto srcImage = _renderTargetTextures[textureIndex]->GetImage();
+            auto dstImage = _vulkanTextures[textureIndex]->GetImage();
+            auto width = _d3dTextures[textureIndex]->GetWidth();
+            auto height = _d3dTextures[textureIndex]->GetHeight();
 
             VkResult result = bluevk::vkResetCommandBuffer(blitCommandBuffer, 0);
             if (result != VK_SUCCESS) {
@@ -261,83 +267,87 @@ class ThermionVulkanContext::Impl {
                 return;
             }
 
-            // Source barrier: render target texture (COLOR_ATTACHMENT_OPTIMAL -> TRANSFER_SRC_OPTIMAL)
-            VkImageMemoryBarrier srcBarrier{};
-            srcBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            srcBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-            srcBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-            srcBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-            srcBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-            srcBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            srcBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            srcBarrier.image = srcImage;
-            srcBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            // Blit only the specific texture pair
+            {
 
-            // Destination barrier: D3D-interop texture (UNDEFINED -> TRANSFER_DST_OPTIMAL)
-            VkImageMemoryBarrier dstBarrier{};
-            dstBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            dstBarrier.srcAccessMask = 0;
-            dstBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            dstBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            dstBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            dstBarrier.image = dstImage;
-            dstBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                // Source barrier: render target texture (COLOR_ATTACHMENT_OPTIMAL -> TRANSFER_SRC_OPTIMAL)
+                VkImageMemoryBarrier srcBarrier{};
+                srcBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                srcBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+                srcBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                srcBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+                srcBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                srcBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                srcBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                srcBarrier.image = srcImage;
+                srcBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-            // Pre-blit barriers
-            VkImageMemoryBarrier preBlitBarriers[] = {srcBarrier, dstBarrier};
-            vkCmdPipelineBarrier(
-                blitCommandBuffer,
-                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                VK_PIPELINE_STAGE_TRANSFER_BIT,
-                0,
-                0, nullptr,
-                0, nullptr,
-                2, preBlitBarriers
-            );
+                // Destination barrier: D3D-interop texture (UNDEFINED -> TRANSFER_DST_OPTIMAL)
+                VkImageMemoryBarrier dstBarrier{};
+                dstBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                dstBarrier.srcAccessMask = 0;
+                dstBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                dstBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                dstBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                dstBarrier.image = dstImage;
+                dstBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-            // Define blit region
-            VkImageBlit blit{};
-            blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            blit.srcOffsets[0] = {0, 0, 0};
-            blit.srcOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
-            blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            blit.dstOffsets[0] = {0, 0, 0};
-            blit.dstOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
+                // Pre-blit barriers
+                VkImageMemoryBarrier preBlitBarriers[] = {srcBarrier, dstBarrier};
+                vkCmdPipelineBarrier(
+                    blitCommandBuffer,
+                    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    0,
+                    0, nullptr,
+                    0, nullptr,
+                    2, preBlitBarriers
+                );
 
-            // Perform blit (handles RGBA->BGRA format conversion automatically)
-            bluevk::vkCmdBlitImage(
-                blitCommandBuffer,
-                srcImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                1, &blit,
-                VK_FILTER_NEAREST
-            );
+                // Define blit region
+                VkImageBlit blit{};
+                blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                blit.srcOffsets[0] = {0, 0, 0};
+                blit.srcOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
+                blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                blit.dstOffsets[0] = {0, 0, 0};
+                blit.dstOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
 
-            // Post-blit barriers
-            // Source: transition back to COLOR_ATTACHMENT_OPTIMAL for next render
-            srcBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-            srcBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-            srcBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-            srcBarrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+                // Perform blit (handles RGBA->BGRA format conversion automatically)
+                bluevk::vkCmdBlitImage(
+                    blitCommandBuffer,
+                    srcImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                    dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                    1, &blit,
+                    VK_FILTER_NEAREST
+                );
 
-            // Destination: transition to SHADER_READ_ONLY_OPTIMAL for D3D sampling
-            dstBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            dstBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-            dstBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            dstBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                // Post-blit barriers
+                // Source: transition back to COLOR_ATTACHMENT_OPTIMAL for next render
+                srcBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                srcBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+                srcBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                srcBarrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-            VkImageMemoryBarrier postBlitBarriers[] = {srcBarrier, dstBarrier};
-            bluevk::vkCmdPipelineBarrier(
-                blitCommandBuffer,
-                VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                0,
-                0, nullptr,
-                0, nullptr,
-                2, postBlitBarriers
-            );
+                // Destination: transition to SHADER_READ_ONLY_OPTIMAL for D3D sampling
+                dstBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                dstBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                dstBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                dstBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+                VkImageMemoryBarrier postBlitBarriers[] = {srcBarrier, dstBarrier};
+                bluevk::vkCmdPipelineBarrier(
+                    blitCommandBuffer,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                    0,
+                    0, nullptr,
+                    0, nullptr,
+                    2, postBlitBarriers
+                );
+            }
 
             // End command buffer
             result = bluevk::vkEndCommandBuffer(blitCommandBuffer);
@@ -639,8 +649,8 @@ void* ThermionVulkanContext::GetSharedContext() {
     return pImpl->GetSharedContext();
 }
 
-void ThermionVulkanContext::BlitFromSwapchain() {
-    pImpl->BlitFromSwapchain();
+void ThermionVulkanContext::BlitFromSwapchain(HANDLE d3dTextureHandle) {
+    pImpl->BlitFromSwapchain(d3dTextureHandle);
 }
 
 void ThermionVulkanContext::readPixelsFromImage(

--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -32,6 +32,9 @@ class ThermionVulkanContext::Impl {
         ~Impl() {
             std::cerr << "ThermionVulkanContext destructor " << _vulkanTextures.size() << " Vulkan textures / "
                       << _d3dTextures.size() << " D3D textures / " << _renderTargetTextures.size() << " render targets remain" << std::endl;
+            if (blitFence != VK_NULL_HANDLE) {
+                bluevk::vkDestroyFence(device, blitFence, nullptr);
+            }
             _d3dContext = std::nullptr_t();
         }
         
@@ -143,26 +146,13 @@ class ThermionVulkanContext::Impl {
 
             vkAllocateCommandBuffers(device, &cmdBufInfo, &blitCommandBuffer);
 
-            createSyncObjects();
-
-            VkSemaphoreGetWin32HandleInfoKHR handleInfo{};
-            handleInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR;
-            handleInfo.semaphore = sharedSemaphore;
-            handleInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
-
-            HANDLE semaphoreHandle = NULL;
-
-            auto fpGetSemaphoreWin32Handle = (PFN_vkGetSemaphoreWin32HandleKHR)vkGetDeviceProcAddr(device, "vkGetSemaphoreWin32HandleKHR");
-            if (fpGetSemaphoreWin32Handle) {
-                fpGetSemaphoreWin32Handle(device, &handleInfo, &semaphoreHandle);
-            } else { 
-                ERROR("Failed to resolve vkGetSemaphoreWin32HandleKHR");
-            }
-
-            if(semaphoreHandle == VK_NULL_HANDLE) {
-                ERROR("Failed to create Vulkan semaphore");
-            } else {
-                _d3dContext->ImportSemaphore(semaphoreHandle);
+            // Create blit fence
+            VkFenceCreateInfo fenceInfo{};
+            fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+            fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;  // Start signaled so first reset works
+            VkResult fenceResult = bluevk::vkCreateFence(device, &fenceInfo, nullptr, &blitFence);
+            if (fenceResult != VK_SUCCESS) {
+                std::cout << "[ERROR] Failed to create blit fence" << std::endl;
             }
 
         }
@@ -356,30 +346,30 @@ class ThermionVulkanContext::Impl {
                 return;
             }
 
-            uint64_t signalValue = ++currentSemaphoreValue;
-
-            // Setup Timeline Submit Info
-            VkTimelineSemaphoreSubmitInfo timelineInfo{};
-            timelineInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
-            timelineInfo.signalSemaphoreValueCount = 1;
-            timelineInfo.pSignalSemaphoreValues = &signalValue;
-
             // Setup Standard Submit Info
             VkSubmitInfo submitInfo{};
             submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-            submitInfo.pNext = &timelineInfo;
+            // submitInfo.pNext = &timelineInfo;
             submitInfo.commandBufferCount = 1;
             submitInfo.pCommandBuffers = &blitCommandBuffer;
-            submitInfo.signalSemaphoreCount = 1;
-            submitInfo.pSignalSemaphores = &sharedSemaphore;
+            // submitInfo.signalSemaphoreCount = 1;
+            // submitInfo.pSignalSemaphores = &sharedSemaphore;
 
-            result = bluevk::vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE);
+            // Wait for any previous blit to complete and reset fence
+            bluevk::vkWaitForFences(device, 1, &blitFence, VK_TRUE, UINT64_MAX);
+            bluevk::vkResetFences(device, 1, &blitFence);
 
-            _d3dContext->SetWaitForSemaphore(signalValue);
+            result = bluevk::vkQueueSubmit(queue, 1, &submitInfo, blitFence);
 
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to submit queue: " << result << std::endl;
                 return;
+            }
+
+            // Wait for blit to complete before returning
+            result = bluevk::vkWaitForFences(device, 1, &blitFence, VK_TRUE, UINT64_MAX);
+            if (result != VK_SUCCESS) {
+                std::cout << "Failed to wait for blit fence: " << result << std::endl;
             }
         }
 
@@ -586,11 +576,9 @@ class ThermionVulkanContext::Impl {
         VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
         VkDevice device = VK_NULL_HANDLE;
         VkCommandPool commandPool = VK_NULL_HANDLE;
-        VkCommandBuffer blitCommandBuffer = VK_NULL_HANDLE; 
+        VkCommandBuffer blitCommandBuffer = VK_NULL_HANDLE;
+        VkFence blitFence = VK_NULL_HANDLE;
         VkQueue queue = VK_NULL_HANDLE;
-
-        VkSemaphore sharedSemaphore = VK_NULL_HANDLE;
-        uint64_t currentSemaphoreValue = 0;
         
         std::unique_ptr<thermion::windows::d3d::D3DContext> _d3dContext;
     
@@ -601,27 +589,7 @@ class ThermionVulkanContext::Impl {
         std::unique_ptr<TVulkanPlatform> _platform;
         filament::backend::VulkanPlatform::VulkanSharedContext _sharedContext{};
 
-        void createSyncObjects() {
-            VkExportSemaphoreCreateInfo exportInfo{};
-            exportInfo.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO;
-            // D3D12_FENCE is the handle type that maps to ID3D11Fence
-            exportInfo.handleTypes = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
 
-            VkSemaphoreTypeCreateInfo timelineInfo{};
-            timelineInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
-            timelineInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-            timelineInfo.initialValue = 0;
-            timelineInfo.pNext = &exportInfo;
-
-            VkSemaphoreCreateInfo semaphoreInfo{};
-            semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-            semaphoreInfo.pNext = &timelineInfo;
-
-            VkResult result = bluevk::vkCreateSemaphore(device, &semaphoreInfo, nullptr, &sharedSemaphore);
-            if (result != VK_SUCCESS) {
-                std::cout << "Failed to create shared semaphore: " << result << std::endl;
-            }
-        }
 
 };
 

--- a/thermion_dart/native/src/windows/vulkan/vulkan_texture.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_texture.cpp
@@ -7,19 +7,28 @@
 namespace thermion::windows::vulkan
 {
 
-    VulkanTexture::VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, HANDLE d3dTextureHandle) : _image(image), _device(device),  _imageMemory(imageMemory), _width(width), _height(height), _d3dTextureHandle(d3dTextureHandle) {};
+    // Constructor for D3D-interop textures (doesn't own memory)
+    VulkanTexture::VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, HANDLE d3dTextureHandle)
+        : _image(image), _device(device), _imageMemory(imageMemory), _width(width), _height(height), _d3dTextureHandle(d3dTextureHandle), _ownsMemory(false) {}
+
+    // Constructor for pure Vulkan textures (owns memory)
+    VulkanTexture::VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, bool ownsMemory)
+        : _image(image), _device(device), _imageMemory(imageMemory), _width(width), _height(height), _d3dTextureHandle(nullptr), _ownsMemory(ownsMemory) {}
 
     VulkanTexture::~VulkanTexture() {
         bluevk::vkDeviceWaitIdle(_device);
         if(_image != VK_NULL_HANDLE) {
             bluevk::vkDestroyImage(_device, _image, nullptr);
-        } else { 
+        } else {
             std::cout << "Warning : no vkImage found" << std::endl;
         }
 
+        // Only free memory if we own it (pure Vulkan textures)
+        // D3D-interop textures have memory imported from D3D without ownership transfer
         // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImportMemoryWin32HandleInfoKHR.html
-        // imageMemory has been imported from D3D without transferring ownership
-        // therefore we don't need to release
+        if (_ownsMemory && _imageMemory != VK_NULL_HANDLE) {
+            bluevk::vkFreeMemory(_device, _imageMemory, nullptr);
+        }
     }         
     
 
@@ -161,5 +170,74 @@ namespace thermion::windows::vulkan
             return nullptr;
         }
         return std::make_unique<VulkanTexture>(image, device, imageMemory, width, height, d3dTextureHandle);
+    }
+
+    std::unique_ptr<VulkanTexture> VulkanTexture::createPure(
+        VkDevice device,
+        VkPhysicalDevice physicalDevice,
+        uint32_t width,
+        uint32_t height)
+    {
+        // Create image without external memory support (pure Vulkan)
+        VkImageCreateInfo imageInfo = {
+            .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+            .pNext = nullptr,  // No external memory info
+            .flags = 0,
+            .imageType = VK_IMAGE_TYPE_2D,
+            .format = VK_FORMAT_R8G8B8A8_UNORM,  // RGBA format for render target
+            .extent = {width, height, 1},
+            .mipLevels = 1,
+            .arrayLayers = 1,
+            .samples = VK_SAMPLE_COUNT_1_BIT,
+            .tiling = VK_IMAGE_TILING_OPTIMAL,
+            .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+            .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+            .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED
+        };
+
+        VkImage image;
+        VkResult result = bluevk::vkCreateImage(device, &imageInfo, nullptr, &image);
+        if (result != VK_SUCCESS) {
+            ERROR("Failed to create pure Vulkan image");
+            return nullptr;
+        }
+
+        std::cout << "Created pure Vulkan vkImage " << (int64_t)image << std::endl;
+
+        // Get memory requirements
+        VkMemoryRequirements memRequirements;
+        bluevk::vkGetImageMemoryRequirements(device, image, &memRequirements);
+
+        // Allocate device-local memory
+        uint32_t memoryTypeIndex = findOptimalMemoryType(
+            physicalDevice,
+            memRequirements.memoryTypeBits,
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
+        );
+
+        VkMemoryAllocateInfo allocInfo = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+            .pNext = nullptr,
+            .allocationSize = memRequirements.size,
+            .memoryTypeIndex = memoryTypeIndex
+        };
+
+        VkDeviceMemory imageMemory;
+        result = bluevk::vkAllocateMemory(device, &allocInfo, nullptr, &imageMemory);
+        if (result != VK_SUCCESS) {
+            bluevk::vkDestroyImage(device, image, nullptr);
+            ERROR("Failed to allocate memory for pure Vulkan image");
+            return nullptr;
+        }
+
+        result = bluevk::vkBindImageMemory(device, image, imageMemory, 0);
+        if (result != VK_SUCCESS) {
+            bluevk::vkFreeMemory(device, imageMemory, nullptr);
+            bluevk::vkDestroyImage(device, image, nullptr);
+            ERROR("Failed to bind memory for pure Vulkan image");
+            return nullptr;
+        }
+
+        return std::make_unique<VulkanTexture>(image, device, imageMemory, width, height, true);
     }
 }

--- a/thermion_dart/native/src/windows/vulkan/vulkan_texture.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_texture.cpp
@@ -190,7 +190,8 @@ namespace thermion::windows::vulkan
             .arrayLayers = 1,
             .samples = VK_SAMPLE_COUNT_1_BIT,
             .tiling = VK_IMAGE_TILING_OPTIMAL,
-            .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+            // ALL THREE FLAGS REQUIRED: Filament needs SAMPLED_BIT for render target textures
+        .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
             .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
             .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED
         };

--- a/thermion_dart/test/view_tests.dart
+++ b/thermion_dart/test/view_tests.dart
@@ -476,8 +476,7 @@ void main() async {
         b: 1.0,
         outlineWidth: 1.0,
       );
-      await FilamentApp.instance!
-          .setClearOptions(1, 1, 1, 0, clear: true, discard: false);
+      
       await FilamentApp.instance!.render();
 
       await testHelper.capture(null, "stencil_highlight_1px_blue",
@@ -485,8 +484,7 @@ void main() async {
 
       // Test that highlight follows object translation
       await cube.setTransform(Matrix4.translation(Vector3(2, 0, 0)));
-      await FilamentApp.instance!
-          .setClearOptions(1, 1, 1, 0, clear: true, discard: false);
+      
       await FilamentApp.instance!.render();
 
       await testHelper.capture(null, "stencil_highlight_after_translate",
@@ -495,8 +493,7 @@ void main() async {
       // Test that highlight follows object rotation
       await cube.setTransform(
           Matrix4.translation(Vector3(-2, 1, 0)) * Matrix4.rotationZ(0.5));
-      await FilamentApp.instance!
-          .setClearOptions(1, 1, 1, 0, clear: true, discard: false);
+      
       await FilamentApp.instance!.render();
 
       await testHelper.capture(null, "stencil_highlight_after_rotate",
@@ -505,8 +502,7 @@ void main() async {
       // Test that highlight works after camera change
       final camera = await result.viewer.view.getCamera();
       await camera.lookAt(Vector3(5, 3, 10), focus: Vector3(0, 0, 0));
-      await FilamentApp.instance!
-          .setClearOptions(1, 1, 1, 0, clear: true, discard: false);
+      
       await FilamentApp.instance!.render();
 
       await testHelper.capture(null, "stencil_highlight_after_camera_move",

--- a/thermion_flutter/thermion_flutter/lib/src/options.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/options.dart
@@ -29,7 +29,7 @@ class NativeOptions {
 
   const NativeOptions(
       {this.backend,
-      this.renderTargetColorTextureFormat = TextureFormat.RGBA32F,
+      this.renderTargetColorTextureFormat = TextureFormat.RGBA8,
       this.renderTargetDepthTextureFormat = TextureFormat.DEPTH24_STENCIL8,
       this.createOverlay = false});
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -23,10 +23,6 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
 
   static SwapChain? _swapChain;
 
-  SwapChain? getActiveSwapchain() {
-    return _swapChain;
-  }
-
   static Future<Uint8List> loadAsset(String path) async {
     if (path.startsWith("file://")) {
       return File(path.replaceAll("file://", "")).readAsBytesSync();

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -173,7 +173,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
       _swapChain = await FilamentApp.instance!.createSwapChain(
         Pointer<Void>.fromAddress(descriptor.windowHandle!),
       );
-      await FilamentApp.instance!.register(_swapChain!, view);
+
     } else {
       final color = await FilamentApp.instance!.createTexture(
         descriptor.width,
@@ -212,18 +212,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
       await view.setRenderTarget(renderTarget);
     }
 
-    await view.setViewport(width, height);
-
-    var camera = await view.getCamera();
-    var near = await camera.getNear();
-    var far = await camera.getCullingFar();
-    var focalLength = await camera.getFocalLength();
-
-    await camera.setLensProjection(
-      near: near,
-      far: far,
-      focalLength: focalLength,
-      aspect: width.toDouble() / height.toDouble());
+    await FilamentApp.instance!.register(_swapChain!, view);
 
     _descriptors.add(descriptor);
 

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -131,7 +131,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
     // dimensions don't seem to matter).
     // TODO - see if we can use `renderStandaloneView` in FilamentViewer to
     // avoid this
-    if (Platform.isMacOS || Platform.isIOS) {
+    if (Platform.isMacOS || Platform.isIOS || Platform.isWindows) {
       if (destroySwapchain && _swapChain != null) {
         await FilamentApp.instance!.destroySwapChain(_swapChain!);
         _swapChain = null;
@@ -165,22 +165,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
           channel, width, height);
     }
 
-    if (Platform.isWindows) {
-      if (_swapChain != null) {
-        await FilamentApp.instance!.unregister(_swapChain!, view);
-        await FilamentApp.instance!.destroySwapChain(_swapChain!);
-      }
-
-      _swapChain = await FilamentApp.instance!.createHeadlessSwapChain(
-          descriptor.width, descriptor.height,
-          hasStencilBuffer: true);
-
-      _logger.info(
-        "Created headless swapchain ${descriptor.width}x${descriptor.height}",
-      );
-
-      await FilamentApp.instance!.register(_swapChain!, view);
-    } else if (Platform.isAndroid) {
+    if (Platform.isAndroid) {
       if (_swapChain != null) {
         await FilamentApp.instance!.unregister(_swapChain!, view);
         await FilamentApp.instance!.destroySwapChain(_swapChain!);
@@ -221,6 +206,8 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
         color: color,
         depth: depth,
       );
+
+      _logger.info("Created render target for hardware texture ID ${descriptor.hardwareId}");
 
       await view.setRenderTarget(renderTarget);
     }

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -25,18 +25,40 @@ class _ThermionWidgetState extends State<ThermionWidget> {
     if (widget.enableOverlay) {
       final overlayView = widget.viewer.view.getOverlayView();
 
-        return Stack(children: [
-          Positioned.fill(
-              child: ThermionWidgetInternal(
-                key: Key("main_texture_view"),
-                view: widget.viewer.view)),
-          Positioned.fill(
-            
+      return Stack(children: [
+        Positioned.fill(
             child: ThermionWidgetInternal(
-              key: Key("overlay_texture_view"),
-              view: overlayView!))
-        ]);
+                key: Key("main_texture_view"),
+                onTextureUpdated: (descriptor) async {
+                  if (descriptor == null) {
+                    return;
+                  }
+                  final view = widget.viewer.view;
+                  var camera = await view.getCamera();
+                  var near = await camera.getNear();
+                  var far = await camera.getCullingFar();
+                  var focalLength = await camera.getFocalLength();
 
+                  await camera.setLensProjection(
+                      near: near,
+                      far: far,
+                      focalLength: focalLength,
+                      aspect: descriptor.width.toDouble() /
+                          descriptor.height.toDouble());
+
+                  await view.setViewport(descriptor.width, descriptor.height);
+                },
+                view: widget.viewer.view)),
+        Positioned.fill(
+            child: ThermionWidgetInternal(
+                key: Key("overlay_texture_view"),
+                view: overlayView!,
+                onTextureUpdated: (descriptor) async {
+                  if (descriptor == null) {
+                    return;
+                  }
+                }))
+      ]);
     }
     return ThermionWidgetInternal(view: widget.viewer.view);
   }

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -22,22 +22,22 @@ class ThermionWidget extends StatefulWidget {
 class _ThermionWidgetState extends State<ThermionWidget> {
   @override
   Widget build(BuildContext context) {
-    // if (widget.enableOverlay) {
-    //   final overlayView = widget.viewer.view.getOverlayView();
+    if (widget.enableOverlay) {
+      final overlayView = widget.viewer.view.getOverlayView();
 
-    //     return Stack(children: [
-    //       Positioned.fill(
-    //           child: ThermionWidgetInternal(
-    //             key: Key("main_texture_view"),
-    //             view: widget.viewer.view)),
-    //       Positioned.fill(
+        return Stack(children: [
+          Positioned.fill(
+              child: ThermionWidgetInternal(
+                key: Key("main_texture_view"),
+                view: widget.viewer.view)),
+          Positioned.fill(
             
-    //         child: ThermionWidgetInternal(
-    //           key: Key("overlay_texture_view"),
-    //           view: overlayView!))
-    //     ]);
+            child: ThermionWidgetInternal(
+              key: Key("overlay_texture_view"),
+              view: overlayView!))
+        ]);
 
-    // }
+    }
     return ThermionWidgetInternal(view: widget.viewer.view);
   }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_native_texture.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_native_texture.dart
@@ -1,17 +1,20 @@
 import 'dart:async';
+
 import 'package:flutter/material.dart' hide View;
 import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
 import 'package:thermion_flutter/thermion_flutter.dart' hide Texture;
 
-// Inserts [view] into the widget tree by allocating a hardware surface 
-// and binding to the [view]. The actual implementation 
-// (e.g. texture vs window, render target vs swapchain, etc) will differ by 
+// Inserts [view] into the widget tree by allocating a hardware surface
+// and binding to the [view]. The actual implementation
+// (e.g. texture vs window, render target vs swapchain, etc) will differ by
 // the actual platform; see [ThermionFlutterPluginImpl] for details.
 class ThermionWidgetInternal extends StatefulWidget {
   
   final View view;
+  
+  final void Function(PlatformTextureDescriptor? descriptor)? onTextureUpdated;
 
-  ThermionWidgetInternal({super.key, required this.view});
+  ThermionWidgetInternal({super.key, required this.view, this.onTextureUpdated});
 
   @override
   State<ThermionWidgetInternal> createState() => _ThermionWidgetInternalState();
@@ -93,6 +96,8 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
   void _allocateTexture(int width, int height) async {
     final texture = await ThermionFlutterPlugin.instance
         .createTextureAndBindToView(widget.view, width, height);
+
+    widget.onTextureUpdated?.call(texture);
 
     if (!mounted) {
       texture?.destroy();

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_stub.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_stub.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart' hide View;
 import 'package:thermion_flutter/thermion_flutter.dart';
 
+import '../../../platform/src/platform_texture_descriptor.dart';
+
 // A stub implementation to satisfy the analyzer.
 class ThermionWidgetInternal extends StatelessWidget {
   
   final View view;
+  
+  final void Function(PlatformTextureDescriptor? descriptor)? onTextureUpdated;
 
-  const ThermionWidgetInternal({
-    super.key,
-    required this.view
-  });
+  const ThermionWidgetInternal(
+      {super.key, required this.view, this.onTextureUpdated});
 
   @override
   Widget build(BuildContext context) {

--- a/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
+++ b/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
@@ -96,6 +96,8 @@ namespace thermion::tflutter::windows
       return;
     }
 
+    auto vkImage = _context->GetVulkanImageForSurface(d3dHandle);
+
     auto flutterTexture = std::make_unique<FlutterD3DTexture>(d3dHandle, width, height);
 
     auto flutterTextureId = _textureRegistrar->RegisterTexture(flutterTexture->GetFlutterTexture());
@@ -107,7 +109,7 @@ namespace thermion::tflutter::windows
 
     std::vector<flutter::EncodableValue> resultList;
     resultList.push_back(flutter::EncodableValue(flutterTextureId));
-    resultList.push_back(flutter::EncodableValue((int64_t) nullptr));
+    resultList.push_back(flutter::EncodableValue((int64_t)vkImage));
     resultList.push_back(flutter::EncodableValue((int64_t) nullptr));
     result->Success(resultList);
   }
@@ -190,7 +192,7 @@ namespace thermion::tflutter::windows
     {
       if (_context)
       {
-        _context->BlitFromSwapchain();
+        // _context->BlitFromSwapchain();
         const auto *flutterTextureId = std::get_if<int64_t>(methodCall.arguments());
 
         if (!flutterTextureId || *flutterTextureId == -1)

--- a/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
+++ b/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
@@ -192,7 +192,7 @@ namespace thermion::tflutter::windows
     {
       if (_context)
       {
-        // _context->BlitFromSwapchain();
+        _context->BlitFromSwapchain();
         const auto *flutterTextureId = std::get_if<int64_t>(methodCall.arguments());
 
         if (!flutterTextureId || *flutterTextureId == -1)

--- a/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
+++ b/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
@@ -192,17 +192,30 @@ namespace thermion::tflutter::windows
     {
       if (_context)
       {
-        _context->BlitFromSwapchain();
         const auto *flutterTextureId = std::get_if<int64_t>(methodCall.arguments());
 
         if (!flutterTextureId || *flutterTextureId == -1)
         {
           std::cout << "Bad texture" << std::endl;
+          result->Success(flutter::EncodableValue((int64_t) nullptr));
           return;
         }
-        // std::cout << "Marking texture" << (*flutterTextureId) << "available" << std::endl;
+
+        // Find the FlutterD3DTexture for this flutterTextureId
+        auto it = std::find_if(_flutterTextures.begin(), _flutterTextures.end(), [=](auto &&ft)
+                               { return ft->GetFlutterTextureId() == *flutterTextureId; });
+
+        if (it == _flutterTextures.end()) {
+          std::cerr << "Failed to find Flutter texture for ID " << *flutterTextureId << std::endl;
+          result->Success(flutter::EncodableValue((int64_t) nullptr));
+          return;
+        }
+
+        HANDLE d3dTextureHandle = (*it)->GetD3DTextureHandle();
+        _context->BlitFromSwapchain(d3dTextureHandle);
+
         _textureRegistrar->MarkTextureFrameAvailable(*flutterTextureId);
-      } else { 
+      } else {
         std::cout << "No context" << std::endl;
       }
       result->Success(flutter::EncodableValue((int64_t) nullptr));


### PR DESCRIPTION
Previously the Windows implementation created a Vulkan/D3D texture that was passed to Flutter, then performed a blit from the Filament swapchain on every frame. As the Filament Vulkan backend did not support importing external textures, this was the only option. 

Not only is this is not consistent with other platforms (e.g. macOS, where we render each view into its own render target with the backing texture passed to Flutter), it also prevents composing views/render targets directly in Flutter. This is important for things like object highlights.

I have now had the chance to create a custom Filament build for Windows with support for importing external Vulkan textures, so we can now make the Windows implementation consistent. 