### PR TITLE
fix: resolve bone animation bugs (getBoneNames, playback, loop)

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -5571,7 +5571,8 @@ external void AnimationManager_resetToRestPose(
         ffi.Float,
         ffi.Float,
         ffi.Float,
-        ffi.Float)>(isLeaf: true)
+        ffi.Float,
+        ffi.Bool)>(isLeaf: true)
 external bool AnimationManager_addBoneAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -5583,6 +5584,7 @@ external bool AnimationManager_addBoneAnimation(
   double fadeOutInSecs,
   double fadeInInSecs,
   double maxDelta,
+  bool loop,
 );
 
 @ffi.Native<

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_animation_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_animation_manager.dart
@@ -235,7 +235,8 @@ class FFIAnimationManager
       List<double> frameData, int numFrames, double frameLengthInMs,
       {double fadeOutInSecs = 0.0,
       double fadeInInSecs = 0.0,
-      double maxDelta = 0.1}) {
+      double maxDelta = 0.1,
+      bool loop = false}) {
     late Pointer stackPtr;
     if (FILAMENT_WASM) {
       stackPtr = stackSave();
@@ -255,7 +256,8 @@ class FFIAnimationManager
           frameLengthInMs,
           fadeOutInSecs,
           fadeInInSecs,
-          maxDelta);
+          maxDelta,
+          loop);
     } finally {
       frameDataPtr.free();
       if (FILAMENT_WASM) {
@@ -285,34 +287,25 @@ class FFIAnimationManager
       return [];
     }
 
-    late Pointer stackPtr;
-    if (FILAMENT_WASM) {
-      stackPtr = stackSave();
+    // The native AnimationManager_getBoneNames is unimplemented (no-op),
+    // so we resolve bone names via NameComponentManager instead.
+    // For each bone entity, look up its name in the NameComponentManager.
+    final boneNames = <String>[];
+    for (int i = 0; i < boneCount; i++) {
+      final boneEntity = getBone(asset, skinIndex, i);
+      if (boneEntity != null) {
+        final namePtr = bindings.NameComponentManager_getName(
+            app.nameComponentManager, boneEntity);
+        if (namePtr != bindings.nullptr) {
+          boneNames.add(namePtr.cast<Utf8>().toDartString());
+        } else {
+          boneNames.add('');
+        }
+      } else {
+        boneNames.add('');
+      }
     }
-
-    throw UnimplementedError();
-
-    // final namePointers = allocate<Char>(boneCount);
-    // try {
-    //   bindings.AnimationManager_getBoneNames(
-    //       animationManager, asset.getNativeHandle(), namePointers.cast(), skinIndex);
-
-    //   final boneNames = <String>[];
-    //   for (int i = 0; i < boneCount; i++) {
-    //     final namePtr = namePointers[i];
-    //     if (namePtr != nullptr) {
-    //       final name = namePtr.cast<Utf8>().toDartString();
-    //       boneNames.add(name);
-    //     }
-    //   }
-
-    //   return boneNames;
-    // } finally {
-    //   free(namePointers.cast());
-    //   if (FILAMENT_WASM) {
-    //     stackRestore(stackPtr);
-    //   }
-    // }
+    return boneNames;
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -381,7 +381,18 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future<List<String>> getBoneNames({int skinIndex = 0}) async {
-    return FilamentApp.instance!.animationManager.getBoneNames(this, skinIndex);
+    // The native getBoneCount/getBoneNames requires a GltfSceneAssetInstance,
+    // not a top-level GltfSceneAsset. Auto-resolve to instance(0) if needed.
+    ThermionAsset target = this;
+    if (!isInstance) {
+      try {
+        target = await getInstance(0);
+      } catch (_) {
+        // Fall through with self
+      }
+    }
+    return FilamentApp.instance!.animationManager
+        .getBoneNames(target, skinIndex);
   }
 
   List<String>? _gltfAnimationNames;
@@ -517,7 +528,8 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       {int skinIndex = 0,
       double fadeOutInSecs = 0.0,
       double fadeInInSecs = 0.0,
-      double maxDelta = 1.0}) async {
+      double maxDelta = 1.0,
+      bool loop = false}) async {
     if (animation.space != Space.Bone &&
         animation.space != Space.ParentWorldRotation) {
       throw UnimplementedError("TODO - support ${animation.space}");
@@ -525,9 +537,20 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     if (skinIndex != 0) {
       throw UnimplementedError("TODO - support skinIndex != 0 ");
     }
-    var boneNames = await getBoneNames();
+    // Resolve to instance(0) if this is a top-level asset — the native
+    // bone APIs (getBoneCount, getBone, getRestLocalTransforms) require
+    // a GltfSceneAssetInstance, not a GltfSceneAsset.
+    FFIAsset instanceAsset = this;
+    if (!isInstance) {
+      try {
+        instanceAsset = (await getInstance(0)) as FFIAsset;
+      } catch (_) {
+        // Fall through with self
+      }
+    }
+    var boneNames = await instanceAsset.getBoneNames(skinIndex: skinIndex);
     var restLocalTransformsData = FilamentApp.instance!.animationManager
-        .getRestLocalTransforms(this, skinIndex);
+        .getRestLocalTransforms(instanceAsset, skinIndex);
     var restLocalTransforms = <Matrix4>[];
     for (int i = 0; i < boneNames.length; i++) {
       var values = <double>[];
@@ -542,7 +565,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     var data = allocate<Float>(numFrames * 16);
 
     var bones = await Future.wait(List<Future<ThermionEntity>>.generate(
-        boneNames.length, (i) => getBone(i)));
+        boneNames.length, (i) => instanceAsset.getBone(i)));
 
     for (int i = 0; i < animation.bones.length; i++) {
       var boneName = animation.bones[i];
@@ -597,7 +620,8 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
           entityBoneIndex, frameDataList, numFrames, animation.frameLengthInMs,
           fadeOutInSecs: fadeOutInSecs,
           fadeInInSecs: fadeInInSecs,
-          maxDelta: maxDelta);
+          maxDelta: maxDelta,
+          loop: loop);
     }
     free(data);
   }

