### PR TITLE
fix: restore 60fps web rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,25 @@ dart run thermion_dart:download_web -o custom  # → custom/
 
 #### Iterating on native C++ against web
 
-If you're modifying `thermion_dart`'s native code and want to test on web without bumping `native/web/web.version` and waiting for CI to rebuild the R2 artifacts, build the emscripten target locally and set `THERMION_WEB_LOCAL=1`:
+If you're modifying `thermion_dart`'s native code and want to test on web without bumping `native/web/web.version` and waiting for CI to rebuild the R2 artifacts, build the emscripten target locally and opt in via your app's `pubspec.yaml`:
+
+```yaml
+hooks:
+  user_defines:
+    thermion_dart:
+      web_local: true
+```
 
 ```bash
 # Build the wasm (from native/web/build):
-cmake --build .
+emcmake cmake ..
+emmake make
 
-# Then run/build your Flutter app with the env var set:
-THERMION_WEB_LOCAL=1 flutter run -d chrome
+# Then run/build your Flutter app:
+flutter run -d chrome
 ```
 
-When set, the build hook copies `thermion_dart.{js,wasm}` from `thermion_dart/native/web/build/build/out/` into your app's `web/` directory instead of downloading from R2. Unset the variable to go back to the pinned prebuilt.
+When set, the build hook copies `thermion_dart.{js,wasm}` from `thermion_dart/native/web/build/build/out/` into your app's `web/` directory instead of downloading from R2. Remove the flag (or set it to `false`) to go back to the pinned prebuilt.
 
 ### Sponsors, Contributors & Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -67,25 +67,34 @@ In your Flutter app:
 
 ### Web
 
-Before building for web, download the pre-compiled JS/WASM artifacts:
-
-```bash
-dart run thermion_dart:download_web
-```
-
-This fetches `thermion_dart.js` and `thermion_dart.wasm` from Cloudflare and copies them into your app's `web/` directory. Artifacts are cached under `.dart_tool/`, so subsequent runs are instant unless the version changes.
-
-To specify a different output directory:
-
-```bash
-dart run thermion_dart:download_web -o path/to/web
-```
-
-Then build as usual:
+Web builds need two files (`thermion_dart.js` and `thermion_dart.wasm`) sitting alongside your app's `web/index.html`. In the normal case, `thermion_dart`'s build hook fetches them for you on `flutter run`/`flutter build web` — no extra step required:
 
 ```bash
 flutter build web
 ```
