### PR TITLE
fix: Adding async to transformManager.createComponent() call in ffi_filament_app.dart

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -1450,7 +1450,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       {bool createTransformComponent = true}) async {
     final entity = await withIntCallback((cb) => EntityManager_createEntityRenderThread(Engine_getEntityManager(engine), cb));
     if (createTransformComponent) {
-      transformManager.createComponent(entity);
+      await transformManager.createComponent(entity);
     }
     return entity;
   }


### PR DESCRIPTION
In thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart, transformManager.createComponent() was being called without an await in createEntity(). This led to cases where calls to the transform would silently fail after calling createEntity() because the transform component hadn't added yet.