### PR TITLE
Windows: Use render target/imported Vulkan texture

### DIFF
--- a/.tickets/t-4ef0.md
+++ b/.tickets/t-4ef0.md
@@ -1,0 +1,388 @@
+---
+id: t-4ef0
+status: open
+deps: []
+links: []
+created: 2026-01-14T09:18:24Z
+type: task
+priority: 2
+assignee: Nick Fisher
+---
+# overlay-dart
+
+# Plan: Replace OverlayComponentManager with Dart Implementation
+
+## Goal
+Replace the C++ `OverlayComponentManager` with a pure Dart implementation to reduce complexity and eliminate C++/Dart boundary crossing for overlay logic.
+
+## Current State
+- C++ `OverlayComponentManager` in `native/include/components/OverlayComponentManager.hpp` handles:
+  - Two-pass rendering: silhouette pass -> edge detection pass
+  - Material creation (silhouette + edge_outline)
+  - Render targets, views, scenes, cameras, skyboxes
+  - Fullscreen quad for edge detection
+  - Entity tracking and transform parenting
+
+## FFI Bindings Available
+Most required FFI bindings already exist:
+- `Material_createSilhouetteMaterialRenderThread`, `Material_createEdgeOutlineMaterialRenderThread`
+- `Texture_buildRenderThread` (supports R8, RGBA8, DEPTH32F formats)
+- `RenderTarget_createRenderThread`
+- `Engine_createScene`, `Engine_createView`, `Engine_createCamera`
+- `View_setRenderTarget`, `View_setPostProcessing`, `View_setShadowsEnabled`, `View_setFrustumCullingEnabled`
+- `Skybox_setColor`, `Scene_setSkybox`
+- `Camera_setProjection` (supports orthographic)
+- `VertexBufferBuilder_*`, `IndexBufferBuilder_*`
+- `MaterialInstance_setParameterTexture`, `MaterialInstance_setParameterFloat2`, etc.
+- `RenderableBuilder_*`
+- `TransformManager_setParent`
+
+## Missing FFI Binding (Must Add First)
+**`Engine_buildColoredSkybox`** - Create a skybox with a solid color (no cubemap texture)
+
+Current `Engine_buildSkybox` requires a texture, but for clearing render targets we need:
+```cpp
+Skybox::Builder().color({r, g, b, a}).build(*engine)
+```
+
+### Step 0: Add colored skybox C API
+**Files to modify:**
+- `native/include/c_api/TEngine.h` - Add declaration
+- `native/src/c_api/TEngine.cpp` - Add implementation
+- `native/include/c_api/ThermionDartRenderThreadApi.h` - Add render thread variant
+- `native/src/c_api/ThermionDartRenderThreadApi.cpp` - Add render thread implementation
+- Regenerate FFI bindings
+
+```cpp
+// TEngine.h
+EMSCRIPTEN_KEEPALIVE TSkybox *Engine_buildColoredSkybox(TEngine *tEngine, float r, float g, float b, float a);
+
+// TEngine.cpp
+EMSCRIPTEN_KEEPALIVE TSkybox *Engine_buildColoredSkybox(TEngine *tEngine, float r, float g, float b, float a) {
+    auto *engine = reinterpret_cast<Engine *>(tEngine);
+    auto *skybox = filament::Skybox::Builder()
+        .color({r, g, b, a})
+        .build(*engine);
+    return reinterpret_cast<TSkybox *>(skybox);
+}
+
+// ThermionDartRenderThreadApi.h
+EMSCRIPTEN_KEEPALIVE void Engine_buildColoredSkyboxRenderThread(
+    TEngine *tEngine, float r, float g, float b, float a,
+    void (*onComplete)(TSkybox *)
+);
+```
+
+## Implementation Plan
+
+### Step 1: Create `HighlightOverlayManager` Dart class
+**File:** `thermion_dart/lib/src/filament/src/overlay/highlight_overlay_manager.dart`
+
+```dart
+class HighlightOverlayManager {
+  final ThermionViewer viewer;
+
+  // Materials (created once, reused)
+  Pointer<TMaterial>? _silhouetteMaterial;
+  Pointer<TMaterial>? _edgeMaterial;
+
+  // Silhouette pass resources
+  Pointer<TTexture>? _silhouetteTexture;
+  Pointer<TTexture>? _silhouetteDepth;
+  Pointer<TRenderTarget>? _silhouetteTarget;
+  Pointer<TScene>? _silhouetteScene;
+  Pointer<TView>? _silhouetteView;
+  Pointer<TSkybox>? _silhouetteSkybox;
+
+  // Overlay (edge detection) pass resources
+  Pointer<TTexture>? _overlayTexture;
+  Pointer<TTexture>? _overlayDepth;
+  Pointer<TRenderTarget>? _overlayTarget;
+  Pointer<TScene>? _overlayScene;
+  Pointer<TView>? _overlayView;
+  Pointer<TSkybox>? _overlaySkybox;
+  Pointer<TCamera>? _overlayCamera;
+  int _overlayCameraEntity = 0;
+  Pointer<TMaterialInstance>? _edgeMaterialInstance;
+
+  // Fullscreen quad
+  Pointer<TVertexBuffer>? _quadVB;
+  Pointer<TIndexBuffer>? _quadIB;
+  int _quadEntity = 0;
+
+  // Tracking
+  final Map<int, _SilhouetteComponent> _highlights = {};
+  int _width = 0;
+  int _height = 0;
+  bool _initialized = false;
+
+  // Outline settings
+  double outlineWidth = 2.0;
+  double outlineR = 1.0, outlineG = 0.5, outlineB = 0.0;
+}
+```
+
+### Step 2: Implement initialization
+```dart
+Future<void> initialize(int width, int height, {int? hardwareTextureId}) async {
+  if (_initialized) return;
+
+  _width = width;
+  _height = height;
+
+  // Create materials
+  _silhouetteMaterial = await _createSilhouetteMaterial();
+  _edgeMaterial = await _createEdgeMaterial();
+
+  // Create silhouette pass resources
+  await _createSilhouetteRenderTargets();
+  await _createSilhouetteView();
+
+  // Create overlay pass resources
+  await _createOverlayRenderTargets(hardwareTextureId);
+  await _createOverlayView();
+  await _createFullscreenQuad();
+
+  _initialized = true;
+}
+```
+
+### Step 3: Implement render target creation
+```dart
+Future<void> _createSilhouetteRenderTargets() async {
+  // R8 format for silhouette (single channel)
+  _silhouetteTexture = await Texture_buildRenderThread(
+    engine, width, height, 1, 1,
+    TextureUsage.COLOR_ATTACHMENT | TextureUsage.SAMPLEABLE,
+    0, SamplerType.SAMPLER_2D, TextureFormat.R8
+  );
+
+  // DEPTH32F for depth
+  _silhouetteDepth = await Texture_buildRenderThread(
+    engine, width, height, 1, 1,
+    TextureUsage.DEPTH_ATTACHMENT,
+    0, SamplerType.SAMPLER_2D, TextureFormat.DEPTH32F
+  );
+
+  _silhouetteTarget = await RenderTarget_createRenderThread(
+    engine, width, height, _silhouetteTexture, _silhouetteDepth
+  );
+}
+```
+
+### Step 4: Implement view creation with skybox clearing
+*(Depends on Step 0 - `Engine_buildColoredSkyboxRenderThread`)*
+
+```dart
+Future<Pointer<TSkybox>> _createColoredSkybox(double r, double g, double b, double a) async {
+  return withPointerCallback((cb) =>
+    Engine_buildColoredSkyboxRenderThread(_engine, r, g, b, a, cb));
+}
+
+Future<void> _createSilhouetteView() async {
+  _silhouetteScene = Engine_createScene(engine);
+
+  // Black skybox to clear render target
+  _silhouetteSkybox = await _createColoredSkybox(0.0, 0.0, 0.0, 1.0);
+  Scene_setSkybox(_silhouetteScene!, _silhouetteSkybox!);
+
+  _silhouetteView = await Engine_createViewRenderThread(engine);
+  View_setScene(_silhouetteView!, _silhouetteScene!);
+  View_setViewport(_silhouetteView!, 0, 0, _width, _height);
+  View_setRenderTarget(_silhouetteView!, _silhouetteTarget!);
+  View_setPostProcessing(_silhouetteView!, false);
+  View_setShadowsEnabled(_silhouetteView!, false);
+}
+
+Future<void> _createOverlayView() async {
+  _overlayScene = Engine_createScene(engine);
+
+  // TRANSPARENT skybox to clear overlay (fixes tinting bug!)
+  _overlaySkybox = await _createColoredSkybox(0.0, 0.0, 0.0, 0.0);
+  Scene_setSkybox(_overlayScene!, _overlaySkybox!);
+
+  // Orthographic camera for fullscreen quad
+  _overlayCameraEntity = EntityManager_createEntity(entityManager);
+  _overlayCamera = await Engine_createCameraRenderThread(engine, _overlayCameraEntity);
+  Camera_setProjection(_overlayCamera!, ProjectionType.ORTHO, -1, 1, -1, 1, 0, 1);
+
+  _overlayView = await Engine_createViewRenderThread(engine);
+  View_setScene(_overlayView!, _overlayScene!);
+  View_setCamera(_overlayView!, _overlayCamera!);
+  View_setViewport(_overlayView!, 0, 0, _width, _height);
+  View_setRenderTarget(_overlayView!, _overlayTarget!);
+  View_setPostProcessing(_overlayView!, false);
+  View_setShadowsEnabled(_overlayView!, false);
+  View_setFrustumCullingEnabled(_overlayView!, false);
+}
+```
+
+### Step 5: Implement fullscreen quad
+```dart
+Future<void> _createFullscreenQuad() async {
+  // Fullscreen triangle (more efficient than quad)
+  final positions = Float32List.fromList([
+    -1.0, -1.0, 0.5,
+     3.0, -1.0, 0.5,
+    -1.0,  3.0, 0.5,
+  ]);
+  final indices = Uint16List.fromList([0, 1, 2]);
+
+  // Build vertex buffer
+  final vbBuilder = VertexBufferBuilder_create();
+  VertexBufferBuilder_vertexCount(vbBuilder, 3);
+  VertexBufferBuilder_bufferCount(vbBuilder, 1);
+  VertexBufferBuilder_attribute(vbBuilder, VertexAttribute.POSITION, 0,
+    AttributeType.FLOAT3, 0, 12);
+  _quadVB = await VertexBufferBuilder_buildRenderThread(vbBuilder, engine);
+  await VertexBuffer_setBufferAtRenderThread(engine, _quadVB!, 0, positions.buffer, ...);
+
+  // Build index buffer
+  final ibBuilder = IndexBufferBuilder_create();
+  IndexBufferBuilder_indexCount(ibBuilder, 3);
+  IndexBufferBuilder_bufferType(ibBuilder, IndexType.USHORT);
+  _quadIB = await IndexBufferBuilder_buildRenderThread(ibBuilder, engine);
+  await IndexBuffer_setBufferRenderThread(engine, _quadIB!, indices.buffer, ...);
+
+  // Create edge material instance
+  _edgeMaterialInstance = await Material_createInstanceRenderThread(_edgeMaterial!);
+  _updateEdgeMaterialParams();
+
+  // Build renderable
+  _quadEntity = EntityManager_createEntity(entityManager);
+  final rb = RenderableBuilder_create(1);
+  RenderableBuilder_geometry(rb, 0, PrimitiveType.TRIANGLES, _quadVB!, _quadIB!, 0, 3);
+  RenderableBuilder_material(rb, 0, _edgeMaterialInstance!);
+  RenderableBuilder_culling(rb, false);
+  RenderableBuilder_castShadows(rb, false);
+  RenderableBuilder_receiveShadows(rb, false);
+  await RenderableBuilder_buildRenderThread(rb, engine, _quadEntity);
+
+  Scene_addEntity(_overlayScene!, _quadEntity);
+}
+
+void _updateEdgeMaterialParams() {
+  // Set silhouette texture sampler
+  MaterialInstance_setParameterTexture(_edgeMaterialInstance!, "silhouette",
+    _silhouetteTexture!, sampler);
+
+  // Set texel size
+  MaterialInstance_setParameterFloat2(_edgeMaterialInstance!, "texelSize",
+    1.0 / _width, 1.0 / _height);
+
+  // Set outline color and width
+  MaterialInstance_setParameterFloat3(_edgeMaterialInstance!, "outlineColor",
+    outlineR, outlineG, outlineB);
+  MaterialInstance_setParameterFloat(_edgeMaterialInstance!, "outlineWidth",
+    outlineWidth);
+}
+```
+
+### Step 6: Implement addHighlight/removeHighlight
+```dart
+Future<void> addHighlight(int targetEntity, Pointer<TVertexBuffer> vb,
+    Pointer<TIndexBuffer> ib, int indexCount) async {
+  if (_highlights.containsKey(targetEntity)) return;
+
+  // Create silhouette material instance
+  final silhouetteMi = await Material_createInstanceRenderThread(_silhouetteMaterial!);
+
+  // Create silhouette entity
+  final silhouetteEntity = EntityManager_createEntity(entityManager);
+
+  // Build silhouette renderable (same geometry, silhouette material)
+  final rb = RenderableBuilder_create(1);
+  RenderableBuilder_geometry(rb, 0, PrimitiveType.TRIANGLES, vb, ib, 0, indexCount);
+  RenderableBuilder_material(rb, 0, silhouetteMi);
+  RenderableBuilder_culling(rb, true);
+  RenderableBuilder_castShadows(rb, false);
+  RenderableBuilder_receiveShadows(rb, false);
+  await RenderableBuilder_buildRenderThread(rb, engine, silhouetteEntity);
+
+  // Parent to target entity (follows transforms)
+  TransformManager_setParent(transformManager, silhouetteEntity, targetEntity);
+
+  // Add to silhouette scene
+  Scene_addEntity(_silhouetteScene!, silhouetteEntity);
+
+  _highlights[targetEntity] = _SilhouetteComponent(silhouetteEntity, silhouetteMi);
+}
+
+Future<void> removeHighlight(int targetEntity) async {
+  final component = _highlights.remove(targetEntity);
+  if (component == null) return;
+
+  Scene_removeEntity(_silhouetteScene!, component.entity);
+  // ... destroy renderable, material instance, entity
+}
+```
+
+### Step 7: Integrate with FFIView
+**File:** `thermion_dart/lib/src/filament/src/implementation/ffi_view.dart`
+
+Replace `overlayManager` pointer with `HighlightOverlayManager` instance:
+
+```dart
+HighlightOverlayManager? _highlightOverlay;
+
+@override
+Future<void> enableHighlightOverlay({int? hardwareTextureId}) async {
+  _highlightOverlay ??= HighlightOverlayManager(this);
+  await _highlightOverlay!.initialize(
+    viewportWidth, viewportHeight,
+    hardwareTextureId: hardwareTextureId
+  );
+}
+
+@override
+Future<void> disableHighlightOverlay() async {
+  await _highlightOverlay?.dispose();
+  _highlightOverlay = null;
+}
+
+@override
+Future<void> addStencilHighlight(ThermionEntity entity, ...) async {
+  final vb = getVertexBuffer(entity);
+  final ib = getIndexBuffer(entity);
+  await _highlightOverlay?.addHighlight(entity.id, vb, ib, indexCount);
+}
+```
+
+### Step 8: Update render loop
+In the render method, render both views:
+```dart
+if (_highlightOverlay?.hasHighlights == true) {
+  // Render silhouette pass first
+  await Renderer_renderRenderThread(renderer, _highlightOverlay!.silhouetteView);
+  // Render edge detection pass
+  await Renderer_renderRenderThread(renderer, _highlightOverlay!.overlayView);
+}
+```
+
+## Files to Modify/Create
+
+1. **CREATE:** `thermion_dart/lib/src/filament/src/overlay/highlight_overlay_manager.dart`
+   - New Dart class implementing all overlay logic
+
+2. **MODIFY:** `thermion_dart/lib/src/filament/src/implementation/ffi_view.dart`
+   - Replace `Pointer<TOverlayManager>` with `HighlightOverlayManager`
+   - Update `enableHighlightOverlay`, `disableHighlightOverlay`, `addStencilHighlight`, etc.
+
+3. **DELETE (eventually):** C++ OverlayComponentManager code
+   - `native/include/components/OverlayComponentManager.hpp`
+   - `native/include/c_api/TOverlayManager.h`
+   - `native/src/c_api/TOverlayManager.cpp`
+   - Related render thread API functions
+
+## Benefits
+- Single language (Dart) for overlay logic
+- Easier debugging
+- No render thread callbacks needed for simple operations
+- Cleaner resource management with Dart async/await
+- Transparent skybox fix included (fixes tinting bug)
+
+## Migration Strategy
+1. Implement Dart `HighlightOverlayManager` alongside existing C++ version
+2. Test with existing highlight tests
+3. Switch `ffi_view.dart` to use Dart implementation
+4. Remove C++ code once validated

