### PR TITLE
fix(ffi): use calloc for material instance pointers passed to render thread

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -120,31 +120,24 @@ class FFIAsset extends ThermionAsset {
       throw Exception(
           "keepData must have been specified as true when this asset was created");
     }
-    var ptrList = IntPtrList(materialInstances?.length ?? 0);
-    late Pointer stackPtr;
-    if (FILAMENT_WASM) {
-      //stackPtr = stackSave();
-    }
-
+    // Allocate material instance pointers in native memory. The pointer
+    // array is read asynchronously by the render thread, so it must not be
+    // backed by Dart GC-managed memory (the GC may relocate the backing
+    // store between the queue and the read, causing a SIGSEGV).
+    final miCount = materialInstances?.length ?? 0;
+    final ptrList = calloc<IntPtr>(miCount == 0 ? 1 : miCount);
     if (materialInstances != null && materialInstances.isNotEmpty) {
-      ptrList.setRange(
-          0,
-          materialInstances.length,
-          materialInstances
-              .cast<FFIMaterialInstance>()
-              .map((mi) => mi.pointer.address)
-              .toList());
+      for (int i = 0; i < materialInstances.length; i++) {
+        ptrList[i] = (materialInstances[i] as FFIMaterialInstance).pointer.address;
+      }
     }
 
     var created = await withPointerCallback<TSceneAsset>((cb) {
       SceneAsset_createInstanceRenderThread(
-          asset, ptrList.address.cast(), materialInstances?.length ?? 0, cb);
+          asset, ptrList.cast(), miCount, cb);
     });
 
-    if (FILAMENT_WASM) {
-      //stackRestore(stackPtr);
-      ptrList.free();
-    }
+    calloc.free(ptrList);
 
     if (created == nullptr) {
       throw Exception("Failed to create instance");

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -1357,16 +1357,16 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     cAabb.halfExtentY = halfExtentY;
     cAabb.halfExtentZ = halfExtentZ;
 
-    // Prepare material instance pointers
-    final ptrList = makeIntPtrList(materialInstances?.length ?? 0);
+    // Prepare material instance pointers in native-allocated memory.
+    // The pointer array is read asynchronously by the render thread, so it
+    // must not be backed by Dart GC-managed memory (the GC may relocate the
+    // backing store between the queue and the read, causing a SIGSEGV).
+    final miCount = materialInstances?.length ?? 0;
+    final ptrList = calloc<IntPtr>(miCount == 0 ? 1 : miCount);
     if (materialInstances != null) {
-      ptrList.setRange(
-          0,
-          materialInstances.length,
-          materialInstances
-              .cast<FFIMaterialInstance>()
-              .map((mi) => mi.pointer.address)
-              .toList());
+      for (int i = 0; i < materialInstances.length; i++) {
+        ptrList[i] = (materialInstances[i] as FFIMaterialInstance).pointer.address;
+      }
     }
 
     // Create the scene asset from buffers
@@ -1375,8 +1375,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
           engine,
           vertexBuffer.getNativeHandle(),
           indexBuffer.getNativeHandle(),
-          ptrList.address.cast(),
-          ptrList.length ?? 0,
+          ptrList.cast(),
+          miCount,
           geometry.primitiveType.index,
           cAabb,
           callback);
@@ -1385,7 +1385,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
     geometry.dispose();
 
-    ptrList.free();
+    calloc.free(ptrList);
     tangentQuaternions?.free();
 
     if (FILAMENT_WASM) {


### PR DESCRIPTION
`SceneAsset_createFromBuffersRenderThread` and `SceneAsset_createInstanceRenderThread` read the material instance pointer array asynchronously on the render thread. The array was backed by a Dart GC-managed `Int64List` (via `makeIntPtrList`/`IntPtrList`). Between the queue and the render thread read, the Dart GC may relocate or collect the backing store, leaving the render thread reading from unmapped memory — SIGSEGV in `GeometrySceneAsset` constructor's `vector::insert`.

Replace the GC-managed `Int64List` with `calloc`-allocated native memory that is stable across the async boundary and explicitly freed after the render thread callback completes.