+
+The hook reads `native/web/web.version`, downloads the matching artifacts from Cloudflare R2, caches them under `.dart_tool/thermion_dart/web/<sha>/`, and copies them into your app's `web/` directory. Subsequent builds are instant unless the version changes.
+
+If you want to fetch them ahead of time (e.g. for an offline build), you can do so manually:
+
+```bash
+dart run thermion_dart:download_web            # → ./web/
+dart run thermion_dart:download_web -o custom  # → custom/
+```
+
+#### Iterating on native C++ against web
+
+If you're modifying `thermion_dart`'s native code and want to test on web without bumping `native/web/web.version` and waiting for CI to rebuild the R2 artifacts, build the emscripten target locally and set `THERMION_WEB_LOCAL=1`:
+
+```bash
+# Build the wasm (from native/web/build):
+cmake --build .
+
+# Then run/build your Flutter app with the env var set:
+THERMION_WEB_LOCAL=1 flutter run -d chrome
+```
+
+When set, the build hook copies `thermion_dart.{js,wasm}` from `thermion_dart/native/web/build/build/out/` into your app's `web/` directory instead of downloading from R2. Unset the variable to go back to the pinned prebuilt.
 
 ### Sponsors, Contributors & Acknowledgments
 

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -567,6 +567,41 @@ Future<void> _downloadWebArtifacts(BuildInput input, Logger logger) async {
   final packageRoot =
       input.packageRoot.toFilePath(windows: Platform.isWindows);
 
+  // Local-build override: skip the R2 download and copy from the emscripten
+  // build output instead. Set THERMION_WEB_LOCAL=1 when iterating on native
+  // C++ that needs to ship to web.
+  if (Platform.environment['THERMION_WEB_LOCAL'] == '1') {
+    final localOut = Directory(
+        path.join(packageRoot, 'native', 'web', 'build', 'build', 'out'));
+    if (!localOut.existsSync()) {
+      logger.warning(
+          'THERMION_WEB_LOCAL=1 but ${localOut.path} does not exist; '
+          'build the web target first, then re-run.');
+      return;
+    }
+    final consumingPackageRoot =
+        _extractConsumingPackageRoot(input.outputDirectory.toString(), logger);
+    if (consumingPackageRoot == null) {
+      logger.warning('Could not determine consuming package root');
+      return;
+    }
+    final webDir = Directory(path.join(consumingPackageRoot, 'web'));
+    if (!webDir.existsSync()) {
+      logger.info('No web/ directory at ${webDir.path}; skipping');
+      return;
+    }
+    for (final name in ['thermion_dart.js', 'thermion_dart.wasm']) {
+      final src = File(path.join(localOut.path, name));
+      if (!src.existsSync()) {
+        logger.warning('$name not found in ${localOut.path}');
+        continue;
+      }
+      src.copySync(path.join(webDir.path, name));
+      logger.info('[THERMION_WEB_LOCAL] Copied $name from ${localOut.path}');
+    }
+    return;
+  }
+
   final versionFile =
       File(path.join(packageRoot, 'native', 'web', 'web.version'));
   if (!versionFile.existsSync()) {

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -568,14 +568,16 @@ Future<void> _downloadWebArtifacts(BuildInput input, Logger logger) async {
       input.packageRoot.toFilePath(windows: Platform.isWindows);
 
   // Local-build override: skip the R2 download and copy from the emscripten
-  // build output instead. Set THERMION_WEB_LOCAL=1 when iterating on native
-  // C++ that needs to ship to web.
-  if (Platform.environment['THERMION_WEB_LOCAL'] == '1') {
+  // build output instead. Set `web_local: true` under
+  // `hooks.user_defines.thermion_dart` in the consuming app's pubspec.yaml
+  // when iterating on native C++ that needs to ship to web.
+  final webLocal = input.userDefines["web_local"];
+  if (webLocal == true || webLocal == "true" || webLocal == 1 || webLocal == "1") {
     final localOut = Directory(
         path.join(packageRoot, 'native', 'web', 'build', 'build', 'out'));
     if (!localOut.existsSync()) {
       logger.warning(
-          'THERMION_WEB_LOCAL=1 but ${localOut.path} does not exist; '
+          'web_local: true set but ${localOut.path} does not exist; '
           'build the web target first, then re-run.');
       return;
     }
@@ -597,7 +599,7 @@ Future<void> _downloadWebArtifacts(BuildInput input, Logger logger) async {
         continue;
       }
       src.copySync(path.join(webDir.path, name));
-      logger.info('[THERMION_WEB_LOCAL] Copied $name from ${localOut.path}');
+      logger.info('[web_local] Copied $name from ${localOut.path}');
     }
     return;
   }

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -1703,6 +1703,16 @@ external void RenderManager_removeSwapChain(
   ffi.Pointer<TSwapChain> swapChain,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
 @ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
 external void FrameScheduler_start(
   FrameCallback callback,

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -1713,6 +1713,13 @@ external void RenderManager_attachToRenderThread(
   ffi.Pointer<TRenderManager> tRenderer,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderManager_setPaused(
+  ffi.Pointer<TRenderManager> tRenderer,
+  bool paused,
+);
+
 @ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
 external void FrameScheduler_start(
   FrameCallback callback,

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -982,6 +982,12 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TRenderManager> tRenderer,
     Pointer<TSwapChain> swapChain,
   );
+  external void _RenderManager_requestRender(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_attachToRenderThread(
+    Pointer<TRenderManager> tRenderer,
+  );
   external void _FrameScheduler_start(
     FrameCallback callback,
     int targetFps,
@@ -5256,6 +5262,22 @@ void RenderManager_removeSwapChain(
 ) {
   final result = GeneratedBindings.instance
       ._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_requestRender(
+  Pointer<TRenderManager> tRenderer,
+) {
+  final result =
+      GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_attachToRenderThread(
+  Pointer<TRenderManager> tRenderer,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_attachToRenderThread(tRenderer.cast());
   return result;
 }
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -988,6 +988,10 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _RenderManager_attachToRenderThread(
     Pointer<TRenderManager> tRenderer,
   );
+  external void _RenderManager_setPaused(
+    Pointer<TRenderManager> tRenderer,
+    bool paused,
+  );
   external void _FrameScheduler_start(
     FrameCallback callback,
     int targetFps,
@@ -5278,6 +5282,15 @@ void RenderManager_attachToRenderThread(
 ) {
   final result = GeneratedBindings.instance
       ._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_setPaused(
+  Pointer<TRenderManager> tRenderer,
+  bool paused,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_setPaused(tRenderer.cast(), paused);
   return result;
 }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -763,13 +763,12 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       // deadlocking the worker's main loop from the main browser thread,
       // and pre-refactor web was already fire-and-forget via requestFrame.
       RenderManager_requestRender(renderManager);
-      return;
+    } else {
+      await withVoidCallback((requestId, cb) {
+        RenderManager_renderRenderThread(
+            renderManager, frameTimeInNanos.toBigInt, requestId, cb);
+      });
     }
-
-    await withVoidCallback((requestId, cb) {
-      RenderManager_renderRenderThread(
-          renderManager, frameTimeInNanos.toBigInt, requestId, cb);
-    });
   }
 
   ///

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -134,6 +134,10 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
     final renderManager = RenderManager_create(engine, renderer);
 
+    // On web, rendering is driven by the RenderThread's rAF mainLoop via
+    // RenderManager::tick(). Wire the two together; no-op on native.
+    RenderManager_attachToRenderThread(renderManager);
+
     final animationManager = await withPointerCallback<TAnimationManager>(
       (cb) => AnimationManager_createRenderThread(engine, cb),
     );
@@ -751,6 +755,16 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     _processingRenderHooks = false;
 
     final frameTimeInNanos = DateTime.now().microsecondsSinceEpoch * 1000;
+
+    if (FILAMENT_SINGLE_THREADED) {
+      // Web: fire-and-forget. The render completes across the next N rAF
+      // cycles (N = number of swapchains) driven by RenderThread::iter()
+      // calling RenderManager::tick(). We cannot await completion without
+      // deadlocking the worker's main loop from the main browser thread,
+      // and pre-refactor web was already fire-and-forget via requestFrame.
+      RenderManager_requestRender(renderManager);
+      return;
+    }
 
     await withVoidCallback((requestId, cb) {
       RenderManager_renderRenderThread(

--- a/thermion_dart/native/include/c_api/TRenderManager.h
+++ b/thermion_dart/native/include/c_api/TRenderManager.h
@@ -22,6 +22,7 @@ extern "C"
 	// and only calls these on the web build.
 	EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderer);
+	EMSCRIPTEN_KEEPALIVE void RenderManager_setPaused(TRenderManager *tRenderer, bool paused);
 
 #ifdef __cplusplus
 }

--- a/thermion_dart/native/include/c_api/TRenderManager.h
+++ b/thermion_dart/native/include/c_api/TRenderManager.h
@@ -17,6 +17,12 @@ extern "C"
 	EMSCRIPTEN_KEEPALIVE void RenderManager_setRenderable(TRenderManager *tRenderer, TSwapChain *swapChain, TView **views, uint8_t numViews);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_removeSwapChain(TRenderManager *tRenderer, TSwapChain *swapChain);
 
+	// Web path. On native these are either no-ops (attach) or equivalent to a
+	// synchronous render (requestRender). Dart branches on FILAMENT_SINGLE_THREADED
+	// and only calls these on the web build.
+	EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer);
+	EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderer);
+
 #ifdef __cplusplus
 }
 #endif

--- a/thermion_dart/native/include/rendering/RenderManager.hpp
+++ b/thermion_dart/native/include/rendering/RenderManager.hpp
@@ -62,9 +62,10 @@ namespace thermion
         void setPaused(bool paused);
 
         /// Web path: called once per rAF from RenderThread::iter().
-        /// Renders at most one swapchain per invocation so the browser can
-        /// commit the frame between swapchains. Returns true when a full
-        /// frame (all swapchains) has been completed.
+        /// Renders all attached swapchains synchronously (in practice there
+        /// is only one on web — see ARCHITECTURE.md), then calls
+        /// mEngine->execute() to drain the Filament WebGL backend command
+        /// buffer. Returns true if any swapchain produced a visible frame.
         bool tick(uint64_t frameTimeInNanos);
 
         /// @brief

--- a/thermion_dart/native/include/rendering/RenderManager.hpp
+++ b/thermion_dart/native/include/rendering/RenderManager.hpp
@@ -55,6 +55,12 @@ namespace thermion
         /// driven from RenderThread::iter() on each rAF via tick().
         void requestRender();
 
+        /// Web: pause/resume rendering. When paused, tick() skips animation
+        /// updates and swapchain rendering but still drains the Filament
+        /// backend command buffer (mEngine->execute()) so any state changes
+        /// queued before pause complete cleanly and don't burst on resume.
+        void setPaused(bool paused);
+
         /// Web path: called once per rAF from RenderThread::iter().
         /// Renders at most one swapchain per invocation so the browser can
         /// commit the frame between swapchains. Returns true when a full
@@ -105,6 +111,11 @@ namespace thermion
         // rAF. Rejection retries (beginFrame failing) keep the flag set so
         // RenderThread's 12ms iter-loop can retry in the same rAF.
         bool mRenderRequested = false;
+
+        // Web: when true, tick() short-circuits animations + swapchain render.
+        // mEngine->execute() still runs so the backend command buffer keeps
+        // draining (matches native "scheduler keeps ticking" pause semantics).
+        bool mPaused = false;
     };
 
 }

--- a/thermion_dart/native/include/rendering/RenderManager.hpp
+++ b/thermion_dart/native/include/rendering/RenderManager.hpp
@@ -45,10 +45,21 @@ namespace thermion
         }
         ~RenderManager();
 
-        /// @brief
-        /// @param frameTimeInNanos
+        /// Synchronously render every attached swapchain's views in one pass.
+        /// Used by the native path, where Dart awaits a queued task that
+        /// invokes this directly.
         bool render(
             uint64_t frameTimeInNanos);
+
+        /// Flip the "render wanted" flag. Used on web — the actual work is
+        /// driven from RenderThread::iter() on each rAF via tick().
+        void requestRender();
+
+        /// Web path: called once per rAF from RenderThread::iter().
+        /// Renders at most one swapchain per invocation so the browser can
+        /// commit the frame between swapchains. Returns true when a full
+        /// frame (all swapchains) has been completed.
+        bool tick(uint64_t frameTimeInNanos);
 
         /// @brief
         /// @param swapChain
@@ -77,12 +88,23 @@ namespace thermion
             View *views[numViewAttachments];
         };
 
+        // Factored out of render() so tick() can invoke them piecewise.
+        // Both assume mMutex is held by the caller.
+        void updateAnimationsAndPlugins(uint64_t frameTimeInNanos);
+        bool renderSwapChainAt(size_t index, uint64_t frameTimeInNanos);
+
         std::mutex mMutex;
         Engine *mEngine = nullptr;
         Renderer *mRenderer = nullptr;
         std::vector<AnimationManager *> mAnimationManagers;
         std::vector<ViewAttachment> mViewAttachments;
         std::chrono::high_resolution_clock::time_point mLastRender;
+
+        // Web: tick() checks this flag and renders if set, then clears it.
+        // Set by Dart via RenderManager_requestRender() on each main-thread
+        // rAF. Rejection retries (beginFrame failing) keep the flag set so
+        // RenderThread's 12ms iter-loop can retry in the same rAF.
+        bool mRenderRequested = false;
     };
 
 }

--- a/thermion_dart/native/include/rendering/RenderManager.hpp
+++ b/thermion_dart/native/include/rendering/RenderManager.hpp
@@ -115,7 +115,10 @@ namespace thermion
         // Web: when true, tick() short-circuits animations + swapchain render.
         // mEngine->execute() still runs so the backend command buffer keeps
         // draining (matches native "scheduler keeps ticking" pause semantics).
-        bool mPaused = false;
+        // Note: this gates *rendering only* — task queue drain in
+        // RenderThread::iter() is outside this flag, so FFI state changes
+        // (setTransform, addEntity, etc.) continue to apply while paused.
+        bool mRenderPaused = false;
     };
 
 }

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -16,6 +16,8 @@
 
 namespace thermion {
 
+class RenderManager;
+
 /**
  * @brief A render loop implementation that manages rendering on a separate thread.
  * 
@@ -69,6 +71,11 @@ public:
     #ifdef __EMSCRIPTEN__
     emscripten::ProxyingQueue queue;
     pthread_t outer;
+
+    // Web-only: iter() invokes mRenderManager->tick() on each rAF so rendering
+    // is driven by the browser's frame cadence rather than a Dart-queued task.
+    void setRenderManager(RenderManager* rm) { mRenderManager = rm; }
+    RenderManager* mRenderManager = nullptr;
     #endif
 
 private:

--- a/thermion_dart/native/src/c_api/TRenderManager.cpp
+++ b/thermion_dart/native/src/c_api/TRenderManager.cpp
@@ -50,6 +50,11 @@ EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer)
     renderManager->requestRender();
 }
 
+EMSCRIPTEN_KEEPALIVE void RenderManager_setPaused(TRenderManager *tRenderer, bool paused) {
+    auto *renderManager = reinterpret_cast<RenderManager *>(tRenderer);
+    renderManager->setPaused(paused);
+}
+
 EMSCRIPTEN_KEEPALIVE void RenderManager_setRenderable(TRenderManager *tRenderer, TSwapChain *tSwapChain, TView **tViews, uint8_t numViews) {
     auto *renderManager = reinterpret_cast<RenderManager *>(tRenderer);
     auto *swapChain = reinterpret_cast<filament::SwapChain *>(tSwapChain);

--- a/thermion_dart/native/src/c_api/TRenderManager.cpp
+++ b/thermion_dart/native/src/c_api/TRenderManager.cpp
@@ -45,6 +45,11 @@ EMSCRIPTEN_KEEPALIVE void RenderManager_render(TRenderManager *tRenderer, uint64
     renderManager->render(frameTimeInNanos);
 }
 
+EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer) {
+    auto *renderManager = reinterpret_cast<RenderManager *>(tRenderer);
+    renderManager->requestRender();
+}
+
 EMSCRIPTEN_KEEPALIVE void RenderManager_setRenderable(TRenderManager *tRenderer, TSwapChain *tSwapChain, TView **tViews, uint8_t numViews) {
     auto *renderManager = reinterpret_cast<RenderManager *>(tRenderer);
     auto *swapChain = reinterpret_cast<filament::SwapChain *>(tSwapChain);

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -82,6 +82,20 @@ extern "C"
     auto fut = _renderThread->addTask(lambda);
   }
 
+  EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderManager)
+  {
+#ifdef __EMSCRIPTEN__
+    if (!_renderThread) {
+      Log("WARNING - RenderManager_attachToRenderThread called with no RenderThread active.");
+      return;
+    }
+    auto *rm = reinterpret_cast<RenderManager *>(tRenderManager);
+    _renderThread->setRenderManager(rm);
+#else
+    (void)tRenderManager; // no-op on native
+#endif
+  }
+
   EMSCRIPTEN_KEEPALIVE void RenderManager_setRenderableRenderThread(
     TRenderManager *tRenderer,
     TSwapChain *tSwapChain,

--- a/thermion_dart/native/src/rendering/RenderManager.cpp
+++ b/thermion_dart/native/src/rendering/RenderManager.cpp
@@ -95,79 +95,85 @@ namespace thermion
     TRACE("Set %d view attachments for swapchain", numViews);
   }
 
+  void RenderManager::updateAnimationsAndPlugins(uint64_t frameTimeInNanos)
+  {
+    for (auto animationManager : mAnimationManagers)
+    {
+      animationManager->update(frameTimeInNanos);
+    }
+    thermion::plugin::UpdatePlugins(frameTimeInNanos);
+  }
+
+  bool RenderManager::renderSwapChainAt(size_t index, uint64_t frameTimeInNanos)
+  {
+    if (index >= mViewAttachments.size()) return false;
+    auto &attachment = mViewAttachments[index];
+    if (!attachment.swapChain)
+    {
+      Log("No swapchain, ignoring");
+      return false;
+    }
+
+    auto beforeBegin = std::chrono::high_resolution_clock::now();
+    bool beginFrame = mRenderer->beginFrame(attachment.swapChain, frameTimeInNanos);
+    auto afterBegin = std::chrono::high_resolution_clock::now();
+    float beginMs = std::chrono::duration_cast<std::chrono::nanoseconds>(afterBegin - beforeBegin).count() / 1e6f;
+
+    if (!beginFrame)
+    {
+      float sinceLastMs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                              std::chrono::high_resolution_clock::now() - mLastRender).count() / 1e6f;
+      TRACE("Skipping frame for swapchain %zu (%.3f ms since last endFrame())", index, sinceLastMs);
+      (void)beginMs;
+      return false;
+    }
+
+    float sinceLastMs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::high_resolution_clock::now() - mLastRender).count() / 1e6f;
+    TRACE("Beginning frame for swapchain %zu (%.3f ms since last endFrame())", index, sinceLastMs);
+
+    int numRendered = 0;
+    for (int i = 0; i < numViewAttachments; i++)
+    {
+      if (!attachment.views[i]) break;
+      numRendered++;
+      mRenderer->render(attachment.views[i]);
+    }
+
+    auto beforeEnd = std::chrono::high_resolution_clock::now();
+    mRenderer->endFrame();
+    mLastRender = std::chrono::high_resolution_clock::now();
+    float endFrameMs = std::chrono::duration_cast<std::chrono::nanoseconds>(mLastRender - beforeEnd).count() / 1e6f;
+
+    TRACE("%d views rendered for swapchain %zu", numRendered, index);
+
+    if (endFrameMs > 5.0f) {
+      fprintf(stderr, "[RENDER] endFrame() took %.1fms (GPU stall?)\n", endFrameMs);
+    }
+
+    return numRendered > 0;
+  }
+
   bool RenderManager::render(uint64_t frameTimeInNanos)
   {
     auto startTime = std::chrono::high_resolution_clock::now();
 
     std::lock_guard lock(mMutex);
 
-    for (auto animationManager : mAnimationManagers)
-    {
-      animationManager->update(frameTimeInNanos);
-    }
-
-    thermion::plugin::UpdatePlugins(frameTimeInNanos);
+    updateAnimationsAndPlugins(frameTimeInNanos);
 
     auto durationNs = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - mLastRender).count() / 1e6f;
     TRACE("Updated animations in %.3f ms", durationNs);
 
     bool rendered = false;
-    int swapChainIndex = 0;
     int skippedCount = 0;
-
-    // Render each swapchain
-    for (auto &attachment : mViewAttachments)
+    for (size_t i = 0; i < mViewAttachments.size(); i++)
     {
-      if (!attachment.swapChain)
-      {
-        Log("No swapchain, ignoring");
-        continue;
-      }
-
-      auto beforeBegin = std::chrono::high_resolution_clock::now();
-      bool beginFrame = mRenderer->beginFrame(attachment.swapChain, frameTimeInNanos);
-      auto afterBegin = std::chrono::high_resolution_clock::now();
-      float beginMs = std::chrono::duration_cast<std::chrono::nanoseconds>(afterBegin - beforeBegin).count() / 1e6f;
-
-      if (beginFrame)
-      {
-        durationNs = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - mLastRender).count() / 1e6f;
-        TRACE("Beginning frame for swapchain %d (%.3f ms since last endFrame())", swapChainIndex, durationNs);
-
-        int numRendered = 0;
-        for (int i = 0; i < numViewAttachments; i++)
-        {
-          if (!attachment.views[i]) {
-            break;
-          }
-          numRendered++;
-          mRenderer->render(attachment.views[i]);
-        }
-
-        auto beforeEnd = std::chrono::high_resolution_clock::now();
-        mRenderer->endFrame();
-        mLastRender = std::chrono::high_resolution_clock::now();
-        float endFrameMs = std::chrono::duration_cast<std::chrono::nanoseconds>(mLastRender - beforeEnd).count() / 1e6f;
-
-        TRACE("%d views rendered for swapchain %d", numRendered, swapChainIndex);
-        if (numRendered > 0) {
-          rendered = true;
-        }
-
-        // Log if endFrame took a long time (GPU stall / sync)
-        if (endFrameMs > 5.0f) {
-          fprintf(stderr, "[RENDER] endFrame() took %.1fms (GPU stall?)\n", endFrameMs);
-        }
-      }
-      else
-      {
+      if (renderSwapChainAt(i, frameTimeInNanos)) {
+        rendered = true;
+      } else if (mViewAttachments[i].swapChain) {
         skippedCount++;
-        durationNs = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - mLastRender).count() / 1e6f;
-        TRACE("Skipping frame for swapchain %d (%.3f ms since last endFrame())", swapChainIndex, durationNs);
-        fprintf(stderr, "[RENDER] beginFrame() REJECTED sc=%d (%.1fms since last, beginFrame took %.1fms)\n",
-                swapChainIndex, durationNs, beginMs);
       }
-      swapChainIndex++;
     }
 
     #ifdef __EMSCRIPTEN__
@@ -178,7 +184,7 @@ namespace thermion
     durationNs = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
     float durationMs = durationNs / 1e6f;
 
-    TRACE("Total render() time for %d swapchains: %.3f ms", swapChainIndex, durationMs);
+    TRACE("Total render() time for %zu swapchains: %.3f ms", mViewAttachments.size(), durationMs);
 
     static int renderCount = 0;
     static int totalSkips = 0;
@@ -200,6 +206,52 @@ namespace thermion
       }
     }
     return rendered;
+  }
+
+  void RenderManager::requestRender()
+  {
+    std::lock_guard lock(mMutex);
+    mRenderRequested = true;
+  }
+
+  bool RenderManager::tick(uint64_t frameTimeInNanos)
+  {
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    // Render unconditionally on every worker rAF. The mRenderRequested flag
+    // is kept in the API for symmetry with the native path but is not
+    // gating on web: Dart's main-thread _tick and this worker's mainLoop
+    // are independent 60Hz rAFs that aren't phase-locked. Gating on the flag
+    // drops ~5-10 fps whenever the worker rAF fires before Dart has had a
+    // chance to set it.
+    (void)mRenderRequested;
+
+    // Match pre-refactor RenderTicker semantics: render all swapchains
+    // synchronously and ALWAYS call mEngine->execute() — even if every
+    // beginFrame rejected. Filament's WebGL backend queues commands in an
+    // internal buffer that needs to be drained every rAF, independent of
+    // whether a visible frame was produced. Skipping execute() on rejection
+    // stalls the backend.
+    updateAnimationsAndPlugins(frameTimeInNanos);
+
+    bool anyRendered = false;
+    for (size_t i = 0; i < mViewAttachments.size(); i++)
+    {
+      if (!mViewAttachments[i].swapChain) continue;
+      if (renderSwapChainAt(i, frameTimeInNanos)) {
+        anyRendered = true;
+      }
+    }
+
+#ifdef __EMSCRIPTEN__
+    mEngine->execute();
+#endif
+
+    if (anyRendered) {
+      mRenderRequested = false;
+    }
+
+    return anyRendered;
   }
 
   void RenderManager::addAnimationManager(AnimationManager *animationManager)

--- a/thermion_dart/native/src/rendering/RenderManager.cpp
+++ b/thermion_dart/native/src/rendering/RenderManager.cpp
@@ -217,7 +217,7 @@ namespace thermion
   void RenderManager::setPaused(bool paused)
   {
     std::lock_guard lock(mMutex);
-    mPaused = paused;
+    mRenderPaused = paused;
   }
 
   bool RenderManager::tick(uint64_t frameTimeInNanos)
@@ -239,7 +239,7 @@ namespace thermion
     // independent of whether a visible frame was produced. Skipping
     // execute() stalls the backend and causes a burst on resume.
     bool anyRendered = false;
-    if (!mPaused) {
+    if (!mRenderPaused) {
       updateAnimationsAndPlugins(frameTimeInNanos);
 
       for (size_t i = 0; i < mViewAttachments.size(); i++)

--- a/thermion_dart/native/src/rendering/RenderManager.cpp
+++ b/thermion_dart/native/src/rendering/RenderManager.cpp
@@ -214,6 +214,12 @@ namespace thermion
     mRenderRequested = true;
   }
 
+  void RenderManager::setPaused(bool paused)
+  {
+    std::lock_guard lock(mMutex);
+    mPaused = paused;
+  }
+
   bool RenderManager::tick(uint64_t frameTimeInNanos)
   {
     std::lock_guard<std::mutex> lock(mMutex);
@@ -228,18 +234,20 @@ namespace thermion
 
     // Match pre-refactor RenderTicker semantics: render all swapchains
     // synchronously and ALWAYS call mEngine->execute() — even if every
-    // beginFrame rejected. Filament's WebGL backend queues commands in an
-    // internal buffer that needs to be drained every rAF, independent of
-    // whether a visible frame was produced. Skipping execute() on rejection
-    // stalls the backend.
-    updateAnimationsAndPlugins(frameTimeInNanos);
-
+    // beginFrame rejected or we're paused. Filament's WebGL backend queues
+    // commands in an internal buffer that needs to be drained every rAF,
+    // independent of whether a visible frame was produced. Skipping
+    // execute() stalls the backend and causes a burst on resume.
     bool anyRendered = false;
-    for (size_t i = 0; i < mViewAttachments.size(); i++)
-    {
-      if (!mViewAttachments[i].swapChain) continue;
-      if (renderSwapChainAt(i, frameTimeInNanos)) {
-        anyRendered = true;
+    if (!mPaused) {
+      updateAnimationsAndPlugins(frameTimeInNanos);
+
+      for (size_t i = 0; i < mViewAttachments.size(); i++)
+      {
+        if (!mViewAttachments[i].swapChain) continue;
+        if (renderSwapChainAt(i, frameTimeInNanos)) {
+          anyRendered = true;
+        }
       }
     }
 

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -1,4 +1,5 @@
 #include "rendering/RenderThread.hpp"
+#include "rendering/RenderManager.hpp"
 
 #include <functional>
 #include <stdlib.h>
@@ -106,6 +107,16 @@ void RenderThread::iter()
         taskLock.unlock();
         task();
         taskLock.lock();
+    }
+    taskLock.unlock();
+
+    // Render at most one swapchain per rAF so Filament's WebGL backend can
+    // commit the frame between iterations. When no render has been requested,
+    // tick() is a cheap flag-check and returns immediately.
+    if (mRenderManager) {
+        auto frameTimeInNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                    now.time_since_epoch()).count();
+        mRenderManager->tick(frameTimeInNanos);
     }
 #else
     // On native, process one task then wait for more

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -64,7 +64,73 @@ TODO
 
 ## Web
 
-TODO
+On web, Thermion compiles to a single emscripten pthread + WebGL build. Native C++ (`thermion_dart.wasm`) runs inside the browser, Flutter's Dart code calls into it via generated JS-interop bindings, and rendering happens on a separate WebWorker thread that owns the canvas.
+
+### Build-time artifacts
+
+The emscripten build produces two files — `thermion_dart.js` and `thermion_dart.wasm` — that need to sit alongside the Flutter app's `web/index.html`. In normal use, `thermion_dart`'s build hook (`hook/build.dart`, `_downloadWebArtifacts`) reads `native/web/web.version`, downloads the matching zip from Cloudflare R2, caches it under `.dart_tool/thermion_dart/web/<sha>/`, and copies the two files into the consuming package's `web/` directory. CI rebuilds and uploads these artifacts when `web.version` is bumped.
+
+For local iteration on native C++ that needs to ship to web: set `THERMION_WEB_LOCAL=1`, build the emscripten target (`native/web/build/build/out/thermion_dart.{js,wasm}`), and the build hook will copy from that local path instead of hitting R2. See `_downloadWebArtifacts` in `hook/build.dart`.
+
+### Threading model
+
+Two threads matter:
+
+- **Main browser thread**: where Dart executes (Flutter's engine runs on the main thread on web). All `FilamentApp` method calls originate here.
+- **Render worker**: a pthread spun up at startup by `RenderThread::RenderThread()` via `pthread_create` with `emscripten_pthread_attr_settransferredcanvases(&attr, "#thermion_canvas")`. This transfers ownership of the OffscreenCanvas to the worker, which then owns the WebGL context for the lifetime of the app. The worker's entry point installs `emscripten_set_main_loop_arg(&mainLoop, ...)` so that `RenderThread::iter()` is called on the worker's own `requestAnimationFrame` cadence.
+
+Dart and the worker communicate via emscripten's proxying queue + a lock-protected task deque (`RenderThread::_tasks`). Dart never calls Filament directly from the main thread — every call crosses the thread boundary as a packaged task.
+
+### Dart → worker call pattern
+
+Every generated FFI binding that needs to touch Filament takes the `*_RenderThread` shape — e.g. `Renderer_beginFrameRenderThread(..., requestId, onComplete)`. The Dart side wraps these with `withVoidCallback` / `withPointerCallback` / etc., which:
+
+1. Register a callback port keyed by a fresh `requestId`.
+2. Call the `*_RenderThread` FFI function. The C wrapper packages the target call + a capture of `(requestId, onComplete)` into a `std::packaged_task`, pushes it onto `RenderThread::_tasks`, and returns immediately.
+3. Dart awaits the completer associated with `requestId`.
+
+On the worker side, `RenderThread::iter()` (emscripten branch) drains every queued task synchronously, each of which runs its underlying Filament call and then fires `onComplete(requestId)`. The callback is proxied back to the main thread via `emscripten::ProxyingQueue::proxySync` (the `PROXY(...)` macro in `ThermionDartRenderThreadApi.cpp`), which resolves the Dart future.
+
+The net effect is that Dart code can `await` a Filament call as if it were synchronous, but the actual GL work happens on the worker where the canvas lives.
+
+### Render loop
+
+Unlike the native path, Dart on web does **not** await individual renders. `FFIFilamentApp.render()` branches on `FILAMENT_SINGLE_THREADED`:
+
+- **Native** queues a `RenderManager_renderRenderThread` task and awaits its completion. `RenderManager::render()` runs the whole pipeline (animations + plugins + all swapchains' beginFrame/render/endFrame + `mEngine->execute()`) as one synchronous task.
+- **Web** calls `RenderManager_requestRender(renderManager)` — fire-and-forget. This flips `mRenderRequested = true` but is effectively a no-op (see [Why `mRenderRequested` is bypassed on web](#why-mrenderrequested-is-bypassed-on-web) below).
+
+Rendering is driven entirely from the worker's mainLoop. Each worker rAF, `RenderThread::iter()` drains the task queue and calls `RenderManager::tick(now)`. `tick()`:
+
+1. Runs `updateAnimationsAndPlugins(now)`.
+2. For each attached swapchain: `renderSwapChainAt(i)` (beginFrame → render each view → endFrame).
+3. **Always** calls `mEngine->execute()` — even if every `beginFrame` rejected.
+
+All three steps happen in a single `tick()` invocation, matching the pre-refactor `RenderTicker::render()` pattern exactly. One frame per worker rAF = ~60fps at display vsync.
+
+### Invariants the render loop depends on
+
+Two things about this loop are load-bearing and easy to break accidentally. Both were discovered through failed attempts to restructure it:
+
+1. **`mEngine->execute()` runs every rAF, unconditionally.** Filament's WebGL backend queues commands in a backend command buffer; `execute()` drains it on the GL context. Skipping `execute()` when every `beginFrame` rejected (which seems like it should be a safe optimization — nothing was queued) stalls the backend entirely after startup. The command buffer needs to be drained each rAF regardless of whether a visible frame was produced.
+
+2. **`beginFrame`, `endFrame`, and `execute` must all happen in the same `tick()` invocation.** Earlier attempts split these across ticks to fit a clean state machine ("tick N renders, tick N+1 executes"), to pipeline across frames (execute previous at top of tick, render next at bottom), or to schedule execute as a `setTimeout(0)` microtask. Every variation either hung, rejected every `beginFrame` after the first, or dropped rendering entirely. The pre-refactor shape — begin/render/end/execute inline under the RenderManager mutex — is the only arrangement empirically shown to work on this combination of emscripten pthreads + OffscreenCanvas + Filament WebGL backend. Don't try to pipeline or split these phases without first understanding why it broke before.
+
+### Why `mRenderRequested` is bypassed on web
+
+The flag was originally intended to gate rendering so Dart could control when frames are produced. In practice, both Dart's main-thread `_tick` and the worker's `mainLoop` run at 60Hz but are **not phase-locked** — they're independent rAFs on different threads. When the worker rAF fires slightly before Dart's has set the flag, the worker finds it clear and skips, losing that frame. Over a second, phase drift costs ~5-10 fps (measured: ~50-55 fps instead of 60).
+
+The fix is to render unconditionally on every worker rAF and let Dart's flag-setting be a no-op. This matches pre-refactor semantics (the `RenderTicker` also ran every worker rAF once it was requested). The flag is kept in the API for symmetry with native but is not gating on the web path.
+
+**Trade-off**: there's currently no way to *pause* rendering on web — `pauseFrameScheduler()` / `resumeFrameScheduler()` on `ThermionFlutterPluginImpl` are empty. If a pause path is needed (e.g. for tab visibility), wire those hooks to a `mPaused` flag checked at the top of `tick()`.
+
+### Key files
+
+- `thermion_dart/native/src/rendering/RenderThread.cpp` — pthread + emscripten mainLoop, task queue.
+- `thermion_dart/native/src/rendering/RenderManager.cpp` — `render()` (native), `requestRender()`/`tick()` (web).
+- `thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp` — `*_RenderThread` C shims + proxy-back callbacks.
+- `thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart` — `FFIFilamentApp.render()` branches on `FILAMENT_SINGLE_THREADED`.
+- `thermion_dart/hook/build.dart` — web artifact download + `THERMION_WEB_LOCAL` override.
 
 ## Windows
 

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -6,6 +6,86 @@ This document explains Flutter-specific implementation details, mostly about how
 
 On all platforms except Android, we create Filament with a headless swapchain, then render into a (hardware accelerated) texture that Flutter imports into its own widget hierarchy via a Texture widget. This allows the Filament viewport to be transformed/composed completely within the Flutter hierarchy (i.e. you could rotate/scale/translate the ThermionWidget in Flutter if you wanted, or insert other widgets above/below).
 
+## Render lifecycle (native)
+
+This section describes the per-frame lifecycle on native platforms (macOS/iOS/Windows/Android/Linux). Web has its own model — see [Web](#web) below.
+
+### Frame sources
+
+Thermion does not drive rendering from Flutter's `SchedulerBinding` on most platforms. Instead, a platform-native `FrameScheduler` (`thermion_dart/native/src/c_api/FrameSchedulerApi.cpp`) provides the vsync signal:
+
+| Platform | Source |
+|---|---|
+| macOS | `CVDisplayLinkScheduler` (CVDisplayLink vsync) |
+| iOS | `CADisplayLinkScheduler` |
+| Windows | `DXGIFrameScheduler` (DXGI `WaitForVBlank`) |
+| Android | `AChoreographerFrameScheduler` |
+| Linux | Flutter's `SchedulerBinding.addPersistentFrameCallback` (see below) |
+
+Linux is the odd one out: Flutter's persistent frame callback drives a non-blocking `FrameScheduler_requestRender` on the native render thread (`_initializeNativeRenderLoop` in `thermion_flutter_plugin_native.dart`). This keeps Thermion in lockstep with Flutter's Skia compositor, which matters on Linux where there is no independent display-link API we can reliably use.
+
+The `FrameScheduler` dispatches its callback to Dart in one of two ways:
+
+- **Release**: a raw C function pointer (`ffi.NativeCallable`) — minimum latency.
+- **Debug** (hot-restart safe): `Dart_PostCObject_DL` onto a `ReceivePort`. `Dart_PostCObject` silently drops messages to dead ports, so stale native schedulers created in a previous isolate can't crash the new one.
+
+### Per-frame sequence
+
+On each vsync tick, the following runs:
+
+1. **`_onFrame(frameTimeNanos)`** (`thermion_flutter_plugin_native.dart`) — the Dart-side entry point.
+   - Returns early if `_schedulerActive`, `FilamentApp.instance`, `_rendering`, `_resizing`, or `_frameSchedulerPaused` are set. The `_rendering` re-entrancy guard is what protects against frame pile-up if a render runs long — late frames are **dropped**, not queued.
+2. **`_renderFrame()`** (async) awaits `FilamentApp.instance.render()`.
+3. **`FFIFilamentApp.render()`** (`thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart`) runs registered render hooks, then on the native branch:
+   ```dart
+   await withVoidCallback((requestId, cb) =>
+       RenderManager_renderRenderThread(renderManager, frameTimeInNanos, requestId, cb));
+   ```
+   This packages a `std::packaged_task` onto `RenderThread::_tasks` and returns a Dart future that resolves when the callback proxies back.
+4. **`RenderThread::iter()`** (non-emscripten branch) pops one task from the deque, runs it, then `condition_variable::wait_for(2000μs)` for the next. No polling.
+5. **`RenderManager::render()`** runs synchronously on the render thread under `mMutex`:
+   - `updateAnimationsAndPlugins(frameTimeInNanos)`
+   - for each attached swapchain: `Renderer::beginFrame` → `Renderer::render(view)` per view → `Renderer::endFrame`
+   - returns `true` if any swapchain committed a frame
+6. The task's completion callback fires `onComplete(requestId)` back on the main thread via the proxying queue; `withVoidCallback`'s future resolves.
+7. Back in `_renderFrame`, for each `PlatformTextureDescriptor` we call **`markTextureFrameAvailable()`**.
+8. The Texture widget schedules a repaint; Flutter's compositor samples the updated hardware texture on its next frame.
+
+Steps 3–6 are a single Dart `await`: the Flutter frame callback does not return until `endFrame` has completed on the render thread. The render does **not** run on the platform thread — it runs on the dedicated `RenderThread` — so the UI isolate isn't blocked on GPU work beyond the round-trip wait.
+
+### `markTextureFrameAvailable`
+
+`markTextureFrameAvailable` is how we tell Flutter "the texture you imported has new contents; please sample it on the next compositor pass." It is called **after** `endFrame` returns on the render thread (i.e. after the callback has crossed back to the main thread). Implementations:
+
+- **Darwin**: direct Objective-C call — `SwiftThermionFlutterPluginObjCAPI.markTextureFrameAvailableWithFlutterTextureId_` (`darwin_platform_texture_descriptor.dart`).
+- **Android/Linux/Windows**: platform channel — `channel.invokeMethod("markTextureFrameAvailable", flutterTextureId)` (`method_channel_platform_texture_descriptor.dart`).
+
+On Linux with `FrameScheduler_setPostRenderCallback`, the mark happens entirely in native code (`thermion_flutter_mark_textures`) without bouncing to Dart, removing one round-trip per frame.
+
+### Composite path
+
+The Flutter side is a standard `Texture(textureId: descriptor.flutterTextureId, filterQuality: none, freeze: false)` widget. The hardware texture backing it is platform-specific:
+
+- **Metal** (macOS/iOS): Filament writes into a Metal texture whose handle is passed in via `importedTextureHandle`.
+- **Vulkan** (Windows, Linux fallback): see [Linux § Vulkan](#vulkan) — either a single exportable `VkImage` or a Filament→Flutter blit pair.
+- **OpenGL** (Android, Linux preferred): imported GL texture handle.
+
+Compositing itself is Flutter's responsibility — the Texture widget participates in the normal widget tree, so transforms/opacity/clipping all work. The trade-off is one extra texture sample per frame versus drawing directly into the Flutter surface (which Thermion does not do).
+
+### Interleaving with FFI calls
+
+Every Dart → Filament call (e.g. moving a camera, adding an entity) goes through a `*_RenderThread` shim that queues a task onto the same `RenderThread::_tasks` deque used by `RenderManager_renderRenderThread`. Tasks drain FIFO, one per `iter()`, so there is no preemption: a slow FFI call queued just before a render will delay that render until it finishes. Most FFI operations complete in microseconds so this is rarely visible, but bulk operations (e.g. loading a large glTF) can cause a single dropped frame because `_rendering` is still `true` when the next vsync fires.
+
+The deque is lock-protected (`_taskMutex`); `iter()` holds the lock only long enough to pop, releases it to run the task, then re-acquires. This means Dart can enqueue new work while a render is in flight — it just won't run until the current task yields.
+
+### Pause/resume
+
+`pauseFrameScheduler()` / `resumeFrameScheduler()` on `ThermionFlutterPluginImpl` toggle a Dart-side `_frameSchedulerPaused` flag. The **native** `FrameScheduler` keeps ticking — Dart just short-circuits `_onFrame`. This keeps the scheduler's vsync subscription warm (no cost to resuming) but avoids queuing tasks onto the render thread while paused. If you need the scheduler itself to stop (e.g. app backgrounding on platforms that penalise active display-link subscriptions), call `FrameScheduler_stop` explicitly.
+
+### Diagnostics
+
+`_onFrame` wraps each frame in a `Stopwatch` and logs `[DART] 120-frame avg/max/jank/drop` at 120-frame intervals. A frame > 20ms counts as jank; a vsync that arrives while `_rendering` is still `true` counts as a drop. In port mode (debug), port transit latency is measured separately and logged when it exceeds 2ms.
+
 ## Linux
 
 Flutter on Linux/Wayland uses EGL/GDK for rendering with Skia. 

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -34,7 +34,7 @@ The `FrameScheduler` dispatches its callback to Dart in one of two ways:
 On each vsync tick, the following runs:
 
 1. **`_onFrame(frameTimeNanos)`** (`thermion_flutter_plugin_native.dart`) — the Dart-side entry point.
-   - Returns early if `_schedulerActive`, `FilamentApp.instance`, `_rendering`, `_resizing`, or `_frameSchedulerPaused` are set. The `_rendering` re-entrancy guard is what protects against frame pile-up if a render runs long — late frames are **dropped**, not queued.
+   - Returns early if `_schedulerActive`, `FilamentApp.instance`, `_rendering`, `_resizing`, or `_renderPaused` are set. The `_rendering` re-entrancy guard is what protects against frame pile-up if a render runs long — late frames are **dropped**, not queued.
 2. **`_renderFrame()`** (async) awaits `FilamentApp.instance.render()`.
 3. **`FFIFilamentApp.render()`** (`thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart`) runs registered render hooks, then on the native branch:
    ```dart
@@ -80,7 +80,20 @@ The deque is lock-protected (`_taskMutex`); `iter()` holds the lock only long en
 
 ### Pause/resume
 
-`pauseFrameScheduler()` / `resumeFrameScheduler()` on `ThermionFlutterPluginImpl` toggle a Dart-side `_frameSchedulerPaused` flag. The **native** `FrameScheduler` keeps ticking — Dart just short-circuits `_onFrame`. This keeps the scheduler's vsync subscription warm (no cost to resuming) but avoids queuing tasks onto the render thread while paused. If you need the scheduler itself to stop (e.g. app backgrounding on platforms that penalise active display-link subscriptions), call `FrameScheduler_stop` explicitly.
+**The invariant (both platforms): pause stops rendering only. The task queue keeps draining.**
+
+`pauseFrameScheduler()` / `resumeFrameScheduler()` gate the **render pipeline** — on native, Dart's `_onFrame` short-circuits (so no `RenderManager_render` task is queued); on web, `RenderManager::tick()` skips `updateAnimationsAndPlugins` + the swapchain loop. Neither path touches `RenderThread::_tasks`, so every `*_RenderThread` FFI call (`setTransform`, `addEntity`, material/camera updates, etc.) continues to queue and execute exactly as it does when running. `await`-ing an FFI call during pause will not hang; state accumulated during pause is visible on the first render after resume.
+
+On native this means:
+
+- the platform `FrameScheduler` keeps ticking — Dart just ignores the callbacks. Scheduler vsync subscription stays warm so resume is free. If you need the scheduler itself stopped (e.g. to avoid penalties from active display-link subscriptions when backgrounded), call `FrameScheduler_stop` explicitly.
+- `_renderPaused` (`thermion_flutter_plugin_native.dart`) is the Dart-side gate. It is checked only in `_onFrame`; nothing else in the plugin reads it.
+
+On web this means:
+
+- `mRenderPaused` on `RenderManager` is flipped via `RenderManager_setPaused`. `tick()` consults it around the animation + render block; `mEngine->execute()` stays unconditional so the Filament WebGL backend command buffer keeps draining (otherwise GL-queuing tasks like texture uploads would pile up and burst on resume).
+- animations freeze during pause because `updateAnimationsAndPlugins` is part of the render pipeline. This matches native (where `render()` is not called at all, so animations also don't advance). Callers who need the animation clock to keep running without visible frames should not use pause — render into an offscreen swapchain instead.
+- the worker rAF itself can't be cleanly cancelled from another thread under emscripten's main loop, so the per-rAF wakeup still happens; pause is a flag-check, not a subscription cancel.
 
 ### Diagnostics
 
@@ -204,9 +217,7 @@ The fix is to render unconditionally on every worker rAF and let Dart's flag-set
 
 ### Pause/resume on web
 
-`pauseFrameScheduler()` / `resumeFrameScheduler()` call `RenderManager_setPaused(renderManager, bool)`, which flips an `mPaused` flag on the RenderManager. When paused, `tick()` skips `updateAnimationsAndPlugins` and the swapchain loop, but **still calls `mEngine->execute()`**. This matches the native pause semantics (scheduler keeps ticking, render work short-circuits) and is necessary because the Filament WebGL backend queues commands in a backend buffer that must be drained every rAF — otherwise any FFI state changes issued while paused would pile up and flush in a burst on resume.
-
-The worker rAF itself can't be cleanly cancelled from another thread in emscripten's main loop, so we can't avoid the per-rAF wakeup entirely; the pause is a flag-check, not a subscription cancel.
+See [Pause/resume](#pauseresume) in the native lifecycle section — the invariant and the web-specific notes (`mRenderPaused`, `mEngine->execute()` staying unconditional, animation freeze) are documented together.
 
 ### Key files
 

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -165,6 +165,10 @@ The emscripten build produces two files — `thermion_dart.js` and `thermion_dar
 
 For local iteration on native C++ that needs to ship to web: add `web_local: true` under `hooks.user_defines.thermion_dart` in the consuming app's pubspec.yaml, build the emscripten target (`native/web/build/build/out/thermion_dart.{js,wasm}`), and the build hook will copy from that local path instead of hitting R2. See `_downloadWebArtifacts` in `hook/build.dart`.
 
+### Single-swapchain invariant
+
+Web is fundamentally single-swapchain. `emscripten_pthread_attr_settransferredcanvases(&attr, "#thermion_canvas")` transfers exactly one canvas to the render worker, and the WebGL context lives on that canvas. There is no second canvas to bind a second swapchain to without re-architecting the worker model. The `RenderManager::tick()` loop over `mViewAttachments` is therefore always a one-iteration loop in practice — the generality is kept for parity with the native `render()` path, not because multiple swapchains are expected. Anything that would require a second render target on web (picture-in-picture, offscreen capture) has to be built on views + RTT into a texture, not additional swapchains.
+
 ### Threading model
 
 Two threads matter:

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -70,7 +70,7 @@ On web, Thermion compiles to a single emscripten pthread + WebGL build. Native C
 
 The emscripten build produces two files — `thermion_dart.js` and `thermion_dart.wasm` — that need to sit alongside the Flutter app's `web/index.html`. In normal use, `thermion_dart`'s build hook (`hook/build.dart`, `_downloadWebArtifacts`) reads `native/web/web.version`, downloads the matching zip from Cloudflare R2, caches it under `.dart_tool/thermion_dart/web/<sha>/`, and copies the two files into the consuming package's `web/` directory. CI rebuilds and uploads these artifacts when `web.version` is bumped.
 
-For local iteration on native C++ that needs to ship to web: set `THERMION_WEB_LOCAL=1`, build the emscripten target (`native/web/build/build/out/thermion_dart.{js,wasm}`), and the build hook will copy from that local path instead of hitting R2. See `_downloadWebArtifacts` in `hook/build.dart`.
+For local iteration on native C++ that needs to ship to web: add `web_local: true` under `hooks.user_defines.thermion_dart` in the consuming app's pubspec.yaml, build the emscripten target (`native/web/build/build/out/thermion_dart.{js,wasm}`), and the build hook will copy from that local path instead of hitting R2. See `_downloadWebArtifacts` in `hook/build.dart`.
 
 ### Threading model
 

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -202,7 +202,11 @@ The flag was originally intended to gate rendering so Dart could control when fr
 
 The fix is to render unconditionally on every worker rAF and let Dart's flag-setting be a no-op. This matches pre-refactor semantics (the `RenderTicker` also ran every worker rAF once it was requested). The flag is kept in the API for symmetry with native but is not gating on the web path.
 
-**Trade-off**: there's currently no way to *pause* rendering on web — `pauseFrameScheduler()` / `resumeFrameScheduler()` on `ThermionFlutterPluginImpl` are empty. If a pause path is needed (e.g. for tab visibility), wire those hooks to a `mPaused` flag checked at the top of `tick()`.
+### Pause/resume on web
+
+`pauseFrameScheduler()` / `resumeFrameScheduler()` call `RenderManager_setPaused(renderManager, bool)`, which flips an `mPaused` flag on the RenderManager. When paused, `tick()` skips `updateAnimationsAndPlugins` and the swapchain loop, but **still calls `mEngine->execute()`**. This matches the native pause semantics (scheduler keeps ticking, render work short-circuits) and is necessary because the Filament WebGL backend queues commands in a backend buffer that must be drained every rAF — otherwise any FFI state changes issued while paused would pile up and flush in a burst on resume.
+
+The worker rAF itself can't be cleanly cancelled from another thread in emscripten's main loop, so we can't avoid the per-rAF wakeup entirely; the pause is a flag-check, not a subscription cancel.
 
 ### Key files
 

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -101,7 +101,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   static bool _usePortMode = false;
   static bool _dartApiInitialized = false;
 
-  static bool _frameSchedulerPaused = false;
+  static bool _renderPaused = false;
 
   // Diagnostic timing state
   static int _diagFrameCount = 0;
@@ -124,7 +124,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
     // or if we're in a hot restart scenario where FilamentApp is null
     if (!_schedulerActive || FilamentApp.instance == null) return;
 
-    if (_rendering || _resizing || _frameSchedulerPaused) return;
+    if (_rendering || _resizing || _renderPaused) return;
     _rendering = true;
     _diagStopwatch.reset();
     _diagStopwatch.start();
@@ -445,11 +445,11 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   }
 
   void pauseFrameScheduler() {
-    _frameSchedulerPaused = true;
+    _renderPaused = true;
   }
 
   void resumeFrameScheduler() {
-    _frameSchedulerPaused = false;
+    _renderPaused = false;
   }
 
   /// Creates Filament textures + render target and binds them to [view].

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
@@ -183,8 +183,18 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   }
 
   @override
-  void pauseFrameScheduler() {}
+  void pauseFrameScheduler() {
+    final app = FilamentApp.instance as FFIFilamentApp?;
+    if (app != null) {
+      RenderManager_setPaused(app.renderManager, true);
+    }
+  }
 
   @override
-  void resumeFrameScheduler() {}
+  void resumeFrameScheduler() {
+    final app = FilamentApp.instance as FFIFilamentApp?;
+    if (app != null) {
+      RenderManager_setPaused(app.renderManager, false);
+    }
+  }
 }


### PR DESCRIPTION
`f05c2481` decoupled `RenderManager` from `RenderThread`, breaking the render loop on web. This migrates the web render loop to live alongside the new `RenderManager`:

- **`RenderManager::tick(now)`** — runs animations/plugins + per-swapchain `beginFrame/render/endFrame` + `mEngine->execute()` in a single synchronous call under the RenderManager mutex. Matches pre-refactor `RenderTicker::render()` exactly.
- **`RenderThread::iter()`** calls `tick()` once per worker rAF, after draining the task queue. `RenderManager_attachToRenderThread()` wires them at `FFIFilamentApp.create()`.
- **`FFIFilamentApp.render()` on web** becomes fire-and-forget: `RenderManager_requestRender()` just flips a flag. The flag is kept in the API for native symmetry but is **not gating** on web — see `ARCHITECTURE.md` for why (Dart's main-thread `_tick` and the worker's `mainLoop` are independent 60Hz rAFs that aren't phase-locked; gating on the flag drops ~5-10 fps).

### Notes

1. **`mEngine->execute()` runs on every rAF, unconditionally** — even when every `beginFrame` rejected. Filament's backend command buffer needs to be drained each rAF regardless of whether a visible frame was produced.
2. **`beginFrame`, `endFrame`, and `execute()` must happen in the same `tick()` call.** Attempts to split (state machines, pipelining, `setTimeout(0)`-scheduled execute) all broke rendering.

