### PR TITLE
Refactor/filament app singleton

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
@@ -1,4 +1,3 @@
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 
 import '../../../utils/src/matrix.dart';
@@ -11,10 +10,9 @@ class FFICamera extends Camera<Pointer<TCamera>> {
     return camera;
   }
 
-  final FFIFilamentApp app;
   late ThermionEntity _entity;
 
-  FFICamera(this.camera, this.app) {
+  FFICamera(this.camera) {
     _entity = Camera_getEntity(camera);
   }
 
@@ -281,7 +279,7 @@ class FFICamera extends Camera<Pointer<TCamera>> {
   }
 
   Future destroy() async {
-    Engine_destroyCamera(app.engine, camera);
+    Engine_destroyCamera(FilamentApp.instance!.engine, camera);
   }
 
   Future setExposure(

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 import 'package:thermion_dart/thermion_dart.dart';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 
 /// FFI implementation of ColorGrading
 class FFIColorGrading extends ColorGrading {
   final Pointer<TColorGrading> pointer;
-  final FFIFilamentApp app;
 
-  FFIColorGrading(this.pointer, this.app);
+  FFIColorGrading(this.pointer);
 
   @override
   Pointer<TColorGrading> getNativeHandle() => pointer;
@@ -15,17 +13,16 @@ class FFIColorGrading extends ColorGrading {
   @override
   Future dispose() async {
     await withVoidCallback((requestId, cb) =>
-        Engine_destroyColorGradingRenderThread(app.engine, pointer, requestId, cb));
+        Engine_destroyColorGradingRenderThread(FilamentApp.instance!.engine, pointer, requestId, cb));
   }
 }
 
 /// FFI implementation of ColorGradingBuilder
 class FFIColorGradingBuilder extends ColorGradingBuilder {
   final Pointer<TColorGradingBuilder> _builder;
-  final FFIFilamentApp _app;
   bool _built = false;
 
-  FFIColorGradingBuilder(this._builder, this._app);
+  FFIColorGradingBuilder(this._builder);
 
   void _checkNotBuilt() {
     if (_built) {
@@ -163,12 +160,12 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
     _checkNotBuilt();
     _built = true;
     final ptr = await withPointerCallback<TColorGrading>((cb) =>
-        ColorGradingBuilder_buildRenderThread(_builder, _app.engine, cb));
+        ColorGradingBuilder_buildRenderThread(_builder, FilamentApp.instance!.engine, cb));
     await withVoidCallback((requestId, cb) =>
         ColorGradingBuilder_destroyRenderThread(_builder, requestId, cb));
     if (ptr == nullptr) {
       throw Exception('Failed to build ColorGrading');
     }
-    return FFIColorGrading(ptr, _app);
+    return FFIColorGrading(ptr);
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -270,8 +270,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
   Future<View> createView({bool createScene = false}) async {
     final view = await FFIView(
         await withPointerCallback<TView>(
-            (cb) => Engine_createViewRenderThread(engine, cb)),
-        this);
+            (cb) => Engine_createViewRenderThread(engine, cb)));
     await view.setFrustumCullingEnabled(true);
     await view.setBloom(false, 0.0);
     await view.setBlendMode(BlendMode.transparent);
@@ -298,8 +297,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     targetEntity ??= await createEntity(createTransformComponent: false);
     return FFICamera(
         await withPointerCallback<TCamera>(
-            (cb) => Engine_createCameraRenderThread(engine, targetEntity!, cb)),
-        this);
+            (cb) => Engine_createCameraRenderThread(engine, targetEntity!, cb)));
   }
 
   ///
@@ -416,7 +414,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       throw Exception("Failed to create RenderTarget");
     }
 
-    return FFIRenderTarget(renderTarget, this);
+    return FFIRenderTarget(renderTarget);
   }
 
   ///
@@ -528,7 +526,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       //stackRestore(stackPtr);
       data.free();
     }
-    return FFIMaterial(ptr, this);
+    return FFIMaterial(ptr);
   }
 
   ///
@@ -622,7 +620,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       throw Exception("Failed to create material instance");
     }
 
-    var instance = FFIMaterialInstance(materialInstance, this);
+    var instance = FFIMaterialInstance(materialInstance);
     return instance;
   }
 
@@ -785,8 +783,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     if (_imageMaterial == null) {
       var ptr = await withPointerCallback<TMaterial>(
           (cb) => Material_createImageMaterialRenderThread(engine, cb));
-      _imageMaterial =
-          FFIMaterial(ptr, FilamentApp.instance! as FFIFilamentApp);
+      _imageMaterial = FFIMaterial(ptr);
     }
     var instance =
         await _imageMaterial!.createInstance() as FFIMaterialInstance;
@@ -1118,7 +1115,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       final materialPtr = await withPointerCallback<TMaterial>((cb) {
         Material_createGizmoMaterialRenderThread(engine, cb);
       });