--- a/.tickets/t-a24f.md
+++ b/.tickets/t-a24f.md
@@ -1,0 +1,49 @@
+---
+id: t-a24f
+status: open
+deps: []
+links: []
+created: 2026-01-24T06:56:32Z
+type: task
+priority: 2
+assignee: Nick Fisher
+---
+# Use same VkQueue for Filament rendering and blit operations
+
+Investigate using the same VkQueue from Filament's Platform instance for blit operations to ensure proper GPU synchronization without explicit semaphores.
+
+## Design
+
+## Current State
+
+The blit operations in vulkan_context.cpp use a VkQueue obtained from createCommandResources(), while Filament uses the queue specified in the VulkanSharedContext passed via GetSharedContext().
+
+## Problem
+
+If these are different queues, the pipeline barriers in Blit() are insufficient for Filament→Blit synchronization:
+- Pipeline barriers only synchronize within a queue
+- Cross-queue sync requires semaphores or queue family ownership transfers
+
+## Analysis
+
+### If Same Queue (Preferred)
+- Pipeline barriers are sufficient
+- Implicit queue submission ordering provides sync
+- Current barrier (srcAccessMask=COLOR_ATTACHMENT_WRITE, oldLayout=COLOR_ATTACHMENT_OPTIMAL) correctly waits for render
+
+### If Different Queues (Requires Changes)
+Options:
+1. **Use Filament's queue for blit**: Access via Platform instance, submit blit commands to same queue
+2. **Add semaphore**: Filament signals after render, blit waits before starting
+3. **Timeline semaphore**: More flexible, allows multiple sync points
+
+## Implementation Path
+
+1. Verify queue configuration in createCommandResources() vs _sharedContext
+2. If different: modify to use Platform's queue for blit submission
+3. If not possible: implement semaphore-based sync
+
+## Files to Investigate
+- thermion_dart/native/src/windows/vulkan/vulkan_context.cpp (createCommandResources, queue usage)
+- Filament's VulkanPlatform interface for queue access
+

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -65,7 +65,7 @@ outputDirectory : ${outputDirectory.path}
         .listSync(recursive: true)
         .whereType<File>()
         .map((f) => f.path)
