### PR TITLE
(Dart/Flutter) Support widget-based overlays (i.e. allow stacking multiple ThermionWidgets)

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
@@ -41,8 +41,11 @@ class EdgeDetectionView extends FFIView {
   final ThermionEntity _fullscreenQuadEntity;
   final FFITextureSampler _edgeSampler;
 
-  // Silhouette texture to sample (set externally)
-  final Texture silhouetteTexture;
+  // Silhouette texture to sample (mutable for resize support)
+  Texture _silhouetteTexture;
+
+  /// The silhouette texture being sampled for edge detection
+  Texture get silhouetteTexture => _silhouetteTexture;
 
   EdgeDetectionView._(
     super.view,
@@ -57,8 +60,8 @@ class EdgeDetectionView extends FFIView {
     required FFIIndexBuffer quadIB,
     required ThermionEntity fullscreenQuadEntity,
     required FFITextureSampler edgeSampler,
-    required this.silhouetteTexture
-  })  : 
+    required Texture silhouetteTexture,
+  })  : _silhouetteTexture = silhouetteTexture,
         _edgeMaterial = material,
         _edgeScene = scene,
         _skybox = skybox,
@@ -239,6 +242,13 @@ class EdgeDetectionView extends FFIView {
     await _updateEdgeMaterialParams();
   }
 