--- a/thermion_dart/lib/src/filament/src/interface/animation_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/animation_manager.dart
@@ -183,7 +183,8 @@ abstract class AnimationManager<T> extends NativeHandle<T> {
       double frameLengthInMs,
       {double fadeOutInSecs = 0.0,
       double fadeInInSecs = 0.0,
-      double maxDelta = 0.1});
+      double maxDelta = 0.1,
+      bool loop = false});
 
   /// Gets the entity ID for a specific bone.
   ///

--- a/thermion_dart/lib/src/filament/src/interface/asset.dart
+++ b/thermion_dart/lib/src/filament/src/interface/asset.dart
@@ -276,7 +276,8 @@ abstract class ThermionAsset<T> extends NativeHandle<T> {
       {int skinIndex = 0,
       double fadeInInSecs = 0.0,
       double fadeOutInSecs = 0.0,
-      double maxDelta = 1.0}) async {
+      double maxDelta = 1.0,
+      bool loop = false}) async {
     throw UnimplementedError();
   }
 

--- a/thermion_dart/native/include/c_api/TAnimationManager.h
+++ b/thermion_dart/native/include/c_api/TAnimationManager.h
@@ -42,7 +42,8 @@ extern "C"
 		float frameLengthInMs,
 		float fadeOutInSecs,
 		float fadeInInSecs,
-		float maxDelta);
+		float maxDelta,
+		bool loop);
 
 	EMSCRIPTEN_KEEPALIVE EntityId AnimationManager_getBone(
 		TAnimationManager *tAnimationManager,

--- a/thermion_dart/native/include/scene/AnimationManager.hpp
+++ b/thermion_dart/native/include/scene/AnimationManager.hpp
@@ -115,7 +115,8 @@ namespace thermion
             float frameLengthInMs,
             float fadeOutInSecs,
             float fadeInInSecs,
-            float maxDelta);
+            float maxDelta,
+            bool loop = false);
 
         
         /// @param instance

--- a/thermion_dart/native/src/c_api/TAnimationManager.cpp
+++ b/thermion_dart/native/src/c_api/TAnimationManager.cpp
@@ -196,13 +196,14 @@ extern "C"
         float frameLengthInMs,
         float fadeOutInSecs,
         float fadeInInSecs,
-        float maxDelta)
+        float maxDelta,
+        bool loop)
     {
         auto sceneAsset = reinterpret_cast<SceneAsset *>(tSceneAsset);
         if(sceneAsset->getType() != SceneAsset::SceneAssetType::Gltf) {
             return false;
         }
-        
+
         auto animationManager = reinterpret_cast<AnimationManager *>(tAnimationManager);
         GltfSceneAssetInstance *instance;
 
@@ -213,9 +214,9 @@ extern "C"
             instance = reinterpret_cast<GltfSceneAssetInstance *>(sceneAsset->getInstanceAt(0));
         }
         animationManager->addBoneAnimationComponent(instance);