-        .where((f) => !(f.contains("CMakeLists") || f.contains("main.cpp")))
+        .where((f) => !(f.contains("CMakeLists") || f.contains("main.cpp") || f.contains("build")))
         .toList();
 
     if (targetOS != OS.windows) {
@@ -95,9 +95,8 @@ outputDirectory : ${outputDirectory.path}
       "filament",
       "backend",
       "filameshio",
-      if (targetOS != OS.iOS) "filamat",
+	if (targetOS == OS.linux) "filamat_combined" else if (targetOS != OS.iOS) "filamat",
       if (targetOS == OS.linux) "shaders",
-      //"geometry",
       "utils",
       "filabridge",
       "gltfio_core",
@@ -118,7 +117,7 @@ outputDirectory : ${outputDirectory.path}
       "uberarchive",
       "zstd",
       //"mikktspace",
-      "geometry",
+      if (targetOS == OS.linux) "geometry_combined" else "geometry",
       if (targetOS == OS.macOS && buildMode == BuildMode.debug) ...["matdbg", "fgviewer"]
     ];
 

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -387,7 +387,7 @@ Future<Directory> getLibDir(Uri packageRoot, OS targetOS,
   var url = _getLibraryUrl(platform, mode);
 
   if (targetOS == OS.windows) {
-    url = url.replaceAll(".zip", "-vulkan.zip");
+    url = url.replaceAll(".zip", "-vulkan-texture-import.zip");
   }
 
   final filename = url.split("/").last;

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_texture.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_texture.dart
@@ -22,10 +22,15 @@ class FFITexture extends Texture {
   }
 
   @override
-  Future<void> dispose() async {
+  Future<void> destroy() async {
     await withVoidCallback((requestId, cb) {
       Engine_destroyTextureRenderThread(_engine, pointer, requestId, cb);
     });
+  }
+
+  @override
+  Future<void> dispose() async {
+    return destroy();
   }
 
   @override
@@ -75,7 +80,10 @@ class FFITexture extends Texture {
   @override
   Future<void> setImage(int level, Uint8List buffer, int width, int height,
       PixelDataFormat format, PixelDataType type,
-      {int depth = 1, int xOffset = 0, int yOffset = 0, int zOffset = 0 }) async {
+      {int depth = 1,
+      int xOffset = 0,
+      int yOffset = 0,
+      int zOffset = 0}) async {
     final success = await withBoolCallback((cb) {
       Texture_setImageRenderThread(
           _engine,
@@ -83,7 +91,9 @@ class FFITexture extends Texture {
           level,
           buffer.address,
           buffer.lengthInBytes,
-          xOffset, yOffset, zOffset,
+          xOffset,
+          yOffset,
+          zOffset,
           width,
           height,
           depth,

--- a/thermion_dart/lib/src/filament/src/interface/render_target.dart
+++ b/thermion_dart/lib/src/filament/src/interface/render_target.dart
@@ -4,5 +4,8 @@ import 'package:thermion_dart/thermion_dart.dart';
 abstract class RenderTarget<T> extends NativeHandle {
   Future<Texture> getColorTexture();
   Future<Texture> getDepthTexture();
+  
+  // Destroy the render target. Does not destroy any attached textures; these
+  // must be destroyed individually. 
   Future destroy();
 }

--- a/thermion_dart/lib/src/filament/src/interface/texture.dart
+++ b/thermion_dart/lib/src/filament/src/interface/texture.dart
@@ -351,8 +351,13 @@ abstract class Texture {
   /// Generates mipmaps automatically for the texture
   Future generateMipmaps();
 
-  /// Disposes the texture resources
+  // Destroys this texture.
+  @Deprecated("Call destroy() instead")
   Future dispose();
+
+  // Destroys this texture.
+  Future destroy();
+
 }
 
 /// Pixel data format enum, representing different channel combinations

--- a/thermion_dart/native/include/ThermionWin32.h
+++ b/thermion_dart/native/include/ThermionWin32.h
@@ -36,4 +36,5 @@
 #pragma comment(lib, "vulkan-1.lib")
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "mikktspace.lib")
  

--- a/thermion_dart/native/include/windows/vulkan/d3d_context.h
+++ b/thermion_dart/native/include/windows/vulkan/d3d_context.h
@@ -26,9 +26,6 @@ namespace thermion::windows::d3d {
                 return _D3D11Device;
             }
 
-            void ImportSemaphore(HANDLE handle);
-            
-            void SetWaitForSemaphore(uint64_t value);
 
         private:
             ID3D11DeviceContext* _D3D11DeviceContext = nullptr;

--- a/thermion_dart/native/include/windows/vulkan/vulkan_context.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_context.h
@@ -29,15 +29,17 @@ namespace thermion::windows::vulkan {
         ThermionVulkanContext();
         ~ThermionVulkanContext();
         
-        HANDLE CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top);        
-        
+        HANDLE CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top);
+
+        VkImage GetVulkanImageForSurface(HANDLE d3dTextureHandle);
+
         void DestroyRenderingSurface(HANDLE handle);
                 
         void Flush();
       
         filament::backend::VulkanPlatform *GetPlatform();
       
-        void BlitFromSwapchain();
+        void BlitFromSwapchain(HANDLE d3dTextureHandle);
 
         void* GetSharedContext();
       

--- a/thermion_dart/native/include/windows/vulkan/vulkan_context.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_context.h
@@ -34,12 +34,11 @@ namespace thermion::windows::vulkan {
         VkImage GetVulkanImageForSurface(HANDLE d3dTextureHandle);
 
         void DestroyRenderingSurface(HANDLE handle);
-                
-        void Flush();
-      
+                      
         filament::backend::VulkanPlatform *GetPlatform();
       
-        void BlitFromSwapchain(HANDLE d3dTextureHandle);
+        // Blits the contents of the paired Vulkan texture to the specified D3D texture handle
+        void Blit(HANDLE d3dTextureHandle);
 
         void* GetSharedContext();
       

--- a/thermion_dart/native/include/windows/vulkan/vulkan_texture.h
+++ b/thermion_dart/native/include/windows/vulkan/vulkan_texture.h
@@ -12,14 +12,23 @@ typedef void *HANDLE;
 
 class DLL_EXPORT VulkanTexture {
     public:
+        // Constructor for D3D-interop textures (doesn't own memory)
         VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, HANDLE d3dTextureHandle);
+
+        // Constructor for pure Vulkan textures (owns memory)
+        VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, bool ownsMemory);
+
         ~VulkanTexture();
 
-        HANDLE GetD3DTextureHandle() { 
+        HANDLE GetD3DTextureHandle() {
             return _d3dTextureHandle;
         }
 
+        // Factory method for D3D-interop textures
         static std::unique_ptr<VulkanTexture> create(VkDevice device, VkPhysicalDevice physicalDevice, uint32_t width, uint32_t height, HANDLE d3dTextureHandle);
+
+        // Factory method for pure Vulkan textures (render target backing)
+        static std::unique_ptr<VulkanTexture> createPure(VkDevice device, VkPhysicalDevice physicalDevice, uint32_t width, uint32_t height);
 
         VkImage GetImage() {
             return _image;
@@ -30,7 +39,8 @@ class DLL_EXPORT VulkanTexture {
         VkDeviceMemory _imageMemory = VK_NULL_HANDLE;
         uint32_t _width = 0;
         uint32_t _height = 0;
-        HANDLE _d3dTextureHandle;
+        HANDLE _d3dTextureHandle = nullptr;
+        bool _ownsMemory = false;
 };
 
 }

--- a/thermion_dart/native/src/windows/vulkan/d3d_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/d3d_context.cpp
@@ -189,23 +189,5 @@ namespace thermion::windows::d3d
         _D3D11DeviceContext->Flush();
     }
 
-    void D3DContext::ImportSemaphore(HANDLE handle)
-    {
-        if (!_D3D11Device5) return;
-
-        // Open the shared fence from Vulkan
-        HRESULT hr = _D3D11Device5->OpenSharedFence(handle, __uuidof(ID3D11Fence), (void**)&_sharedFence);
-        if (FAILED(hr)) {
-            std::cout << "Failed to open shared fence from Vulkan" << std::endl;
-        }
-    }
-
-    void D3DContext::SetWaitForSemaphore(uint64_t value) {
-        if (_D3D11DeviceContext4 && _sharedFence) {
-            // Instruct the GPU to wait until the fence reaches 'value'
-            // This is a GPU-side wait, it does not block the CPU.
-            _D3D11DeviceContext4->Wait(_sharedFence.Get(), value);
-        }
-    }
 
 }

--- a/thermion_dart/native/src/windows/vulkan/main.cpp
+++ b/thermion_dart/native/src/windows/vulkan/main.cpp
@@ -83,7 +83,7 @@ int main()
    std::cout << "SAVED PIXELS" << std::endl;
 
    // ctx->GetTexture()->Flush();
-   ctx->BlitFromSwapchain();      
+   ctx->Blit();      
 
    std::vector<uint8_t> outPixels(width * height * 4);
 

--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -211,11 +211,7 @@ class ThermionVulkanContext::Impl {
             return VK_NULL_HANDLE;
         }
 
-        void Flush() {
-            // ?? what to do here
-        }
-
-        void BlitFromSwapchain(HANDLE d3dTextureHandle) {
+        void Blit(HANDLE d3dTextureHandle) {
             // Find the texture index for this handle
             size_t textureIndex = SIZE_MAX;
             for (size_t i = 0; i < _d3dTextures.size(); i++) {
@@ -226,12 +222,12 @@ class ThermionVulkanContext::Impl {
             }
 
             if (textureIndex == SIZE_MAX) {
-                ERROR("BlitFromSwapchain: texture handle not found");
+                ERROR("Texture handle not found");
                 return;
             }
 
             if (textureIndex >= _renderTargetTextures.size() || textureIndex >= _vulkanTextures.size()) {
-                ERROR("BlitFromSwapchain: texture index out of bounds");
+                ERROR("Texture index out of bounds");
                 return;
             }
 
@@ -617,8 +613,8 @@ void* ThermionVulkanContext::GetSharedContext() {
     return pImpl->GetSharedContext();
 }
 
-void ThermionVulkanContext::BlitFromSwapchain(HANDLE d3dTextureHandle) {
-    pImpl->BlitFromSwapchain(d3dTextureHandle);
+void ThermionVulkanContext::Blit(HANDLE d3dTextureHandle) {
+    pImpl->Blit(d3dTextureHandle);
 }
 
 void ThermionVulkanContext::readPixelsFromImage(

--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -30,7 +30,11 @@ class ThermionVulkanContext::Impl {
     public:
 
         ~Impl() {
-            std::cerr << "ThermionVulkanContext destructor " << _vulkanTextures.size() << " Vulkan textures / " << _d3dTextures.size() << " D3D textures remain" << std::endl;
+            std::cerr << "ThermionVulkanContext destructor " << _vulkanTextures.size() << " Vulkan textures / "
+                      << _d3dTextures.size() << " D3D textures / " << _renderTargetTextures.size() << " render targets remain" << std::endl;
+            if (blitFence != VK_NULL_HANDLE) {
+                bluevk::vkDestroyFence(device, blitFence, nullptr);
+            }
             _d3dContext = std::nullptr_t();
         }
         
@@ -142,35 +146,29 @@ class ThermionVulkanContext::Impl {
 
             vkAllocateCommandBuffers(device, &cmdBufInfo, &blitCommandBuffer);
 
-            createSyncObjects();
-
-            VkSemaphoreGetWin32HandleInfoKHR handleInfo{};
-            handleInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR;
-            handleInfo.semaphore = sharedSemaphore;
-            handleInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
-
-            HANDLE semaphoreHandle = NULL;
-
-            auto fpGetSemaphoreWin32Handle = (PFN_vkGetSemaphoreWin32HandleKHR)vkGetDeviceProcAddr(device, "vkGetSemaphoreWin32HandleKHR");
-            if (fpGetSemaphoreWin32Handle) {
-                fpGetSemaphoreWin32Handle(device, &handleInfo, &semaphoreHandle);
-            } else { 
-                ERROR("Failed to resolve vkGetSemaphoreWin32HandleKHR");
-            }
-
-            if(semaphoreHandle == VK_NULL_HANDLE) {
-                ERROR("Failed to create Vulkan semaphore");
-            } else {
-                _d3dContext->ImportSemaphore(semaphoreHandle);
+            // Create blit fence
+            VkFenceCreateInfo fenceInfo{};
+            fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+            fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;  // Start signaled so first reset works
+            VkResult fenceResult = bluevk::vkCreateFence(device, &fenceInfo, nullptr, &blitFence);
+            if (fenceResult != VK_SUCCESS) {
+                std::cout << "[ERROR] Failed to create blit fence" << std::endl;
             }
 
         }
 
         HANDLE CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top) {
-            
+
             Log("Creating Vulkan texture %dx%d", width, height);
 
-            // creates the D3D texture
+            // 1. Create pure Vulkan texture for render target (returned to Flutter as hardware texture ID)
+            auto renderTargetTexture = VulkanTexture::createPure(device, physicalDevice, width, height);
+            if(!renderTargetTexture) {
+                ERROR("Failed to create pure Vulkan render target texture");
+                return NULL;
+            }
+
+            // 2. Create D3D texture and D3D-interop Vulkan texture (for Flutter display)
             auto d3dTexture = _d3dContext->CreateTexture(width, height);
             auto d3dTextureHandle = d3dTexture->GetTextureHandle();
             auto vkTexture = VulkanTexture::create(device, physicalDevice, width, height, d3dTextureHandle);
@@ -179,10 +177,7 @@ class ThermionVulkanContext::Impl {
                 return NULL;
             }
 
-            // fillImageWithColor(device, commandPool, queue, image, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED,  // Current image layout
-            //     { width, height, 1 }, // Image extent
-            //     0.0f, 1.0f, 0.0f, 1.0f);    // Red color (RGBA))
-            
+            _renderTargetTextures.push_back(std::move(renderTargetTexture));
             _d3dTextures.push_back(std::move(d3dTexture));
             _vulkanTextures.push_back(std::move(vkTexture));
             return d3dTextureHandle;
@@ -190,61 +185,64 @@ class ThermionVulkanContext::Impl {
     
         void DestroyRenderingSurface(HANDLE handle) {
             std::cerr << "Destroying rendering surface " << handle << std::endl;
-            auto vulkanNewEnd = std::remove_if(_vulkanTextures.begin(), _vulkanTextures.end(), [=](auto&& vkTexture) {
-                return vkTexture->GetD3DTextureHandle() == handle;
-            });
-            
-            if (vulkanNewEnd != _vulkanTextures.end()) {
-                _vulkanTextures.erase(vulkanNewEnd, _vulkanTextures.end());
-            } else { 
-                std::cerr << "Vulkan texture not found?" << std::endl;
-            }
-            
-            auto d3dNewEnd = std::remove_if(_d3dTextures.begin(), _d3dTextures.end(), [=](auto&& d3dTexture) {
-                return d3dTexture->GetTextureHandle() == handle;
-            });
-            
-            if (d3dNewEnd != _d3dTextures.end()) {
-                _d3dTextures.erase(d3dNewEnd, _d3dTextures.end());
-            } else { 
-                std::cerr << "D3D texture not found?" << std::endl;
-            }
-            std::cerr << "Rendering surface destroyed, " << _vulkanTextures.size() << " Vulkan textures / " << _d3dTextures.size() << " D3D textures remain" << std::endl;
 
+            // Find index of the D3D texture with this handle and remove from all three vectors
+            for (size_t i = 0; i < _d3dTextures.size(); i++) {
+                if (_d3dTextures[i]->GetTextureHandle() == handle) {
+                    _renderTargetTextures.erase(_renderTargetTextures.begin() + i);
+                    _vulkanTextures.erase(_vulkanTextures.begin() + i);
+                    _d3dTextures.erase(_d3dTextures.begin() + i);
+                    std::cerr << "Rendering surface destroyed, " << _vulkanTextures.size() << " Vulkan textures / "
+                              << _d3dTextures.size() << " D3D textures / " << _renderTargetTextures.size() << " render targets remain" << std::endl;
+                    return;
+                }
+            }
+            std::cerr << "D3D texture not found for handle " << handle << std::endl;
+        }
+
+        VkImage GetVulkanImageForSurface(HANDLE handle) {
+            // Find the index of the D3D texture with this handle and return the corresponding render target VkImage
+            for (size_t i = 0; i < _d3dTextures.size(); i++) {
+                if (_d3dTextures[i]->GetTextureHandle() == handle) {
+                    // Return the corresponding render target texture's VkImage (not the D3D-interop one)
+                    return _renderTargetTextures[i]->GetImage();
+                }
+            }
+            return VK_NULL_HANDLE;
         }
 
         void Flush() {
             // ?? what to do here
         }
 
-        void BlitFromSwapchain() {
-            
-            std::lock_guard lock(_platform->mutex);
-            if(!_platform->current) {
-                ERROR("No platform");
+        void BlitFromSwapchain(HANDLE d3dTextureHandle) {
+            // Find the texture index for this handle
+            size_t textureIndex = SIZE_MAX;
+            for (size_t i = 0; i < _d3dTextures.size(); i++) {
+                if (_d3dTextures[i]->GetTextureHandle() == d3dTextureHandle) {
+                    textureIndex = i;
+                    break;
+                }
+            }
+
+            if (textureIndex == SIZE_MAX) {
+                ERROR("BlitFromSwapchain: texture handle not found");
                 return;
             }
 
-            if(_d3dTextures.size() == 0) {
-                ERROR("No D3D textures");
+            if (textureIndex >= _renderTargetTextures.size() || textureIndex >= _vulkanTextures.size()) {
+                ERROR("BlitFromSwapchain: texture index out of bounds");
                 return;
             }
 
-            auto&& vkTexture = _vulkanTextures.back();
-            auto image = vkTexture->GetImage();
+            auto srcImage = _renderTargetTextures[textureIndex]->GetImage();
+            auto dstImage = _vulkanTextures[textureIndex]->GetImage();
+            auto width = _d3dTextures[textureIndex]->GetWidth();
+            auto height = _d3dTextures[textureIndex]->GetHeight();
 
-            auto&& texture = _d3dTextures.back();
-
-            auto height = texture->GetHeight();
-            auto width = texture->GetWidth();
-
-            auto bundle = _platform->getSwapChainBundle(_platform->current);
-            VkImage swapchainImage = bundle.colors[_platform->currentColorIndex];
-
-            VkResult result = bluevk::vkResetCommandBuffer(blitCommandBuffer, 0); 
-
+            VkResult result = bluevk::vkResetCommandBuffer(blitCommandBuffer, 0);
             if (result != VK_SUCCESS) {
-                std::cout << "Failed to allocate command buffer: " << result << std::endl;
+                std::cout << "Failed to reset command buffer: " << result << std::endl;
                 return;
             }
 
@@ -252,104 +250,94 @@ class ThermionVulkanContext::Impl {
             VkCommandBufferBeginInfo beginInfo{};
             beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
             beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-            
+
             result = bluevk::vkBeginCommandBuffer(blitCommandBuffer, &beginInfo);
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to begin command buffer: " << result << std::endl;
                 return;
             }
 
-            // std::cout << "Starting blit operation..." << std::endl;
-            
-            // Pre-transition barriers
-            VkImageMemoryBarrier srcBarrier{};
-            srcBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            srcBarrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-            srcBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-            srcBarrier.oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-            srcBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-            srcBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            srcBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            srcBarrier.image = swapchainImage;
-            srcBarrier.subresourceRange = {
-                VK_IMAGE_ASPECT_COLOR_BIT,
-                0, 1, 0, 1
-            };
+            // Blit only the specific texture pair
+            {
 
-            VkImageMemoryBarrier dstBarrier{};
-            dstBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            dstBarrier.srcAccessMask = 0;
-            dstBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            dstBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            dstBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            dstBarrier.image = image;
-            dstBarrier.subresourceRange = {
-                VK_IMAGE_ASPECT_COLOR_BIT,
-                0, 1, 0, 1
-            };
+                // Source barrier: render target texture (COLOR_ATTACHMENT_OPTIMAL -> TRANSFER_SRC_OPTIMAL)
+                VkImageMemoryBarrier srcBarrier{};
+                srcBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                srcBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+                srcBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                srcBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+                srcBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                srcBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                srcBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                srcBarrier.image = srcImage;
+                srcBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-            // std::cout << "Transitioning images to transfer layouts..." << std::endl;
+                // Destination barrier: D3D-interop texture (UNDEFINED -> TRANSFER_DST_OPTIMAL)
+                VkImageMemoryBarrier dstBarrier{};
+                dstBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                dstBarrier.srcAccessMask = 0;
+                dstBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                dstBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                dstBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                dstBarrier.image = dstImage;
+                dstBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-            // Pre-blit barriers
-            VkImageMemoryBarrier preBlitBarriers[] = {srcBarrier, dstBarrier};
-            vkCmdPipelineBarrier(
-                blitCommandBuffer,
-                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 
-                VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-                0,
-                0, nullptr,
-                0, nullptr,
-                2, preBlitBarriers
-            );
+                // Pre-blit barriers
+                VkImageMemoryBarrier preBlitBarriers[] = {srcBarrier, dstBarrier};
+                vkCmdPipelineBarrier(
+                    blitCommandBuffer,
+                    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    0,
+                    0, nullptr,
+                    0, nullptr,
+                    2, preBlitBarriers
+                );
 
-            // Define blit region with bounds checking
-            VkImageBlit blit{};
-            blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            blit.srcOffsets[0] = {0, 0, 0};
-            blit.srcOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
-            blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            blit.dstOffsets[0] = {0, 0, 0};
-            blit.dstOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
+                // Define blit region
+                VkImageBlit blit{};
+                blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                blit.srcOffsets[0] = {0, 0, 0};
+                blit.srcOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
+                blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                blit.dstOffsets[0] = {0, 0, 0};
+                blit.dstOffsets[1] = {static_cast<int32_t>(width), static_cast<int32_t>(height), 1};
 
-            // std::cout << "Executing blit command..." << std::endl;
-            // std::cout << "Source dimensions: " << width << "x" << height << std::endl;
-            // std::cout << "Destination dimensions: " << width << "x" << height << std::endl;
+                // Perform blit (handles RGBA->BGRA format conversion automatically)
+                bluevk::vkCmdBlitImage(
+                    blitCommandBuffer,
+                    srcImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                    dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                    1, &blit,
+                    VK_FILTER_NEAREST
+                );
 
-            // Perform blit with validation
-            bluevk::vkCmdBlitImage(
-                blitCommandBuffer,
-                swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                1, &blit,
-                VK_FILTER_NEAREST 
-            );
+                // Post-blit barriers
+                // Source: transition back to COLOR_ATTACHMENT_OPTIMAL for next render
+                srcBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                srcBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+                srcBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                srcBarrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-            // Post-transition barriers
-            srcBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-            srcBarrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-            srcBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-            srcBarrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+                // Destination: transition to SHADER_READ_ONLY_OPTIMAL for D3D sampling
+                dstBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                dstBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                dstBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                dstBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-            dstBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            dstBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-            dstBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            dstBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-            // std::cout << "Transitioning images back to original layouts..." << std::endl;
-
-            // Post-blit barriers
-            VkImageMemoryBarrier postBlitBarriers[] = {srcBarrier, dstBarrier};
-            bluevk::vkCmdPipelineBarrier(
-                blitCommandBuffer,
-                VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 
-                0,
-                0, nullptr,
-                0, nullptr,
-                2, postBlitBarriers
-            );
+                VkImageMemoryBarrier postBlitBarriers[] = {srcBarrier, dstBarrier};
+                bluevk::vkCmdPipelineBarrier(
+                    blitCommandBuffer,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                    0,
+                    0, nullptr,
+                    0, nullptr,
+                    2, postBlitBarriers
+                );
+            }
 
             // End command buffer
             result = bluevk::vkEndCommandBuffer(blitCommandBuffer);
@@ -358,34 +346,30 @@ class ThermionVulkanContext::Impl {
                 return;
             }
 
-            uint64_t signalValue = ++currentSemaphoreValue;
-
-            // 2. Setup Timeline Submit Info
-            VkTimelineSemaphoreSubmitInfo timelineInfo{};
-            timelineInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
-            timelineInfo.signalSemaphoreValueCount = 1;
-            timelineInfo.pSignalSemaphoreValues = &signalValue;
-
-            // 3. Setup Standard Submit Info
+            // Setup Standard Submit Info
             VkSubmitInfo submitInfo{};
             submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-            submitInfo.pNext = &timelineInfo; // Chain the timeline info
+            // submitInfo.pNext = &timelineInfo;
             submitInfo.commandBufferCount = 1;
             submitInfo.pCommandBuffers = &blitCommandBuffer;
-            
-            // Define the semaphore to signal
-            submitInfo.signalSemaphoreCount = 1;
-            submitInfo.pSignalSemaphores = &sharedSemaphore;
+            // submitInfo.signalSemaphoreCount = 1;
+            // submitInfo.pSignalSemaphores = &sharedSemaphore;
 
-            result = bluevk::vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE);
+            // Wait for any previous blit to complete and reset fence
+            bluevk::vkWaitForFences(device, 1, &blitFence, VK_TRUE, UINT64_MAX);
+            bluevk::vkResetFences(device, 1, &blitFence);
 
-            _d3dContext->SetWaitForSemaphore(signalValue);
-
+            result = bluevk::vkQueueSubmit(queue, 1, &submitInfo, blitFence);
 
             if (result != VK_SUCCESS) {
                 std::cout << "Failed to submit queue: " << result << std::endl;
-                // bluevk::vkDestroyFence(device, fence, nullptr);
                 return;
+            }
+
+            // Wait for blit to complete before returning
+            result = bluevk::vkWaitForFences(device, 1, &blitFence, VK_TRUE, UINT64_MAX);
+            if (result != VK_SUCCESS) {
+                std::cout << "Failed to wait for blit fence: " << result << std::endl;
             }
         }
 
@@ -592,48 +576,31 @@ class ThermionVulkanContext::Impl {
         VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
         VkDevice device = VK_NULL_HANDLE;
         VkCommandPool commandPool = VK_NULL_HANDLE;
-        VkCommandBuffer blitCommandBuffer = VK_NULL_HANDLE; 
+        VkCommandBuffer blitCommandBuffer = VK_NULL_HANDLE;
+        VkFence blitFence = VK_NULL_HANDLE;
         VkQueue queue = VK_NULL_HANDLE;
-
-        VkSemaphore sharedSemaphore = VK_NULL_HANDLE;
-        uint64_t currentSemaphoreValue = 0;
         
         std::unique_ptr<thermion::windows::d3d::D3DContext> _d3dContext;
     
         std::vector<std::unique_ptr<thermion::windows::d3d::D3DTexture>> _d3dTextures;
         std::vector<std::unique_ptr<thermion::windows::vulkan::VulkanTexture>> _vulkanTextures;
+        std::vector<std::unique_ptr<thermion::windows::vulkan::VulkanTexture>> _renderTargetTextures;  // Pure Vulkan textures for render targets
         
         std::unique_ptr<TVulkanPlatform> _platform;
         filament::backend::VulkanPlatform::VulkanSharedContext _sharedContext{};
 
-        void createSyncObjects() {
-            VkExportSemaphoreCreateInfo exportInfo{};
-            exportInfo.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO;
-            // D3D12_FENCE is the handle type that maps to ID3D11Fence
-            exportInfo.handleTypes = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
 
-            VkSemaphoreTypeCreateInfo timelineInfo{};
-            timelineInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
-            timelineInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-            timelineInfo.initialValue = 0;
-            timelineInfo.pNext = &exportInfo;
-
-            VkSemaphoreCreateInfo semaphoreInfo{};
-            semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-            semaphoreInfo.pNext = &timelineInfo;
-
-            VkResult result = bluevk::vkCreateSemaphore(device, &semaphoreInfo, nullptr, &sharedSemaphore);
-            if (result != VK_SUCCESS) {
-                std::cout << "Failed to create shared semaphore: " << result << std::endl;
-            }
-        }
 
 };
 
 HANDLE ThermionVulkanContext::CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top) {
     return pImpl->CreateRenderingSurface(width, height, left, top);
 }
-  
+
+VkImage ThermionVulkanContext::GetVulkanImageForSurface(HANDLE handle) {
+    return pImpl->GetVulkanImageForSurface(handle);
+}
+
 void ThermionVulkanContext::DestroyRenderingSurface(HANDLE handle) {
     pImpl->DestroyRenderingSurface(handle);
 }
@@ -650,8 +617,8 @@ void* ThermionVulkanContext::GetSharedContext() {
     return pImpl->GetSharedContext();
 }
 
-void ThermionVulkanContext::BlitFromSwapchain() {
-    pImpl->BlitFromSwapchain();
+void ThermionVulkanContext::BlitFromSwapchain(HANDLE d3dTextureHandle) {
+    pImpl->BlitFromSwapchain(d3dTextureHandle);
 }
 
 void ThermionVulkanContext::readPixelsFromImage(

--- a/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_context.cpp
@@ -601,10 +601,6 @@ void ThermionVulkanContext::DestroyRenderingSurface(HANDLE handle) {
     pImpl->DestroyRenderingSurface(handle);
 }
 
-void ThermionVulkanContext::Flush() {
-    pImpl->Flush();
-}
-
 filament::backend::VulkanPlatform *ThermionVulkanContext::GetPlatform() { 
 return pImpl->GetPlatform();
 }

--- a/thermion_dart/native/src/windows/vulkan/vulkan_texture.cpp
+++ b/thermion_dart/native/src/windows/vulkan/vulkan_texture.cpp
@@ -7,19 +7,28 @@
 namespace thermion::windows::vulkan
 {
 
-    VulkanTexture::VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, HANDLE d3dTextureHandle) : _image(image), _device(device),  _imageMemory(imageMemory), _width(width), _height(height), _d3dTextureHandle(d3dTextureHandle) {};
+    // Constructor for D3D-interop textures (doesn't own memory)
+    VulkanTexture::VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, HANDLE d3dTextureHandle)
+        : _image(image), _device(device), _imageMemory(imageMemory), _width(width), _height(height), _d3dTextureHandle(d3dTextureHandle), _ownsMemory(false) {}
+
+    // Constructor for pure Vulkan textures (owns memory)
+    VulkanTexture::VulkanTexture(VkImage image, VkDevice device, VkDeviceMemory imageMemory, uint32_t width, uint32_t height, bool ownsMemory)
+        : _image(image), _device(device), _imageMemory(imageMemory), _width(width), _height(height), _d3dTextureHandle(nullptr), _ownsMemory(ownsMemory) {}
 
     VulkanTexture::~VulkanTexture() {
         bluevk::vkDeviceWaitIdle(_device);
         if(_image != VK_NULL_HANDLE) {
             bluevk::vkDestroyImage(_device, _image, nullptr);
-        } else { 
+        } else {
             std::cout << "Warning : no vkImage found" << std::endl;
         }
 
+        // Only free memory if we own it (pure Vulkan textures)
+        // D3D-interop textures have memory imported from D3D without ownership transfer
         // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImportMemoryWin32HandleInfoKHR.html
-        // imageMemory has been imported from D3D without transferring ownership
-        // therefore we don't need to release
+        if (_ownsMemory && _imageMemory != VK_NULL_HANDLE) {
+            bluevk::vkFreeMemory(_device, _imageMemory, nullptr);
+        }
     }         
     
 
@@ -161,5 +170,75 @@ namespace thermion::windows::vulkan
             return nullptr;
         }
         return std::make_unique<VulkanTexture>(image, device, imageMemory, width, height, d3dTextureHandle);
+    }
+
+    std::unique_ptr<VulkanTexture> VulkanTexture::createPure(
+        VkDevice device,
+        VkPhysicalDevice physicalDevice,
+        uint32_t width,
+        uint32_t height)
+    {
+        // Create image without external memory support (pure Vulkan)
+        VkImageCreateInfo imageInfo = {
+            .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+            .pNext = nullptr,  // No external memory info
+            .flags = 0,
+            .imageType = VK_IMAGE_TYPE_2D,
+            .format = VK_FORMAT_R8G8B8A8_UNORM,  // RGBA format for render target
+            .extent = {width, height, 1},
+            .mipLevels = 1,
+            .arrayLayers = 1,
+            .samples = VK_SAMPLE_COUNT_1_BIT,
+            .tiling = VK_IMAGE_TILING_OPTIMAL,
+            // ALL THREE FLAGS REQUIRED: Filament needs SAMPLED_BIT for render target textures
+        .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+            .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+            .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED
+        };
+
+        VkImage image;
+        VkResult result = bluevk::vkCreateImage(device, &imageInfo, nullptr, &image);
+        if (result != VK_SUCCESS) {
+            ERROR("Failed to create pure Vulkan image");
+            return nullptr;
+        }
+
+        std::cout << "Created pure Vulkan vkImage " << (int64_t)image << std::endl;
+
+        // Get memory requirements
+        VkMemoryRequirements memRequirements;
+        bluevk::vkGetImageMemoryRequirements(device, image, &memRequirements);
+
+        // Allocate device-local memory
+        uint32_t memoryTypeIndex = findOptimalMemoryType(
+            physicalDevice,
+            memRequirements.memoryTypeBits,
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
+        );
+
+        VkMemoryAllocateInfo allocInfo = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+            .pNext = nullptr,
+            .allocationSize = memRequirements.size,
+            .memoryTypeIndex = memoryTypeIndex
+        };
+
+        VkDeviceMemory imageMemory;
+        result = bluevk::vkAllocateMemory(device, &allocInfo, nullptr, &imageMemory);
+        if (result != VK_SUCCESS) {
+            bluevk::vkDestroyImage(device, image, nullptr);
+            ERROR("Failed to allocate memory for pure Vulkan image");
+            return nullptr;
+        }
+
+        result = bluevk::vkBindImageMemory(device, image, imageMemory, 0);
+        if (result != VK_SUCCESS) {
+            bluevk::vkFreeMemory(device, imageMemory, nullptr);
+            bluevk::vkDestroyImage(device, image, nullptr);
+            ERROR("Failed to bind memory for pure Vulkan image");
+            return nullptr;
+        }
+
+        return std::make_unique<VulkanTexture>(image, device, imageMemory, width, height, true);
     }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/options.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/options.dart
@@ -29,7 +29,7 @@ class NativeOptions {
 
   const NativeOptions(
       {this.backend,
-      this.renderTargetColorTextureFormat = TextureFormat.RGBA32F,
+      this.renderTargetColorTextureFormat = TextureFormat.RGBA8,
       this.renderTargetDepthTextureFormat = TextureFormat.DEPTH24_STENCIL8,
       this.createOverlay = false});
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -23,10 +23,6 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
 
   static SwapChain? _swapChain;
 
-  SwapChain? getActiveSwapchain() {
-    return _swapChain;
-  }
-
   static Future<Uint8List> loadAsset(String path) async {
     if (path.startsWith("file://")) {
       return File(path.replaceAll("file://", "")).readAsBytesSync();
@@ -131,7 +127,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
     // dimensions don't seem to matter).
     // TODO - see if we can use `renderStandaloneView` in FilamentViewer to
     // avoid this
-    if (Platform.isMacOS || Platform.isIOS) {
+    if (Platform.isMacOS || Platform.isIOS || Platform.isWindows) {
       if (destroySwapchain && _swapChain != null) {
         await FilamentApp.instance!.destroySwapChain(_swapChain!);
         _swapChain = null;
@@ -165,22 +161,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
           channel, width, height);
     }
 
-    if (Platform.isWindows) {
-      if (_swapChain != null) {
-        await FilamentApp.instance!.unregister(_swapChain!, view);
-        await FilamentApp.instance!.destroySwapChain(_swapChain!);
-      }
-
-      _swapChain = await FilamentApp.instance!.createHeadlessSwapChain(
-          descriptor.width, descriptor.height,
-          hasStencilBuffer: true);
-
-      _logger.info(
-        "Created headless swapchain ${descriptor.width}x${descriptor.height}",
-      );
-
-      await FilamentApp.instance!.register(_swapChain!, view);
-    } else if (Platform.isAndroid) {
+    if (Platform.isAndroid) {
       if (_swapChain != null) {
         await FilamentApp.instance!.unregister(_swapChain!, view);
         await FilamentApp.instance!.destroySwapChain(_swapChain!);
@@ -188,7 +169,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
       _swapChain = await FilamentApp.instance!.createSwapChain(
         Pointer<Void>.fromAddress(descriptor.windowHandle!),
       );
-      await FilamentApp.instance!.register(_swapChain!, view);
+
     } else {
       final color = await FilamentApp.instance!.createTexture(
         descriptor.width,

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -206,6 +206,8 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
       await view.setRenderTarget(renderTarget);
     }
 
+    await FilamentApp.instance!.register(_swapChain!, view);
+
     await view.setViewport(width, height);
 
     var camera = await view.getCamera();

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -196,6 +196,8 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
         textureSamplerType: TextureSamplerType.SAMPLER_2D,
       );
 
+      final existingRenderTarget = await view.getRenderTarget();
+
       var renderTarget = await FilamentApp.instance!.createRenderTarget(
         descriptor.width,
         descriptor.height,
@@ -204,6 +206,14 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
       );
 
       await view.setRenderTarget(renderTarget);
+
+      if (existingRenderTarget != null) {
+        final color = await existingRenderTarget.getColorTexture();
+        final depth = await existingRenderTarget.getDepthTexture();
+        await color.destroy();
+        await depth.destroy();
+        await existingRenderTarget.destroy();
+      }
     }
 
     await FilamentApp.instance!.register(_swapChain!, view);

--- a/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
+++ b/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
@@ -212,7 +212,7 @@ namespace thermion::tflutter::windows
         }
 
         HANDLE d3dTextureHandle = (*it)->GetD3DTextureHandle();
-        _context->BlitFromSwapchain(d3dTextureHandle);
+        _context->Blit(d3dTextureHandle);
 
         _textureRegistrar->MarkTextureFrameAvailable(*flutterTextureId);
       } else {

--- a/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
+++ b/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
@@ -96,6 +96,8 @@ namespace thermion::tflutter::windows
       return;
     }
 
+    auto vkImage = _context->GetVulkanImageForSurface(d3dHandle);
+
     auto flutterTexture = std::make_unique<FlutterD3DTexture>(d3dHandle, width, height);
 
     auto flutterTextureId = _textureRegistrar->RegisterTexture(flutterTexture->GetFlutterTexture());
@@ -107,7 +109,7 @@ namespace thermion::tflutter::windows
 
     std::vector<flutter::EncodableValue> resultList;
     resultList.push_back(flutter::EncodableValue(flutterTextureId));
-    resultList.push_back(flutter::EncodableValue((int64_t) nullptr));
+    resultList.push_back(flutter::EncodableValue((int64_t)vkImage));
     resultList.push_back(flutter::EncodableValue((int64_t) nullptr));
     result->Success(resultList);
   }
@@ -190,17 +192,30 @@ namespace thermion::tflutter::windows
     {
       if (_context)
       {
-        _context->BlitFromSwapchain();
         const auto *flutterTextureId = std::get_if<int64_t>(methodCall.arguments());
 
         if (!flutterTextureId || *flutterTextureId == -1)
         {
           std::cout << "Bad texture" << std::endl;
+          result->Success(flutter::EncodableValue((int64_t) nullptr));
           return;
         }
-        // std::cout << "Marking texture" << (*flutterTextureId) << "available" << std::endl;
+
+        // Find the FlutterD3DTexture for this flutterTextureId
+        auto it = std::find_if(_flutterTextures.begin(), _flutterTextures.end(), [=](auto &&ft)
+                               { return ft->GetFlutterTextureId() == *flutterTextureId; });
+
+        if (it == _flutterTextures.end()) {
+          std::cerr << "Failed to find Flutter texture for ID " << *flutterTextureId << std::endl;
+          result->Success(flutter::EncodableValue((int64_t) nullptr));
+          return;
+        }
+
+        HANDLE d3dTextureHandle = (*it)->GetD3DTextureHandle();
+        _context->BlitFromSwapchain(d3dTextureHandle);
+
         _textureRegistrar->MarkTextureFrameAvailable(*flutterTextureId);
-      } else { 
+      } else {
         std::cout << "No context" << std::endl;
       }
       result->Success(flutter::EncodableValue((int64_t) nullptr));


### PR DESCRIPTION
Previously the Windows implementation created a Vulkan/D3D texture that was passed to Flutter, then performed a blit from the Filament swapchain on every frame. As the Filament Vulkan backend did not support importing external textures, this was the only option.

Not only is this is not consistent with other platforms (e.g. macOS, where we render each view into its own render target with the backing texture passed to Flutter), it also prevents composing views/render targets directly in Flutter. This is important for things like object highlights.

I have now had the chance to create a custom Filament build for Windows with support for importing external Vulkan textures, so we can now make the Windows implementation consistent.