### PR TITLE
fix: return actual MaterialInstance from FFITexturedQuad.getMaterialInstanceAt

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_textured_quad.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_textured_quad.dart
@@ -180,8 +180,11 @@ class FFITexturedQuad extends TexturedQuad {
 
   @override
   Future<MaterialInstance> getMaterialInstanceAt(
-      {ThermionEntity? entity, int index = 0}) {
-    throw UnimplementedError();
+      {ThermionEntity? entity, int index = 0}) async {
+    if (index == 0 && (entity == null || entity == this.entity)) {
+      return mi;
+    }
+    throw Exception();
   }
 
   ThermionAsset? get boundingBoxAsset => throw UnimplementedError();


### PR DESCRIPTION
- `FFITexturedQuad.getMaterialInstanceAt` was throwing `UnimplementedError` instead of returning the quad's material instance. Now returns `mi` when index=0 and entity matches.