-      _gizmoMaterial ??= FFIMaterial(materialPtr, this);
+      _gizmoMaterial ??= FFIMaterial(materialPtr);
     }
 
     var gltfResourceLoader = await withPointerCallback<TGltfResourceLoader>(

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_material.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_material.dart
@@ -1,25 +1,24 @@
 import 'dart:async';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 
 class FFIMaterial extends Material<Pointer<TMaterial>> {
-  final FFIFilamentApp app;
+  
   final Pointer<TMaterial> pointer;
 
-  FFIMaterial(this.pointer, this.app);
+  FFIMaterial(this.pointer);
 
   @override
   Future<MaterialInstance> createInstance() async {
     var ptr = await withPointerCallback<TMaterialInstance>((cb) {
       Material_createInstanceRenderThread(pointer, cb);
     });
-    return FFIMaterialInstance(ptr, this.app);
+    return FFIMaterialInstance(ptr);
   }
 
   Future destroy() async {
     await withVoidCallback((requestId, cb) {
-      Engine_destroyMaterialRenderThread(app.engine, pointer, requestId, cb);
+      Engine_destroyMaterialRenderThread(FilamentApp.instance!.engine, pointer, requestId, cb);
     });
   }
 
@@ -37,9 +36,8 @@ class FFIMaterial extends Material<Pointer<TMaterial>> {
 
 class FFIMaterialInstance extends MaterialInstance<Pointer<TMaterialInstance>> {
   final Pointer<TMaterialInstance> pointer;
-  final FFIFilamentApp app;
 
-  FFIMaterialInstance(this.pointer, this.app) {
+  FFIMaterialInstance(this.pointer) {
     if (pointer == nullptr) {
       throw Exception("MaterialInstance not found");
     }
@@ -180,7 +178,7 @@ class FFIMaterialInstance extends MaterialInstance<Pointer<TMaterialInstance>> {
   Future destroy() async {
     await withVoidCallback((requestId, cb) {
       Engine_destroyMaterialInstanceRenderThread(
-          app.engine, this.pointer, requestId, cb);
+          FilamentApp.instance!.engine, this.pointer, requestId, cb);
     });
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_target.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_target.dart
@@ -1,30 +1,28 @@
 import 'package:thermion_dart/src/bindings/bindings.dart';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 
 class FFIRenderTarget extends RenderTarget<Pointer<TRenderTarget>> {
   final Pointer<TRenderTarget> renderTarget;
-  final FFIFilamentApp app;
 
-  FFIRenderTarget(this.renderTarget, this.app);
+  FFIRenderTarget(this.renderTarget);
 
   @override
   Future<Texture> getColorTexture() async {
     final ptr = RenderTarget_getColorTexture(renderTarget);
-    return FFITexture(app.engine, ptr);
+    return FFITexture(FilamentApp.instance!.engine, ptr);
   }
 
   @override
   Future<Texture> getDepthTexture() async {
     final ptr = RenderTarget_getDepthTexture(renderTarget);
-    return FFITexture(app.engine, ptr);
+    return FFITexture(FilamentApp.instance!.engine, ptr);
   }
 
   @override
   Future destroy() async {
     await withVoidCallback((requestId, cb) => RenderTarget_destroyRenderThread(
-        app.engine, renderTarget, requestId, cb));
+        FilamentApp.instance!.engine, renderTarget, requestId, cb));
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -22,16 +22,14 @@ class FFIView extends View<Pointer<TView>> {
 
   Pointer<TView> getNativeHandle() => view;
 
-  final FFIFilamentApp app;
-
   RenderTarget? renderTarget;
 
   late CallbackHolder<PickCallbackFunction> _onPickResultHolder;
 
-  FFIView(this.view, this.app) {
+  FFIView(this.view) {
     final renderTargetPtr = View_getRenderTarget(view);
     if (renderTargetPtr != nullptr) {
-      renderTarget = FFIRenderTarget(renderTargetPtr, app);
+      renderTarget = FFIRenderTarget(renderTargetPtr);
     }
 
     _onPickResultHolder = _onPickResult.asCallback();
@@ -80,7 +78,7 @@ class FFIView extends View<Pointer<TView>> {
       } else {
         // Manager exists but not yet initialized — initialize now with this RT
         await _highlightOverlayManager!.initialize(this, renderTarget, null);
-        await app.updateRenderOrder();
+        await (FilamentApp.instance! as FFIFilamentApp).updateRenderOrder();
         _logger.info("Highlight overlay late-initialized with render target");
         return;
       }
@@ -112,7 +110,7 @@ class FFIView extends View<Pointer<TView>> {
   @override
   Future<Camera> getCamera() async {
     final cameraPtr = View_getCamera(view);
-    return FFICamera(cameraPtr, app);
+    return FFICamera(cameraPtr);
   }
 
   @override
@@ -143,7 +141,7 @@ class FFIView extends View<Pointer<TView>> {
   Future setToneMapper(ToneMapper mapper) async {
     final colorGrading = await withPointerCallback<TColorGrading>((cb) =>
         ColorGrading_createRenderThread(
-            app.engine, mapper.getNativeHandle(), cb));
+            FilamentApp.instance!.engine, mapper.getNativeHandle(), cb));
     if (colorGrading == nullptr) {
       throw Exception("Failed to create color grading");
     }
@@ -166,7 +164,7 @@ class FFIView extends View<Pointer<TView>> {
     if (builderPtr == nullptr) {
       throw Exception('Failed to create ColorGradingBuilder');
     }
-    return FFIColorGradingBuilder(builderPtr, app);
+    return FFIColorGradingBuilder(builderPtr);
   }
 
   @override
@@ -189,7 +187,7 @@ class FFIView extends View<Pointer<TView>> {
     if (colorGradingPtr == nullptr) {
       return null;
     }
-    return FFIColorGrading(colorGradingPtr, app);
+    return FFIColorGrading(colorGradingPtr);
   }
 
   Future setStencilBufferEnabled(bool enabled) async {
@@ -316,7 +314,7 @@ class FFIView extends View<Pointer<TView>> {
 
     Texture? skyColor;
     if (tOptions.skyColor != nullptr) {
-      skyColor = FFITexture(app.engine, tOptions.skyColor);
+      skyColor = FFITexture(FilamentApp.instance!.engine, tOptions.skyColor);
     }
 
     return FogOptions(
@@ -494,7 +492,7 @@ class FFIView extends View<Pointer<TView>> {
     // Create manager if not exists
     if (_highlightOverlayManager == null) {
       _highlightOverlayManager = await HighlightOverlayManager.create(
-        app,
+        FilamentApp.instance! as FFIFilamentApp,
         width: width,
         height: height,
       );
@@ -507,7 +505,7 @@ class FFIView extends View<Pointer<TView>> {
     // Get swapchain if render target is null (Android/swapchain case)
     FFISwapChain? swapChain;
     if (renderTarget == null) {
-      swapChain = await app.getSwapChain(this) as FFISwapChain?;
+      swapChain = await FilamentApp.instance!.getSwapChain(this) as FFISwapChain?;
     }
 
     // Initialize if we have RT/swapchain and not yet initialized
@@ -522,7 +520,7 @@ class FFIView extends View<Pointer<TView>> {
       _logger.warning("No render target or swapchain available for highlight overlay");
     }
 
-    await app.updateRenderOrder();
+    await (FilamentApp.instance! as FFIFilamentApp).updateRenderOrder();
 
     return true;
   }
@@ -540,7 +538,7 @@ class FFIView extends View<Pointer<TView>> {
     _highlightOverlayManager = null;
 
     // Update render order to remove silhouette/overlay views
-    await app.updateRenderOrder();
+    await (FilamentApp.instance! as FFIFilamentApp).updateRenderOrder();
 
     _logger.info("Highlight overlay disabled");
   }
@@ -589,7 +587,7 @@ class FFIView extends View<Pointer<TView>> {
     }
 
     final indexCount = IndexBuffer_getIndexCount(indexBuffer);
-    final ffiIndexBuffer = FFIIndexBuffer(indexBuffer, app.engine);
+    final ffiIndexBuffer = FFIIndexBuffer(indexBuffer, FilamentApp.instance!.engine);
 
     for (final entity in entities) {
       if (!await FilamentApp.instance!.isRenderable(entity)) {
@@ -608,7 +606,7 @@ class FFIView extends View<Pointer<TView>> {
     }
 
     // Update render order to include silhouette/overlay views
-    await app.updateRenderOrder();
+    await (FilamentApp.instance! as FFIFilamentApp).updateRenderOrder();
 
     _logger.info("Added stencil highlight for asset (entity ${asset.entity})");
   }
@@ -642,7 +640,7 @@ class FFIView extends View<Pointer<TView>> {
     }
 
     // Update render order to remove silhouette/overlay views if no more highlights
-    await app.updateRenderOrder();
+    await (FilamentApp.instance! as FFIFilamentApp).updateRenderOrder();
   }
 
   void setName(String name) {

--- a/thermion_dart/lib/src/filament/src/implementation/grid_overlay.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/grid_overlay.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:thermion_dart/src/filament/src/implementation/ffi_asset.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_material.dart';
@@ -38,7 +36,7 @@ class GridOverlay {
       FFIFilamentApp app, {List<LinearColor> axisColors = kDefaultAxisColors, LinearColor gridColor = kDefaultGridColor } ) async {
     if (_instance == null) {
       _gridMaterial ??=
-          FFIMaterial(Material_createGridMaterial(app.engine), app);
+          FFIMaterial(Material_createGridMaterial(app.engine));
 
       final assets = <FFIAsset>[];
 


### PR DESCRIPTION
We don't need to pass around the FilamentApp instance, this is now a singleton whose lifetime matches the life of the application and can be accessed via the static FilamentApp.instance property.