+  /// Update the silhouette texture reference (called when SilhouetteView resizes)
+  Future<void> updateSilhouetteTexture(Texture newTexture) async {
+    _silhouetteTexture = newTexture;
+    await _updateEdgeMaterialParams();
+    _logger.info("Updated silhouette texture reference");
+  }
+
   /// Update viewport size.
   @override
   Future setViewport(int width, int height) async {
@@ -287,7 +297,7 @@ class EdgeDetectionView extends FFIView {
     // Set silhouette texture
     await _edgeMaterialInstance.setParameterTexture(
       'silhouette',
-      silhouetteTexture! as FFITexture,
+      _silhouetteTexture as FFITexture,
       _edgeSampler,
     );
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -496,6 +496,9 @@ class FFIView extends View<Pointer<TView>> {
     final camera = await getCamera();
     await _highlightOverlayManager!.setCamera(camera);
 
+    await app.updateRenderOrder();
+
+
     _logger.info("Highlight overlay enabled");
     return true;
   }

--- a/thermion_dart/lib/src/filament/src/implementation/highlight_overlay_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/highlight_overlay_manager.dart
@@ -41,6 +41,7 @@ class HighlightOverlayManager {
       width: actualWidth,
       height: actualHeight,
     );
+    await silhouetteView.setBlendMode(BlendMode.transparent);
 
     // Create edge detection view (second pass)
     final edgeDetectionView = await EdgeDetectionView.create(
@@ -49,6 +50,12 @@ class HighlightOverlayManager {
       height: actualHeight,
       silhouetteTexture: silhouetteView.colorTexture,
     );
+
+    // Wire up texture resize callback so EdgeDetectionView gets notified
+    // when SilhouetteView resizes its render target
+    silhouetteView.onTextureResized = (newTexture) async {
+      await edgeDetectionView.updateSilhouetteTexture(newTexture);
+    };
 
     final manager = HighlightOverlayManager._(
       app,
@@ -66,7 +73,6 @@ class HighlightOverlayManager {
   /// Set the camera for the silhouette view.
   Future<void> setCamera(Camera camera) async {
     await silhouetteView.setCamera(camera);
-    await overlayView.setCamera(camera);
   }
 
   /// Update viewport size for both views.

--- a/thermion_dart/lib/src/filament/src/implementation/silhouette_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/silhouette_view.dart
@@ -21,8 +21,8 @@ class _SilhouetteComponent {
 
 /// Manages the first (silhouette) rendering pass for highlighted entities.
 ///
-/// Renders highlighted entities as white silhouettes to a standalone texture/render target. 
-/// 
+/// Renders highlighted entities as white silhouettes to a standalone texture/render target.
+///
 /// This texture is passed to the edge detection pass.
 ///
 class SilhouetteView extends FFIView {
@@ -31,10 +31,17 @@ class SilhouetteView extends FFIView {
   // Material (owned by this class)
   final FFIMaterial _silhouetteMaterial;
 
-  // Render target resources
-  final FFITexture _colorTexture;
-  final FFITexture _depthTexture;
-  final FFIRenderTarget _renderTarget;
+  // Render target resources (mutable for resize support)
+  FFITexture _colorTexture;
+  FFITexture _depthTexture;
+  FFIRenderTarget _renderTarget;
+
+  // Track current texture dimensions
+  int _textureWidth = 0;
+  int _textureHeight = 0;
+
+  // Callback to notify when texture changes (for EdgeDetectionView)
+  Future<void> Function(Texture)? onTextureResized;
 
   // Scene resources (separate from parent's scene)
   final FFIScene _silhouetteScene;
@@ -52,8 +59,7 @@ class SilhouetteView extends FFIView {
     required FFIRenderTarget renderTarget,
     required FFIScene scene,
     required Skybox skybox,
-  })  : 
-        _silhouetteMaterial = material,
+  })  : _silhouetteMaterial = material,
         _colorTexture = colorTexture,
         _depthTexture = depthTexture,
         _renderTarget = renderTarget,
@@ -99,7 +105,8 @@ class SilhouetteView extends FFIView {
 
     // Create scene with black skybox to clear render target
     final silhouetteScene = await app.createScene() as FFIScene;
-    final skybox = await app.createColoredSkybox(r: 0.0, g: 0.0, b: 0.0, a: 1.0);
+    final skybox =
+        await app.createColoredSkybox(r: 0.0, g: 0.0, b: 0.0, a: 1.0);
     await silhouetteScene.setSkybox(skybox);
 
     // Create the SilhouetteView with all resources
@@ -114,6 +121,10 @@ class SilhouetteView extends FFIView {
       skybox: skybox,
     );
 
+    // Initialize texture dimensions to prevent resize on first setViewport
+    silhouetteView._textureWidth = width;
+    silhouetteView._textureHeight = height;
+
     // Configure this view
     await silhouetteView.setScene(silhouetteScene);
     await silhouetteView.setViewport(width, height);
@@ -122,6 +133,69 @@ class SilhouetteView extends FFIView {
     await silhouetteView.setShadowsEnabled(false);
 
     return silhouetteView;
+  }
+
+  @override
+  Future setViewport(int width, int height) async {
+    _logger.info("setViewport $width x $height (current texture: ${_textureWidth}x${_textureHeight})");
+    await super.setViewport(width, height);
+
+    // Resize if dimensions are valid and different from current texture size
+    if (width > 0 && height > 0 &&
+        (width != _textureWidth || height != _textureHeight)) {
+      await _resizeRenderTarget(width, height);
+    }
+  }
+
+  Future _resizeRenderTarget(int width, int height) async {
+    _logger.info("Resizing render target from ${_textureWidth}x${_textureHeight} to ${width}x${height}");
+
+    // Store old resources for cleanup
+    final oldColorTexture = _colorTexture;
+    final oldDepthTexture = _depthTexture;
+    final oldRenderTarget = _renderTarget;
+
+    // Create new textures
+    _colorTexture = await app.createTexture(
+      width,
+      height,
+      flags: {
+        TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
+        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+      },
+      textureFormat: TextureFormat.RGBA8,
+    ) as FFITexture;
+
+    _depthTexture = await app.createTexture(
+      width,
+      height,
+      flags: {TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT},
+      textureFormat: TextureFormat.DEPTH32F,
+    ) as FFITexture;
+
+    _renderTarget = await app.createRenderTarget(
+      width,
+      height,
+      color: _colorTexture,
+      depth: _depthTexture,
+    ) as FFIRenderTarget;
+
+    // Set new render target on view
+    await setRenderTarget(_renderTarget);
+
+    // Update tracked dimensions
+    _textureWidth = width;
+    _textureHeight = height;
+
+    // Notify listeners (EdgeDetectionView needs new texture reference)
+    await onTextureResized?.call(_colorTexture);
+
+    // Destroy old resources
+    await oldRenderTarget.destroy();
+    await oldColorTexture.dispose();
+    await oldDepthTexture.dispose();
+
+    _logger.info("Render target resized successfully");
   }
 
   /// The color texture containing white silhouettes (for edge detection sampling).
@@ -156,10 +230,8 @@ class SilhouetteView extends FFIView {
   @override
   View? getOverlayView() => throw Exception();
 
-
   @override
   bool hasHighlights() => _components.isNotEmpty;
-
 
   /// Add a highlight for the given entity.
   Future<void> addHighlight({

--- a/thermion_dart/test/view_tests.dart
+++ b/thermion_dart/test/view_tests.dart
@@ -476,8 +476,7 @@ void main() async {
         b: 1.0,
         outlineWidth: 1.0,
       );
-      await FilamentApp.instance!
-          .setClearOptions(1, 1, 1, 0, clear: true, discard: false);
+      
       await FilamentApp.instance!.render();
 
       await testHelper.capture(null, "stencil_highlight_1px_blue",
@@ -485,8 +484,7 @@ void main() async {
 
       // Test that highlight follows object translation
       await cube.setTransform(Matrix4.translation(Vector3(2, 0, 0)));
-      await FilamentApp.instance!
-          .setClearOptions(1, 1, 1, 0, clear: true, discard: false);
+      
       await FilamentApp.instance!.render();
 
       await testHelper.capture(null, "stencil_highlight_after_translate",
@@ -495,8 +493,7 @@ void main() async {
       // Test that highlight follows object rotation
       await cube.setTransform(
           Matrix4.translation(Vector3(-2, 1, 0)) * Matrix4.rotationZ(0.5));
-      await FilamentApp.instance!
-          .setClearOptions(1, 1, 1, 0, clear: true, discard: false);
+      
       await FilamentApp.instance!.render();
 
       await testHelper.capture(null, "stencil_highlight_after_rotate",
@@ -505,8 +502,7 @@ void main() async {
       // Test that highlight works after camera change
       final camera = await result.viewer.view.getCamera();
       await camera.lookAt(Vector3(5, 3, 10), focus: Vector3(0, 0, 0));
-      await FilamentApp.instance!
-          .setClearOptions(1, 1, 1, 0, clear: true, discard: false);
+      
       await FilamentApp.instance!.render();
 
       await testHelper.capture(null, "stencil_highlight_after_camera_move",

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -22,22 +22,44 @@ class ThermionWidget extends StatefulWidget {
 class _ThermionWidgetState extends State<ThermionWidget> {
   @override
   Widget build(BuildContext context) {
-    // if (widget.enableOverlay) {
-    //   final overlayView = widget.viewer.view.getOverlayView();
+    if (widget.enableOverlay) {
+      final overlayView = widget.viewer.view.getOverlayView();
 
-    //     return Stack(children: [
-    //       Positioned.fill(
-    //           child: ThermionWidgetInternal(
-    //             key: Key("main_texture_view"),
-    //             view: widget.viewer.view)),
-    //       Positioned.fill(
-            
-    //         child: ThermionWidgetInternal(
-    //           key: Key("overlay_texture_view"),
-    //           view: overlayView!))
-    //     ]);
+      return Stack(children: [
+        Positioned.fill(
+            child: ThermionWidgetInternal(
+                key: Key("main_texture_view"),
+                onTextureUpdated: (descriptor) async {
+                  if (descriptor == null) {
+                    return;
+                  }
+                  final view = widget.viewer.view;
+                  var camera = await view.getCamera();
+                  var near = await camera.getNear();
+                  var far = await camera.getCullingFar();
+                  var focalLength = await camera.getFocalLength();
 
-    // }
+                  await camera.setLensProjection(
+                      near: near,
+                      far: far,
+                      focalLength: focalLength,
+                      aspect: descriptor.width.toDouble() /
+                          descriptor.height.toDouble());
+
+                  await view.setViewport(descriptor.width, descriptor.height);
+                },
+                view: widget.viewer.view)),
+        Positioned.fill(
+            child: ThermionWidgetInternal(
+                key: Key("overlay_texture_view"),
+                view: overlayView!,
+                onTextureUpdated: (descriptor) async {
+                  if (descriptor == null) {
+                    return;
+                  }
+                }))
+      ]);
+    }
     return ThermionWidgetInternal(view: widget.viewer.view);
   }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_native_texture.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_native_texture.dart
@@ -1,17 +1,20 @@
 import 'dart:async';
+
 import 'package:flutter/material.dart' hide View;
 import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
 import 'package:thermion_flutter/thermion_flutter.dart' hide Texture;
 
-// Inserts [view] into the widget tree by allocating a hardware surface 
-// and binding to the [view]. The actual implementation 
-// (e.g. texture vs window, render target vs swapchain, etc) will differ by 
+// Inserts [view] into the widget tree by allocating a hardware surface
+// and binding to the [view]. The actual implementation
+// (e.g. texture vs window, render target vs swapchain, etc) will differ by
 // the actual platform; see [ThermionFlutterPluginImpl] for details.
 class ThermionWidgetInternal extends StatefulWidget {
   
   final View view;
+  
+  final void Function(PlatformTextureDescriptor? descriptor)? onTextureUpdated;
 
-  ThermionWidgetInternal({super.key, required this.view});
+  ThermionWidgetInternal({super.key, required this.view, this.onTextureUpdated});
 
   @override
   State<ThermionWidgetInternal> createState() => _ThermionWidgetInternalState();
@@ -93,6 +96,8 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
   void _allocateTexture(int width, int height) async {
     final texture = await ThermionFlutterPlugin.instance
         .createTextureAndBindToView(widget.view, width, height);
+
+    widget.onTextureUpdated?.call(texture);
 
     if (!mounted) {
       texture?.destroy();

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_stub.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_stub.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart' hide View;
 import 'package:thermion_flutter/thermion_flutter.dart';
 
+import '../../../platform/src/platform_texture_descriptor.dart';
+
 // A stub implementation to satisfy the analyzer.
 class ThermionWidgetInternal extends StatelessWidget {
   
   final View view;
+  
+  final void Function(PlatformTextureDescriptor? descriptor)? onTextureUpdated;
 
-  const ThermionWidgetInternal({
-    super.key,
-    required this.view
-  });
+  const ThermionWidgetInternal(
+      {super.key, required this.view, this.onTextureUpdated});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This PR refactors the highlight overlay system to remove the C++ implementation (which duplicated a lot of unnecessary code) in favour of a simpler Dart implementation (HighlightOverlayManager). Each View has its own HighlightOverlayManager which creates two internal Views (each with their own Scene). The first View renders the silhouette of any objects marked via `View.setStencilHighlight` into a render target, and the second View reads from the color attachment of the first to detect the edges of the silhouette. By default, this second view renders into the swapchain, but on Flutter, passing `enableOverlay` to a `ThermionWidget` will setup a render target for the second view and compose this on top of the 'main' view.

This is only supported on macOS, iOS and Windows, where we have a strict association where a ThermionWidget is associated with exactly one View and one RenderTarget/texture. This makes it easier to compose one or more Views on top of another, e.g. for highlight overlays. Web and Android support to be handled separately.