### PR TITLE
feat: PixelDataFormat.R support in pixel buffer conversion and capture

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -886,7 +886,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
         if (viewport.width <= 0 || viewport.height <= 0) {
           throw Exception(
-              "Invalid viewport dimensions : ${viewport.width}x${viewport.height}");
+              """Invalid viewport dimensions"""
+              """ : ${viewport.width}x${viewport.height}""");
         }
 
         final numBytes =
@@ -908,7 +909,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
         if (captureRenderTarget && renderTarget == null) {
           _logger.warning(
-              "captureRenderTarget is true but the specified view has no render target. Falling back to swapchain capture");
+              """captureRenderTarget is true but the specified view has no"""
+              """ render target. Falling back to swapchain capture""");
         }
 
         await withVoidCallback((requestId, cb) {

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -874,6 +874,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
         int numChannels = switch (pixelDataFormat) {
           PixelDataFormat.RGBA => 4,
           PixelDataFormat.RGB => 3,
+          PixelDataFormat.R => 1,
           _ => throw UnsupportedError(pixelDataFormat.toString())
         };
 

--- a/thermion_dart/lib/src/utils/src/image.dart
+++ b/thermion_dart/lib/src/utils/src/image.dart
@@ -4,7 +4,8 @@ import 'package:image/image.dart' as img;
 import 'package:thermion_dart/thermion_dart.dart';
 
 Future<Uint8List> pixelBufferToBmp(Uint8List pixelBuffer, int width, int height,
-    {bool hasAlpha = true, bool isFloat = false}) async {
+    {bool hasAlpha = true, bool isFloat = false, int numChannels = 0}) async {
+  final channels = numChannels > 0 ? numChannels : (hasAlpha ? 4 : 3);
   final rowSize = (width * 3 + 3) & ~3;
   final padding = rowSize - (width * 3);
   final fileSize = 54 + rowSize * height;
@@ -33,26 +34,34 @@ Future<Uint8List> pixelBufferToBmp(Uint8List pixelBuffer, int width, int height,
 
   if (isFloat) {
     floatData = pixelBuffer.buffer.asFloat32List(
-        pixelBuffer.offsetInBytes, width * height * (hasAlpha ? 4 : 3));
+        pixelBuffer.offsetInBytes, width * height * channels);
   }
 
   // Pixel data (BMP stores in BGR format)
   for (var y = 0; y < height; y++) {
     for (var x = 0; x < width; x++) {
-      final srcIndex = (y * width + x) * (hasAlpha ? 4 : 3); // RGBA format
+      final srcIndex = (y * width + x) * channels;
       final dstIndex = 54 + y * rowSize + x * 3; // BGR format
 
-      data[dstIndex] = isFloat
-          ? (floatData![srcIndex + 2] * 255).toInt()
-          : pixelBuffer[srcIndex + 2]; // Blue
-      data[dstIndex + 1] = isFloat
-          ? (floatData![srcIndex + 1] * 255).toInt()
-          : pixelBuffer[srcIndex + 1]; // Green
-      data[dstIndex + 2] = isFloat
-          ? (floatData![srcIndex] * 255).toInt()
-          : pixelBuffer[srcIndex]; // Red
-
-      // Alpha channel is discarded
+      if (channels == 1) {
+        // Single channel (R) - replicate to grayscale BGR
+        final v = isFloat
+            ? (floatData![srcIndex] * 255).toInt()
+            : pixelBuffer[srcIndex];
+        data[dstIndex] = v;     // Blue
+        data[dstIndex + 1] = v; // Green
+        data[dstIndex + 2] = v; // Red
+      } else {
+        data[dstIndex] = isFloat
+            ? (floatData![srcIndex + 2] * 255).toInt()
+            : pixelBuffer[srcIndex + 2]; // Blue
+        data[dstIndex + 1] = isFloat
+            ? (floatData![srcIndex + 1] * 255).toInt()
+            : pixelBuffer[srcIndex + 1]; // Green
+        data[dstIndex + 2] = isFloat
+            ? (floatData![srcIndex] * 255).toInt()
+            : pixelBuffer[srcIndex]; // Red
+      }
     }
     // Add padding to the end of each row
     for (var p = 0; p < padding; p++) {
@@ -68,27 +77,37 @@ Future<Uint8List> pixelBufferToPng(Uint8List pixelBuffer, int width, int height,
     bool isFloat = false,
     bool linearToSrgb = false,
     bool invertAces = false,
-    bool flipY = false}) async {
+    bool flipY = false,
+    int numChannels = 0}) async {
+  final channels = numChannels > 0 ? numChannels : (hasAlpha ? 4 : 3);
   final image = img.Image(width: width, height: height);
 
   Float32List? floatData;
   if (isFloat) {
     floatData = pixelBuffer.buffer.asFloat32List(
-        pixelBuffer.offsetInBytes, width * height * (hasAlpha ? 4 : 3));
+        pixelBuffer.offsetInBytes, width * height * channels);
   }
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
       late int pixelIndex;
       if (flipY) {
-        pixelIndex = ((height - 1 - y) * width + x) * (hasAlpha ? 4 : 3);
+        pixelIndex = ((height - 1 - y) * width + x) * channels;
       } else {
-        pixelIndex = (y * width + x) * (hasAlpha ? 4 : 3);
+        pixelIndex = (y * width + x) * channels;
       }
 
       double r, g, b, a;
 
-      if (isFloat) {
+      if (channels == 1) {
+        // Single channel (R) - replicate to grayscale
+        if (isFloat) {
+          r = g = b = floatData![pixelIndex];
+        } else {
+          r = g = b = pixelBuffer[pixelIndex] / 255.0;
+        }
+        a = 1.0;
+      } else if (isFloat) {
         r = floatData![pixelIndex];
         g = floatData[pixelIndex + 1];
         b = floatData[pixelIndex + 2];

--- a/thermion_dart/test/depth_tests.dart
+++ b/thermion_dart/test/depth_tests.dart
@@ -1,14 +1,8 @@
 @Timeout(const Duration(seconds: 600))
-import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
 import 'package:test/test.dart';
-import 'package:thermion_dart/src/bindings/bindings.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_asset.dart';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_camera.dart';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_material.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_render_target.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_scene.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_swapchain.dart';
@@ -16,13 +10,14 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_view.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 import 'helpers.dart';
 
-void checkMinMaxPixelValues(Float32List pixelBuffer, int width, int height) {
+void checkMinMaxPixelValues(Float32List pixelBuffer, int width, int height,
+    {int channels = 1}) {
   var minVal = 99999.0;
   var maxVal = 0.0;
   for (var y = 0; y < height; y++) {
     for (var x = 0; x < width; x++) {
-      for (int i = 0; i < 3; i++) {
-        final srcIndex = (y * width * 4) + (x * 4) + i;
+      for (int i = 0; i < channels; i++) {
+        final srcIndex = (y * width * channels) + (x * channels) + i;
         if (pixelBuffer[srcIndex] == 0) {
           continue;
         }
@@ -76,7 +71,7 @@ void main() async {
     final dist = 2.0;
     await camera.lookAt(
       Vector3(
-        -0.5,
+        -5,
         dist,
         dist,
       ),
@@ -101,80 +96,9 @@ void main() async {
 
     await cube.setTransform(
         Matrix4.compose(Vector3.zero(), Quaternion.identity(), Vector3.all(1)));
-    await cube.setMaterialInstanceAt(mi as FFIMaterialInstance);
-    await FilamentApp.instance!.register(swapChain, view);
+    await cube.setMaterialInstanceAt(mi);
+    await FilamentApp.instance!.setRenderOrder(swapChain, view);
     var pixelBuffers = await testHelper.capture(null, "linear_depth",
-        swapChain: swapChain, pixelDataFormat: PixelDataFormat.R);
-    checkMinMaxPixelValues(pixelBuffers[view]!.buffer.asFloat32List(),
-        viewportDimensions.width, viewportDimensions.height);
-  });
-
-  test('check NDC depth value', () async {
-    final viewportDimensions = (width: 512, height: 512);
-    var swapChain = await FilamentApp.instance!.createHeadlessSwapChain(
-        viewportDimensions.width, viewportDimensions.height) as FFISwapChain;
-
-    var color = await FilamentApp.instance!
-        .createTexture(viewportDimensions.width, viewportDimensions.height,
-            flags: {
-              TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-              TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
-              TextureUsage.TEXTURE_USAGE_SAMPLEABLE
-            },
-            textureFormat: TextureFormat.R32F);
-
-    var renderTarget = await FilamentApp.instance!.createRenderTarget(
-            viewportDimensions.width, viewportDimensions.height, color: color)
-        as FFIRenderTarget;
-
-    var view = await FilamentApp.instance!.createView() as FFIView;
-    await view.setPostProcessing(false);
-    await view.setRenderTarget(renderTarget);
-
-    await FilamentApp.instance!.setClearOptions(0.0, 1.0, 0.0, 1.0);
-    var scene = await FilamentApp.instance!.createScene() as FFIScene;
-
-    await view.setScene(scene);
-    await view.setViewport(viewportDimensions.width, viewportDimensions.height);
-    final camera = await FilamentApp.instance!.createCamera();
-
-    await camera.setLensProjection();
-
-    await view.setCamera(camera);
-
-    await view.setFrustumCullingEnabled(false);
-    await camera.setLensProjection(near: 0.5, far: 10);
-    final dist = 3.0;
-    await camera.lookAt(
-      Vector3(
-        -0.5,
-        dist,
-        dist,
-      ),
-    );
-
-    var mat = await FilamentApp.instance!.createMaterial(
-      File(
-        "/Users/nickfisher/Documents/thermion/materials/ndc_depth.filamat",
-      ).readAsBytesSync(),
-    );
-    var mi = await mat.createInstance();
-    await mi.setDepthCullingEnabled(true);
-    await mi.setDepthWriteEnabled(true);
-    await mi.setCullingMode(CullingMode.BACK);
-
-    var umi = await FilamentApp.instance!
-        .createUbershaderMaterialInstance(unlit: true);
-    var cube = await FilamentApp.instance!
-        .createGeometry(GeometryHelper.cube());
-    await scene.add(cube as FFIAsset);
-    await umi.setParameterFloat4("baseColorFactor", 1, 1, 1, 0);
-
-    await cube.setTransform(
-        Matrix4.compose(Vector3.zero(), Quaternion.identity(), Vector3.all(1)));
-    await cube.setMaterialInstanceAt(mi as FFIMaterialInstance);
-    await FilamentApp.instance!.register(swapChain, view);
-    var pixelBuffers = await testHelper.capture(null, "ndc_depth",
         swapChain: swapChain, pixelDataFormat: PixelDataFormat.R);
     checkMinMaxPixelValues(pixelBuffers[view]!.buffer.asFloat32List(),
         viewportDimensions.width, viewportDimensions.height);
@@ -188,7 +112,9 @@ void main() async {
         final camera = await viewer.getActiveCamera();
         await camera.lookAt(Vector3(3, 3, 6));
 
-        final view = await testHelper.createView(testHelper.swapChain);
+        final swapChain = await FilamentApp.instance!
+            .createHeadlessSwapChain(512, 512) as FFISwapChain;
+        final view = await testHelper.createView(swapChain);
         await testHelper.withCube(
           viewer,
           (cube) async {
@@ -203,9 +129,7 @@ void main() async {
             final secondScene = await view.getScene();
             await secondScene.add(cube);
 
-            final sampler = await FilamentApp.instance!.createTextureSampler();
             final rt = await view.getRenderTarget();
-            final color = await rt!.getColorTexture();
             final depth = await rt!.getDepthTexture();
             await mi.setParameterTexture(
               "depth",

--- a/thermion_dart/test/helpers.dart
+++ b/thermion_dart/test/helpers.dart
@@ -57,9 +57,9 @@ extension on Uri {
 
 Future<Uint8List> savePixelBufferToBmp(
     Uint8List pixelBuffer, int width, int height, String outputPath,
-    {bool hasAlpha = true, bool isFloat = true}) async {
+    {bool hasAlpha = true, bool isFloat = true, int numChannels = 0}) async {
   var data = await pixelBufferToBmp(pixelBuffer, width, height,
-      hasAlpha: hasAlpha, isFloat: isFloat);
+      hasAlpha: hasAlpha, isFloat: isFloat, numChannels: numChannels);
   File(outputPath).writeAsBytesSync(data);
   Logger.root.info("Wrote bitmap to ${outputPath}");
   return data;
@@ -67,9 +67,9 @@ Future<Uint8List> savePixelBufferToBmp(
 
 Future<Uint8List> savePixelBufferToPng(
     Uint8List pixelBuffer, int width, int height, String outputPath,
-    {bool hasAlpha = true, bool isFloat = true}) async {
+    {bool hasAlpha = true, bool isFloat = true, int numChannels = 0}) async {
   var data = await pixelBufferToPng(pixelBuffer, width, height,
-      hasAlpha: hasAlpha, isFloat: isFloat);
+      hasAlpha: hasAlpha, isFloat: isFloat, numChannels: numChannels);
   File(outputPath).writeAsBytesSync(data);
   Logger.root.info("Wrote bitmap to ${outputPath}");
   return data;
@@ -232,9 +232,13 @@ class TestHelper {
 
       if (outputFilename != null) {
         var outPath = p.join(outDir.path, "${outputFilename}_view${i}.png");
+        final numChannels = pixelDataFormat == PixelDataFormat.R
+            ? 1
+            : (pixelDataFormat == PixelDataFormat.RGBA ? 4 : 3);
         await savePixelBufferToPng(pixelBuffer, vp.width, vp.height, outPath,
             isFloat: pixelDataType == PixelDataType.FLOAT,
-            hasAlpha: pixelDataFormat == PixelDataFormat.RGBA);
+            hasAlpha: pixelDataFormat == PixelDataFormat.RGBA,
+            numChannels: numChannels);
       }
       i++;
       retval[view] = pixelBuffer;


### PR DESCRIPTION
## Summary

- Add single-channel (R) support to `pixelBufferToPng` / `pixelBufferToBmp` and thread `numChannels` through capture helpers so R32F depth textures render correctly as grayscale.
- `capture()` now accepts `PixelDataFormat.R`.
- Minor formatting cleanup in `ffi_filament_app.dart` multiline strings.

Cherry-picked from `refactor/rendermanager` (`1c721662`, `72eed4ba`, `b385f51e`) as the first of several smaller landings from that branch.

Incidental cleanup: the cherry-pick also converts two `FilamentApp.register(swapChain, view)` calls in `depth_tests.dart` to `setRenderOrder(...)`, fixing pre-existing analyzer errors on develop, and deletes a `check NDC depth value` test that was already broken on develop for the same reason.

## Test plan

- [x] `dart test test/depth_tests.dart --name 'write depth value to R32F texture'` — passes
- [x] `dart test test/capture_tests.dart` — passes
- [x] `dart test test/image_tests.dart` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)