-        animationManager->addBoneAnimation(instance, skinIndex, boneIndex, frameData, numFrames, frameLengthInMs, fadeOutInSecs, fadeInInSecs, maxDelta);
+        animationManager->addBoneAnimation(instance, skinIndex, boneIndex, frameData, numFrames, frameLengthInMs, fadeOutInSecs, fadeInInSecs, maxDelta, loop);
         return true;
-        
+
     }
 
     EMSCRIPTEN_KEEPALIVE EntityId AnimationManager_getBone(

--- a/thermion_dart/native/src/components/BoneAnimationComponentManager.cpp
+++ b/thermion_dart/native/src/components/BoneAnimationComponentManager.cpp
@@ -40,7 +40,7 @@ namespace thermion
                 ///                    
                 for (int i = (int)boneAnimations.size() - 1; i >= 0; i--)
                 {
-                    auto animationStatus = boneAnimations[i];
+                    auto &animationStatus = boneAnimations[i];
 
                     // Initialize start time on first use
                     if (animationStatus.startTimeInNanos == 0) {

--- a/thermion_dart/native/src/scene/AnimationManager.cpp
+++ b/thermion_dart/native/src/scene/AnimationManager.cpp
@@ -277,7 +277,8 @@ namespace thermion
                                             float frameLengthInMs,
                                             float fadeOutInSecs,
                                             float fadeInInSecs,
-                                            float maxDelta)
+                                            float maxDelta,
+                                            bool loop)
     {
         std::lock_guard lock(mMutex);
 
@@ -312,6 +313,7 @@ namespace thermion
         animation.frameLengthInMs = frameLengthInMs;
         animation.startTimeInNanos = 0; // Will be set when first update() is called
         animation.reverse = false;
+        animation.loop = loop;
         animation.durationInSecs = (frameLengthInMs * numFrames) / 1000.0f;
         animation.lengthInFrames = numFrames;
         animation.frameLengthInMs = frameLengthInMs;


### PR DESCRIPTION
## Summary

Fixes four issues preventing `addBoneAnimation` from working with separate animation GLB files (i.e., models and animations stored in different .glb files sharing the same skeleton).

- **`getBoneNames` segfault**: Native `getBoneCount`/`getBoneNames` do an unsafe `reinterpret_cast<GltfSceneAssetInstance*>` without checking `isInstance()`, causing a segfault when called on top-level assets returned by `loadGltf`. Fixed in Dart by auto-resolving to `getInstance(0)`.
- **`getBoneNames` returns empty strings**: The C++ `AnimationManager_getBoneNames` body retrieves bone entities but never writes names to the output buffer (no-op). Replaced Dart-side implementation with `NameComponentManager_getName` lookups on each bone entity.
- **Bone animation never plays**: In `BoneAnimationComponentManager::update()`, `auto animationStatus = boneAnimations[i]` copies the struct instead of referencing it. `startTimeInNanos` is written to a discarded copy every frame, so the animation permanently stays in initialization (`continue`). Fixed with `auto &animationStatus`.
- **No `loop` parameter**: `addBoneAnimation` had no way to specify looping — `BoneAnimation::loop` was never set and defaulted to `false`. Added `loop` parameter through the full stack (C++ → C API → FFI bindings → Dart).

## Files changed

| File | Change |
|------|--------|
| `BoneAnimationComponentManager.cpp` | `auto` → `auto&` (1 char fix) |
| `AnimationManager.hpp/.cpp` | Add `loop` param to `addBoneAnimation` |
| `TAnimationManager.h/.cpp` | Add `loop` param to C API |
| `thermion_dart_ffi.g.dart` | Add `loop` to FFI binding |
| `ffi_animation_manager.dart` | Implement `getBoneNames` via NameComponentManager; add `loop` param |
| `ffi_asset.dart` | Auto-resolve to `getInstance(0)` in `getBoneNames`/`addBoneAnimation`; add `loop` param |
| `animation_manager.dart` | Add `loop` to interface |
| `asset.dart` | Add `loop` to interface |

## Test plan

- [x] Load a .glb model with skeleton but no embedded animations
- [x] Load a separate .glb with animations for the same skeleton
- [x] Call `getBoneNames()` on the model — returns correct 23 bone names (was segfault)
- [x] Call `addBoneAnimation(animData, loop: true)` — animation plays and loops (was stuck in T-pose)
- [x] Verified on macOS (Metal backend, Apple M2 Max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)