### PR TITLE
feat: add pauseFrameScheduler/resumeFrameScheduler

### DIFF
--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -92,6 +92,8 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   static bool _usePortMode = false;
   static bool _dartApiInitialized = false;
 
+  static bool _frameSchedulerPaused = false;
+
   /// Called by native FrameScheduler at vsync/timer intervals.
   /// Not async — guards against re-entrant calls with [_rendering] flag.
   ///
@@ -102,7 +104,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
     // or if we're in a hot restart scenario where FilamentApp is null
     if (!_schedulerActive || FilamentApp.instance == null) return;
 
-    if (_rendering || _resizing) return;
+    if (_rendering || _resizing || _frameSchedulerPaused) return;
     _rendering = true;
     _renderFrame().then((_) {
       _rendering = false;
@@ -311,6 +313,15 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
     return swapChain;
   }
 
+  void pauseFrameScheduler() {
+    _frameSchedulerPaused = true;
+  }
+
+  void resumeFrameScheduler() {
+    _frameSchedulerPaused = false;
+  }
+
+  @override
   Future<PlatformTextureDescriptor?> createTextureAndBindToView(
     View view,
     int width,

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
@@ -170,4 +170,10 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
     resizeWebCanvas(width, height);
     return descriptor;
   }
+
+  @override
+  void pauseFrameScheduler() {}
+
+  @override
+  void resumeFrameScheduler() {}
 }

--- a/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
@@ -27,6 +27,10 @@ abstract class ThermionFlutterPlugin {
     _options = options;
   }
 
+  void pauseFrameScheduler();
+
+  void resumeFrameScheduler();
+
   // Initialize the plugin and create the default swapchain.
   Future<SwapChain?> initialize({bool destroySwapchain = true});
 
@@ -67,4 +71,6 @@ abstract class ThermionFlutterPlugin {
 
     return viewer;
   }
+
+  
 }


### PR DESCRIPTION
Adds `pauseFrameScheduler()` / `resumeFrameScheduler()` to `ThermionFlutterPlugin` — a `_frameSchedulerPaused` flag that gates `_onFrame()` so no frames render while paused.
Added no-op stubs on the web plugin to satisfy the abstract interface
