### PR TITLE
feat: expose LUT format and dimensions on ColorGradingBuilder

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -19,6 +19,187 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 @ffi.Native<ffi.Uint64>()
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+        ffi.Int,
+        ffi.UnsignedInt,
+        Aabb3)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tVertexBuffer,
+  ffi.Pointer<TIndexBuffer> tIndexBuffer,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<TFilamentAsset>,
+        ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
+);
+
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getType(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_destroy(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void SceneAsset_addToScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void SceneAsset_removeFromScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getEntity(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getChildEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
+    isLeaf: true)
+external void SceneAsset_getChildEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getCameraEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getLightEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int index,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>,
+        ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
+  ffi.Pointer<TSceneAsset> asset,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external Aabb3 SceneAsset_getBoundingBox(
+  ffi.Pointer<TSceneAsset> asset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TVertexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_releaseSourceData(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
+external void SceneAsset_setFlatShading(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size,
+        ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getBones(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
+external int SceneAsset_getBoneCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+);
+
+@ffi.Native<
+    ffi.Pointer<ffi.Char> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+);
+
 @ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
     isLeaf: true)
 external ffi.Pointer<TMaterialInstance> Material_createInstance(
@@ -295,399 +476,637 @@ external int Material_getBlendingMode(
 );
 
 @ffi.Native<
-    ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>,
+    ffi.Pointer<TTexture> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint8,
+        ffi.Uint16,
+        ffi.IntPtr,
+        ffi.UnsignedInt,
         ffi.UnsignedInt)>(isLeaf: true)
-external int LightManager_createLight(
+external ffi.Pointer<TTexture> Texture_build(
+  ffi.Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import$,
+  int sampler,
+  int format,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
+        ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void Texture_setExternalImage(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<ffi.Void> externalImage,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external void LightManager_destroyLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_hasComponent(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external int LightManager_getType(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isDirectional(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isPointLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isSpotLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityCandela(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double falloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSpotLightOuterCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSpotLightInnerCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloSize,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloFalloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
-    isLeaf: true)
-external void LightManager_setShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-);
-
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external TShadowOptions LightManager_getShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt,
-        ffi.Bool)>(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
+@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
+external int Texture_getLevels(
+  ffi.Pointer<TTexture> tTexture,
 );
 
 @ffi.Native<
     ffi.Bool Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
-external bool LightManager_getLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TLinearImage>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Int)>(isLeaf: true)
+external bool Texture_loadImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Uint32,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32)>(isLeaf: true)
+external bool Texture_setImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getWidth(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getHeight(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getDepth(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getUsage(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external void Texture_generateMipMaps(
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TKtx1Bundle> Function(
+        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(
+  ffi.Pointer<ffi.Uint8> ktxData,
+  int length,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void Ktx1Bundle_getSphericalHarmonics(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  ffi.Pointer<ffi.Float> harmonics,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external bool Ktx1Bundle_isCubemap(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external void Ktx1Bundle_destroy(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  VoidCallback onTextureUploadComplete,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+);
+
+@ffi.Native<
+    ffi.Pointer<TLinearImage> Function(
+        ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+external ffi.Pointer<TLinearImage> Image_createEmpty(
+  int width,
+  int height,
   int channel,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
+@ffi.Native<
+    ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
+        ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TLinearImage> Image_decode(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> name,
+  bool alpha,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(
+    isLeaf: true)
+external ffi.Pointer<ffi.Float> Image_getBytes(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external void Image_destroy(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getWidth(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getHeight(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getChannels(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
+    isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getColorTexture(
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
+    isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_create();
+
+@ffi.Native<
+    ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt,
+        ffi.UnsignedInt, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTextureSampler> Function(
+        ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(
+  int compareMode,
+  int compareFunc,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setMinFilter(
+  ffi.Pointer<TTextureSampler> sampler,
+  int filter,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setMagFilter(
+  ffi.Pointer<TTextureSampler> sampler,
+  int filter,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeS(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeT(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeR(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(
+    isLeaf: true)
+external void TextureSampler_setAnisotropy(
+  ffi.Pointer<TTextureSampler> sampler,
+  double anisotropy,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setCompareMode(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+  int func,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
+external void TextureSampler_destroy(
+  ffi.Pointer<TTextureSampler> sampler,
+);
+
+@ffi.Native<
+    ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>,
+        ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TEngine> Engine_create(
+  int backend,
+  ffi.Pointer<ffi.Void> platform,
+  ffi.Pointer<ffi.Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getSupportedFeatureLevel(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_destroy(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TRenderer> Engine_createRenderer(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSwapChain> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Void> window,
+  int flags,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSwapChain> Function(
+        ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  int flags,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
+    isLeaf: true)
+external void Engine_destroySwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSwapChain> tSwapChain,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Engine_destroyView(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void Engine_destroyScene(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TScene> tScene,
 );
 
 @ffi.Native<
     ffi.Void Function(
-        ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
+        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void Engine_destroyColorGrading(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TColorGrading> tColorGrading,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
+    isLeaf: true)
+external ffi.Pointer<TCamera> Engine_createCamera(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
+    isLeaf: true)
+external void Engine_destroyCamera(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TCamera> tCamera,
+);
+
+@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TView> Engine_createView(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
+    isLeaf: true)
+external ffi.Pointer<TCamera> Engine_getCameraComponent(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+);
+
+@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TTransformManager> Engine_getTransformManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TLightManager> Engine_getLightManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TEntityManager> Engine_getEntityManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
+external void Engine_setAutomaticInstancingEnabled(
+  ffi.Pointer<TEngine> tEngine,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getMaxAutomaticInstances(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
+    isLeaf: true)
+external void Engine_destroyTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TFence> Engine_createFence(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
+    isLeaf: true)
+external void Engine_destroyFence(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TFence> tFence,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_flushAndWait(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_execute(
+  ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float,
-        ffi.Float)>(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
+    ffi.Pointer<TMaterial> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Engine_buildMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> materialData,
+  int length,
 );
 
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
     isLeaf: true)
-external double LightManager_rgbToColorTemperature(
+external void Engine_destroyMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterial> tMaterial,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void Engine_destroyMaterialInstance(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TScene> Engine_createScene(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSkybox> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float,
+        ffi.Float, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
+  ffi.Pointer<TEngine> tEngine,
   double r,
   double g,
   double b,
+  double a,
 );
 
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
+@ffi.Native<
+    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TIndirectLight>
+    Engine_buildIndirectLightFromIrradianceTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TIndirectLight>
+    Engine_buildIndirectLightFromIrradianceHarmonics(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<ffi.Float> irradianceHarmonics,
+  double intensity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
+    isLeaf: true)
+external void Engine_destroySkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSkybox> tSkybox,
 );
 
 @ffi.Native<
     ffi.Void Function(
-        ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void FilamentAsset_getEntities(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-  ffi.Pointer<EntityId> out,
+        ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Engine_destroyIndirectLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
 );
 
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
+@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
+external int EntityManager_createEntity(
+  ffi.Pointer<TEntityManager> tEntityManager,
 );
 
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
     isLeaf: true)
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
+external void EntityManager_destroyEntity(
+  ffi.Pointer<TEntityManager> tEntityManager,
+  int entityId,
 );
 
-@ffi.Native<
-    ffi.Pointer<TGltfAssetLoader> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
+external void Fence_waitAndDestroy(
+  ffi.Pointer<TFence> tFence,
+);
+
+@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
 );
 
 @ffi.Native<
-    ffi.Pointer<TFilamentAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint8)>(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int numInstances,
+    ffi.Bool Function(
+        ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external bool DebugRegistry_hasProperty(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
 );
 
 @ffi.Native<
-    ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>,
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  ffi.Pointer<TFilamentAsset> tAsset,
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Bool)>(isLeaf: true)
+external bool DebugRegistry_setProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  bool value,
 );
 
 @ffi.Native<
-    ffi.Pointer<TMaterialProvider> Function(
-        ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getResourceUriCount(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Int)>(isLeaf: true)
+external bool DebugRegistry_setProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  int value,
 );
 
 @ffi.Native<
-    ffi.Pointer<ffi.Pointer<ffi.Char>> Function(
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Float)>(isLeaf: true)
+external bool DebugRegistry_setProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  double value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Bool>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Bool> outValue,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Int>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Int> outValue,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Float> outValue,
 );
 
 @ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
@@ -1231,617 +1650,6 @@ external ffi.Pointer<ffi.Char> View_getName(
   ffi.Pointer<TView> tView,
 );
 
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
-
-@ffi.Native<
-    ffi.Pointer<ffi.Char> Function(
-        ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientationBuilder>
-    SurfaceOrientationBuilder_create();
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_vertexCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_normals(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> normals,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_tangents(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> tangents,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_uvs(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> uvs,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_positions(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> positions,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangleCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_uint(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint32> triangles,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_ushort(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint16> triangles,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSurfaceOrientation> Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
-    isLeaf: true)
-external void SurfaceOrientationBuilder_destroy(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external int SurfaceOrientation_getVertexCount(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_float4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Float> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_short4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Int16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_half4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Uint16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external void SurfaceOrientation_destroy(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void IndirectLight_setRotation(
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-  ffi.Pointer<ffi.Double> rotation,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTexture> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint8,
-        ffi.Uint16,
-        ffi.IntPtr,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTexture> Texture_build(
-  ffi.Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import$,
-  int sampler,
-  int format,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
-        ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void Texture_setExternalImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<ffi.Void> externalImage,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getLevels(
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TLinearImage>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Int)>(isLeaf: true)
-external bool Texture_loadImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Uint32,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32)>(isLeaf: true)
-external bool Texture_setImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getWidth(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getHeight(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getDepth(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getUsage(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external void Texture_generateMipMaps(
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TKtx1Bundle> Function(
-        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(
-  ffi.Pointer<ffi.Uint8> ktxData,
-  int length,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void Ktx1Bundle_getSphericalHarmonics(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  ffi.Pointer<ffi.Float> harmonics,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external bool Ktx1Bundle_isCubemap(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external void Ktx1Bundle_destroy(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  VoidCallback onTextureUploadComplete,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTexture> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-);
-
-@ffi.Native<
-    ffi.Pointer<TLinearImage> Function(
-        ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
-external ffi.Pointer<TLinearImage> Image_createEmpty(
-  int width,
-  int height,
-  int channel,
-);
-
-@ffi.Native<
-    ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
-        ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
-external ffi.Pointer<TLinearImage> Image_decode(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> name,
-  bool alpha,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(
-    isLeaf: true)
-external ffi.Pointer<ffi.Float> Image_getBytes(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external void Image_destroy(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getWidth(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getHeight(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getChannels(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getColorTexture(
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_create();
-
-@ffi.Native<
-    ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt,
-        ffi.UnsignedInt, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTextureSampler> Function(
-        ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(
-  int compareMode,
-  int compareFunc,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setMinFilter(
-  ffi.Pointer<TTextureSampler> sampler,
-  int filter,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setMagFilter(
-  ffi.Pointer<TTextureSampler> sampler,
-  int filter,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeS(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeT(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeR(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(
-    isLeaf: true)
-external void TextureSampler_setAnisotropy(
-  ffi.Pointer<TTextureSampler> sampler,
-  double anisotropy,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setCompareMode(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-  int func,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
-external void TextureSampler_destroy(
-  ffi.Pointer<TTextureSampler> sampler,
-);
-
-@ffi.Native<
-    ffi.Pointer<TRenderManager> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
-    isLeaf: true)
-external void RenderManager_render(
-  ffi.Pointer<TRenderManager> tRenderer,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
-        ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)>(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
-external void RenderManager_removeSwapChain(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
-    isLeaf: true)
-external void RenderManager_setPaused(
-  ffi.Pointer<TRenderManager> tRenderer,
-  bool paused,
-);
-
-@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_start(
-  FrameCallback callback,
-  int targetFps,
-);
-
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void FrameScheduler_setRenderThread(
-  ffi.Pointer<ffi.Void> renderThread,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void FrameScheduler_setRenderManager(
-  ffi.Pointer<TRenderManager> rm,
-);
-
-@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
-    isLeaf: true)
-external void FrameScheduler_setPostRenderCallback(
-  PostRenderCallback callback,
-  ffi.Pointer<ffi.Void> userData,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Uint64)>(isLeaf: true)
-external void FrameScheduler_requestRender(
-  int frameTimeNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startNativeRenderLoop(
-  int targetFps,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(
-  ffi.Pointer<ffi.Void> data,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(
-  int port,
-  int targetFps,
-);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
-
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(
-  int t,
-);
-
-@ffi.Native<
-    ffi.Pointer<TGizmo> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<TView>,
-        ffi.Pointer<TMaterial>,
-        ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TGizmo> Gizmo_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> assetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32,
-        GizmoPickCallback)>(isLeaf: true)
-external void Gizmo_pick(
-  ffi.Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  GizmoPickCallback callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void Gizmo_highlight(
-  ffi.Pointer<TGizmo> tGizmo,
-  int axis,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(
-  ffi.Pointer<TGizmo> tGizmo,
-);
-
 @ffi.Native<
     ffi.Pointer<TMaterialInstance> Function(
         ffi.Pointer<TMaterialProvider>,
@@ -1925,60 +1733,6 @@ external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   bool hasVolume,
 );
 
-@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
-    isLeaf: true)
-external void IndexBufferBuilder_indexCount(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void IndexBufferBuilder_bufferType(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndexBuffer> Function(
-        ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
-external void IndexBufferBuilder_destroy(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(
-  ffi.Pointer<TIndexBuffer> buffer,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
-external void IndexBuffer_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
-    isLeaf: true)
-external void IndexBuffer_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-);
-
 @ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
 
@@ -2055,225 +1809,58 @@ external void VertexBuffer_destroy(
   ffi.Pointer<TVertexBuffer> buffer,
 );
 
-@ffi.Native<
-    ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(isLeaf: true)
-external ffi.Pointer<TRenderTarget> RenderTarget_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> color,
-  ffi.Pointer<TTexture> depth,
-);
+@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external void RenderTarget_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
     isLeaf: true)
-external void Scene_setSkybox(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TSkybox> skybox,
+external void IndexBufferBuilder_indexCount(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int count,
 );
 
 @ffi.Native<
     ffi.Void Function(
-        ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Scene_setIndirectLight(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
+        ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void IndexBufferBuilder_bufferType(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int indexType,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external void Scene_addFilamentAsset(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TFilamentAsset> asset,
+    ffi.Pointer<TIndexBuffer> Function(
+        ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
+external void IndexBufferBuilder_destroy(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external int IndexBuffer_getIndexCount(
+  ffi.Pointer<TIndexBuffer> buffer,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void Camera_setExposure(
-  ffi.Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+external void IndexBuffer_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
 );
 
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
     isLeaf: true)
-external void Camera_getFrustum(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> out,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double, ffi.Bool)>(isLeaf: true)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
-    isLeaf: true)
-external void Camera_lookAt(
-  ffi.Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(
-  ffi.Pointer<TCamera> camera,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(
-  ffi.Pointer<TCamera> camera,
-  double focusDistance,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-    isLeaf: true)
-external void Camera_setModelMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> tModelMatrix,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>,
-        ffi.UnsignedInt,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
+external void IndexBuffer_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
 );
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
@@ -2387,418 +1974,6 @@ external void TransformManager_openLocalTransformTransaction(
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
 external void TransformManager_commitLocalTransformTransaction(
   ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Double, ffi.Double,
-        ffi.Double, ffi.Double, ffi.Uint8, ffi.Bool, ffi.Bool)>(isLeaf: true)
-external void Renderer_setClearOptions(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>,
-        ffi.Uint64)>(isLeaf: true)
-external bool Renderer_beginFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Renderer_render(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Renderer_renderStandaloneView(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Pointer<TRenderTarget>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size)>(isLeaf: true)
-external void Renderer_readPixels(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8,
-        ffi.Uint8)>(isLeaf: true)
-external void Renderer_setFrameInterval(
-  ffi.Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-);
-
-@ffi.Native<
-    ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>,
-        ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)>(isLeaf: true)
-external ffi.Pointer<TEngine> Engine_create(
-  int backend,
-  ffi.Pointer<ffi.Void> platform,
-  ffi.Pointer<ffi.Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getSupportedFeatureLevel(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_destroy(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TRenderer> Engine_createRenderer(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSwapChain> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Void> window,
-  int flags,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSwapChain> Function(
-        ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  int flags,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
-    isLeaf: true)
-external void Engine_destroySwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSwapChain> tSwapChain,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Engine_destroyView(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void Engine_destroyScene(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void Engine_destroyColorGrading(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TColorGrading> tColorGrading,
-);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-    isLeaf: true)
-external ffi.Pointer<TCamera> Engine_createCamera(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
-    isLeaf: true)
-external void Engine_destroyCamera(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TCamera> tCamera,
-);
-
-@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TView> Engine_createView(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-    isLeaf: true)
-external ffi.Pointer<TCamera> Engine_getCameraComponent(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-);
-
-@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TTransformManager> Engine_getTransformManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TLightManager> Engine_getLightManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TEntityManager> Engine_getEntityManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
-external void Engine_setAutomaticInstancingEnabled(
-  ffi.Pointer<TEngine> tEngine,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getMaxAutomaticInstances(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
-    isLeaf: true)
-external void Engine_destroyTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TFence> Engine_createFence(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
-    isLeaf: true)
-external void Engine_destroyFence(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TFence> tFence,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_flushAndWait(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_execute(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TMaterial> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Engine_buildMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> materialData,
-  int length,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
-    isLeaf: true)
-external void Engine_destroyMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterial> tMaterial,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external void Engine_destroyMaterialInstance(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TScene> Engine_createScene(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSkybox> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float,
-        ffi.Float, ffi.Float)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)>(isLeaf: true)
-external ffi.Pointer<TIndirectLight>
-    Engine_buildIndirectLightFromIrradianceTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)>(isLeaf: true)
-external ffi.Pointer<TIndirectLight>
-    Engine_buildIndirectLightFromIrradianceHarmonics(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<ffi.Float> irradianceHarmonics,
-  double intensity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
-    isLeaf: true)
-external void Engine_destroySkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSkybox> tSkybox,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Engine_destroyIndirectLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
-external int EntityManager_createEntity(
-  ffi.Pointer<TEntityManager> tEntityManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
-    isLeaf: true)
-external void EntityManager_destroyEntity(
-  ffi.Pointer<TEntityManager> tEntityManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
-external void Fence_waitAndDestroy(
-  ffi.Pointer<TFence> tFence,
-);
-
-@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external bool DebugRegistry_hasProperty(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Bool)>(isLeaf: true)
-external bool DebugRegistry_setProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  bool value,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Int)>(isLeaf: true)
-external bool DebugRegistry_setProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  int value,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Float)>(isLeaf: true)
-external bool DebugRegistry_setProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  double value,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Bool>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Bool> outValue,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Int>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Int> outValue,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Float> outValue,
 );
 
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
@@ -4879,6 +4054,502 @@ external void RenderableManager_setBonesFromBoneRenderThread(
   VoidCallback onComplete,
 );
 
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void IndirectLight_setRotation(
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+  ffi.Pointer<ffi.Double> rotation,
+);
+
+@ffi.Native<
+    ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>,
+        ffi.UnsignedInt)>(isLeaf: true)
+external int LightManager_createLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external void LightManager_destroyLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_hasComponent(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external int LightManager_getType(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isDirectional(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isPointLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isSpotLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityCandela(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double falloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSpotLightOuterCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSpotLightInnerCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloSize,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloFalloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
+    isLeaf: true)
+external void LightManager_setShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external TShadowOptions LightManager_getShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt,
+        ffi.Bool)>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool LightManager_getLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float,
+        ffi.Float)>(isLeaf: true)
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
+    isLeaf: true)
+external double LightManager_rgbToColorTemperature(
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void Camera_setExposure(
+  ffi.Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+    isLeaf: true)
+external void Camera_getFrustum(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> out,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double, ffi.Bool)>(isLeaf: true)
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
+    isLeaf: true)
+external void Camera_lookAt(
+  ffi.Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(
+  ffi.Pointer<TCamera> camera,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(
+  ffi.Pointer<TCamera> camera,
+  double focusDistance,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+    isLeaf: true)
+external void Camera_setModelMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> tModelMatrix,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>,
+        ffi.UnsignedInt,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+);
+
 @ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
     isLeaf: true)
 external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
@@ -4938,26 +4609,6 @@ external void Skybox_setColor(
   double g,
   double b,
   double a,
-);
-
-@ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
-external void dummy(
-  TGltfMeshData dummy,
-);
-
-@ffi.Native<
-    ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
-external int GltfParser_parseBuffer(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> meshName,
-  ffi.Pointer<TGltfMeshData> outMeshData,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
-external void GltfParser_freeMeshData(
-  ffi.Pointer<TGltfMeshData> meshData,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(
@@ -5441,185 +5092,510 @@ external int RenderableBuilder_build(
   int entity,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
+    isLeaf: true)
+external void Scene_setSkybox(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TSkybox> skybox,
+);
+
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-        ffi.Int,
+    ffi.Void Function(
+        ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Scene_setIndirectLight(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external void Scene_addFilamentAsset(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TFilamentAsset> asset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external ffi.Pointer<TRenderTarget> RenderTarget_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> color,
+  ffi.Pointer<TTexture> depth,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void RenderTarget_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientationBuilder>
+    SurfaceOrientationBuilder_create();
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_vertexCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_normals(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> normals,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_tangents(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> tangents,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_uvs(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> uvs,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_positions(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> positions,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangleCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_uint(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint32> triangles,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_ushort(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint16> triangles,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSurfaceOrientation> Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
+    isLeaf: true)
+external void SurfaceOrientationBuilder_destroy(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external int SurfaceOrientation_getVertexCount(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_float4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Float> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_short4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Int16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_half4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Uint16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external void SurfaceOrientation_destroy(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
+external void dummy(
+  TGltfMeshData dummy,
+);
+
+@ffi.Native<
+    ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
+external int GltfParser_parseBuffer(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> meshName,
+  ffi.Pointer<TGltfMeshData> outMeshData,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
+external void GltfParser_freeMeshData(
+  ffi.Pointer<TGltfMeshData> meshData,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Double, ffi.Double,
+        ffi.Double, ffi.Double, ffi.Uint8, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void Renderer_setClearOptions(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>,
+        ffi.Uint64)>(isLeaf: true)
+external bool Renderer_beginFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Renderer_endFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Renderer_render(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Renderer_renderStandaloneView(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Pointer<TRenderTarget>,
         ffi.UnsignedInt,
-        Aabb3)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+        ffi.UnsignedInt,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size)>(isLeaf: true)
+external void Renderer_readPixels(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8,
+        ffi.Uint8)>(isLeaf: true)
+external void Renderer_setFrameInterval(
+  ffi.Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+);
+
+@ffi.Native<
+    ffi.Pointer<TRenderManager> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tVertexBuffer,
-  ffi.Pointer<TIndexBuffer> tIndexBuffer,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(
+  ffi.Pointer<TRenderManager> tRenderer,
 );
 
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<TFilamentAsset>,
-        ffi.Bool)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
-);
-
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void SceneAsset_addToScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void SceneAsset_removeFromScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
-    isLeaf: true)
-external void SceneAsset_getChildEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
 );
 
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int index,
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
 );
 
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>,
-        ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
-  ffi.Pointer<TSceneAsset> asset,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(
-  ffi.Pointer<TSceneAsset> asset,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
+    isLeaf: true)
+external void RenderManager_render(
+  ffi.Pointer<TRenderManager> tRenderer,
+  int frameTimeInNanos,
 );
 
 @ffi.Native<
-    ffi.Pointer<TVertexBuffer> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
+    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
+        ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)>(isLeaf: true)
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
 );
 
 @ffi.Native<
-    ffi.Pointer<TIndexBuffer> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
+    ffi.Void Function(
+        ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void RenderManager_removeSwapChain(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(
+  ffi.Pointer<TRenderManager> tRenderer,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(
+  ffi.Pointer<TRenderManager> tRenderer,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size,
-        ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getBones(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  ffi.Pointer<EntityId> out,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderManager_setPaused(
+  ffi.Pointer<TRenderManager> tRenderer,
+  bool paused,
 );
 
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-);
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
 
 @ffi.Native<
     ffi.Pointer<ffi.Char> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
+        ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(
+  int t,
+);
+
+@ffi.Native<
+    ffi.Pointer<TGizmo> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<TView>,
+        ffi.Pointer<TMaterial>,
+        ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TGizmo> Gizmo_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> assetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32,
+        GizmoPickCallback)>(isLeaf: true)
+external void Gizmo_pick(
+  ffi.Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  GizmoPickCallback callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void Gizmo_highlight(
+  ffi.Pointer<TGizmo> tGizmo,
+  int axis,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
+external void Gizmo_unhighlight(
+  ffi.Pointer<TGizmo> tGizmo,
+);
+
+@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_start(
+  FrameCallback callback,
+  int targetFps,
+);
+
+@ffi.Native<ffi.Void Function()>(isLeaf: true)
+external void FrameScheduler_stop();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void FrameScheduler_setRenderThread(
+  ffi.Pointer<ffi.Void> renderThread,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void FrameScheduler_setRenderManager(
+  ffi.Pointer<TRenderManager> rm,
+);
+
+@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
+    isLeaf: true)
+external void FrameScheduler_setPostRenderCallback(
+  PostRenderCallback callback,
+  ffi.Pointer<ffi.Void> userData,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Uint64)>(isLeaf: true)
+external void FrameScheduler_requestRender(
+  int frameTimeNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startNativeRenderLoop(
+  int targetFps,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(
+  ffi.Pointer<ffi.Void> data,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(
+  int port,
+  int targetFps,
+);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
+
+@ffi.Native<
+    ffi.Pointer<TGltfAssetLoader> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<
+    ffi.Pointer<TFilamentAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint8)>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>,
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  ffi.Pointer<TFilamentAsset> tAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialProvider> Function(
+        ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getResourceUriCount(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<ffi.Pointer<ffi.Char>> Function(
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
 );
 
 @ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(
@@ -5869,6 +5845,30 @@ external bool AnimationManager_setGltfAnimationTime(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int animationIndex,
   double timeInSeconds,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void FilamentAsset_getEntities(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
@@ -6321,312 +6321,6 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-final class TShadowOptions extends ffi.Struct {
-  @ffi.Uint32()
-  external int mapSize;
-
-  @ffi.Uint8()
-  external int shadowCascades;
-
-  @ffi.Array.multi([3])
-  external ffi.Array<ffi.Float> cascadeSplitPositions;
-
-  @ffi.Float()
-  external double constantBias;
-
-  @ffi.Float()
-  external double normalBias;
-
-  @ffi.Float()
-  external double shadowFar;
-
-  @ffi.Float()
-  external double shadowNearHint;
-
-  @ffi.Float()
-  external double shadowFarHint;
-
-  @ffi.Bool()
-  external bool stable;
-
-  @ffi.Bool()
-  external bool lispsm;
-
-  @ffi.Float()
-  external double polygonOffsetConstant;
-
-  @ffi.Float()
-  external double polygonOffsetSlope;
-
-  @ffi.Bool()
-  external bool screenSpaceContactShadows;
-
-  @ffi.Uint8()
-  external int stepCount;
-
-  @ffi.Float()
-  external double maxShadowDistance;
-
-  @ffi.Bool()
-  external bool vsmElvsm;
-
-  @ffi.Float()
-  external double vsmBlurWidth;
-
-  @ffi.Float()
-  external double shadowBulbRadius;
-
-  @ffi.Float()
-  external double transformX;
-
-  @ffi.Float()
-  external double transformY;
-
-  @ffi.Float()
-  external double transformZ;
-
-  @ffi.Float()
-  external double transformW;
-}
-
-final class TViewport extends ffi.Struct {
-  @ffi.Int32()
-  external int left;
-
-  @ffi.Int32()
-  external int bottom;
-
-  @ffi.Uint32()
-  external int width;
-
-  @ffi.Uint32()
-  external int height;
-}
-
-/// Copied from FogOptions in View.h
-final class TFogOptions extends ffi.Struct {
-  @ffi.Float()
-  external double distance;
-
-  @ffi.Float()
-  external double cutOffDistance;
-
-  @ffi.Float()
-  external double maximumOpacity;
-
-  @ffi.Float()
-  external double height;
-
-  @ffi.Float()
-  external double heightFalloff;
-
-  @ffi.Float()
-  external double density;
-
-  @ffi.Float()
-  external double inScatteringStart;
-
-  @ffi.Float()
-  external double inScatteringSize;
-
-  external ffi.Pointer<TTexture> skyColor;
-
-  @ffi.Float()
-  external double linearColorR;
-
-  @ffi.Float()
-  external double linearColorG;
-
-  @ffi.Float()
-  external double linearColorB;
-
-  @ffi.Bool()
-  external bool fogColorFromIbl;
-
-  @ffi.Bool()
-  external bool enabled;
-}
-
-final class TToneMapper extends ffi.Opaque {}
-
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
-}
-
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
-}
-
-sealed class TLutFormat {
-  static const INTEGER = 0;
-  static const FLOAT = 1;
-}
-
-final class TColorGradingBuilder extends ffi.Opaque {}
-
-/// Options for DPCF and PCSS Shadowing.
-final class TSoftShadowOptions extends ffi.Struct {
-  @ffi.Float()
-  external double penumbraScale;
-
-  @ffi.Float()
-  external double penumbraRatioScale;
-}
-
-/// Options for VSM Shadowing.
-final class TVsmShadowOptions extends ffi.Struct {
-  @ffi.Uint8()
-  external int anisotropy;
-
-  @ffi.Bool()
-  external bool mipmapping;
-
-  @ffi.Uint8()
-  external int msaaSamples;
-
-  @ffi.Bool()
-  external bool highPrecision;
-
-  @ffi.Float()
-  external double minVarianceScale;
-
-  @ffi.Float()
-  external double lightBleedReduction;
-}
-
-/// Screen Space Cone Tracing (SSCT) options
-/// Ambient shadows from dominant light
-final class TSsct extends ffi.Struct {
-  /// !< full cone angle in radian, between 0 and pi/2
-  @ffi.Float()
-  external double lightConeRad;
-
-  /// !< how far shadows can be cast
-  @ffi.Float()
-  external double shadowDistance;
-
-  /// !< max distance for contact
-  @ffi.Float()
-  external double contactDistanceMax;
-
-  /// !< intensity
-  @ffi.Float()
-  external double intensity;
-
-  /// !< light direction X
-  @ffi.Float()
-  external double lightDirectionX;
-
-  /// !< light direction Y
-  @ffi.Float()
-  external double lightDirectionY;
-
-  /// !< light direction Z
-  @ffi.Float()
-  external double lightDirectionZ;
-
-  /// !< depth bias in world units (mitigate self shadowing)
-  @ffi.Float()
-  external double depthBias;
-
-  /// !< depth slope bias (mitigate self shadowing)
-  @ffi.Float()
-  external double depthSlopeBias;
-
-  /// !< tracing sample count, between 1 and 255
-  @ffi.Uint8()
-  external int sampleCount;
-
-  /// !< # of rays to trace, between 1 and 255
-  @ffi.Uint8()
-  external int rayCount;
-
-  /// !< enables or disables SSCT
-  @ffi.Bool()
-  external bool enabled;
-}
-
-/// Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
-final class TAmbientOcclusionOptions extends ffi.Struct {
-  /// !< Ambient Occlusion radius in meters, between 0 and ~10
-  @ffi.Float()
-  external double radius;
-
-  /// !< Controls ambient occlusion's contrast. Must be positive
-  @ffi.Float()
-  external double power;
-
-  /// !< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm
-  @ffi.Float()
-  external double bias;
-
-  /// !< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0
-  @ffi.Float()
-  external double resolution;
-
-  /// !< Strength of the Ambient Occlusion effect
-  @ffi.Float()
-  external double intensity;
-
-  /// !< depth distance that constitute an edge for filtering
-  @ffi.Float()
-  external double bilateralThreshold;
-
-  /// !< affects # of samples used for AO
-  @ffi.UnsignedInt()
-  external int quality;
-
-  /// !< affects AO smoothness
-  @ffi.UnsignedInt()
-  external int lowPassFilter;
-
-  /// !< affects AO buffer upsampling quality
-  @ffi.UnsignedInt()
-  external int upsampling;
-
-  /// !< enables or disables screen-space ambient occlusion
-  @ffi.Bool()
-  external bool enabled;
-
-  /// !< enables bent normals computation from AO, and specular AO
-  @ffi.Bool()
-  external bool bentNormals;
-
-  /// !< min angle in radian to consider
-  @ffi.Float()
-  external double minHorizonAngleRad;
-
-  external TSsct ssct;
-}
-
-typedef PickCallbackFunction = ffi.Void Function(
-    ffi.Uint32 requestId,
-    EntityId entityId,
-    ffi.Float depth,
-    ffi.Float fragX,
-    ffi.Float fragY,
-    ffi.Float fragZ);
-typedef DartPickCallbackFunction = void Function(
-    int requestId,
-    DartEntityId entityId,
-    double depth,
-    double fragX,
-    double fragY,
-    double fragZ);
-typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
-
 sealed class TTextureSamplerType {
   static const SAMPLER_2D = 0;
   static const SAMPLER_2D_ARRAY = 1;
@@ -6880,15 +6574,354 @@ sealed class TSamplerCompareMode {
   static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
 }
 
-typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
-typedef PostRenderCallbackFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(
-    ffi.Pointer<ffi.Void> userData);
-typedef PostRenderCallback
-    = ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+final class TViewport extends ffi.Struct {
+  @ffi.Int32()
+  external int left;
+
+  @ffi.Int32()
+  external int bottom;
+
+  @ffi.Uint32()
+  external int width;
+
+  @ffi.Uint32()
+  external int height;
+}
+
+/// Copied from FogOptions in View.h
+final class TFogOptions extends ffi.Struct {
+  @ffi.Float()
+  external double distance;
+
+  @ffi.Float()
+  external double cutOffDistance;
+
+  @ffi.Float()
+  external double maximumOpacity;
+
+  @ffi.Float()
+  external double height;
+
+  @ffi.Float()
+  external double heightFalloff;
+
+  @ffi.Float()
+  external double density;
+
+  @ffi.Float()
+  external double inScatteringStart;
+
+  @ffi.Float()
+  external double inScatteringSize;
+
+  external ffi.Pointer<TTexture> skyColor;
+
+  @ffi.Float()
+  external double linearColorR;
+
+  @ffi.Float()
+  external double linearColorG;
+
+  @ffi.Float()
+  external double linearColorB;
+
+  @ffi.Bool()
+  external bool fogColorFromIbl;
+
+  @ffi.Bool()
+  external bool enabled;
+}
+
+final class TToneMapper extends ffi.Opaque {}
+
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
+}
+
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
+}
+
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
+}
+
+final class TColorGradingBuilder extends ffi.Opaque {}
+
+/// Options for DPCF and PCSS Shadowing.
+final class TSoftShadowOptions extends ffi.Struct {
+  @ffi.Float()
+  external double penumbraScale;
+
+  @ffi.Float()
+  external double penumbraRatioScale;
+}
+
+/// Options for VSM Shadowing.
+final class TVsmShadowOptions extends ffi.Struct {
+  @ffi.Uint8()
+  external int anisotropy;
+
+  @ffi.Bool()
+  external bool mipmapping;
+
+  @ffi.Uint8()
+  external int msaaSamples;
+
+  @ffi.Bool()
+  external bool highPrecision;
+
+  @ffi.Float()
+  external double minVarianceScale;
+
+  @ffi.Float()
+  external double lightBleedReduction;
+}
+
+/// Screen Space Cone Tracing (SSCT) options
+/// Ambient shadows from dominant light
+final class TSsct extends ffi.Struct {
+  /// !< full cone angle in radian, between 0 and pi/2
+  @ffi.Float()
+  external double lightConeRad;
+
+  /// !< how far shadows can be cast
+  @ffi.Float()
+  external double shadowDistance;
+
+  /// !< max distance for contact
+  @ffi.Float()
+  external double contactDistanceMax;
+
+  /// !< intensity
+  @ffi.Float()
+  external double intensity;
+
+  /// !< light direction X
+  @ffi.Float()
+  external double lightDirectionX;
+
+  /// !< light direction Y
+  @ffi.Float()
+  external double lightDirectionY;
+
+  /// !< light direction Z
+  @ffi.Float()
+  external double lightDirectionZ;
+
+  /// !< depth bias in world units (mitigate self shadowing)
+  @ffi.Float()
+  external double depthBias;
+
+  /// !< depth slope bias (mitigate self shadowing)
+  @ffi.Float()
+  external double depthSlopeBias;
+
+  /// !< tracing sample count, between 1 and 255
+  @ffi.Uint8()
+  external int sampleCount;
+
+  /// !< # of rays to trace, between 1 and 255
+  @ffi.Uint8()
+  external int rayCount;
+
+  /// !< enables or disables SSCT
+  @ffi.Bool()
+  external bool enabled;
+}
+
+/// Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+final class TAmbientOcclusionOptions extends ffi.Struct {
+  /// !< Ambient Occlusion radius in meters, between 0 and ~10
+  @ffi.Float()
+  external double radius;
+
+  /// !< Controls ambient occlusion's contrast. Must be positive
+  @ffi.Float()
+  external double power;
+
+  /// !< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm
+  @ffi.Float()
+  external double bias;
+
+  /// !< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0
+  @ffi.Float()
+  external double resolution;
+
+  /// !< Strength of the Ambient Occlusion effect
+  @ffi.Float()
+  external double intensity;
+
+  /// !< depth distance that constitute an edge for filtering
+  @ffi.Float()
+  external double bilateralThreshold;
+
+  /// !< affects # of samples used for AO
+  @ffi.UnsignedInt()
+  external int quality;
+
+  /// !< affects AO smoothness
+  @ffi.UnsignedInt()
+  external int lowPassFilter;
+
+  /// !< affects AO buffer upsampling quality
+  @ffi.UnsignedInt()
+  external int upsampling;
+
+  /// !< enables or disables screen-space ambient occlusion
+  @ffi.Bool()
+  external bool enabled;
+
+  /// !< enables bent normals computation from AO, and specular AO
+  @ffi.Bool()
+  external bool bentNormals;
+
+  /// !< min angle in radian to consider
+  @ffi.Float()
+  external double minHorizonAngleRad;
+
+  external TSsct ssct;
+}
+
+typedef PickCallbackFunction = ffi.Void Function(
+    ffi.Uint32 requestId,
+    EntityId entityId,
+    ffi.Float depth,
+    ffi.Float fragX,
+    ffi.Float fragY,
+    ffi.Float fragZ);
+typedef DartPickCallbackFunction = void Function(
+    int requestId,
+    DartEntityId entityId,
+    double depth,
+    double fragX,
+    double fragY,
+    double fragZ);
+typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
+typedef FilamentRenderCallbackFunction = ffi.Void Function(
+    ffi.Pointer<ffi.Void> owner);
+typedef DartFilamentRenderCallbackFunction = void Function(
+    ffi.Pointer<ffi.Void> owner);
+typedef FilamentRenderCallback
+    = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+final class TShadowOptions extends ffi.Struct {
+  @ffi.Uint32()
+  external int mapSize;
+
+  @ffi.Uint8()
+  external int shadowCascades;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.Float> cascadeSplitPositions;
+
+  @ffi.Float()
+  external double constantBias;
+
+  @ffi.Float()
+  external double normalBias;
+
+  @ffi.Float()
+  external double shadowFar;
+
+  @ffi.Float()
+  external double shadowNearHint;
+
+  @ffi.Float()
+  external double shadowFarHint;
+
+  @ffi.Bool()
+  external bool stable;
+
+  @ffi.Bool()
+  external bool lispsm;
+
+  @ffi.Float()
+  external double polygonOffsetConstant;
+
+  @ffi.Float()
+  external double polygonOffsetSlope;
+
+  @ffi.Bool()
+  external bool screenSpaceContactShadows;
+
+  @ffi.Uint8()
+  external int stepCount;
+
+  @ffi.Float()
+  external double maxShadowDistance;
+
+  @ffi.Bool()
+  external bool vsmElvsm;
+
+  @ffi.Float()
+  external double vsmBlurWidth;
+
+  @ffi.Float()
+  external double shadowBulbRadius;
+
+  @ffi.Float()
+  external double transformX;
+
+  @ffi.Float()
+  external double transformY;
+
+  @ffi.Float()
+  external double transformZ;
+
+  @ffi.Float()
+  external double transformW;
+}
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+final class TGltfMeshData extends ffi.Struct {
+  external ffi.Pointer<ffi.Float> vertices;
+
+  @ffi.Uint32()
+  external int vertexCount;
+
+  external ffi.Pointer<ffi.Uint32> indices;
+
+  @ffi.Uint32()
+  external int indexCount;
+
+  @ffi.UnsignedInt()
+  external int primitiveType;
+}
 
 sealed class TGizmoAxis {
   static const X = 0;
@@ -6910,50 +6943,15 @@ typedef DartGizmoPickCallbackFunction = void Function(
     int resultType, double x, double y, double z);
 typedef GizmoPickCallback
     = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-typedef FilamentRenderCallbackFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> owner);
-typedef DartFilamentRenderCallbackFunction = void Function(
-    ffi.Pointer<ffi.Void> owner);
-typedef FilamentRenderCallback
-    = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
-
-final class TGltfMeshData extends ffi.Struct {
-  external ffi.Pointer<ffi.Float> vertices;
-
-  @ffi.Uint32()
-  external int vertexCount;
-
-  external ffi.Pointer<ffi.Uint32> indices;
-
-  @ffi.Uint32()
-  external int indexCount;
-
-  @ffi.UnsignedInt()
-  external int primitiveType;
-}
+typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
+typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
+typedef PostRenderCallbackFunction = ffi.Void Function(
+    ffi.Pointer<ffi.Void> userData);
+typedef DartPostRenderCallbackFunction = void Function(
+    ffi.Pointer<ffi.Void> userData);
+typedef PostRenderCallback
+    = ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
 
 final class TMovementIntentCalculator extends ffi.Opaque {}
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -19,187 +19,6 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 @ffi.Native<ffi.Uint64>()
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
-@ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-        ffi.Int,
-        ffi.UnsignedInt,
-        Aabb3)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tVertexBuffer,
-  ffi.Pointer<TIndexBuffer> tIndexBuffer,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<TFilamentAsset>,
-        ffi.Bool)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
-);
-
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void SceneAsset_addToScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void SceneAsset_removeFromScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
-    isLeaf: true)
-external void SceneAsset_getChildEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int index,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>,
-        ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
-  ffi.Pointer<TSceneAsset> asset,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(
-  ffi.Pointer<TSceneAsset> asset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TVertexBuffer> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndexBuffer> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size,
-        ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getBones(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-);
-
-@ffi.Native<
-    ffi.Pointer<ffi.Char> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-);
-
 @ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
     isLeaf: true)
 external ffi.Pointer<TMaterialInstance> Material_createInstance(
@@ -476,637 +295,399 @@ external int Material_getBlendingMode(
 );
 
 @ffi.Native<
-    ffi.Pointer<TTexture> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint8,
-        ffi.Uint16,
-        ffi.IntPtr,
-        ffi.UnsignedInt,
+    ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>,
         ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTexture> Texture_build(
-  ffi.Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import$,
-  int sampler,
-  int format,
+external int LightManager_createLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external void LightManager_destroyLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_hasComponent(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external int LightManager_getType(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isDirectional(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isPointLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isSpotLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
-        ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void Texture_setExternalImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<ffi.Void> externalImage,
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
 );
 
-@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getLevels(
-  ffi.Pointer<TTexture> tTexture,
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TLinearImage>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Int)>(isLeaf: true)
-external bool Texture_loadImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Uint32,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32)>(isLeaf: true)
-external bool Texture_setImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getWidth(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getHeight(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getDepth(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getUsage(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external void Texture_generateMipMaps(
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TKtx1Bundle> Function(
-        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(
-  ffi.Pointer<ffi.Uint8> ktxData,
-  int length,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void Ktx1Bundle_getSphericalHarmonics(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  ffi.Pointer<ffi.Float> harmonics,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external bool Ktx1Bundle_isCubemap(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external void Ktx1Bundle_destroy(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  VoidCallback onTextureUploadComplete,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTexture> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-);
-
-@ffi.Native<
-    ffi.Pointer<TLinearImage> Function(
-        ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
-external ffi.Pointer<TLinearImage> Image_createEmpty(
-  int width,
-  int height,
-  int channel,
-);
-
-@ffi.Native<
-    ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
-        ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
-external ffi.Pointer<TLinearImage> Image_decode(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> name,
-  bool alpha,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(
-    isLeaf: true)
-external ffi.Pointer<ffi.Float> Image_getBytes(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external void Image_destroy(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getWidth(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getHeight(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getChannels(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getColorTexture(
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_create();
-
-@ffi.Native<
-    ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt,
-        ffi.UnsignedInt, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTextureSampler> Function(
-        ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(
-  int compareMode,
-  int compareFunc,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setMinFilter(
-  ffi.Pointer<TTextureSampler> sampler,
-  int filter,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setMagFilter(
-  ffi.Pointer<TTextureSampler> sampler,
-  int filter,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeS(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeT(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeR(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(
-    isLeaf: true)
-external void TextureSampler_setAnisotropy(
-  ffi.Pointer<TTextureSampler> sampler,
-  double anisotropy,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setCompareMode(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-  int func,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
-external void TextureSampler_destroy(
-  ffi.Pointer<TTextureSampler> sampler,
-);
-
-@ffi.Native<
-    ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>,
-        ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)>(isLeaf: true)
-external ffi.Pointer<TEngine> Engine_create(
-  int backend,
-  ffi.Pointer<ffi.Void> platform,
-  ffi.Pointer<ffi.Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getSupportedFeatureLevel(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_destroy(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TRenderer> Engine_createRenderer(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSwapChain> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Void> window,
-  int flags,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSwapChain> Function(
-        ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  int flags,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
-    isLeaf: true)
-external void Engine_destroySwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSwapChain> tSwapChain,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Engine_destroyView(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void Engine_destroyScene(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void Engine_destroyColorGrading(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TColorGrading> tColorGrading,
-);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-    isLeaf: true)
-external ffi.Pointer<TCamera> Engine_createCamera(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
-    isLeaf: true)
-external void Engine_destroyCamera(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TCamera> tCamera,
-);
-
-@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TView> Engine_createView(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-    isLeaf: true)
-external ffi.Pointer<TCamera> Engine_getCameraComponent(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-);
-
-@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TTransformManager> Engine_getTransformManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TLightManager> Engine_getLightManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TEntityManager> Engine_getEntityManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
-external void Engine_setAutomaticInstancingEnabled(
-  ffi.Pointer<TEngine> tEngine,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getMaxAutomaticInstances(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
-    isLeaf: true)
-external void Engine_destroyTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TFence> Engine_createFence(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
-    isLeaf: true)
-external void Engine_destroyFence(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TFence> tFence,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_flushAndWait(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_execute(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TMaterial> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Engine_buildMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> materialData,
-  int length,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
-    isLeaf: true)
-external void Engine_destroyMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterial> tMaterial,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external void Engine_destroyMaterialInstance(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TScene> Engine_createScene(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSkybox> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float,
-        ffi.Float, ffi.Float)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
-  ffi.Pointer<TEngine> tEngine,
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
   double r,
   double g,
   double b,
-  double a,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)>(isLeaf: true)
-external ffi.Pointer<TIndirectLight>
-    Engine_buildIndirectLightFromIrradianceTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)>(isLeaf: true)
-external ffi.Pointer<TIndirectLight>
-    Engine_buildIndirectLightFromIrradianceHarmonics(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<ffi.Float> irradianceHarmonics,
-  double intensity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
-    isLeaf: true)
-external void Engine_destroySkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSkybox> tSkybox,
 );
 
 @ffi.Native<
     ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Engine_destroyIndirectLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
 );
 
-@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
-external int EntityManager_createEntity(
-  ffi.Pointer<TEntityManager> tEntityManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
     isLeaf: true)
-external void EntityManager_destroyEntity(
-  ffi.Pointer<TEntityManager> tEntityManager,
-  int entityId,
+external double3 LightManager_getColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
-external void Fence_waitAndDestroy(
-  ffi.Pointer<TFence> tFence,
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
 );
 
-@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityCandela(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
     isLeaf: true)
-external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
-  ffi.Pointer<TEngine> tEngine,
+external double LightManager_getIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double falloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSpotLightOuterCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSpotLightInnerCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloSize,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloFalloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
+    isLeaf: true)
+external void LightManager_setShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external TShadowOptions LightManager_getShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt,
+        ffi.Bool)>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
 );
 
 @ffi.Native<
     ffi.Bool Function(
-        ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external bool DebugRegistry_hasProperty(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
+        ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool LightManager_getLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Bool)>(isLeaf: true)
-external bool DebugRegistry_setProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  bool value,
+    ffi.Void Function(
+        ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Int)>(isLeaf: true)
-external bool DebugRegistry_setProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  int value,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+    ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float,
         ffi.Float)>(isLeaf: true)
-external bool DebugRegistry_setProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  double value,
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
+    isLeaf: true)
+external double LightManager_rgbToColorTemperature(
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Bool>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Bool> outValue,
+    ffi.Void Function(
+        ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void FilamentAsset_getEntities(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Int>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Int> outValue,
+    ffi.Pointer<TGltfAssetLoader> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Float> outValue,
+    ffi.Pointer<TFilamentAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint8)>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>,
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  ffi.Pointer<TFilamentAsset> tAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialProvider> Function(
+        ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getResourceUriCount(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<ffi.Pointer<ffi.Char>> Function(
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
 );
 
 @ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
@@ -1217,6 +798,21 @@ external void ColorGrading_destroy(
 external void ColorGradingBuilder_quality(
   ffi.Pointer<TColorGradingBuilder> builder,
   int level,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_format(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int format,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(
+    isLeaf: true)
+external void ColorGradingBuilder_dimensions(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int dim,
 );
 
 @ffi.Native<
@@ -1635,6 +1231,617 @@ external ffi.Pointer<ffi.Char> View_getName(
   ffi.Pointer<TView> tView,
 );
 
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+
+@ffi.Native<
+    ffi.Pointer<ffi.Char> Function(
+        ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientationBuilder>
+    SurfaceOrientationBuilder_create();
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_vertexCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_normals(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> normals,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_tangents(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> tangents,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_uvs(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> uvs,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_positions(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> positions,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangleCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_uint(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint32> triangles,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_ushort(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint16> triangles,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSurfaceOrientation> Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
+    isLeaf: true)
+external void SurfaceOrientationBuilder_destroy(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external int SurfaceOrientation_getVertexCount(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_float4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Float> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_short4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Int16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_half4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Uint16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external void SurfaceOrientation_destroy(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void IndirectLight_setRotation(
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+  ffi.Pointer<ffi.Double> rotation,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint8,
+        ffi.Uint16,
+        ffi.IntPtr,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTexture> Texture_build(
+  ffi.Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import$,
+  int sampler,
+  int format,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
+        ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void Texture_setExternalImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<ffi.Void> externalImage,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
+external int Texture_getLevels(
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TLinearImage>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Int)>(isLeaf: true)
+external bool Texture_loadImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Uint32,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32)>(isLeaf: true)
+external bool Texture_setImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getWidth(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getHeight(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getDepth(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getUsage(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external void Texture_generateMipMaps(
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TKtx1Bundle> Function(
+        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(
+  ffi.Pointer<ffi.Uint8> ktxData,
+  int length,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void Ktx1Bundle_getSphericalHarmonics(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  ffi.Pointer<ffi.Float> harmonics,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external bool Ktx1Bundle_isCubemap(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external void Ktx1Bundle_destroy(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  VoidCallback onTextureUploadComplete,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+);
+
+@ffi.Native<
+    ffi.Pointer<TLinearImage> Function(
+        ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+external ffi.Pointer<TLinearImage> Image_createEmpty(
+  int width,
+  int height,
+  int channel,
+);
+
+@ffi.Native<
+    ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
+        ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TLinearImage> Image_decode(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> name,
+  bool alpha,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(
+    isLeaf: true)
+external ffi.Pointer<ffi.Float> Image_getBytes(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external void Image_destroy(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getWidth(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getHeight(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getChannels(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
+    isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getColorTexture(
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
+    isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_create();
+
+@ffi.Native<
+    ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt,
+        ffi.UnsignedInt, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTextureSampler> Function(
+        ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(
+  int compareMode,
+  int compareFunc,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setMinFilter(
+  ffi.Pointer<TTextureSampler> sampler,
+  int filter,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setMagFilter(
+  ffi.Pointer<TTextureSampler> sampler,
+  int filter,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeS(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeT(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeR(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(
+    isLeaf: true)
+external void TextureSampler_setAnisotropy(
+  ffi.Pointer<TTextureSampler> sampler,
+  double anisotropy,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setCompareMode(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+  int func,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
+external void TextureSampler_destroy(
+  ffi.Pointer<TTextureSampler> sampler,
+);
+
+@ffi.Native<
+    ffi.Pointer<TRenderManager> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
+    isLeaf: true)
+external void RenderManager_render(
+  ffi.Pointer<TRenderManager> tRenderer,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
+        ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)>(isLeaf: true)
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void RenderManager_removeSwapChain(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderManager_setPaused(
+  ffi.Pointer<TRenderManager> tRenderer,
+  bool paused,
+);
+
+@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_start(
+  FrameCallback callback,
+  int targetFps,
+);
+
+@ffi.Native<ffi.Void Function()>(isLeaf: true)
+external void FrameScheduler_stop();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void FrameScheduler_setRenderThread(
+  ffi.Pointer<ffi.Void> renderThread,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void FrameScheduler_setRenderManager(
+  ffi.Pointer<TRenderManager> rm,
+);
+
+@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
+    isLeaf: true)
+external void FrameScheduler_setPostRenderCallback(
+  PostRenderCallback callback,
+  ffi.Pointer<ffi.Void> userData,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Uint64)>(isLeaf: true)
+external void FrameScheduler_requestRender(
+  int frameTimeNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startNativeRenderLoop(
+  int targetFps,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(
+  ffi.Pointer<ffi.Void> data,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(
+  int port,
+  int targetFps,
+);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
+
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(
+  int t,
+);
+
+@ffi.Native<
+    ffi.Pointer<TGizmo> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<TView>,
+        ffi.Pointer<TMaterial>,
+        ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TGizmo> Gizmo_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> assetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32,
+        GizmoPickCallback)>(isLeaf: true)
+external void Gizmo_pick(
+  ffi.Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  GizmoPickCallback callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void Gizmo_highlight(
+  ffi.Pointer<TGizmo> tGizmo,
+  int axis,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
+external void Gizmo_unhighlight(
+  ffi.Pointer<TGizmo> tGizmo,
+);
+
 @ffi.Native<
     ffi.Pointer<TMaterialInstance> Function(
         ffi.Pointer<TMaterialProvider>,
@@ -1718,6 +1925,60 @@ external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   bool hasVolume,
 );
 
+@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
+    isLeaf: true)
+external void IndexBufferBuilder_indexCount(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void IndexBufferBuilder_bufferType(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndexBuffer> Function(
+        ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
+external void IndexBufferBuilder_destroy(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external int IndexBuffer_getIndexCount(
+  ffi.Pointer<TIndexBuffer> buffer,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+external void IndexBuffer_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
+    isLeaf: true)
+external void IndexBuffer_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+);
+
 @ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
 
@@ -1794,58 +2055,225 @@ external void VertexBuffer_destroy(
   ffi.Pointer<TVertexBuffer> buffer,
 );
 
-@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
-    isLeaf: true)
-external void IndexBufferBuilder_indexCount(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int count,
+@ffi.Native<
+    ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external ffi.Pointer<TRenderTarget> RenderTarget_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> color,
+  ffi.Pointer<TTexture> depth,
 );
 
 @ffi.Native<
     ffi.Void Function(
-        ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void IndexBufferBuilder_bufferType(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int indexType,
+        ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void RenderTarget_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
 );
 
-@ffi.Native<
-    ffi.Pointer<TIndexBuffer> Function(
-        ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
-external void IndexBufferBuilder_destroy(
-  ffi.Pointer<TIndexBufferBuilder> builder,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
 );
 
-@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(
-  ffi.Pointer<TIndexBuffer> buffer,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
-external void IndexBuffer_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
     isLeaf: true)
-external void IndexBuffer_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
+external void Scene_setSkybox(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TSkybox> skybox,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Scene_setIndirectLight(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external void Scene_addFilamentAsset(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TFilamentAsset> asset,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void Camera_setExposure(
+  ffi.Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+    isLeaf: true)
+external void Camera_getFrustum(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> out,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double, ffi.Bool)>(isLeaf: true)
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
+    isLeaf: true)
+external void Camera_lookAt(
+  ffi.Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(
+  ffi.Pointer<TCamera> camera,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(
+  ffi.Pointer<TCamera> camera,
+  double focusDistance,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+    isLeaf: true)
+external void Camera_setModelMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> tModelMatrix,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>,
+        ffi.UnsignedInt,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
 );
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
@@ -1959,6 +2387,418 @@ external void TransformManager_openLocalTransformTransaction(
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
 external void TransformManager_commitLocalTransformTransaction(
   ffi.Pointer<TTransformManager> tTransformManager,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Double, ffi.Double,
+        ffi.Double, ffi.Double, ffi.Uint8, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void Renderer_setClearOptions(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>,
+        ffi.Uint64)>(isLeaf: true)
+external bool Renderer_beginFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Renderer_endFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Renderer_render(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Renderer_renderStandaloneView(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Pointer<TRenderTarget>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size)>(isLeaf: true)
+external void Renderer_readPixels(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8,
+        ffi.Uint8)>(isLeaf: true)
+external void Renderer_setFrameInterval(
+  ffi.Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+);
+
+@ffi.Native<
+    ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>,
+        ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TEngine> Engine_create(
+  int backend,
+  ffi.Pointer<ffi.Void> platform,
+  ffi.Pointer<ffi.Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getSupportedFeatureLevel(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_destroy(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TRenderer> Engine_createRenderer(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSwapChain> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Void> window,
+  int flags,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSwapChain> Function(
+        ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  int flags,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
+    isLeaf: true)
+external void Engine_destroySwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSwapChain> tSwapChain,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Engine_destroyView(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void Engine_destroyScene(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void Engine_destroyColorGrading(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TColorGrading> tColorGrading,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
+    isLeaf: true)
+external ffi.Pointer<TCamera> Engine_createCamera(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
+    isLeaf: true)
+external void Engine_destroyCamera(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TCamera> tCamera,
+);
+
+@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TView> Engine_createView(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
+    isLeaf: true)
+external ffi.Pointer<TCamera> Engine_getCameraComponent(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+);
+
+@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TTransformManager> Engine_getTransformManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TLightManager> Engine_getLightManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TEntityManager> Engine_getEntityManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
+external void Engine_setAutomaticInstancingEnabled(
+  ffi.Pointer<TEngine> tEngine,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getMaxAutomaticInstances(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
+    isLeaf: true)
+external void Engine_destroyTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TFence> Engine_createFence(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
+    isLeaf: true)
+external void Engine_destroyFence(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TFence> tFence,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_flushAndWait(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_execute(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterial> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Engine_buildMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> materialData,
+  int length,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
+    isLeaf: true)
+external void Engine_destroyMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterial> tMaterial,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void Engine_destroyMaterialInstance(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TScene> Engine_createScene(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSkybox> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float,
+        ffi.Float, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TIndirectLight>
+    Engine_buildIndirectLightFromIrradianceTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TIndirectLight>
+    Engine_buildIndirectLightFromIrradianceHarmonics(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<ffi.Float> irradianceHarmonics,
+  double intensity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
+    isLeaf: true)
+external void Engine_destroySkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSkybox> tSkybox,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Engine_destroyIndirectLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
+external int EntityManager_createEntity(
+  ffi.Pointer<TEntityManager> tEntityManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
+    isLeaf: true)
+external void EntityManager_destroyEntity(
+  ffi.Pointer<TEntityManager> tEntityManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
+external void Fence_waitAndDestroy(
+  ffi.Pointer<TFence> tFence,
+);
+
+@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external bool DebugRegistry_hasProperty(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Bool)>(isLeaf: true)
+external bool DebugRegistry_setProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  bool value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Int)>(isLeaf: true)
+external bool DebugRegistry_setProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  int value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Float)>(isLeaf: true)
+external bool DebugRegistry_setProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  double value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Bool>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Bool> outValue,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Int>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Int> outValue,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Float> outValue,
 );
 
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
@@ -4039,502 +4879,6 @@ external void RenderableManager_setBonesFromBoneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void IndirectLight_setRotation(
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-  ffi.Pointer<ffi.Double> rotation,
-);
-
-@ffi.Native<
-    ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>,
-        ffi.UnsignedInt)>(isLeaf: true)
-external int LightManager_createLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external void LightManager_destroyLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_hasComponent(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external int LightManager_getType(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isDirectional(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isPointLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isSpotLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityCandela(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double falloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSpotLightOuterCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSpotLightInnerCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloSize,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloFalloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
-    isLeaf: true)
-external void LightManager_setShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-);
-
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external TShadowOptions LightManager_getShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt,
-        ffi.Bool)>(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
-external bool LightManager_getLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float,
-        ffi.Float)>(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
-    isLeaf: true)
-external double LightManager_rgbToColorTemperature(
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void Camera_setExposure(
-  ffi.Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-    isLeaf: true)
-external void Camera_getFrustum(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> out,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double, ffi.Bool)>(isLeaf: true)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
-    isLeaf: true)
-external void Camera_lookAt(
-  ffi.Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(
-  ffi.Pointer<TCamera> camera,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(
-  ffi.Pointer<TCamera> camera,
-  double focusDistance,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-    isLeaf: true)
-external void Camera_setModelMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> tModelMatrix,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>,
-        ffi.UnsignedInt,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-);
-
 @ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
     isLeaf: true)
 external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
@@ -4594,6 +4938,26 @@ external void Skybox_setColor(
   double g,
   double b,
   double a,
+);
+
+@ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
+external void dummy(
+  TGltfMeshData dummy,
+);
+
+@ffi.Native<
+    ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
+external int GltfParser_parseBuffer(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> meshName,
+  ffi.Pointer<TGltfMeshData> outMeshData,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
+external void GltfParser_freeMeshData(
+  ffi.Pointer<TGltfMeshData> meshData,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(
@@ -5077,510 +5441,185 @@ external int RenderableBuilder_build(
   int entity,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
-    isLeaf: true)
-external void Scene_setSkybox(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TSkybox> skybox,
-);
-
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Scene_setIndirectLight(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external void Scene_addFilamentAsset(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TFilamentAsset> asset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(isLeaf: true)
-external ffi.Pointer<TRenderTarget> RenderTarget_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> color,
-  ffi.Pointer<TTexture> depth,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external void RenderTarget_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientationBuilder>
-    SurfaceOrientationBuilder_create();
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_vertexCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_normals(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> normals,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_tangents(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> tangents,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_uvs(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> uvs,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_positions(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> positions,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangleCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_uint(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint32> triangles,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_ushort(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint16> triangles,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSurfaceOrientation> Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
-    isLeaf: true)
-external void SurfaceOrientationBuilder_destroy(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external int SurfaceOrientation_getVertexCount(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_float4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Float> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_short4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Int16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_half4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Uint16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external void SurfaceOrientation_destroy(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
-external void dummy(
-  TGltfMeshData dummy,
-);
-
-@ffi.Native<
-    ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
-external int GltfParser_parseBuffer(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> meshName,
-  ffi.Pointer<TGltfMeshData> outMeshData,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
-external void GltfParser_freeMeshData(
-  ffi.Pointer<TGltfMeshData> meshData,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Double, ffi.Double,
-        ffi.Double, ffi.Double, ffi.Uint8, ffi.Bool, ffi.Bool)>(isLeaf: true)
-external void Renderer_setClearOptions(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>,
-        ffi.Uint64)>(isLeaf: true)
-external bool Renderer_beginFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Renderer_render(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Renderer_renderStandaloneView(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Pointer<TRenderTarget>,
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+        ffi.Int,
         ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size)>(isLeaf: true)
-external void Renderer_readPixels(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8,
-        ffi.Uint8)>(isLeaf: true)
-external void Renderer_setFrameInterval(
-  ffi.Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-);
-
-@ffi.Native<
-    ffi.Pointer<TRenderManager> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
+        Aabb3)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TVertexBuffer> tVertexBuffer,
+  ffi.Pointer<TIndexBuffer> tIndexBuffer,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<TFilamentAsset>,
+        ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
     isLeaf: true)
-external void RenderManager_render(
-  ffi.Pointer<TRenderManager> tRenderer,
-  int frameTimeInNanos,
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
-        ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)>(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getType(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
-external void RenderManager_removeSwapChain(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_destroy(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
     isLeaf: true)
-external void RenderManager_setPaused(
-  ffi.Pointer<TRenderManager> tRenderer,
-  bool paused,
+external void SceneAsset_addToScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
 );
 
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void SceneAsset_removeFromScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getEntity(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getChildEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
+    isLeaf: true)
+external void SceneAsset_getChildEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getCameraEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getLightEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int index,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>,
+        ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
+  ffi.Pointer<TSceneAsset> asset,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external Aabb3 SceneAsset_getBoundingBox(
+  ffi.Pointer<TSceneAsset> asset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TVertexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_releaseSourceData(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
+external void SceneAsset_setFlatShading(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size,
+        ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getBones(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
+external int SceneAsset_getBoneCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+);
 
 @ffi.Native<
     ffi.Pointer<ffi.Char> Function(
-        ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(
-  int t,
-);
-
-@ffi.Native<
-    ffi.Pointer<TGizmo> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<TView>,
-        ffi.Pointer<TMaterial>,
-        ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TGizmo> Gizmo_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> assetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32,
-        GizmoPickCallback)>(isLeaf: true)
-external void Gizmo_pick(
-  ffi.Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  GizmoPickCallback callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void Gizmo_highlight(
-  ffi.Pointer<TGizmo> tGizmo,
-  int axis,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(
-  ffi.Pointer<TGizmo> tGizmo,
-);
-
-@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_start(
-  FrameCallback callback,
-  int targetFps,
-);
-
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void FrameScheduler_setRenderThread(
-  ffi.Pointer<ffi.Void> renderThread,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void FrameScheduler_setRenderManager(
-  ffi.Pointer<TRenderManager> rm,
-);
-
-@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
-    isLeaf: true)
-external void FrameScheduler_setPostRenderCallback(
-  PostRenderCallback callback,
-  ffi.Pointer<ffi.Void> userData,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Uint64)>(isLeaf: true)
-external void FrameScheduler_requestRender(
-  int frameTimeNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startNativeRenderLoop(
-  int targetFps,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(
-  ffi.Pointer<ffi.Void> data,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(
-  int port,
-  int targetFps,
-);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
-
-@ffi.Native<
-    ffi.Pointer<TGltfAssetLoader> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
-
-@ffi.Native<
-    ffi.Pointer<TFilamentAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint8)>(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int numInstances,
-);
-
-@ffi.Native<
-    ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>,
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  ffi.Pointer<TFilamentAsset> tAsset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TMaterialProvider> Function(
-        ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getResourceUriCount(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<
-    ffi.Pointer<ffi.Pointer<ffi.Char>> Function(
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+        ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
 );
 
 @ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(
@@ -5830,30 +5869,6 @@ external bool AnimationManager_setGltfAnimationTime(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int animationIndex,
   double timeInSeconds,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void FilamentAsset_getEntities(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
@@ -6306,6 +6321,312 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+final class TShadowOptions extends ffi.Struct {
+  @ffi.Uint32()
+  external int mapSize;
+
+  @ffi.Uint8()
+  external int shadowCascades;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.Float> cascadeSplitPositions;
+
+  @ffi.Float()
+  external double constantBias;
+
+  @ffi.Float()
+  external double normalBias;
+
+  @ffi.Float()
+  external double shadowFar;
+
+  @ffi.Float()
+  external double shadowNearHint;
+
+  @ffi.Float()
+  external double shadowFarHint;
+
+  @ffi.Bool()
+  external bool stable;
+
+  @ffi.Bool()
+  external bool lispsm;
+
+  @ffi.Float()
+  external double polygonOffsetConstant;
+
+  @ffi.Float()
+  external double polygonOffsetSlope;
+
+  @ffi.Bool()
+  external bool screenSpaceContactShadows;
+
+  @ffi.Uint8()
+  external int stepCount;
+
+  @ffi.Float()
+  external double maxShadowDistance;
+
+  @ffi.Bool()
+  external bool vsmElvsm;
+
+  @ffi.Float()
+  external double vsmBlurWidth;
+
+  @ffi.Float()
+  external double shadowBulbRadius;
+
+  @ffi.Float()
+  external double transformX;
+
+  @ffi.Float()
+  external double transformY;
+
+  @ffi.Float()
+  external double transformZ;
+
+  @ffi.Float()
+  external double transformW;
+}
+
+final class TViewport extends ffi.Struct {
+  @ffi.Int32()
+  external int left;
+
+  @ffi.Int32()
+  external int bottom;
+
+  @ffi.Uint32()
+  external int width;
+
+  @ffi.Uint32()
+  external int height;
+}
+
+/// Copied from FogOptions in View.h
+final class TFogOptions extends ffi.Struct {
+  @ffi.Float()
+  external double distance;
+
+  @ffi.Float()
+  external double cutOffDistance;
+
+  @ffi.Float()
+  external double maximumOpacity;
+
+  @ffi.Float()
+  external double height;
+
+  @ffi.Float()
+  external double heightFalloff;
+
+  @ffi.Float()
+  external double density;
+
+  @ffi.Float()
+  external double inScatteringStart;
+
+  @ffi.Float()
+  external double inScatteringSize;
+
+  external ffi.Pointer<TTexture> skyColor;
+
+  @ffi.Float()
+  external double linearColorR;
+
+  @ffi.Float()
+  external double linearColorG;
+
+  @ffi.Float()
+  external double linearColorB;
+
+  @ffi.Bool()
+  external bool fogColorFromIbl;
+
+  @ffi.Bool()
+  external bool enabled;
+}
+
+final class TToneMapper extends ffi.Opaque {}
+
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
+}
+
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
+}
+
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
+}
+
+final class TColorGradingBuilder extends ffi.Opaque {}
+
+/// Options for DPCF and PCSS Shadowing.
+final class TSoftShadowOptions extends ffi.Struct {
+  @ffi.Float()
+  external double penumbraScale;
+
+  @ffi.Float()
+  external double penumbraRatioScale;
+}
+
+/// Options for VSM Shadowing.
+final class TVsmShadowOptions extends ffi.Struct {
+  @ffi.Uint8()
+  external int anisotropy;
+
+  @ffi.Bool()
+  external bool mipmapping;
+
+  @ffi.Uint8()
+  external int msaaSamples;
+
+  @ffi.Bool()
+  external bool highPrecision;
+
+  @ffi.Float()
+  external double minVarianceScale;
+
+  @ffi.Float()
+  external double lightBleedReduction;
+}
+
+/// Screen Space Cone Tracing (SSCT) options
+/// Ambient shadows from dominant light
+final class TSsct extends ffi.Struct {
+  /// !< full cone angle in radian, between 0 and pi/2
+  @ffi.Float()
+  external double lightConeRad;
+
+  /// !< how far shadows can be cast
+  @ffi.Float()
+  external double shadowDistance;
+
+  /// !< max distance for contact
+  @ffi.Float()
+  external double contactDistanceMax;
+
+  /// !< intensity
+  @ffi.Float()
+  external double intensity;
+
+  /// !< light direction X
+  @ffi.Float()
+  external double lightDirectionX;
+
+  /// !< light direction Y
+  @ffi.Float()
+  external double lightDirectionY;
+
+  /// !< light direction Z
+  @ffi.Float()
+  external double lightDirectionZ;
+
+  /// !< depth bias in world units (mitigate self shadowing)
+  @ffi.Float()
+  external double depthBias;
+
+  /// !< depth slope bias (mitigate self shadowing)
+  @ffi.Float()
+  external double depthSlopeBias;
+
+  /// !< tracing sample count, between 1 and 255
+  @ffi.Uint8()
+  external int sampleCount;
+
+  /// !< # of rays to trace, between 1 and 255
+  @ffi.Uint8()
+  external int rayCount;
+
+  /// !< enables or disables SSCT
+  @ffi.Bool()
+  external bool enabled;
+}
+
+/// Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+final class TAmbientOcclusionOptions extends ffi.Struct {
+  /// !< Ambient Occlusion radius in meters, between 0 and ~10
+  @ffi.Float()
+  external double radius;
+
+  /// !< Controls ambient occlusion's contrast. Must be positive
+  @ffi.Float()
+  external double power;
+
+  /// !< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm
+  @ffi.Float()
+  external double bias;
+
+  /// !< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0
+  @ffi.Float()
+  external double resolution;
+
+  /// !< Strength of the Ambient Occlusion effect
+  @ffi.Float()
+  external double intensity;
+
+  /// !< depth distance that constitute an edge for filtering
+  @ffi.Float()
+  external double bilateralThreshold;
+
+  /// !< affects # of samples used for AO
+  @ffi.UnsignedInt()
+  external int quality;
+
+  /// !< affects AO smoothness
+  @ffi.UnsignedInt()
+  external int lowPassFilter;
+
+  /// !< affects AO buffer upsampling quality
+  @ffi.UnsignedInt()
+  external int upsampling;
+
+  /// !< enables or disables screen-space ambient occlusion
+  @ffi.Bool()
+  external bool enabled;
+
+  /// !< enables bent normals computation from AO, and specular AO
+  @ffi.Bool()
+  external bool bentNormals;
+
+  /// !< min angle in radian to consider
+  @ffi.Float()
+  external double minHorizonAngleRad;
+
+  external TSsct ssct;
+}
+
+typedef PickCallbackFunction = ffi.Void Function(
+    ffi.Uint32 requestId,
+    EntityId entityId,
+    ffi.Float depth,
+    ffi.Float fragX,
+    ffi.Float fragY,
+    ffi.Float fragZ);
+typedef DartPickCallbackFunction = void Function(
+    int requestId,
+    DartEntityId entityId,
+    double depth,
+    double fragX,
+    double fragY,
+    double fragZ);
+typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
+
 sealed class TTextureSamplerType {
   static const SAMPLER_2D = 0;
   static const SAMPLER_2D_ARRAY = 1;
@@ -6559,349 +6880,15 @@ sealed class TSamplerCompareMode {
   static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
 }
 
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-final class TViewport extends ffi.Struct {
-  @ffi.Int32()
-  external int left;
-
-  @ffi.Int32()
-  external int bottom;
-
-  @ffi.Uint32()
-  external int width;
-
-  @ffi.Uint32()
-  external int height;
-}
-
-/// Copied from FogOptions in View.h
-final class TFogOptions extends ffi.Struct {
-  @ffi.Float()
-  external double distance;
-
-  @ffi.Float()
-  external double cutOffDistance;
-
-  @ffi.Float()
-  external double maximumOpacity;
-
-  @ffi.Float()
-  external double height;
-
-  @ffi.Float()
-  external double heightFalloff;
-
-  @ffi.Float()
-  external double density;
-
-  @ffi.Float()
-  external double inScatteringStart;
-
-  @ffi.Float()
-  external double inScatteringSize;
-
-  external ffi.Pointer<TTexture> skyColor;
-
-  @ffi.Float()
-  external double linearColorR;
-
-  @ffi.Float()
-  external double linearColorG;
-
-  @ffi.Float()
-  external double linearColorB;
-
-  @ffi.Bool()
-  external bool fogColorFromIbl;
-
-  @ffi.Bool()
-  external bool enabled;
-}
-
-final class TToneMapper extends ffi.Opaque {}
-
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
-}
-
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
-}
-
-final class TColorGradingBuilder extends ffi.Opaque {}
-
-/// Options for DPCF and PCSS Shadowing.
-final class TSoftShadowOptions extends ffi.Struct {
-  @ffi.Float()
-  external double penumbraScale;
-
-  @ffi.Float()
-  external double penumbraRatioScale;
-}
-
-/// Options for VSM Shadowing.
-final class TVsmShadowOptions extends ffi.Struct {
-  @ffi.Uint8()
-  external int anisotropy;
-
-  @ffi.Bool()
-  external bool mipmapping;
-
-  @ffi.Uint8()
-  external int msaaSamples;
-
-  @ffi.Bool()
-  external bool highPrecision;
-
-  @ffi.Float()
-  external double minVarianceScale;
-
-  @ffi.Float()
-  external double lightBleedReduction;
-}
-
-/// Screen Space Cone Tracing (SSCT) options
-/// Ambient shadows from dominant light
-final class TSsct extends ffi.Struct {
-  /// !< full cone angle in radian, between 0 and pi/2
-  @ffi.Float()
-  external double lightConeRad;
-
-  /// !< how far shadows can be cast
-  @ffi.Float()
-  external double shadowDistance;
-
-  /// !< max distance for contact
-  @ffi.Float()
-  external double contactDistanceMax;
-
-  /// !< intensity
-  @ffi.Float()
-  external double intensity;
-
-  /// !< light direction X
-  @ffi.Float()
-  external double lightDirectionX;
-
-  /// !< light direction Y
-  @ffi.Float()
-  external double lightDirectionY;
-
-  /// !< light direction Z
-  @ffi.Float()
-  external double lightDirectionZ;
-
-  /// !< depth bias in world units (mitigate self shadowing)
-  @ffi.Float()
-  external double depthBias;
-
-  /// !< depth slope bias (mitigate self shadowing)
-  @ffi.Float()
-  external double depthSlopeBias;
-
-  /// !< tracing sample count, between 1 and 255
-  @ffi.Uint8()
-  external int sampleCount;
-
-  /// !< # of rays to trace, between 1 and 255
-  @ffi.Uint8()
-  external int rayCount;
-
-  /// !< enables or disables SSCT
-  @ffi.Bool()
-  external bool enabled;
-}
-
-/// Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
-final class TAmbientOcclusionOptions extends ffi.Struct {
-  /// !< Ambient Occlusion radius in meters, between 0 and ~10
-  @ffi.Float()
-  external double radius;
-
-  /// !< Controls ambient occlusion's contrast. Must be positive
-  @ffi.Float()
-  external double power;
-
-  /// !< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm
-  @ffi.Float()
-  external double bias;
-
-  /// !< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0
-  @ffi.Float()
-  external double resolution;
-
-  /// !< Strength of the Ambient Occlusion effect
-  @ffi.Float()
-  external double intensity;
-
-  /// !< depth distance that constitute an edge for filtering
-  @ffi.Float()
-  external double bilateralThreshold;
-
-  /// !< affects # of samples used for AO
-  @ffi.UnsignedInt()
-  external int quality;
-
-  /// !< affects AO smoothness
-  @ffi.UnsignedInt()
-  external int lowPassFilter;
-
-  /// !< affects AO buffer upsampling quality
-  @ffi.UnsignedInt()
-  external int upsampling;
-
-  /// !< enables or disables screen-space ambient occlusion
-  @ffi.Bool()
-  external bool enabled;
-
-  /// !< enables bent normals computation from AO, and specular AO
-  @ffi.Bool()
-  external bool bentNormals;
-
-  /// !< min angle in radian to consider
-  @ffi.Float()
-  external double minHorizonAngleRad;
-
-  external TSsct ssct;
-}
-
-typedef PickCallbackFunction = ffi.Void Function(
-    ffi.Uint32 requestId,
-    EntityId entityId,
-    ffi.Float depth,
-    ffi.Float fragX,
-    ffi.Float fragY,
-    ffi.Float fragZ);
-typedef DartPickCallbackFunction = void Function(
-    int requestId,
-    DartEntityId entityId,
-    double depth,
-    double fragX,
-    double fragY,
-    double fragZ);
-typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
-typedef FilamentRenderCallbackFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> owner);
-typedef DartFilamentRenderCallbackFunction = void Function(
-    ffi.Pointer<ffi.Void> owner);
-typedef FilamentRenderCallback
-    = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
-
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-final class TShadowOptions extends ffi.Struct {
-  @ffi.Uint32()
-  external int mapSize;
-
-  @ffi.Uint8()
-  external int shadowCascades;
-
-  @ffi.Array.multi([3])
-  external ffi.Array<ffi.Float> cascadeSplitPositions;
-
-  @ffi.Float()
-  external double constantBias;
-
-  @ffi.Float()
-  external double normalBias;
-
-  @ffi.Float()
-  external double shadowFar;
-
-  @ffi.Float()
-  external double shadowNearHint;
-
-  @ffi.Float()
-  external double shadowFarHint;
-
-  @ffi.Bool()
-  external bool stable;
-
-  @ffi.Bool()
-  external bool lispsm;
-
-  @ffi.Float()
-  external double polygonOffsetConstant;
-
-  @ffi.Float()
-  external double polygonOffsetSlope;
-
-  @ffi.Bool()
-  external bool screenSpaceContactShadows;
-
-  @ffi.Uint8()
-  external int stepCount;
-
-  @ffi.Float()
-  external double maxShadowDistance;
-
-  @ffi.Bool()
-  external bool vsmElvsm;
-
-  @ffi.Float()
-  external double vsmBlurWidth;
-
-  @ffi.Float()
-  external double shadowBulbRadius;
-
-  @ffi.Float()
-  external double transformX;
-
-  @ffi.Float()
-  external double transformY;
-
-  @ffi.Float()
-  external double transformZ;
-
-  @ffi.Float()
-  external double transformW;
-}
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-final class TGltfMeshData extends ffi.Struct {
-  external ffi.Pointer<ffi.Float> vertices;
-
-  @ffi.Uint32()
-  external int vertexCount;
-
-  external ffi.Pointer<ffi.Uint32> indices;
-
-  @ffi.Uint32()
-  external int indexCount;
-
-  @ffi.UnsignedInt()
-  external int primitiveType;
-}
+typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
+typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
+typedef PostRenderCallbackFunction = ffi.Void Function(
+    ffi.Pointer<ffi.Void> userData);
+typedef DartPostRenderCallbackFunction = void Function(
+    ffi.Pointer<ffi.Void> userData);
+typedef PostRenderCallback
+    = ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
 
 sealed class TGizmoAxis {
   static const X = 0;
@@ -6923,15 +6910,50 @@ typedef DartGizmoPickCallbackFunction = void Function(
     int resultType, double x, double y, double z);
 typedef GizmoPickCallback
     = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
-typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
-typedef PostRenderCallbackFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(
-    ffi.Pointer<ffi.Void> userData);
-typedef PostRenderCallback
-    = ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+typedef FilamentRenderCallbackFunction = ffi.Void Function(
+    ffi.Pointer<ffi.Void> owner);
+typedef DartFilamentRenderCallbackFunction = void Function(
+    ffi.Pointer<ffi.Void> owner);
+typedef FilamentRenderCallback
+    = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+
+final class TGltfMeshData extends ffi.Struct {
+  external ffi.Pointer<ffi.Float> vertices;
+
+  @ffi.Uint32()
+  external int vertexCount;
+
+  external ffi.Pointer<ffi.Uint32> indices;
+
+  @ffi.Uint32()
+  external int indexCount;
+
+  @ffi.UnsignedInt()
+  external int primitiveType;
+}
 
 final class TMovementIntentCalculator extends ffi.Opaque {}
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -32,106 +32,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    Pointer<Aabb3> boundingBoxPtr,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TFilamentAsset> tFilamentAsset,
-    bool rebuildVertices,
-  );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _SceneAsset_getType(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_destroy(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_addToScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-  );
-  external void _SceneAsset_removeFromScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-  );
-  external EntityId _SceneAsset_getEntity(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _SceneAsset_getChildEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_getChildEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<Int32> out,
-  );
-  external Pointer<Int32> _SceneAsset_getCameraEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getCameraEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<Int32> _SceneAsset_getLightEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getLightEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-  );
-  external size_t _SceneAsset_getInstanceCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-  );
-  external void _SceneAsset_getBoundingBox(
-    Pointer<Aabb3> Aabb3_out,
-    Pointer<TSceneAsset> asset,
-  );
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external void _SceneAsset_releaseSourceData(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_setFlatShading(
-    Pointer<TSceneAsset> tSceneAsset,
-    bool flatShading,
-  );
-  external void _SceneAsset_getBones(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    Pointer<Int32> out,
-  );
-  external size_t _SceneAsset_getBoneCount(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-  );
-  external Pointer<Char> _SceneAsset_getBoneName(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    size_t boneIndex,
-  );
   external Pointer<TMaterialInstance> _Material_createInstance(
     Pointer<TMaterial> tMaterial,
   );
@@ -291,358 +191,235 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external int _Material_getBlendingMode(
     Pointer<TMaterial> material,
   );
-  external Pointer<TTexture> _Texture_build(
-    Pointer<TEngine> engine,
-    int width,
-    int height,
-    int depth,
-    int levels,
-    int tUsage,
-    int import1,
-    int sampler,
-    int format,
-  );
-  external void _Texture_setExternalImage(
+  external int _LightManager_createLight(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<Void> externalImage,
-  );
-  external size_t _Texture_getLevels(
-    Pointer<TTexture> tTexture,
-  );
-  external int _Texture_loadImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<TLinearImage> tImage,
-    int bufferFormat,
-    int pixelDataType,
-    int level,
-  );
-  external int _Texture_setImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    int level,
-    Pointer<Uint8> data,
-    size_t size,
-    int x_offset,
-    int y_offset,
-    int z_offset,
-    int width,
-    int height,
-    int depth,
-    int bufferFormat,
-    int pixelDataType,
-  );
-  external int _Texture_getWidth(
-    Pointer<TTexture> tTexture,
-    int level,
-  );
-  external int _Texture_getHeight(
-    Pointer<TTexture> tTexture,
-    int level,
-  );
-  external int _Texture_getDepth(
-    Pointer<TTexture> tTexture,
-    int level,
-  );
-  external int _Texture_getUsage(
-    Pointer<TTexture> tTexture,
-    int level,
-  );
-  external void _Texture_generateMipMaps(
-    Pointer<TTexture> tTexture,
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(
-    Pointer<Uint8> ktxData,
-    size_t length,
-  );
-  external void _Ktx1Bundle_getSphericalHarmonics(
-    Pointer<TKtx1Bundle> tBundle,
-    Pointer<Float32> harmonics,
-  );
-  external int _Ktx1Bundle_isCubemap(
-    Pointer<TKtx1Bundle> tBundle,
-  );
-  external void _Ktx1Bundle_destroy(
-    Pointer<TKtx1Bundle> tBundle,
-  );
-  external Pointer<TTexture> _Ktx1Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TKtx1Bundle> tBundle,
-    int requestId,
-    VoidCallback onTextureUploadComplete,
-  );
-  external Pointer<TTexture> _Ktx2Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> data,
-    size_t size,
-  );
-  external Pointer<TLinearImage> _Image_createEmpty(
-    int width,
-    int height,
-    int channel,
-  );
-  external Pointer<TLinearImage> _Image_decode(
-    Pointer<Uint8> data,
-    size_t length,
-    Pointer<Char> name,
-    bool alpha,
-  );
-  external Pointer<Float32> _Image_getBytes(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external void _Image_destroy(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external int _Image_getWidth(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external int _Image_getHeight(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external int _Image_getChannels(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external Pointer<TTexture> _RenderTarget_getColorTexture(
-    Pointer<TRenderTarget> tRenderTarget,
-  );
-  external Pointer<TTexture> _RenderTarget_getDepthTexture(
-    Pointer<TRenderTarget> tRenderTarget,
-  );
-  external Pointer<TTextureSampler> _TextureSampler_create();
-  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
-    int minFilter,
-    int magFilter,
-    int wrapS,
-    int wrapT,
-    int wrapR,
-  );
-  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(
-    int compareMode,
-    int compareFunc,
-  );
-  external void _TextureSampler_setMinFilter(
-    Pointer<TTextureSampler> sampler,
-    int filter,
-  );
-  external void _TextureSampler_setMagFilter(
-    Pointer<TTextureSampler> sampler,
-    int filter,
-  );
-  external void _TextureSampler_setWrapModeS(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-  );
-  external void _TextureSampler_setWrapModeT(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-  );
-  external void _TextureSampler_setWrapModeR(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-  );
-  external void _TextureSampler_setAnisotropy(
-    Pointer<TTextureSampler> sampler,
-    double anisotropy,
-  );
-  external void _TextureSampler_setCompareMode(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-    int func,
-  );
-  external void _TextureSampler_destroy(
-    Pointer<TTextureSampler> sampler,
-  );
-  external Pointer<TEngine> _Engine_create(
-    int backend,
-    Pointer<Void> platform,
-    Pointer<Void> sharedContext,
-    int stereoscopicEyeCount,
-    bool disableHandleUseAfterFreeCheck,
-  );
-  external int _Engine_getSupportedFeatureLevel(
-    Pointer<TEngine> tEngine,
-  );
-  external void _Engine_destroy(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TRenderer> _Engine_createRenderer(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TSwapChain> _Engine_createSwapChain(
-    Pointer<TEngine> tEngine,
-    Pointer<Void> window,
-    JSBigInt flags,
-  );
-  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
-    Pointer<TEngine> tEngine,
-    int width,
-    int height,
-    JSBigInt flags,
-  );
-  external void _Engine_destroySwapChain(
-    Pointer<TEngine> tEngine,
-    Pointer<TSwapChain> tSwapChain,
-  );
-  external void _Engine_destroyView(
-    Pointer<TEngine> tEngine,
-    Pointer<TView> tView,
-  );
-  external void _Engine_destroyScene(
-    Pointer<TEngine> tEngine,
-    Pointer<TScene> tScene,
-  );
-  external void _Engine_destroyColorGrading(
-    Pointer<TEngine> tEngine,
-    Pointer<TColorGrading> tColorGrading,
-  );
-  external Pointer<TCamera> _Engine_createCamera(
-    Pointer<TEngine> tEngine,
-    EntityId entityId,
-  );
-  external void _Engine_destroyCamera(
-    Pointer<TEngine> tEngine,
-    Pointer<TCamera> tCamera,
-  );
-  external Pointer<TView> _Engine_createView(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TCamera> _Engine_getCameraComponent(
-    Pointer<TEngine> tEngine,
-    EntityId entityId,
-  );
-  external Pointer<TTransformManager> _Engine_getTransformManager(
-    Pointer<TEngine> engine,
-  );
-  external Pointer<TRenderableManager> _Engine_getRenderableManager(
-    Pointer<TEngine> engine,
-  );
-  external Pointer<TLightManager> _Engine_getLightManager(
-    Pointer<TEngine> engine,
-  );
-  external Pointer<TEntityManager> _Engine_getEntityManager(
-    Pointer<TEngine> engine,
-  );
-  external void _Engine_setAutomaticInstancingEnabled(
-    Pointer<TEngine> tEngine,
-    bool enabled,
-  );
-  external size_t _Engine_getMaxAutomaticInstances(
-    Pointer<TEngine> tEngine,
-  );
-  external void _Engine_destroyTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-  );
-  external Pointer<TFence> _Engine_createFence(
-    Pointer<TEngine> tEngine,
-  );
-  external void _Engine_destroyFence(
-    Pointer<TEngine> tEngine,
-    Pointer<TFence> tFence,
-  );
-  external void _Engine_flushAndWait(
-    Pointer<TEngine> tEngine,
-  );
-  external void _Engine_execute(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TMaterial> _Engine_buildMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> materialData,
-    size_t length,
-  );
-  external void _Engine_destroyMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterial> tMaterial,
-  );
-  external void _Engine_destroyMaterialInstance(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialInstance> tMaterialInstance,
-  );
-  external Pointer<TScene> _Engine_createScene(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TSkybox> _Engine_buildSkybox(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-  );
-  external Pointer<TSkybox> _Engine_buildColoredSkybox(
-    Pointer<TEngine> tEngine,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
+  );
+  external void _LightManager_destroyLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_hasComponent(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_getType(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isDirectional(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isPointLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isSpotLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double r,
     double g,
     double b,
-    double a,
   );
-  external Pointer<TIndirectLight>
-      _Engine_buildIndirectLightFromIrradianceTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<TTexture> tIrradianceTexture,
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double intensity,
   );
-  external Pointer<TIndirectLight>
-      _Engine_buildIndirectLightFromIrradianceHarmonics(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<Float32> irradianceHarmonics,
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double intensity,
   );
-  external void _Engine_destroySkybox(
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external double _LightManager_getIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double falloff,
+  );
+  external double _LightManager_getFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external double _LightManager_getSpotLightOuterCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external double _LightManager_getSpotLightInnerCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external double _LightManager_getSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloSize,
+  );
+  external double _LightManager_getSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external double _LightManager_getSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    bool enabled,
+  );
+  external int _LightManager_isShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external int _LightManager_getLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+  );
+  external void _LightManager_computeUniformSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+  );
+  external void _LightManager_computeLogSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+  );
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external double _LightManager_rgbToColorTemperature(
+    double r,
+    double g,
+    double b,
+  );
+  external int _FilamentAsset_getEntityCount(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external void _FilamentAsset_getEntities(
+    Pointer<TFilamentAsset> filamentAsset,
+    Pointer<Int32> out,
+  );
+  external EntityId _FilamentAsset_getWireframe(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external Pointer<Void> _FilamentAsset_getSourceAsset(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
     Pointer<TEngine> tEngine,
-    Pointer<TSkybox> tSkybox,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
   );
-  external void _Engine_destroyIndirectLight(
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
     Pointer<TEngine> tEngine,
-    Pointer<TIndirectLight> tIndirectLight,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
   );
-  external EntityId _EntityManager_createEntity(
-    Pointer<TEntityManager> tEntityManager,
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
   );
-  external void _EntityManager_destroyEntity(
-    Pointer<TEntityManager> tEntityManager,
-    EntityId entityId,
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(
+    Pointer<TGltfAssetLoader> tAssetLoader,
   );
-  external void _Fence_waitAndDestroy(
-    Pointer<TFence> tFence,
+  external int _FilamentAsset_getResourceUriCount(
+    Pointer<TFilamentAsset> tFilamentAsset,
   );
-  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(
-    Pointer<TEngine> tEngine,
-  );
-  external int _DebugRegistry_hasProperty(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-  );
-  external int _DebugRegistry_setProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    bool value,
-  );
-  external int _DebugRegistry_setProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    int value,
-  );
-  external int _DebugRegistry_setProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    double value,
-  );
-  external int _DebugRegistry_getProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Bool> outValue,
-  );
-  external int _DebugRegistry_getProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Int32> outValue,
-  );
-  external int _DebugRegistry_getProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Float32> outValue,
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(
+    Pointer<TFilamentAsset> tFilamentAsset,
   );
   external void _View_getViewport(
     Pointer<TViewport> TViewport_out,
@@ -702,6 +479,14 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _ColorGradingBuilder_quality(
     Pointer<TColorGradingBuilder> builder,
     int level,
+  );
+  external void _ColorGradingBuilder_format(
+    Pointer<TColorGradingBuilder> builder,
+    int format,
+  );
+  external void _ColorGradingBuilder_dimensions(
+    Pointer<TColorGradingBuilder> builder,
+    int dim,
   );
   external void _ColorGradingBuilder_toneMapper(
     Pointer<TColorGradingBuilder> builder,
@@ -942,6 +727,339 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<Char> _View_getName(
     Pointer<TView> tView,
   );
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external Pointer<TSurfaceOrientationBuilder>
+      _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
+  );
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_triangleCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
+  );
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
+  );
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
+  );
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
+    Pointer<TSurfaceOrientationBuilder> builder,
+  );
+  external void _SurfaceOrientationBuilder_destroy(
+    Pointer<TSurfaceOrientationBuilder> builder,
+  );
+  external size_t _SurfaceOrientation_getVertexCount(
+    Pointer<TSurfaceOrientation> orientation,
+  );
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Float32> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_destroy(
+    Pointer<TSurfaceOrientation> orientation,
+  );
+  external void _IndirectLight_setRotation(
+    Pointer<TIndirectLight> tIndirectLight,
+    Pointer<Float64> rotation,
+  );
+  external Pointer<TTexture> _Texture_build(
+    Pointer<TEngine> engine,
+    int width,
+    int height,
+    int depth,
+    int levels,
+    int tUsage,
+    int import1,
+    int sampler,
+    int format,
+  );
+  external void _Texture_setExternalImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<Void> externalImage,
+  );
+  external size_t _Texture_getLevels(
+    Pointer<TTexture> tTexture,
+  );
+  external int _Texture_loadImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<TLinearImage> tImage,
+    int bufferFormat,
+    int pixelDataType,
+    int level,
+  );
+  external int _Texture_setImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    int level,
+    Pointer<Uint8> data,
+    size_t size,
+    int x_offset,
+    int y_offset,
+    int z_offset,
+    int width,
+    int height,
+    int depth,
+    int bufferFormat,
+    int pixelDataType,
+  );
+  external int _Texture_getWidth(
+    Pointer<TTexture> tTexture,
+    int level,
+  );
+  external int _Texture_getHeight(
+    Pointer<TTexture> tTexture,
+    int level,
+  );
+  external int _Texture_getDepth(
+    Pointer<TTexture> tTexture,
+    int level,
+  );
+  external int _Texture_getUsage(
+    Pointer<TTexture> tTexture,
+    int level,
+  );
+  external void _Texture_generateMipMaps(
+    Pointer<TTexture> tTexture,
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(
+    Pointer<Uint8> ktxData,
+    size_t length,
+  );
+  external void _Ktx1Bundle_getSphericalHarmonics(
+    Pointer<TKtx1Bundle> tBundle,
+    Pointer<Float32> harmonics,
+  );
+  external int _Ktx1Bundle_isCubemap(
+    Pointer<TKtx1Bundle> tBundle,
+  );
+  external void _Ktx1Bundle_destroy(
+    Pointer<TKtx1Bundle> tBundle,
+  );
+  external Pointer<TTexture> _Ktx1Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TKtx1Bundle> tBundle,
+    int requestId,
+    VoidCallback onTextureUploadComplete,
+  );
+  external Pointer<TTexture> _Ktx2Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> data,
+    size_t size,
+  );
+  external Pointer<TLinearImage> _Image_createEmpty(
+    int width,
+    int height,
+    int channel,
+  );
+  external Pointer<TLinearImage> _Image_decode(
+    Pointer<Uint8> data,
+    size_t length,
+    Pointer<Char> name,
+    bool alpha,
+  );
+  external Pointer<Float32> _Image_getBytes(
+    Pointer<TLinearImage> tLinearImage,
+  );
+  external void _Image_destroy(
+    Pointer<TLinearImage> tLinearImage,
+  );
+  external int _Image_getWidth(
+    Pointer<TLinearImage> tLinearImage,
+  );
+  external int _Image_getHeight(
+    Pointer<TLinearImage> tLinearImage,
+  );
+  external int _Image_getChannels(
+    Pointer<TLinearImage> tLinearImage,
+  );
+  external Pointer<TTexture> _RenderTarget_getColorTexture(
+    Pointer<TRenderTarget> tRenderTarget,
+  );
+  external Pointer<TTexture> _RenderTarget_getDepthTexture(
+    Pointer<TRenderTarget> tRenderTarget,
+  );
+  external Pointer<TTextureSampler> _TextureSampler_create();
+  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
+    int minFilter,
+    int magFilter,
+    int wrapS,
+    int wrapT,
+    int wrapR,
+  );
+  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(
+    int compareMode,
+    int compareFunc,
+  );
+  external void _TextureSampler_setMinFilter(
+    Pointer<TTextureSampler> sampler,
+    int filter,
+  );
+  external void _TextureSampler_setMagFilter(
+    Pointer<TTextureSampler> sampler,
+    int filter,
+  );
+  external void _TextureSampler_setWrapModeS(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+  );
+  external void _TextureSampler_setWrapModeT(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+  );
+  external void _TextureSampler_setWrapModeR(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+  );
+  external void _TextureSampler_setAnisotropy(
+    Pointer<TTextureSampler> sampler,
+    double anisotropy,
+  );
+  external void _TextureSampler_setCompareMode(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+    int func,
+  );
+  external void _TextureSampler_destroy(
+    Pointer<TTextureSampler> sampler,
+  );
+  external Pointer<TRenderManager> _RenderManager_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderer> tRenderer,
+  );
+  external void _RenderManager_destroy(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_render(
+    Pointer<TRenderManager> tRenderer,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
+  );
+  external void _RenderManager_removeSwapChain(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+  );
+  external void _RenderManager_requestRender(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_attachToRenderThread(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_setPaused(
+    Pointer<TRenderManager> tRenderer,
+    bool paused,
+  );
+  external void _FrameScheduler_start(
+    FrameCallback callback,
+    int targetFps,
+  );
+  external void _FrameScheduler_stop();
+  external void _FrameScheduler_setRenderThread(
+    Pointer<Void> renderThread,
+  );
+  external void _FrameScheduler_setRenderManager(
+    Pointer<TRenderManager> rm,
+  );
+  external void _FrameScheduler_setPostRenderCallback(
+    PostRenderCallback callback,
+    Pointer<Void> userData,
+  );
+  external void _FrameScheduler_requestRender(
+    JSBigInt frameTimeNanos,
+  );
+  external void _FrameScheduler_startNativeRenderLoop(
+    int targetFps,
+  );
+  external int _FrameScheduler_initDartApi(
+    Pointer<Void> data,
+  );
+  external void _FrameScheduler_startWithPort(
+    JSBigInt port,
+    int targetFps,
+  );
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Gizmo_dummy(
+    int t,
+  );
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+  );
+  external void _Gizmo_pick(
+    Pointer<TGizmo> tGizmo,
+    int x,
+    int y,
+    GizmoPickCallback callback,
+  );
+  external void _Gizmo_highlight(
+    Pointer<TGizmo> tGizmo,
+    int axis,
+  );
+  external void _Gizmo_unhighlight(
+    Pointer<TGizmo> tGizmo,
+  );
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
     bool doubleSided,
@@ -982,6 +1100,36 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     bool hasSheen,
     bool hasIOR,
     bool hasVolume,
+  );
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(
+    Pointer<TIndexBufferBuilder> builder,
+    int count,
+  );
+  external void _IndexBufferBuilder_bufferType(
+    Pointer<TIndexBufferBuilder> builder,
+    int indexType,
+  );
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _IndexBufferBuilder_destroy(
+    Pointer<TIndexBufferBuilder> builder,
+  );
+  external size_t _IndexBuffer_getIndexCount(
+    Pointer<TIndexBuffer> buffer,
+  );
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _IndexBuffer_destroy(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
   );
   external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
   external void _VertexBufferBuilder_bufferCount(
@@ -1027,35 +1175,139 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TEngine> engine,
     Pointer<TVertexBuffer> buffer,
   );
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(
-    Pointer<TIndexBufferBuilder> builder,
-    int count,
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
   );
-  external void _IndexBufferBuilder_bufferType(
-    Pointer<TIndexBufferBuilder> builder,
-    int indexType,
+  external void _RenderTarget_destroy(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderTarget> tRenderTarget,
   );
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
+  external void _Scene_addEntity(
+    Pointer<TScene> tScene,
+    EntityId entityId,
   );
-  external void _IndexBufferBuilder_destroy(
-    Pointer<TIndexBufferBuilder> builder,
+  external void _Scene_removeEntity(
+    Pointer<TScene> tScene,
+    EntityId entityId,
   );
-  external size_t _IndexBuffer_getIndexCount(
-    Pointer<TIndexBuffer> buffer,
+  external void _Scene_setSkybox(
+    Pointer<TScene> tScene,
+    Pointer<TSkybox> skybox,
   );
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
+  external void _Scene_setIndirectLight(
+    Pointer<TScene> tScene,
+    Pointer<TIndirectLight> tIndirectLight,
   );
-  external void _IndexBuffer_destroy(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
+  external void _Scene_addFilamentAsset(
+    Pointer<TScene> tScene,
+    Pointer<TFilamentAsset> asset,
+  );
+  external void _Camera_setExposure(
+    Pointer<TCamera> camera,
+    double aperture,
+    double shutterSpeed,
+    double sensitivity,
+  );
+  external double _Camera_getAperture(
+    Pointer<TCamera> camera,
+  );
+  external double _Camera_getShutterSpeed(
+    Pointer<TCamera> camera,
+  );
+  external double _Camera_getSensitivity(
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getModelMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getViewMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getCullingProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getFrustum(
+    Pointer<TCamera> camera,
+    Pointer<Float64> out,
+  );
+  external void _Camera_setProjectionMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> matrix,
+    double near,
+    double far,
+  );
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
+  );
+  external double _Camera_getFocalLength(
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(
+    Pointer<TCamera> camera,
+  );
+  external double _Camera_getCullingFar(
+    Pointer<TCamera> camera,
+  );
+  external double _Camera_getFov(
+    Pointer<TCamera> camera,
+    bool horizontal,
+  );
+  external double _Camera_getFocusDistance(
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_setFocusDistance(
+    Pointer<TCamera> camera,
+    double focusDistance,
+  );
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> tModelMatrix,
+  );
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
   );
   external void _TransformManager_getLocalTransform(
     Pointer<double4x4> double4x4_out,
@@ -1124,6 +1376,241 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _TransformManager_commitLocalTransformTransaction(
     Pointer<TTransformManager> tTransformManager,
+  );
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(
+    Pointer<TRenderer> tRenderer,
+  );
+  external void _Renderer_render(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+  );
+  external void _Renderer_renderStandaloneView(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+  );
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
+  external Pointer<TEngine> _Engine_create(
+    int backend,
+    Pointer<Void> platform,
+    Pointer<Void> sharedContext,
+    int stereoscopicEyeCount,
+    bool disableHandleUseAfterFreeCheck,
+  );
+  external int _Engine_getSupportedFeatureLevel(
+    Pointer<TEngine> tEngine,
+  );
+  external void _Engine_destroy(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TRenderer> _Engine_createRenderer(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TSwapChain> _Engine_createSwapChain(
+    Pointer<TEngine> tEngine,
+    Pointer<Void> window,
+    JSBigInt flags,
+  );
+  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
+    Pointer<TEngine> tEngine,
+    int width,
+    int height,
+    JSBigInt flags,
+  );
+  external void _Engine_destroySwapChain(
+    Pointer<TEngine> tEngine,
+    Pointer<TSwapChain> tSwapChain,
+  );
+  external void _Engine_destroyView(
+    Pointer<TEngine> tEngine,
+    Pointer<TView> tView,
+  );
+  external void _Engine_destroyScene(
+    Pointer<TEngine> tEngine,
+    Pointer<TScene> tScene,
+  );
+  external void _Engine_destroyColorGrading(
+    Pointer<TEngine> tEngine,
+    Pointer<TColorGrading> tColorGrading,
+  );
+  external Pointer<TCamera> _Engine_createCamera(
+    Pointer<TEngine> tEngine,
+    EntityId entityId,
+  );
+  external void _Engine_destroyCamera(
+    Pointer<TEngine> tEngine,
+    Pointer<TCamera> tCamera,
+  );
+  external Pointer<TView> _Engine_createView(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TCamera> _Engine_getCameraComponent(
+    Pointer<TEngine> tEngine,
+    EntityId entityId,
+  );
+  external Pointer<TTransformManager> _Engine_getTransformManager(
+    Pointer<TEngine> engine,
+  );
+  external Pointer<TRenderableManager> _Engine_getRenderableManager(
+    Pointer<TEngine> engine,
+  );
+  external Pointer<TLightManager> _Engine_getLightManager(
+    Pointer<TEngine> engine,
+  );
+  external Pointer<TEntityManager> _Engine_getEntityManager(
+    Pointer<TEngine> engine,
+  );
+  external void _Engine_setAutomaticInstancingEnabled(
+    Pointer<TEngine> tEngine,
+    bool enabled,
+  );
+  external size_t _Engine_getMaxAutomaticInstances(
+    Pointer<TEngine> tEngine,
+  );
+  external void _Engine_destroyTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+  );
+  external Pointer<TFence> _Engine_createFence(
+    Pointer<TEngine> tEngine,
+  );
+  external void _Engine_destroyFence(
+    Pointer<TEngine> tEngine,
+    Pointer<TFence> tFence,
+  );
+  external void _Engine_flushAndWait(
+    Pointer<TEngine> tEngine,
+  );
+  external void _Engine_execute(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TMaterial> _Engine_buildMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> materialData,
+    size_t length,
+  );
+  external void _Engine_destroyMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterial> tMaterial,
+  );
+  external void _Engine_destroyMaterialInstance(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialInstance> tMaterialInstance,
+  );
+  external Pointer<TScene> _Engine_createScene(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TSkybox> _Engine_buildSkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+  );
+  external Pointer<TSkybox> _Engine_buildColoredSkybox(
+    Pointer<TEngine> tEngine,
+    double r,
+    double g,
+    double b,
+    double a,
+  );
+  external Pointer<TIndirectLight>
+      _Engine_buildIndirectLightFromIrradianceTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<TTexture> tIrradianceTexture,
+    double intensity,
+  );
+  external Pointer<TIndirectLight>
+      _Engine_buildIndirectLightFromIrradianceHarmonics(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<Float32> irradianceHarmonics,
+    double intensity,
+  );
+  external void _Engine_destroySkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TSkybox> tSkybox,
+  );
+  external void _Engine_destroyIndirectLight(
+    Pointer<TEngine> tEngine,
+    Pointer<TIndirectLight> tIndirectLight,
+  );
+  external EntityId _EntityManager_createEntity(
+    Pointer<TEntityManager> tEntityManager,
+  );
+  external void _EntityManager_destroyEntity(
+    Pointer<TEntityManager> tEntityManager,
+    EntityId entityId,
+  );
+  external void _Fence_waitAndDestroy(
+    Pointer<TFence> tFence,
+  );
+  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(
+    Pointer<TEngine> tEngine,
+  );
+  external int _DebugRegistry_hasProperty(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+  );
+  external int _DebugRegistry_setProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    bool value,
+  );
+  external int _DebugRegistry_setProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    int value,
+  );
+  external int _DebugRegistry_setProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    double value,
+  );
+  external int _DebugRegistry_getProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Bool> outValue,
+  );
+  external int _DebugRegistry_getProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Int32> outValue,
+  );
+  external int _DebugRegistry_getProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Float32> outValue,
   );
   external Pointer<Void> _RenderThread_create();
   external void _RenderThread_destroy();
@@ -2123,307 +2610,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external void _IndirectLight_setRotation(
-    Pointer<TIndirectLight> tIndirectLight,
-    Pointer<Float64> rotation,
-  );
-  external int _LightManager_createLight(
-    Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
-  );
-  external void _LightManager_destroyLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_hasComponent(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_getType(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isDirectional(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isPointLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isSpotLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double r,
-    double g,
-    double b,
-  );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double falloff,
-  );
-  external double _LightManager_getFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external double _LightManager_getSpotLightInnerCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloSize,
-  );
-  external double _LightManager_getSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    bool enabled,
-  );
-  external int _LightManager_isShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-  );
-  external void _LightManager_computeUniformSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-  );
-  external void _LightManager_computeLogSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-  );
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(
-    double r,
-    double g,
-    double b,
-  );
-  external void _Camera_setExposure(
-    Pointer<TCamera> camera,
-    double aperture,
-    double shutterSpeed,
-    double sensitivity,
-  );
-  external double _Camera_getAperture(
-    Pointer<TCamera> camera,
-  );
-  external double _Camera_getShutterSpeed(
-    Pointer<TCamera> camera,
-  );
-  external double _Camera_getSensitivity(
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getModelMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getViewMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getCullingProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getFrustum(
-    Pointer<TCamera> camera,
-    Pointer<Float64> out,
-  );
-  external void _Camera_setProjectionMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> matrix,
-    double near,
-    double far,
-  );
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
-  );
-  external double _Camera_getFocalLength(
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(
-    Pointer<TCamera> camera,
-  );
-  external double _Camera_getCullingFar(
-    Pointer<TCamera> camera,
-  );
-  external double _Camera_getFov(
-    Pointer<TCamera> camera,
-    bool horizontal,
-  );
-  external double _Camera_getFocusDistance(
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_setFocusDistance(
-    Pointer<TCamera> camera,
-    double focusDistance,
-  );
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> tModelMatrix,
-  );
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
   external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(
     Pointer<TEngine> tEngine,
   );
@@ -2457,6 +2643,18 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     double g,
     double b,
     double a,
+  );
+  external void _dummy(
+    Pointer<TGltfMeshData> dummyPtr,
+  );
+  external int _GltfParser_parseBuffer(
+    Pointer<Uint8> data,
+    size_t length,
+    Pointer<Char> meshName,
+    Pointer<TGltfMeshData> outMeshData,
+  );
+  external void _GltfParser_freeMeshData(
+    Pointer<TGltfMeshData> meshData,
   );
   external void _RenderableManager_destroyEntity(
     Pointer<TRenderableManager> tRenderableManager,
@@ -2736,282 +2934,105 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TEngine> engine,
     EntityId entity,
   );
-  external void _Scene_addEntity(
-    Pointer<TScene> tScene,
-    EntityId entityId,
-  );
-  external void _Scene_removeEntity(
-    Pointer<TScene> tScene,
-    EntityId entityId,
-  );
-  external void _Scene_setSkybox(
-    Pointer<TScene> tScene,
-    Pointer<TSkybox> skybox,
-  );
-  external void _Scene_setIndirectLight(
-    Pointer<TScene> tScene,
-    Pointer<TIndirectLight> tIndirectLight,
-  );
-  external void _Scene_addFilamentAsset(
-    Pointer<TScene> tScene,
-    Pointer<TFilamentAsset> asset,
-  );
-  external Pointer<TRenderTarget> _RenderTarget_create(
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    Pointer<Aabb3> boundingBoxPtr,
   );
-  external void _RenderTarget_destroy(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderTarget> tRenderTarget,
-  );
-  external Pointer<TSurfaceOrientationBuilder>
-      _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
-  );
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_triangleCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
-  );
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
-  );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
-  );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
-    Pointer<TSurfaceOrientationBuilder> builder,
-  );
-  external void _SurfaceOrientationBuilder_destroy(
-    Pointer<TSurfaceOrientationBuilder> builder,
-  );
-  external size_t _SurfaceOrientation_getVertexCount(
-    Pointer<TSurfaceOrientation> orientation,
-  );
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_destroy(
-    Pointer<TSurfaceOrientation> orientation,
-  );
-  external void _dummy(
-    Pointer<TGltfMeshData> dummyPtr,
-  );
-  external int _GltfParser_parseBuffer(
-    Pointer<Uint8> data,
-    size_t length,
-    Pointer<Char> meshName,
-    Pointer<TGltfMeshData> outMeshData,
-  );
-  external void _GltfParser_freeMeshData(
-    Pointer<TGltfMeshData> meshData,
-  );
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(
-    Pointer<TRenderer> tRenderer,
-  );
-  external void _Renderer_render(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-  );
-  external void _Renderer_renderStandaloneView(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-  );
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
-  external Pointer<TRenderManager> _RenderManager_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderer> tRenderer,
-  );
-  external void _RenderManager_destroy(
-    Pointer<TRenderManager> tRenderer,
-  );
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_render(
-    Pointer<TRenderManager> tRenderer,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
-  );
-  external void _RenderManager_removeSwapChain(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-  );
-  external void _RenderManager_requestRender(
-    Pointer<TRenderManager> tRenderer,
-  );
-  external void _RenderManager_attachToRenderThread(
-    Pointer<TRenderManager> tRenderer,
-  );
-  external void _RenderManager_setPaused(
-    Pointer<TRenderManager> tRenderer,
-    bool paused,
-  );
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external void _Gizmo_dummy(
-    int t,
-  );
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(
-    Pointer<TGizmo> tGizmo,
-    int x,
-    int y,
-    GizmoPickCallback callback,
-  );
-  external void _Gizmo_highlight(
-    Pointer<TGizmo> tGizmo,
-    int axis,
-  );
-  external void _Gizmo_unhighlight(
-    Pointer<TGizmo> tGizmo,
-  );
-  external void _FrameScheduler_start(
-    FrameCallback callback,
-    int targetFps,
-  );
-  external void _FrameScheduler_stop();
-  external void _FrameScheduler_setRenderThread(
-    Pointer<Void> renderThread,
-  );
-  external void _FrameScheduler_setRenderManager(
-    Pointer<TRenderManager> rm,
-  );
-  external void _FrameScheduler_setPostRenderCallback(
-    PostRenderCallback callback,
-    Pointer<Void> userData,
-  );
-  external void _FrameScheduler_requestRender(
-    JSBigInt frameTimeNanos,
-  );
-  external void _FrameScheduler_startNativeRenderLoop(
-    int targetFps,
-  );
-  external int _FrameScheduler_initDartApi(
-    Pointer<Void> data,
-  );
-  external void _FrameScheduler_startWithPort(
-    JSBigInt port,
-    int targetFps,
-  );
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
-  );
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
     Pointer<TEngine> tEngine,
     Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
-  );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
-  );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(
-    Pointer<TGltfAssetLoader> tAssetLoader,
-  );
-  external int _FilamentAsset_getResourceUriCount(
+    Pointer<TNameComponentManager> tNameComponentManager,
     Pointer<TFilamentAsset> tFilamentAsset,
+    bool rebuildVertices,
   );
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(
-    Pointer<TFilamentAsset> tFilamentAsset,
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _SceneAsset_getType(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_destroy(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_addToScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external void _SceneAsset_removeFromScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external EntityId _SceneAsset_getEntity(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _SceneAsset_getChildEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_getChildEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<Int32> out,
+  );
+  external Pointer<Int32> _SceneAsset_getCameraEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getCameraEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<Int32> _SceneAsset_getLightEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getLightEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+  );
+  external size_t _SceneAsset_getInstanceCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+  );
+  external void _SceneAsset_getBoundingBox(
+    Pointer<Aabb3> Aabb3_out,
+    Pointer<TSceneAsset> asset,
+  );
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external void _SceneAsset_releaseSourceData(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_setFlatShading(
+    Pointer<TSceneAsset> tSceneAsset,
+    bool flatShading,
+  );
+  external void _SceneAsset_getBones(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    Pointer<Int32> out,
+  );
+  external size_t _SceneAsset_getBoneCount(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+  );
+  external Pointer<Char> _SceneAsset_getBoneName(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    size_t boneIndex,
   );
   external Pointer<TAnimationManager> _AnimationManager_create(
     Pointer<TEngine> tEngine,
@@ -3147,19 +3168,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int animationIndex,
     double timeInSeconds,
   );
-  external int _FilamentAsset_getEntityCount(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external void _FilamentAsset_getEntities(
-    Pointer<TFilamentAsset> filamentAsset,
-    Pointer<Int32> out,
-  );
-  external EntityId _FilamentAsset_getWireframe(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external Pointer<Void> _FilamentAsset_getSourceAsset(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
   external void _MovementIntentExecutor_destroy(
     Pointer<TMovementIntentExecutor> executor,
   );
@@ -3280,242 +3288,6 @@ BigInt get TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER {
   final value = NativeLibrary.instance.getValueBigInt(
       GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER, "i64");
   return bigIntasUintN(64, value).toDart;
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tVertexBuffer,
-  Pointer<TIndexBuffer> tIndexBuffer,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
-) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
-      tEngine.cast(),
-      tVertexBuffer.cast(),
-      tIndexBuffer.cast(),
-      materialInstances.cast(),
-      materialInstanceCount,
-      tPrimitiveType,
-      boundingBoxPtr.cast());
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
-      tEngine.cast(),
-      tAssetLoader.cast(),
-      tNameComponentManager.cast(),
-      tFilamentAsset.cast(),
-      rebuildVertices);
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getFilamentAsset(tSceneAsset.cast());
-  return Pointer<TFilamentAsset>(result);
-}
-
-int SceneAsset_getType(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result =
-      GeneratedBindings.instance._SceneAsset_getType(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_destroy(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result =
-      GeneratedBindings.instance._SceneAsset_destroy(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_addToScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_addToScene(tSceneAsset.cast(), tScene.cast());
-  return result;
-}
-
-void SceneAsset_removeFromScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_removeFromScene(tSceneAsset.cast(), tScene.cast());
-  return result;
-}
-
-DartEntityId SceneAsset_getEntity(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result =
-      GeneratedBindings.instance._SceneAsset_getEntity(tSceneAsset.cast());
-  return result;
-}
-
-int SceneAsset_getChildEntityCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getChildEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_getChildEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getChildEntities(tSceneAsset.cast(), out);
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getCameraEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getCameraEntities(tSceneAsset.cast());
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getCameraEntityCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getLightEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getLightEntities(tSceneAsset.cast());
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getLightEntityCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getLightEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_getInstance(
-  Pointer<TSceneAsset> tSceneAsset,
-  int index,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getInstance(tSceneAsset.cast(), index);
-  return Pointer<TSceneAsset>(result);
-}
-
-Dartsize_t SceneAsset_getInstanceCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getInstanceCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_createInstance(
-  Pointer<TSceneAsset> asset,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createInstance(
-      asset.cast(), materialInstances.cast(), materialInstanceCount);
-  return Pointer<TSceneAsset>(result);
-}
-
-Aabb3 SceneAsset_getBoundingBox(
-  Pointer<TSceneAsset> asset,
-) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getBoundingBox(Aabb3_out.cast(), asset.cast());
-  return Aabb3_out.toDart();
-}
-
-Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getVertexBuffer(tSceneAsset.cast(), primitiveIndex);
-  return Pointer<TVertexBuffer>(result);
-}
-
-Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getIndexBuffer(tSceneAsset.cast(), primitiveIndex);
-  return Pointer<TIndexBuffer>(result);
-}
-
-void SceneAsset_releaseSourceData(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_releaseSourceData(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_setFlatShading(
-  Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_setFlatShading(tSceneAsset.cast(), flatShading);
-  return result;
-}
-
-void SceneAsset_getBones(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
-  return result;
-}
-
-Dartsize_t SceneAsset_getBoneCount(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
-  return result;
-}
-
-Pointer<Char> SceneAsset_getBoneName(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
-  Dartsize_t boneIndex,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
-  return Pointer<Char>(result);
 }
 
 Pointer<TMaterialInstance> Material_createInstance(
@@ -3873,772 +3645,482 @@ int Material_getBlendingMode(
   return result;
 }
 
-Pointer<TTexture> Texture_build(
-  Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import1,
-  int sampler,
-  int format,
-) {
-  final result = GeneratedBindings.instance._Texture_build(engine.cast(), width,
-      height, depth, levels, tUsage, import1, sampler, format);
-  return Pointer<TTexture>(result);
-}
-
-void Texture_setExternalImage(
+int LightManager_createLight(
   Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<Void> externalImage,
+  Pointer<TLightManager> tLightManager,
+  int tLightTtype,
 ) {
-  final result = GeneratedBindings.instance._Texture_setExternalImage(
-      tEngine.cast(), tTexture.cast(), externalImage);
+  final result = GeneratedBindings.instance._LightManager_createLight(
+      tEngine.cast(), tLightManager.cast(), tLightTtype);
   return result;
 }
 
-Dartsize_t Texture_getLevels(
-  Pointer<TTexture> tTexture,
+void LightManager_destroyLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
 ) {
-  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
+  final result = GeneratedBindings.instance
+      ._LightManager_destroyLight(tLightManager.cast(), entity);
   return result;
 }
 
-bool Texture_loadImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
+bool LightManager_hasComponent(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
 ) {
-  final result = GeneratedBindings.instance._Texture_loadImage(tEngine.cast(),
-      tTexture.cast(), tImage.cast(), bufferFormat, pixelDataType, level);
+  final result = GeneratedBindings.instance
+      ._LightManager_hasComponent(tLightManager.cast(), entity);
   return result == 1;
 }
 
-bool Texture_setImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  int level,
-  Pointer<Uint8> data,
-  Dartsize_t size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
+int LightManager_getType(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
 ) {
-  final result = GeneratedBindings.instance._Texture_setImage(
-      tEngine.cast(),
-      tTexture.cast(),
-      level,
-      data,
-      size,
-      x_offset,
-      y_offset,
-      z_offset,
-      width,
-      height,
-      depth,
-      bufferFormat,
-      pixelDataType);
+  final result = GeneratedBindings.instance
+      ._LightManager_getType(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_isDirectional(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_isDirectional(tLightManager.cast(), entity);
   return result == 1;
 }
 
-int Texture_getWidth(
-  Pointer<TTexture> tTexture,
-  int level,
-) {
-  final result =
-      GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getHeight(
-  Pointer<TTexture> tTexture,
-  int level,
-) {
-  final result =
-      GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getDepth(
-  Pointer<TTexture> tTexture,
-  int level,
-) {
-  final result =
-      GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getUsage(
-  Pointer<TTexture> tTexture,
-  int level,
-) {
-  final result =
-      GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
-  return result;
-}
-
-void Texture_generateMipMaps(
-  Pointer<TTexture> tTexture,
-  Pointer<TEngine> tEngine,
+bool LightManager_isPointLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
 ) {
   final result = GeneratedBindings.instance
-      ._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
-  return result;
-}
-
-Pointer<TKtx1Bundle> Ktx1Bundle_create(
-  Pointer<Uint8> ktxData,
-  Dartsize_t length,
-) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
-  return Pointer<TKtx1Bundle>(result);
-}
-
-void Ktx1Bundle_getSphericalHarmonics(
-  Pointer<TKtx1Bundle> tBundle,
-  Pointer<Float32> harmonics,
-) {
-  final result = GeneratedBindings.instance
-      ._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
-  return result;
-}
-
-bool Ktx1Bundle_isCubemap(
-  Pointer<TKtx1Bundle> tBundle,
-) {
-  final result =
-      GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
+      ._LightManager_isPointLight(tLightManager.cast(), entity);
   return result == 1;
 }
 
-void Ktx1Bundle_destroy(
-  Pointer<TKtx1Bundle> tBundle,
-) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
-  return result;
-}
-
-Pointer<TTexture> Ktx1Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  DartVoidCallback onTextureUploadComplete,
-) {
-  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
-      tEngine.cast(),
-      tBundle.cast(),
-      requestId,
-      onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>);
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> Ktx2Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<Uint8> data,
-  Dartsize_t size,
+bool LightManager_isSpotLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
 ) {
   final result = GeneratedBindings.instance
-      ._Ktx2Reader_createTexture(tEngine.cast(), data, size);
-  return Pointer<TTexture>(result);
+      ._LightManager_isSpotLight(tLightManager.cast(), entity);
+  return result == 1;
 }
 
-Pointer<TLinearImage> Image_createEmpty(
-  int width,
-  int height,
-  int channel,
-) {
-  final result =
-      GeneratedBindings.instance._Image_createEmpty(width, height, channel);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<TLinearImage> Image_decode(
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  Pointer<Char> name,
-  bool alpha,
-) {
-  final result =
-      GeneratedBindings.instance._Image_decode(data, length, name, alpha);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<Float32> Image_getBytes(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result =
-      GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
-  return Pointer<Float32>(result);
-}
-
-void Image_destroy(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
-  return result;
-}
-
-int Image_getWidth(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result =
-      GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
-  return result;
-}
-
-int Image_getHeight(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result =
-      GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
-  return result;
-}
-
-int Image_getChannels(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result =
-      GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
-  return result;
-}
-
-Pointer<TTexture> RenderTarget_getColorTexture(
-  Pointer<TRenderTarget> tRenderTarget,
+void LightManager_setPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
 ) {
   final result = GeneratedBindings.instance
-      ._RenderTarget_getColorTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> RenderTarget_getDepthTexture(
-  Pointer<TRenderTarget> tRenderTarget,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderTarget_getDepthTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_create() {
-  final result = GeneratedBindings.instance._TextureSampler_create();
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
-      minFilter, magFilter, wrapS, wrapT, wrapR);
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithComparison(
-  int compareMode,
-  int compareFunc,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_createWithComparison(compareMode, compareFunc);
-  return Pointer<TTextureSampler>(result);
-}
-
-void TextureSampler_setMinFilter(
-  Pointer<TTextureSampler> sampler,
-  int filter,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setMinFilter(sampler.cast(), filter);
+      ._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
   return result;
 }
 
-void TextureSampler_setMagFilter(
-  Pointer<TTextureSampler> sampler,
-  int filter,
+double3 LightManager_getPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(
+      double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
 ) {
   final result = GeneratedBindings.instance
-      ._TextureSampler_setMagFilter(sampler.cast(), filter);
+      ._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
   return result;
 }
 
-void TextureSampler_setWrapModeS(
-  Pointer<TTextureSampler> sampler,
-  int mode,
+double3 LightManager_getDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
 ) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setWrapModeS(sampler.cast(), mode);
-  return result;
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(
+      double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
 }
 
-void TextureSampler_setWrapModeT(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setWrapModeT(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeR(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setWrapModeR(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setAnisotropy(
-  Pointer<TTextureSampler> sampler,
-  double anisotropy,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
-  return result;
-}
-
-void TextureSampler_setCompareMode(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-  int func,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setCompareMode(sampler.cast(), mode, func);
-  return result;
-}
-
-void TextureSampler_destroy(
-  Pointer<TTextureSampler> sampler,
-) {
-  final result =
-      GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
-  return result;
-}
-
-Pointer<TEngine> Engine_create(
-  int backend,
-  Pointer<Void> platform,
-  Pointer<Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-) {
-  final result = GeneratedBindings.instance._Engine_create(backend, platform,
-      sharedContext, stereoscopicEyeCount, disableHandleUseAfterFreeCheck);
-  return Pointer<TEngine>(result);
-}
-
-int Engine_getSupportedFeatureLevel(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_getSupportedFeatureLevel(tEngine.cast());
-  return result;
-}
-
-void Engine_destroy(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
-  return result;
-}
-
-Pointer<TRenderer> Engine_createRenderer(
-  Pointer<TEngine> tEngine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
-  return Pointer<TRenderer>(result);
-}
-
-Pointer<TSwapChain> Engine_createSwapChain(
-  Pointer<TEngine> tEngine,
-  Pointer<Void> window,
-  BigInt flags,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-Pointer<TSwapChain> Engine_createHeadlessSwapChain(
-  Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  BigInt flags,
-) {
-  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
-      tEngine.cast(), width, height, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-void Engine_destroySwapChain(
-  Pointer<TEngine> tEngine,
-  Pointer<TSwapChain> tSwapChain,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
-  return result;
-}
-
-void Engine_destroyView(
-  Pointer<TEngine> tEngine,
-  Pointer<TView> tView,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyView(tEngine.cast(), tView.cast());
-  return result;
-}
-
-void Engine_destroyScene(
-  Pointer<TEngine> tEngine,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyScene(tEngine.cast(), tScene.cast());
-  return result;
-}
-
-void Engine_destroyColorGrading(
-  Pointer<TEngine> tEngine,
-  Pointer<TColorGrading> tColorGrading,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
-  return result;
-}
-
-Pointer<TCamera> Engine_createCamera(
-  Pointer<TEngine> tEngine,
-  DartEntityId entityId,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-void Engine_destroyCamera(
-  Pointer<TEngine> tEngine,
-  Pointer<TCamera> tCamera,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TView> Engine_createView(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
-  return Pointer<TView>(result);
-}
-
-Pointer<TCamera> Engine_getCameraComponent(
-  Pointer<TEngine> tEngine,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_getCameraComponent(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-Pointer<TTransformManager> Engine_getTransformManager(
-  Pointer<TEngine> engine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
-  return Pointer<TTransformManager>(result);
-}
-
-Pointer<TRenderableManager> Engine_getRenderableManager(
-  Pointer<TEngine> engine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
-  return Pointer<TRenderableManager>(result);
-}
-
-Pointer<TLightManager> Engine_getLightManager(
-  Pointer<TEngine> engine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getLightManager(engine.cast());
-  return Pointer<TLightManager>(result);
-}
-
-Pointer<TEntityManager> Engine_getEntityManager(
-  Pointer<TEngine> engine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
-  return Pointer<TEntityManager>(result);
-}
-
-void Engine_setAutomaticInstancingEnabled(
-  Pointer<TEngine> tEngine,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
-  return result;
-}
-
-Dartsize_t Engine_getMaxAutomaticInstances(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_getMaxAutomaticInstances(tEngine.cast());
-  return result;
-}
-
-void Engine_destroyTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
-  return result;
-}
-
-Pointer<TFence> Engine_createFence(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
-  return Pointer<TFence>(result);
-}
-
-void Engine_destroyFence(
-  Pointer<TEngine> tEngine,
-  Pointer<TFence> tFence,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyFence(tEngine.cast(), tFence.cast());
-  return result;
-}
-
-void Engine_flushAndWait(
-  Pointer<TEngine> tEngine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
-  return result;
-}
-
-void Engine_execute(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
-  return result;
-}
-
-Pointer<TMaterial> Engine_buildMaterial(
-  Pointer<TEngine> tEngine,
-  Pointer<Uint8> materialData,
-  Dartsize_t length,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_buildMaterial(tEngine.cast(), materialData, length);
-  return Pointer<TMaterial>(result);
-}
-
-void Engine_destroyMaterial(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterial> tMaterial,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
-  return result;
-}
-
-void Engine_destroyMaterialInstance(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialInstance> tMaterialInstance,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(
-      tEngine.cast(), tMaterialInstance.cast());
-  return result;
-}
-
-Pointer<TScene> Engine_createScene(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TSkybox> Engine_buildSkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_buildSkybox(tEngine.cast(), tTexture.cast());
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TSkybox> Engine_buildColoredSkybox(
-  Pointer<TEngine> tEngine,
+void LightManager_setColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
   double r,
   double g,
   double b,
-  double a,
 ) {
   final result = GeneratedBindings.instance
-      ._Engine_buildColoredSkybox(tEngine.cast(), r, g, b, a);
-  return Pointer<TSkybox>(result);
+      ._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+  return result;
 }
 
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<TTexture> tIrradianceTexture,
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+      tLightManager.cast(), entity, colorTemperature);
+  return result;
+}
+
+double3 LightManager_getColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
   double intensity,
 ) {
   final result = GeneratedBindings.instance
-      ._Engine_buildIndirectLightFromIrradianceTexture(tEngine.cast(),
-          tReflectionsTexture.cast(), tIrradianceTexture.cast(), intensity);
-  return Pointer<TIndirectLight>(result);
+      ._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+  return result;
 }
 
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<Float32> irradianceHarmonics,
+void LightManager_setIntensityCandela(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
   double intensity,
 ) {
-  final result = GeneratedBindings.instance
-      ._Engine_buildIndirectLightFromIrradianceHarmonics(tEngine.cast(),
-          tReflectionsTexture.cast(), irradianceHarmonics, intensity);
-  return Pointer<TIndirectLight>(result);
-}
-
-void Engine_destroySkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TSkybox> tSkybox,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
+      tLightManager.cast(), entity, intensity);
   return result;
 }
 
-void Engine_destroyIndirectLight(
-  Pointer<TEngine> tEngine,
-  Pointer<TIndirectLight> tIndirectLight,
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
 ) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+      tLightManager.cast(), entity, watts, efficiency);
   return result;
 }
 
-DartEntityId EntityManager_createEntity(
-  Pointer<TEntityManager> tEntityManager,
+double LightManager_getIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
 ) {
   final result = GeneratedBindings.instance
-      ._EntityManager_createEntity(tEntityManager.cast());
+      ._LightManager_getIntensity(tLightManager.cast(), entity);
   return result;
 }
 
-void EntityManager_destroyEntity(
-  Pointer<TEntityManager> tEntityManager,
-  DartEntityId entityId,
+void LightManager_setFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double falloff,
 ) {
   final result = GeneratedBindings.instance
-      ._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
+      ._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
   return result;
 }
 
-void Fence_waitAndDestroy(
-  Pointer<TFence> tFence,
+double LightManager_getFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
+      tLightManager.cast(), entity, inner, outer);
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double angularRadius,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+      tLightManager.cast(), entity, angularRadius);
+  return result;
+}
+
+double LightManager_getSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloSize,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+  return result;
+}
+
+double LightManager_getSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloFalloff,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
+      tLightManager.cast(), entity, haloFalloff);
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+  return result;
+}
+
+bool LightManager_isShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_isShadowCaster(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  TShadowOptions options,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+      tLightManager.cast(), entity, optionsPtr.cast());
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+      TShadowOptions_out.cast(), tLightManager.cast(), entity);
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+      tLightManager.cast(), entity, channel, enable);
+  return result;
+}
+
+bool LightManager_getLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_computeUniformSplits(splitPositions, cascades);
+  return result;
+}
+
+void LightManager_computeLogSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_computePracticalSplits(
+          splitPositions, cascades, near, far, lambda);
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(
+  double r,
+  double g,
+  double b,
 ) {
   final result =
-      GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
+      GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
   return result;
 }
 
-Pointer<TDebugRegistry> Engine_getDebugRegistry(
+int FilamentAsset_getEntityCount(
+  Pointer<TFilamentAsset> filamentAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getEntityCount(filamentAsset.cast());
+  return result;
+}
+
+void FilamentAsset_getEntities(
+  Pointer<TFilamentAsset> filamentAsset,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getEntities(filamentAsset.cast(), out);
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(
+  Pointer<TFilamentAsset> filamentAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getWireframe(filamentAsset.cast());
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(
+  Pointer<TFilamentAsset> filamentAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getSourceAsset(filamentAsset.cast());
+  return Pointer<Void>(result);
+}
+
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
   Pointer<TEngine> tEngine,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
 ) {
-  final result =
-      GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
-  return Pointer<TDebugRegistry>(result);
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+      tEngine.cast(), tMaterialProvider.cast(), tNameComponentManager.cast());
+  return Pointer<TGltfAssetLoader>(result);
 }
 
-bool DebugRegistry_hasProperty(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<Uint8> data,
+  Dart__darwin_size_t length,
+  int numInstances,
 ) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
-  return result == 1;
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+      tEngine.cast(), tAssetLoader.cast(), data, length, numInstances);
+  return Pointer<TFilamentAsset>(result);
 }
 
-bool DebugRegistry_setProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  bool value,
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
 ) {
   final result = GeneratedBindings.instance
-      ._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
-  return result == 1;
+      ._GltfAssetLoader_getMaterialInstance(
+          tRenderableManager.cast(), tAsset.cast());
+  return Pointer<TMaterialInstance>(result);
 }
 
-bool DebugRegistry_setProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  int value,
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
+  Pointer<TGltfAssetLoader> tAssetLoader,
 ) {
   final result = GeneratedBindings.instance
-      ._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
-  return result == 1;
+      ._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
 }
 
-bool DebugRegistry_setProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  double value,
+int FilamentAsset_getResourceUriCount(
+  Pointer<TFilamentAsset> tFilamentAsset,
 ) {
   final result = GeneratedBindings.instance
-      ._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
-  return result == 1;
+      ._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
+  return result;
 }
 
-bool DebugRegistry_getProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Bool> outValue,
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(
+  Pointer<TFilamentAsset> tFilamentAsset,
 ) {
   final result = GeneratedBindings.instance
-      ._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Int32> outValue,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Float32> outValue,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
+      ._FilamentAsset_getResourceUris(tFilamentAsset.cast());
+  return Pointer<PointerClass<Char>>(result);
 }
 
 TViewport View_getViewport(
@@ -4781,6 +4263,24 @@ void ColorGradingBuilder_quality(
 ) {
   final result = GeneratedBindings.instance
       ._ColorGradingBuilder_quality(builder.cast(), level);
+  return result;
+}
+
+void ColorGradingBuilder_format(
+  Pointer<TColorGradingBuilder> builder,
+  int format,
+) {
+  final result = GeneratedBindings.instance
+      ._ColorGradingBuilder_format(builder.cast(), format);
+  return result;
+}
+
+void ColorGradingBuilder_dimensions(
+  Pointer<TColorGradingBuilder> builder,
+  int dim,
+) {
+  final result = GeneratedBindings.instance
+      ._ColorGradingBuilder_dimensions(builder.cast(), dim);
   return result;
 }
 
@@ -5306,6 +4806,750 @@ Pointer<Char> View_getName(
   return Pointer<Char>(result);
 }
 
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+Pointer<Char> NameComponentManager_getName(
+  Pointer<TNameComponentManager> tNameComponentManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._NameComponentManager_getName(tNameComponentManager.cast(), entity);
+  return Pointer<Char>(result);
+}
+
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint32> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_build(builder.cast());
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dart__darwin_size_t SurfaceOrientation_getVertexCount(
+  Pointer<TSurfaceOrientation> orientation,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientation_getVertexCount(orientation.cast());
+  return result;
+}
+
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+      orientation.cast(), out, quatCount, stride);
+  return result;
+}
+
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+      orientation.cast(), out, quatCount, stride);
+  return result;
+}
+
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+      orientation.cast(), out, quatCount, stride);
+  return result;
+}
+
+void SurfaceOrientation_destroy(
+  Pointer<TSurfaceOrientation> orientation,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientation_destroy(orientation.cast());
+  return result;
+}
+
+void IndirectLight_setRotation(
+  Pointer<TIndirectLight> tIndirectLight,
+  Pointer<Float64> rotation,
+) {
+  final result = GeneratedBindings.instance
+      ._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+  return result;
+}
+
+Pointer<TTexture> Texture_build(
+  Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import1,
+  int sampler,
+  int format,
+) {
+  final result = GeneratedBindings.instance._Texture_build(engine.cast(), width,
+      height, depth, levels, tUsage, import1, sampler, format);
+  return Pointer<TTexture>(result);
+}
+
+void Texture_setExternalImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  Pointer<Void> externalImage,
+) {
+  final result = GeneratedBindings.instance._Texture_setExternalImage(
+      tEngine.cast(), tTexture.cast(), externalImage);
+  return result;
+}
+
+Dart__darwin_size_t Texture_getLevels(
+  Pointer<TTexture> tTexture,
+) {
+  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
+  return result;
+}
+
+bool Texture_loadImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+) {
+  final result = GeneratedBindings.instance._Texture_loadImage(tEngine.cast(),
+      tTexture.cast(), tImage.cast(), bufferFormat, pixelDataType, level);
+  return result == 1;
+}
+
+bool Texture_setImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  int level,
+  Pointer<Uint8> data,
+  Dart__darwin_size_t size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+) {
+  final result = GeneratedBindings.instance._Texture_setImage(
+      tEngine.cast(),
+      tTexture.cast(),
+      level,
+      data,
+      size,
+      x_offset,
+      y_offset,
+      z_offset,
+      width,
+      height,
+      depth,
+      bufferFormat,
+      pixelDataType);
+  return result == 1;
+}
+
+int Texture_getWidth(
+  Pointer<TTexture> tTexture,
+  int level,
+) {
+  final result =
+      GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getHeight(
+  Pointer<TTexture> tTexture,
+  int level,
+) {
+  final result =
+      GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getDepth(
+  Pointer<TTexture> tTexture,
+  int level,
+) {
+  final result =
+      GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getUsage(
+  Pointer<TTexture> tTexture,
+  int level,
+) {
+  final result =
+      GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
+  return result;
+}
+
+void Texture_generateMipMaps(
+  Pointer<TTexture> tTexture,
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance
+      ._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
+  return result;
+}
+
+Pointer<TKtx1Bundle> Ktx1Bundle_create(
+  Pointer<Uint8> ktxData,
+  Dart__darwin_size_t length,
+) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
+  return Pointer<TKtx1Bundle>(result);
+}
+
+void Ktx1Bundle_getSphericalHarmonics(
+  Pointer<TKtx1Bundle> tBundle,
+  Pointer<Float32> harmonics,
+) {
+  final result = GeneratedBindings.instance
+      ._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
+  return result;
+}
+
+bool Ktx1Bundle_isCubemap(
+  Pointer<TKtx1Bundle> tBundle,
+) {
+  final result =
+      GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
+  return result == 1;
+}
+
+void Ktx1Bundle_destroy(
+  Pointer<TKtx1Bundle> tBundle,
+) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
+  return result;
+}
+
+Pointer<TTexture> Ktx1Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  DartVoidCallback onTextureUploadComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
+      tEngine.cast(),
+      tBundle.cast(),
+      requestId,
+      onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>);
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> Ktx2Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<Uint8> data,
+  Dart__darwin_size_t size,
+) {
+  final result = GeneratedBindings.instance
+      ._Ktx2Reader_createTexture(tEngine.cast(), data, size);
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TLinearImage> Image_createEmpty(
+  int width,
+  int height,
+  int channel,
+) {
+  final result =
+      GeneratedBindings.instance._Image_createEmpty(width, height, channel);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<TLinearImage> Image_decode(
+  Pointer<Uint8> data,
+  Dart__darwin_size_t length,
+  Pointer<Char> name,
+  bool alpha,
+) {
+  final result =
+      GeneratedBindings.instance._Image_decode(data, length, name, alpha);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<Float32> Image_getBytes(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result =
+      GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
+  return Pointer<Float32>(result);
+}
+
+void Image_destroy(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+  return result;
+}
+
+int Image_getWidth(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result =
+      GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
+  return result;
+}
+
+int Image_getHeight(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result =
+      GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
+  return result;
+}
+
+int Image_getChannels(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result =
+      GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
+  return result;
+}
+
+Pointer<TTexture> RenderTarget_getColorTexture(
+  Pointer<TRenderTarget> tRenderTarget,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderTarget_getColorTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> RenderTarget_getDepthTexture(
+  Pointer<TRenderTarget> tRenderTarget,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderTarget_getDepthTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_create() {
+  final result = GeneratedBindings.instance._TextureSampler_create();
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
+      minFilter, magFilter, wrapS, wrapT, wrapR);
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithComparison(
+  int compareMode,
+  int compareFunc,
+) {
+  final result = GeneratedBindings.instance
+      ._TextureSampler_createWithComparison(compareMode, compareFunc);
+  return Pointer<TTextureSampler>(result);
+}
+
+void TextureSampler_setMinFilter(
+  Pointer<TTextureSampler> sampler,
+  int filter,
+) {
+  final result = GeneratedBindings.instance
+      ._TextureSampler_setMinFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setMagFilter(
+  Pointer<TTextureSampler> sampler,
+  int filter,
+) {
+  final result = GeneratedBindings.instance
+      ._TextureSampler_setMagFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setWrapModeS(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+) {
+  final result = GeneratedBindings.instance
+      ._TextureSampler_setWrapModeS(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeT(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+) {
+  final result = GeneratedBindings.instance
+      ._TextureSampler_setWrapModeT(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeR(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+) {
+  final result = GeneratedBindings.instance
+      ._TextureSampler_setWrapModeR(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setAnisotropy(
+  Pointer<TTextureSampler> sampler,
+  double anisotropy,
+) {
+  final result = GeneratedBindings.instance
+      ._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
+  return result;
+}
+
+void TextureSampler_setCompareMode(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+  int func,
+) {
+  final result = GeneratedBindings.instance
+      ._TextureSampler_setCompareMode(sampler.cast(), mode, func);
+  return result;
+}
+
+void TextureSampler_destroy(
+  Pointer<TTextureSampler> sampler,
+) {
+  final result =
+      GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
+  return result;
+}
+
+Pointer<TRenderManager> RenderManager_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderer> tRenderer,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_create(tEngine.cast(), tRenderer.cast());
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(
+  Pointer<TRenderManager> tRenderer,
+) {
+  final result =
+      GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+      tRenderer.cast(), tAnimationManager.cast());
+  return result;
+}
+
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_removeAnimationManager(
+          tRenderer.cast(), tAnimationManager.cast());
+  return result;
+}
+
+void RenderManager_render(
+  Pointer<TRenderManager> tRenderer,
+  BigInt frameTimeInNanos,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+      tRenderer.cast(), swapChain.cast(), views.cast(), numViews);
+  return result;
+}
+
+void RenderManager_removeSwapChain(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_requestRender(
+  Pointer<TRenderManager> tRenderer,
+) {
+  final result =
+      GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_attachToRenderThread(
+  Pointer<TRenderManager> tRenderer,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_setPaused(
+  Pointer<TRenderManager> tRenderer,
+  bool paused,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_setPaused(tRenderer.cast(), paused);
+  return result;
+}
+
+void FrameScheduler_start(
+  DartFrameCallback callback,
+  int targetFps,
+) {
+  final result = GeneratedBindings.instance._FrameScheduler_start(
+      callback as Pointer<NativeFunction<FrameCallbackFunction>>, targetFps);
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+void FrameScheduler_setRenderThread(
+  Pointer<Void> renderThread,
+) {
+  final result =
+      GeneratedBindings.instance._FrameScheduler_setRenderThread(renderThread);
+  return result;
+}
+
+void FrameScheduler_setRenderManager(
+  Pointer<TRenderManager> rm,
+) {
+  final result =
+      GeneratedBindings.instance._FrameScheduler_setRenderManager(rm.cast());
+  return result;
+}
+
+void FrameScheduler_setPostRenderCallback(
+  DartPostRenderCallback callback,
+  Pointer<Void> userData,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_setPostRenderCallback(
+          callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
+          userData);
+  return result;
+}
+
+void FrameScheduler_requestRender(
+  BigInt frameTimeNanos,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_requestRender(frameTimeNanos.toJSBigInt);
+  return result;
+}
+
+void FrameScheduler_startNativeRenderLoop(
+  int targetFps,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_startNativeRenderLoop(targetFps);
+  return result;
+}
+
+int FrameScheduler_initDartApi(
+  Pointer<Void> data,
+) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(
+  BigInt port,
+  int targetFps,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void Gizmo_dummy(
+  int t,
+) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+      tEngine.cast(),
+      assetLoader.cast(),
+      tGltfResourceLoader.cast(),
+      tNameComponentManager.cast(),
+      tView.cast(),
+      tMaterial.cast(),
+      tGizmoType);
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(
+  Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  DartGizmoPickCallback callback,
+) {
+  final result = GeneratedBindings.instance._Gizmo_pick(tGizmo.cast(), x, y,
+      callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>);
+  return result;
+}
+
+void Gizmo_highlight(
+  Pointer<TGizmo> tGizmo,
+  int axis,
+) {
+  final result =
+      GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
+  return result;
+}
+
+void Gizmo_unhighlight(
+  Pointer<TGizmo> tGizmo,
+) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
+}
+
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -5391,6 +5635,75 @@ Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   return Pointer<TMaterialInstance>(result);
 }
 
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
+}
+
+void IndexBufferBuilder_indexCount(
+  Pointer<TIndexBufferBuilder> builder,
+  int count,
+) {
+  final result = GeneratedBindings.instance
+      ._IndexBufferBuilder_indexCount(builder.cast(), count);
+  return result;
+}
+
+void IndexBufferBuilder_bufferType(
+  Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+) {
+  final result = GeneratedBindings.instance
+      ._IndexBufferBuilder_bufferType(builder.cast(), indexType);
+  return result;
+}
+
+Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  Pointer<TIndexBufferBuilder> builder,
+  Pointer<TEngine> engine,
+) {
+  final result = GeneratedBindings.instance
+      ._IndexBufferBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_destroy(
+  Pointer<TIndexBufferBuilder> builder,
+) {
+  final result =
+      GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dart__darwin_size_t IndexBuffer_getIndexCount(
+  Pointer<TIndexBuffer> buffer,
+) {
+  final result =
+      GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
+  return result;
+}
+
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dart__darwin_size_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+      engine.cast(), buffer.cast(), data, sizeInBytes, byteOffset);
+  return result;
+}
+
+void IndexBuffer_destroy(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+) {
+  final result = GeneratedBindings.instance
+      ._IndexBuffer_destroy(engine.cast(), buffer.cast());
+  return result;
+}
+
 Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
   final result = GeneratedBindings.instance._VertexBufferBuilder_create();
   return Pointer<TVertexBufferBuilder>(result);
@@ -5459,7 +5772,7 @@ void VertexBufferBuilder_destroy(
   return result;
 }
 
-Dartsize_t VertexBuffer_getVertexCount(
+Dart__darwin_size_t VertexBuffer_getVertexCount(
   Pointer<TVertexBuffer> buffer,
 ) {
   final result =
@@ -5472,7 +5785,7 @@ void VertexBuffer_setBufferAt(
   Pointer<TVertexBuffer> buffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
 ) {
   final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
@@ -5489,72 +5802,289 @@ void VertexBuffer_destroy(
   return result;
 }
 
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
-}
-
-void IndexBufferBuilder_indexCount(
-  Pointer<TIndexBufferBuilder> builder,
-  int count,
+Pointer<TRenderTarget> RenderTarget_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> color,
+  Pointer<TTexture> depth,
 ) {
   final result = GeneratedBindings.instance
-      ._IndexBufferBuilder_indexCount(builder.cast(), count);
+      ._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
+  return Pointer<TRenderTarget>(result);
+}
+
+void RenderTarget_destroy(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderTarget> tRenderTarget,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
   return result;
 }
 
-void IndexBufferBuilder_bufferType(
-  Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-) {
-  final result = GeneratedBindings.instance
-      ._IndexBufferBuilder_bufferType(builder.cast(), indexType);
-  return result;
-}
-
-Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  Pointer<TIndexBufferBuilder> builder,
-  Pointer<TEngine> engine,
-) {
-  final result = GeneratedBindings.instance
-      ._IndexBufferBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(
-  Pointer<TIndexBufferBuilder> builder,
+void Scene_addEntity(
+  Pointer<TScene> tScene,
+  DartEntityId entityId,
 ) {
   final result =
-      GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
+      GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
   return result;
 }
 
-Dartsize_t IndexBuffer_getIndexCount(
-  Pointer<TIndexBuffer> buffer,
+void Scene_removeEntity(
+  Pointer<TScene> tScene,
+  DartEntityId entityId,
 ) {
   final result =
-      GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
+      GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
   return result;
 }
 
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
+void Scene_setSkybox(
+  Pointer<TScene> tScene,
+  Pointer<TSkybox> skybox,
 ) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-      engine.cast(), buffer.cast(), data, sizeInBytes, byteOffset);
+  final result =
+      GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
   return result;
 }
 
-void IndexBuffer_destroy(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
+void Scene_setIndirectLight(
+  Pointer<TScene> tScene,
+  Pointer<TIndirectLight> tIndirectLight,
 ) {
   final result = GeneratedBindings.instance
-      ._IndexBuffer_destroy(engine.cast(), buffer.cast());
+      ._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Scene_addFilamentAsset(
+  Pointer<TScene> tScene,
+  Pointer<TFilamentAsset> asset,
+) {
+  final result = GeneratedBindings.instance
+      ._Scene_addFilamentAsset(tScene.cast(), asset.cast());
+  return result;
+}
+
+void Camera_setExposure(
+  Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
+  return result;
+}
+
+double Camera_getAperture(
+  Pointer<TCamera> camera,
+) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
+  return result;
+}
+
+double Camera_getSensitivity(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(
+  Pointer<TCamera> camera,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(
+  Pointer<TCamera> camera,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(
+  Pointer<TCamera> camera,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(
+  Pointer<TCamera> camera,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(
+  Pointer<TCamera> camera,
+  Pointer<Float64> out,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
+  return result;
+}
+
+void Camera_setProjectionMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> matrix,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+      camera.cast(), fovInDegrees, aspect, near, far, horizontal);
+  return result;
+}
+
+double Camera_getFocalLength(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
+  return result;
+}
+
+void Camera_lookAt(
+  Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(
+      camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
+  return result;
+}
+
+double Camera_getNear(
+  Pointer<TCamera> camera,
+) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
+  return result;
+}
+
+double Camera_getFov(
+  Pointer<TCamera> camera,
+  bool horizontal,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
+  return result;
+}
+
+double Camera_getFocusDistance(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
+  return result;
+}
+
+void Camera_setFocusDistance(
+  Pointer<TCamera> camera,
+  double focusDistance,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setFocusDistance(camera.cast(), focusDistance);
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance
+      ._Camera_setCustomProjectionWithCulling(
+          camera.cast(), projectionMatrixPtr.cast(), near, far);
+  return result;
+}
+
+void Camera_setModelMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> tModelMatrix,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setModelMatrix(camera.cast(), tModelMatrix);
+  return result;
+}
+
+void Camera_setLensProjection(
+  Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
+  return result;
+}
+
+DartEntityId Camera_getEntity(
+  Pointer<TCamera> camera,
+) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+      tCamera.cast(), projection, left, right, bottom, top, near, far);
   return result;
 }
 
@@ -5709,6 +6239,517 @@ void TransformManager_commitLocalTransformTransaction(
       ._TransformManager_commitLocalTransformTransaction(
           tTransformManager.cast());
   return result;
+}
+
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+      tRenderer.cast(),
+      clearR,
+      clearG,
+      clearB,
+      clearA,
+      clearStencil,
+      clear,
+      discard);
+  return result;
+}
+
+bool Renderer_beginFrame(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TSwapChain> tSwapChain,
+  BigInt frameTimeInNanos,
+) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+      tRenderer.cast(), tSwapChain.cast(), frameTimeInNanos.toJSBigInt);
+  return result == 1;
+}
+
+void Renderer_endFrame(
+  Pointer<TRenderer> tRenderer,
+) {
+  final result =
+      GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+  return result;
+}
+
+void Renderer_render(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TView> tView,
+) {
+  final result = GeneratedBindings.instance
+      ._Renderer_render(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderStandaloneView(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TView> tView,
+) {
+  final result = GeneratedBindings.instance
+      ._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dart__darwin_size_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+      tRenderer.cast(),
+      width,
+      height,
+      xOffset,
+      yOffset,
+      tRenderTarget.cast(),
+      tPixelBufferFormat,
+      tPixelDataType,
+      out,
+      outLength);
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+      tRenderer.cast(), headRoomRatio, scaleRate, history, interval);
+  return result;
+}
+
+Pointer<TEngine> Engine_create(
+  int backend,
+  Pointer<Void> platform,
+  Pointer<Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+) {
+  final result = GeneratedBindings.instance._Engine_create(backend, platform,
+      sharedContext, stereoscopicEyeCount, disableHandleUseAfterFreeCheck);
+  return Pointer<TEngine>(result);
+}
+
+int Engine_getSupportedFeatureLevel(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_getSupportedFeatureLevel(tEngine.cast());
+  return result;
+}
+
+void Engine_destroy(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
+  return result;
+}
+
+Pointer<TRenderer> Engine_createRenderer(
+  Pointer<TEngine> tEngine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
+  return Pointer<TRenderer>(result);
+}
+
+Pointer<TSwapChain> Engine_createSwapChain(
+  Pointer<TEngine> tEngine,
+  Pointer<Void> window,
+  BigInt flags,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+Pointer<TSwapChain> Engine_createHeadlessSwapChain(
+  Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  BigInt flags,
+) {
+  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
+      tEngine.cast(), width, height, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+void Engine_destroySwapChain(
+  Pointer<TEngine> tEngine,
+  Pointer<TSwapChain> tSwapChain,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
+  return result;
+}
+
+void Engine_destroyView(
+  Pointer<TEngine> tEngine,
+  Pointer<TView> tView,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyView(tEngine.cast(), tView.cast());
+  return result;
+}
+
+void Engine_destroyScene(
+  Pointer<TEngine> tEngine,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyScene(tEngine.cast(), tScene.cast());
+  return result;
+}
+
+void Engine_destroyColorGrading(
+  Pointer<TEngine> tEngine,
+  Pointer<TColorGrading> tColorGrading,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
+  return result;
+}
+
+Pointer<TCamera> Engine_createCamera(
+  Pointer<TEngine> tEngine,
+  DartEntityId entityId,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+void Engine_destroyCamera(
+  Pointer<TEngine> tEngine,
+  Pointer<TCamera> tCamera,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
+  return result;
+}
+
+Pointer<TView> Engine_createView(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
+  return Pointer<TView>(result);
+}
+
+Pointer<TCamera> Engine_getCameraComponent(
+  Pointer<TEngine> tEngine,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_getCameraComponent(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+Pointer<TTransformManager> Engine_getTransformManager(
+  Pointer<TEngine> engine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
+  return Pointer<TTransformManager>(result);
+}
+
+Pointer<TRenderableManager> Engine_getRenderableManager(
+  Pointer<TEngine> engine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
+  return Pointer<TRenderableManager>(result);
+}
+
+Pointer<TLightManager> Engine_getLightManager(
+  Pointer<TEngine> engine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getLightManager(engine.cast());
+  return Pointer<TLightManager>(result);
+}
+
+Pointer<TEntityManager> Engine_getEntityManager(
+  Pointer<TEngine> engine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
+  return Pointer<TEntityManager>(result);
+}
+
+void Engine_setAutomaticInstancingEnabled(
+  Pointer<TEngine> tEngine,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
+  return result;
+}
+
+Dart__darwin_size_t Engine_getMaxAutomaticInstances(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_getMaxAutomaticInstances(tEngine.cast());
+  return result;
+}
+
+void Engine_destroyTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
+  return result;
+}
+
+Pointer<TFence> Engine_createFence(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
+  return Pointer<TFence>(result);
+}
+
+void Engine_destroyFence(
+  Pointer<TEngine> tEngine,
+  Pointer<TFence> tFence,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyFence(tEngine.cast(), tFence.cast());
+  return result;
+}
+
+void Engine_flushAndWait(
+  Pointer<TEngine> tEngine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
+  return result;
+}
+
+void Engine_execute(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
+  return result;
+}
+
+Pointer<TMaterial> Engine_buildMaterial(
+  Pointer<TEngine> tEngine,
+  Pointer<Uint8> materialData,
+  Dart__darwin_size_t length,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildMaterial(tEngine.cast(), materialData, length);
+  return Pointer<TMaterial>(result);
+}
+
+void Engine_destroyMaterial(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterial> tMaterial,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
+  return result;
+}
+
+void Engine_destroyMaterialInstance(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialInstance> tMaterialInstance,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(
+      tEngine.cast(), tMaterialInstance.cast());
+  return result;
+}
+
+Pointer<TScene> Engine_createScene(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
+  return Pointer<TScene>(result);
+}
+
+Pointer<TSkybox> Engine_buildSkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildSkybox(tEngine.cast(), tTexture.cast());
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TSkybox> Engine_buildColoredSkybox(
+  Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildColoredSkybox(tEngine.cast(), r, g, b, a);
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildIndirectLightFromIrradianceTexture(tEngine.cast(),
+          tReflectionsTexture.cast(), tIrradianceTexture.cast(), intensity);
+  return Pointer<TIndirectLight>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<Float32> irradianceHarmonics,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildIndirectLightFromIrradianceHarmonics(tEngine.cast(),
+          tReflectionsTexture.cast(), irradianceHarmonics, intensity);
+  return Pointer<TIndirectLight>(result);
+}
+
+void Engine_destroySkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TSkybox> tSkybox,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
+  return result;
+}
+
+void Engine_destroyIndirectLight(
+  Pointer<TEngine> tEngine,
+  Pointer<TIndirectLight> tIndirectLight,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
+  return result;
+}
+
+DartEntityId EntityManager_createEntity(
+  Pointer<TEntityManager> tEntityManager,
+) {
+  final result = GeneratedBindings.instance
+      ._EntityManager_createEntity(tEntityManager.cast());
+  return result;
+}
+
+void EntityManager_destroyEntity(
+  Pointer<TEntityManager> tEntityManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance
+      ._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
+  return result;
+}
+
+void Fence_waitAndDestroy(
+  Pointer<TFence> tFence,
+) {
+  final result =
+      GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
+  return result;
+}
+
+Pointer<TDebugRegistry> Engine_getDebugRegistry(
+  Pointer<TEngine> tEngine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
+  return Pointer<TDebugRegistry>(result);
+}
+
+bool DebugRegistry_hasProperty(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  bool value,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  int value,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  double value,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Bool> outValue,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Int32> outValue,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Float32> outValue,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
 }
 
 Pointer<Void> RenderThread_create() {
@@ -5902,7 +6943,7 @@ void Engine_createViewRenderThread(
 void Engine_buildMaterialRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
@@ -6337,7 +7378,7 @@ void Renderer_readPixelsRenderThread(
   int tPixelBufferFormat,
   int tPixelDataType,
   Pointer<Uint8> out,
-  Dartsize_t outLength,
+  Dart__darwin_size_t outLength,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7202,7 +8243,7 @@ void Image_createEmptyRenderThread(
 
 void Image_decodeRenderThread(
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<Char> name,
   bool alpha,
   Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
@@ -7285,7 +8326,7 @@ void Texture_setImageRenderThread(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -7560,7 +8601,7 @@ void GltfResourceLoader_addResourceDataRenderThread(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7609,7 +8650,7 @@ void GltfAssetLoader_loadRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int numInstances,
   Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
 ) {
@@ -7741,7 +8782,7 @@ void VertexBuffer_setBufferAtRenderThread(
   Pointer<TVertexBuffer> tBuffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7788,7 +8829,7 @@ void IndexBuffer_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TIndexBuffer> tBuffer,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7908,8 +8949,8 @@ void RenderableManager_setBonesFromMat4RenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7929,8 +8970,8 @@ void RenderableManager_setBonesFromBoneRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7943,626 +8984,6 @@ void RenderableManager_setBonesFromBoneRenderThread(
           offset,
           requestId,
           onComplete as Pointer<NativeFunction<VoidCallbackFunction>>);
-  return result;
-}
-
-void IndirectLight_setRotation(
-  Pointer<TIndirectLight> tIndirectLight,
-  Pointer<Float64> rotation,
-) {
-  final result = GeneratedBindings.instance
-      ._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
-  return result;
-}
-
-int LightManager_createLight(
-  Pointer<TEngine> tEngine,
-  Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-      tEngine.cast(), tLightManager.cast(), tLightTtype);
-  return result;
-}
-
-void LightManager_destroyLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_destroyLight(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_hasComponent(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_hasComponent(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-int LightManager_getType(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getType(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_isDirectional(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_isDirectional(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isPointLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_isPointLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_isSpotLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(
-      double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(
-      double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double r,
-  double g,
-  double b,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-      tLightManager.cast(), entity, colorTemperature);
-  return result;
-}
-
-double3 LightManager_getColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityCandela(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
-      tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-      tLightManager.cast(), entity, watts, efficiency);
-  return result;
-}
-
-double LightManager_getIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getIntensity(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double falloff,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
-  return result;
-}
-
-double LightManager_getFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
-      tLightManager.cast(), entity, inner, outer);
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double angularRadius,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-      tLightManager.cast(), entity, angularRadius);
-  return result;
-}
-
-double LightManager_getSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloSize,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
-  return result;
-}
-
-double LightManager_getSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getSunHaloSize(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloFalloff,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
-      tLightManager.cast(), entity, haloFalloff);
-  return result;
-}
-
-double LightManager_getSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
-  return result;
-}
-
-bool LightManager_isShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_isShadowCaster(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  TShadowOptions options,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-      tLightManager.cast(), entity, optionsPtr.cast());
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-      TShadowOptions_out.cast(), tLightManager.cast(), entity);
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-      tLightManager.cast(), entity, channel, enable);
-  return result;
-}
-
-bool LightManager_getLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_computeUniformSplits(splitPositions, cascades);
-  return result;
-}
-
-void LightManager_computeLogSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_computeLogSplits(splitPositions, cascades, near, far);
-  return result;
-}
-
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_computePracticalSplits(
-          splitPositions, cascades, near, far, lambda);
-  return result;
-}
-
-double LightManager_rgbToColorTemperature(
-  double r,
-  double g,
-  double b,
-) {
-  final result =
-      GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
-  return result;
-}
-
-void Camera_setExposure(
-  Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
-  return result;
-}
-
-double Camera_getAperture(
-  Pointer<TCamera> camera,
-) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
-  return result;
-}
-
-double Camera_getSensitivity(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(
-  Pointer<TCamera> camera,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(
-  Pointer<TCamera> camera,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(
-  Pointer<TCamera> camera,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(
-  Pointer<TCamera> camera,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(
-  Pointer<TCamera> camera,
-  Pointer<Float64> out,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
-  return result;
-}
-
-void Camera_setProjectionMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> matrix,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-      camera.cast(), fovInDegrees, aspect, near, far, horizontal);
-  return result;
-}
-
-double Camera_getFocalLength(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
-  return result;
-}
-
-void Camera_lookAt(
-  Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(
-      camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
-  return result;
-}
-
-double Camera_getNear(
-  Pointer<TCamera> camera,
-) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
-  return result;
-}
-
-double Camera_getFov(
-  Pointer<TCamera> camera,
-  bool horizontal,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
-  return result;
-}
-
-double Camera_getFocusDistance(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
-  return result;
-}
-
-void Camera_setFocusDistance(
-  Pointer<TCamera> camera,
-  double focusDistance,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setFocusDistance(camera.cast(), focusDistance);
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance
-      ._Camera_setCustomProjectionWithCulling(
-          camera.cast(), projectionMatrixPtr.cast(), near, far);
-  return result;
-}
-
-void Camera_setModelMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> tModelMatrix,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setModelMatrix(camera.cast(), tModelMatrix);
-  return result;
-}
-
-void Camera_setLensProjection(
-  Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
-  return result;
-}
-
-DartEntityId Camera_getEntity(
-  Pointer<TCamera> camera,
-) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-      tCamera.cast(), projection, left, right, bottom, top, near, far);
   return result;
 }
 
@@ -8612,7 +9033,7 @@ void GltfResourceLoader_addResourceData(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
 ) {
   final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
       tGltfResourceLoader.cast(), uri, data, length);
@@ -8637,6 +9058,33 @@ void Skybox_setColor(
 ) {
   final result =
       GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
+  return result;
+}
+
+void dummy(
+  TGltfMeshData dummy,
+) {
+  final dummyPtr = dummy.address;
+  final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
+  return result;
+}
+
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dart__darwin_size_t length,
+  Pointer<Char> meshName,
+  Pointer<TGltfMeshData> outMeshData,
+) {
+  final result = GeneratedBindings.instance
+      ._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
+  return result;
+}
+
+void GltfParser_freeMeshData(
+  Pointer<TGltfMeshData> meshData,
+) {
+  final result =
+      GeneratedBindings.instance._GltfParser_freeMeshData(meshData.cast());
   return result;
 }
 
@@ -8675,7 +9123,7 @@ bool RenderableManager_isRenderable(
   return result == 1;
 }
 
-Dartsize_t RenderableManager_getComponentCount(
+Dart__darwin_size_t RenderableManager_getComponentCount(
   Pointer<TRenderableManager> tRenderableManager,
 ) {
   final result = GeneratedBindings.instance
@@ -8717,7 +9165,7 @@ void RenderableManager_clearMaterialInstanceAt(
   return result;
 }
 
-Dartsize_t RenderableManager_getPrimitiveCount(
+Dart__darwin_size_t RenderableManager_getPrimitiveCount(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
 ) {
@@ -8942,7 +9390,7 @@ void RenderableManager_setScreenSpaceContactShadows(
 void RenderableManager_setBlendOrderAt(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   int order,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
@@ -8953,7 +9401,7 @@ void RenderableManager_setBlendOrderAt(
 void RenderableManager_setGlobalBlendOrderEnabledAt(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
@@ -8966,15 +9414,15 @@ void RenderableManager_setMorphWeights(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> weights,
-  Dartsize_t count,
-  Dartsize_t offset,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
       tRenderableManager.cast(), entityId, weights, count, offset);
   return result;
 }
 
-Dartsize_t RenderableManager_getMorphTargetCount(
+Dart__darwin_size_t RenderableManager_getMorphTargetCount(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
 ) {
@@ -8988,8 +9436,8 @@ void RenderableManager_setBonesFromMat4(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
       tRenderableManager.cast(), entityId, transforms, boneCount, offset);
@@ -9000,8 +9448,8 @@ void RenderableManager_setBonesFromBone(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
       tRenderableManager.cast(), entityId, bones, boneCount, offset);
@@ -9009,7 +9457,7 @@ void RenderableManager_setBonesFromBone(
 }
 
 Pointer<TRenderableBuilder> RenderableBuilder_create(
-  Dartsize_t primitiveCount,
+  Dart__darwin_size_t primitiveCount,
 ) {
   final result =
       GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
@@ -9036,7 +9484,7 @@ void RenderableBuilder_boundingBox(
 
 void RenderableBuilder_material(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   Pointer<TMaterialInstance> materialInstance,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_material(
@@ -9046,12 +9494,12 @@ void RenderableBuilder_material(
 
 void RenderableBuilder_geometry(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   int type,
   Pointer<TVertexBuffer> vertices,
   Pointer<TIndexBuffer> indices,
-  Dartsize_t offset,
-  Dartsize_t count,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_geometry(
       builder.cast(),
@@ -9149,7 +9597,7 @@ void RenderableBuilder_screenSpaceContactShadows(
 
 void RenderableBuilder_blendOrder(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   int order,
 ) {
   final result = GeneratedBindings.instance
@@ -9159,7 +9607,7 @@ void RenderableBuilder_blendOrder(
 
 void RenderableBuilder_globalBlendOrderEnabled(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
@@ -9170,7 +9618,7 @@ void RenderableBuilder_globalBlendOrderEnabled(
 
 void RenderableBuilder_instances(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t instanceCount,
+  Dart__darwin_size_t instanceCount,
 ) {
   final result = GeneratedBindings.instance
       ._RenderableBuilder_instances(builder.cast(), instanceCount);
@@ -9179,7 +9627,7 @@ void RenderableBuilder_instances(
 
 void RenderableBuilder_skinningFromMat4(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
+  Dart__darwin_size_t boneCount,
   Pointer<Float32> transforms,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(
@@ -9189,7 +9637,7 @@ void RenderableBuilder_skinningFromMat4(
 
 void RenderableBuilder_skinningFromBone(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
+  Dart__darwin_size_t boneCount,
   Pointer<Float32> bones,
 ) {
   final result = GeneratedBindings.instance
@@ -9208,10 +9656,10 @@ void RenderableBuilder_enableSkinningBuffers(
 
 void RenderableBuilder_boneIndicesAndWeights(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   Pointer<Float32> indicesAndWeights,
-  Dartsize_t count,
-  Dartsize_t bonesPerVertex,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t bonesPerVertex,
 ) {
   final result = GeneratedBindings.instance
       ._RenderableBuilder_boneIndicesAndWeights(builder.cast(), primitiveIndex,
@@ -9229,629 +9677,240 @@ int RenderableBuilder_build(
   return result;
 }
 
-void Scene_addEntity(
-  Pointer<TScene> tScene,
-  DartEntityId entityId,
-) {
-  final result =
-      GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_removeEntity(
-  Pointer<TScene> tScene,
-  DartEntityId entityId,
-) {
-  final result =
-      GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_setSkybox(
-  Pointer<TScene> tScene,
-  Pointer<TSkybox> skybox,
-) {
-  final result =
-      GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
-  return result;
-}
-
-void Scene_setIndirectLight(
-  Pointer<TScene> tScene,
-  Pointer<TIndirectLight> tIndirectLight,
-) {
-  final result = GeneratedBindings.instance
-      ._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
-  return result;
-}
-
-void Scene_addFilamentAsset(
-  Pointer<TScene> tScene,
-  Pointer<TFilamentAsset> asset,
-) {
-  final result = GeneratedBindings.instance
-      ._Scene_addFilamentAsset(tScene.cast(), asset.cast());
-  return result;
-}
-
-Pointer<TRenderTarget> RenderTarget_create(
+Pointer<TSceneAsset> SceneAsset_createFromBuffers(
   Pointer<TEngine> tEngine,
-  Pointer<TTexture> color,
-  Pointer<TTexture> depth,
+  Pointer<TVertexBuffer> tVertexBuffer,
+  Pointer<TIndexBuffer> tIndexBuffer,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
 ) {
-  final result = GeneratedBindings.instance
-      ._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
-  return Pointer<TRenderTarget>(result);
-}
-
-void RenderTarget_destroy(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderTarget> tRenderTarget,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
-  return result;
-}
-
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint32> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_build(builder.cast());
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dartsize_t SurfaceOrientation_getVertexCount(
-  Pointer<TSurfaceOrientation> orientation,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientation_getVertexCount(orientation.cast());
-  return result;
-}
-
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-      orientation.cast(), out, quatCount, stride);
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-      orientation.cast(), out, quatCount, stride);
-  return result;
-}
-
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-      orientation.cast(), out, quatCount, stride);
-  return result;
-}
-
-void SurfaceOrientation_destroy(
-  Pointer<TSurfaceOrientation> orientation,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientation_destroy(orientation.cast());
-  return result;
-}
-
-void dummy(
-  TGltfMeshData dummy,
-) {
-  final dummyPtr = dummy.address;
-  final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  Pointer<Char> meshName,
-  Pointer<TGltfMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance
-      ._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
-  return result;
-}
-
-void GltfParser_freeMeshData(
-  Pointer<TGltfMeshData> meshData,
-) {
-  final result =
-      GeneratedBindings.instance._GltfParser_freeMeshData(meshData.cast());
-  return result;
-}
-
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-      tRenderer.cast(),
-      clearR,
-      clearG,
-      clearB,
-      clearA,
-      clearStencil,
-      clear,
-      discard);
-  return result;
-}
-
-bool Renderer_beginFrame(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TSwapChain> tSwapChain,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-      tRenderer.cast(), tSwapChain.cast(), frameTimeInNanos.toJSBigInt);
-  return result == 1;
-}
-
-void Renderer_endFrame(
-  Pointer<TRenderer> tRenderer,
-) {
-  final result =
-      GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
-  return result;
-}
-
-void Renderer_render(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TView> tView,
-) {
-  final result = GeneratedBindings.instance
-      ._Renderer_render(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_renderStandaloneView(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TView> tView,
-) {
-  final result = GeneratedBindings.instance
-      ._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dartsize_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-      tRenderer.cast(),
-      width,
-      height,
-      xOffset,
-      yOffset,
-      tRenderTarget.cast(),
-      tPixelBufferFormat,
-      tPixelDataType,
-      out,
-      outLength);
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-      tRenderer.cast(), headRoomRatio, scaleRate, history, interval);
-  return result;
-}
-
-Pointer<TRenderManager> RenderManager_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderer> tRenderer,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_create(tEngine.cast(), tRenderer.cast());
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(
-  Pointer<TRenderManager> tRenderer,
-) {
-  final result =
-      GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-      tRenderer.cast(), tAnimationManager.cast());
-  return result;
-}
-
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_removeAnimationManager(
-          tRenderer.cast(), tAnimationManager.cast());
-  return result;
-}
-
-void RenderManager_render(
-  Pointer<TRenderManager> tRenderer,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-      tRenderer.cast(), swapChain.cast(), views.cast(), numViews);
-  return result;
-}
-
-void RenderManager_removeSwapChain(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
-  return result;
-}
-
-void RenderManager_requestRender(
-  Pointer<TRenderManager> tRenderer,
-) {
-  final result =
-      GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_attachToRenderThread(
-  Pointer<TRenderManager> tRenderer,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_attachToRenderThread(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_setPaused(
-  Pointer<TRenderManager> tRenderer,
-  bool paused,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_setPaused(tRenderer.cast(), paused);
-  return result;
-}
-
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-Pointer<Char> NameComponentManager_getName(
-  Pointer<TNameComponentManager> tNameComponentManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._NameComponentManager_getName(tNameComponentManager.cast(), entity);
-  return Pointer<Char>(result);
-}
-
-void Gizmo_dummy(
-  int t,
-) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
       tEngine.cast(),
-      assetLoader.cast(),
-      tGltfResourceLoader.cast(),
-      tNameComponentManager.cast(),
-      tView.cast(),
-      tMaterial.cast(),
-      tGizmoType);
-  return Pointer<TGizmo>(result);
+      tVertexBuffer.cast(),
+      tIndexBuffer.cast(),
+      materialInstances.cast(),
+      materialInstanceCount,
+      tPrimitiveType,
+      boundingBoxPtr.cast());
+  return Pointer<TSceneAsset>(result);
 }
 
-void Gizmo_pick(
-  Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  DartGizmoPickCallback callback,
-) {
-  final result = GeneratedBindings.instance._Gizmo_pick(tGizmo.cast(), x, y,
-      callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>);
-  return result;
-}
-
-void Gizmo_highlight(
-  Pointer<TGizmo> tGizmo,
-  int axis,
-) {
-  final result =
-      GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
-  return result;
-}
-
-void Gizmo_unhighlight(
-  Pointer<TGizmo> tGizmo,
-) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
-}
-
-void FrameScheduler_start(
-  DartFrameCallback callback,
-  int targetFps,
-) {
-  final result = GeneratedBindings.instance._FrameScheduler_start(
-      callback as Pointer<NativeFunction<FrameCallbackFunction>>, targetFps);
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-void FrameScheduler_setRenderThread(
-  Pointer<Void> renderThread,
-) {
-  final result =
-      GeneratedBindings.instance._FrameScheduler_setRenderThread(renderThread);
-  return result;
-}
-
-void FrameScheduler_setRenderManager(
-  Pointer<TRenderManager> rm,
-) {
-  final result =
-      GeneratedBindings.instance._FrameScheduler_setRenderManager(rm.cast());
-  return result;
-}
-
-void FrameScheduler_setPostRenderCallback(
-  DartPostRenderCallback callback,
-  Pointer<Void> userData,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_setPostRenderCallback(
-          callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
-          userData);
-  return result;
-}
-
-void FrameScheduler_requestRender(
-  BigInt frameTimeNanos,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_requestRender(frameTimeNanos.toJSBigInt);
-  return result;
-}
-
-void FrameScheduler_startNativeRenderLoop(
-  int targetFps,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_startNativeRenderLoop(targetFps);
-  return result;
-}
-
-int FrameScheduler_initDartApi(
-  Pointer<Void> data,
-) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(
-  BigInt port,
-  int targetFps,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
-      tEngine.cast(), tMaterialProvider.cast(), tNameComponentManager.cast());
-  return Pointer<TGltfAssetLoader>(result);
-}
-
-Pointer<TFilamentAsset> GltfAssetLoader_load(
+Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  int numInstances,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
 ) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
-      tEngine.cast(), tAssetLoader.cast(), data, length, numInstances);
+  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
+      tEngine.cast(),
+      tAssetLoader.cast(),
+      tNameComponentManager.cast(),
+      tFilamentAsset.cast(),
+      rebuildVertices);
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getFilamentAsset(tSceneAsset.cast());
   return Pointer<TFilamentAsset>(result);
 }
 
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
+int SceneAsset_getType(
+  Pointer<TSceneAsset> tSceneAsset,
 ) {
-  final result = GeneratedBindings.instance
-      ._GltfAssetLoader_getMaterialInstance(
-          tRenderableManager.cast(), tAsset.cast());
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
-  Pointer<TGltfAssetLoader> tAssetLoader,
-) {
-  final result = GeneratedBindings.instance
-      ._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
-}
-
-int FilamentAsset_getResourceUriCount(
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
+  final result =
+      GeneratedBindings.instance._SceneAsset_getType(tSceneAsset.cast());
   return result;
 }
 
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(
-  Pointer<TFilamentAsset> tFilamentAsset,
+void SceneAsset_destroy(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result =
+      GeneratedBindings.instance._SceneAsset_destroy(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_addToScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
 ) {
   final result = GeneratedBindings.instance
-      ._FilamentAsset_getResourceUris(tFilamentAsset.cast());
-  return Pointer<PointerClass<Char>>(result);
+      ._SceneAsset_addToScene(tSceneAsset.cast(), tScene.cast());
+  return result;
+}
+
+void SceneAsset_removeFromScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_removeFromScene(tSceneAsset.cast(), tScene.cast());
+  return result;
+}
+
+DartEntityId SceneAsset_getEntity(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result =
+      GeneratedBindings.instance._SceneAsset_getEntity(tSceneAsset.cast());
+  return result;
+}
+
+int SceneAsset_getChildEntityCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getChildEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_getChildEntities(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getChildEntities(tSceneAsset.cast(), out);
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getCameraEntities(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getCameraEntities(tSceneAsset.cast());
+  return Pointer<Int32>(result);
+}
+
+Dart__darwin_size_t SceneAsset_getCameraEntityCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getLightEntities(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getLightEntities(tSceneAsset.cast());
+  return Pointer<Int32>(result);
+}
+
+Dart__darwin_size_t SceneAsset_getLightEntityCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getLightEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_getInstance(
+  Pointer<TSceneAsset> tSceneAsset,
+  int index,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getInstance(tSceneAsset.cast(), index);
+  return Pointer<TSceneAsset>(result);
+}
+
+Dart__darwin_size_t SceneAsset_getInstanceCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getInstanceCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createInstance(
+  Pointer<TSceneAsset> asset,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createInstance(
+      asset.cast(), materialInstances.cast(), materialInstanceCount);
+  return Pointer<TSceneAsset>(result);
+}
+
+Aabb3 SceneAsset_getBoundingBox(
+  Pointer<TSceneAsset> asset,
+) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getBoundingBox(Aabb3_out.cast(), asset.cast());
+  return Aabb3_out.toDart();
+}
+
+Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getVertexBuffer(tSceneAsset.cast(), primitiveIndex);
+  return Pointer<TVertexBuffer>(result);
+}
+
+Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getIndexBuffer(tSceneAsset.cast(), primitiveIndex);
+  return Pointer<TIndexBuffer>(result);
+}
+
+void SceneAsset_releaseSourceData(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_releaseSourceData(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_setFlatShading(
+  Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_setFlatShading(tSceneAsset.cast(), flatShading);
+  return result;
+}
+
+void SceneAsset_getBones(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dart__darwin_size_t skinIndex,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
+  return result;
+}
+
+Dart__darwin_size_t SceneAsset_getBoneCount(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dart__darwin_size_t skinIndex,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
+  return result;
+}
+
+Pointer<Char> SceneAsset_getBoneName(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dart__darwin_size_t skinIndex,
+  Dart__darwin_size_t boneIndex,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
+  return Pointer<Char>(result);
 }
 
 Pointer<TAnimationManager> AnimationManager_create(
@@ -10149,39 +10208,6 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
-int FilamentAsset_getEntityCount(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getEntityCount(filamentAsset.cast());
-  return result;
-}
-
-void FilamentAsset_getEntities(
-  Pointer<TFilamentAsset> filamentAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getEntities(filamentAsset.cast(), out);
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getWireframe(filamentAsset.cast());
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getSourceAsset(filamentAsset.cast());
-  return Pointer<Void>(result);
-}
-
 void MovementIntentExecutor_destroy(
   Pointer<TMovementIntentExecutor> executor,
 ) {
@@ -10347,69 +10373,6 @@ void TransformPipeline_setInvertMouseY(
   return result;
 }
 
-extension TSceneAssetExt on Pointer<TSceneAsset> {
-  TSceneAsset toDart() {
-    return TSceneAsset(this);
-  }
-}
-
-final class TSceneAsset extends Struct {
-  Pointer<TSceneAsset> get address => super.address.cast();
-  TSceneAsset(super.address);
-
-  static Pointer<TSceneAsset> stackAlloc() {
-    return Pointer<TSceneAsset>(
-        NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
-  }
-}
-
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
-  }
-}
-
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
-
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
-  }
-}
-
-extension TVertexBufferExt on Pointer<TVertexBuffer> {
-  TVertexBuffer toDart() {
-    return TVertexBuffer(this);
-  }
-}
-
-final class TVertexBuffer extends Struct {
-  Pointer<TVertexBuffer> get address => super.address.cast();
-  TVertexBuffer(super.address);
-
-  static Pointer<TVertexBuffer> stackAlloc() {
-    return Pointer<TVertexBuffer>(
-        NativeLibrary.instance.stackAlloc<TVertexBuffer>(0));
-  }
-}
-
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
-  }
-}
-
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
-
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(
-        NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
-  }
-}
-
 extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
   TMaterialInstance toDart() {
     return TMaterialInstance(this);
@@ -10425,182 +10388,6 @@ final class TMaterialInstance extends Struct {
         NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
   }
 }
-
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
-}
-
-extension Aabb3Ext on Pointer<Aabb3> {
-  Aabb3 toDart() {
-    return Aabb3(this);
-  }
-}
-
-final class Aabb3 extends Struct {
-  Pointer<Aabb3> get address => super.address.cast();
-  double get centerX {
-    final addr = Pointer<Aabb3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerX(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 0), val.toJS, 'float');
-  }
-
-  double get centerY {
-    final addr = Pointer<Aabb3>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerY(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 4), val.toJS, 'float');
-  }
-
-  double get centerZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerZ(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 8), val.toJS, 'float');
-  }
-
-  double get halfExtentX {
-    final addr = Pointer<Aabb3>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentX(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 12), val.toJS, 'float');
-  }
-
-  double get halfExtentY {
-    final addr = Pointer<Aabb3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentY(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 16), val.toJS, 'float');
-  }
-
-  double get halfExtentZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 20);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentZ(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 20), val.toJS, 'float');
-  }
-
-  Aabb3(super.address);
-
-  static Pointer<Aabb3> stackAlloc() {
-    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
-  }
-}
-
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
-  }
-}
-
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
-
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(
-        NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
-  }
-}
-
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
-  }
-}
-
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
-
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(
-        NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
-  }
-}
-
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
-  }
-}
-
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
-
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(
-        NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
-  }
-}
-
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
-
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
-
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
-  }
-}
-
-typedef EntityId = int;
-typedef DartEntityId = int;
-typedef size_t = int;
-typedef Dartsize_t = int;
 
 extension TMaterialExt on Pointer<TMaterial> {
   TMaterial toDart() {
@@ -10622,6 +10409,21 @@ sealed class TFeatureLevel {
   static const FEATURE_LEVEL_1 = 1;
   static const FEATURE_LEVEL_2 = 2;
   static const FEATURE_LEVEL_3 = 3;
+}
+
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
+  }
+}
+
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
+
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  }
 }
 
 sealed class TCullingMode {
@@ -10730,438 +10532,6 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
-  }
-}
-
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
-
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(
-        NativeLibrary.instance.stackAlloc<TLinearImage>(0));
-  }
-}
-
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
-  }
-}
-
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
-
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(
-        NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
-  }
-}
-
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
-  }
-}
-
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
-
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(
-        NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
-  }
-}
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
-  }
-}
-
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
-
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
-  }
-}
-
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
-  }
-}
-
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
-
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(
-        NativeLibrary.instance.stackAlloc<TSwapChain>(0));
-  }
-}
-
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
-}
-
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
-}
-
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(
-        NativeLibrary.instance.stackAlloc<TColorGrading>(0));
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
-  }
-}
-
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
-
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(
-        NativeLibrary.instance.stackAlloc<TTransformManager>(0));
-  }
-}
-
-extension TRenderableManagerExt on Pointer<TRenderableManager> {
-  TRenderableManager toDart() {
-    return TRenderableManager(this);
-  }
-}
-
-final class TRenderableManager extends Struct {
-  Pointer<TRenderableManager> get address => super.address.cast();
-  TRenderableManager(super.address);
-
-  static Pointer<TRenderableManager> stackAlloc() {
-    return Pointer<TRenderableManager>(
-        NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
-  }
-}
-
 extension TLightManagerExt on Pointer<TLightManager> {
   TLightManager toDart() {
     return TLightManager(this);
@@ -11178,81 +10548,415 @@ final class TLightManager extends Struct {
   }
 }
 
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+typedef EntityId = int;
+typedef DartEntityId = int;
+
+extension double3Ext on Pointer<double3> {
+  double3 toDart() {
+    return double3(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class double3 extends Struct {
+  Pointer<double3> get address => super.address.cast();
+  double get x {
+    final addr = Pointer<double3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(
-        NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  set x(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
+  }
+
+  double get y {
+    final addr = Pointer<double3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set y(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
+  }
+
+  double get z {
+    final addr = Pointer<double3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set z(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
+  }
+
+  double3(super.address);
+
+  static Pointer<double3> stackAlloc() {
+    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
   }
 }
 
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
+extension TShadowOptionsExt on Pointer<TShadowOptions> {
+  TShadowOptions toDart() {
+    return TShadowOptions(this);
   }
 }
 
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
+final class TShadowOptions extends Struct {
+  Pointer<TShadowOptions> get address => super.address.cast();
+  int get mapSize {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
 
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  set mapSize(int val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
+  }
+
+  int get shadowCascades {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set shadowCascades(int val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
+  }
+
+  Array<Float32> get cascadeSplitPositions {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float32>(
+        (numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
+  }
+
+  set cascadeSplitPositions(Array<Float32> val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 5),
+        val.internal.addr.addr.toJS,
+        '*');
+  }
+
+  double get constantBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set constantBias(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
+  }
+
+  double get normalBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set normalBias(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
+  }
+
+  double get shadowFar {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFar(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
+  }
+
+  double get shadowNearHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowNearHint(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
+  }
+
+  double get shadowFarHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFarHint(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
+  }
+
+  bool get stable {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set stable(bool val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 37),
+        (val ? 1 : 0).toJS,
+        'i8');
+  }
+
+  bool get lispsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set lispsm(bool val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 38),
+        (val ? 1 : 0).toJS,
+        'i8');
+  }
+
+  double get polygonOffsetConstant {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetConstant(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
+  }
+
+  double get polygonOffsetSlope {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetSlope(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
+  }
+
+  bool get screenSpaceContactShadows {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set screenSpaceContactShadows(bool val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 47),
+        (val ? 1 : 0).toJS,
+        'i8');
+  }
+
+  int get stepCount {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set stepCount(int val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
+  }
+
+  double get maxShadowDistance {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxShadowDistance(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
+  }
+
+  bool get vsmElvsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set vsmElvsm(bool val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 53),
+        (val ? 1 : 0).toJS,
+        'i8');
+  }
+
+  double get vsmBlurWidth {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set vsmBlurWidth(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
+  }
+
+  double get shadowBulbRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowBulbRadius(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
+  }
+
+  TShadowOptions(super.address);
+
+  static Pointer<TShadowOptions> stackAlloc() {
+    return Pointer<TShadowOptions>(
+        NativeLibrary.instance.stackAlloc<TShadowOptions>(78));
   }
 }
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
   }
 }
 
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
 
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(
+        NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
   }
 }
 
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
   }
 }
 
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
 
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(
-        NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(
+        NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
   }
 }
 
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
   }
 }
 
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
 
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(
-        NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(
+        NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
+  }
+}
+
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(
+        NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
+  }
+}
+
+typedef size_t = __darwin_size_t;
+typedef __darwin_size_t = int;
+typedef Dart__darwin_size_t = int;
+
+extension TRenderableManagerExt on Pointer<TRenderableManager> {
+  TRenderableManager toDart() {
+    return TRenderableManager(this);
+  }
+}
+
+final class TRenderableManager extends Struct {
+  Pointer<TRenderableManager> get address => super.address.cast();
+  TRenderableManager(super.address);
+
+  static Pointer<TRenderableManager> stackAlloc() {
+    return Pointer<TRenderableManager>(
+        NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
   }
 }
 
@@ -11315,6 +11019,21 @@ final class TViewport extends Struct {
   }
 }
 
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
 extension TToneMapperExt on Pointer<TToneMapper> {
   TToneMapper toDart() {
     return TToneMapper(this);
@@ -11328,6 +11047,22 @@ final class TToneMapper extends Struct {
   static Pointer<TToneMapper> stackAlloc() {
     return Pointer<TToneMapper>(
         NativeLibrary.instance.stackAlloc<TToneMapper>(0));
+  }
+}
+
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(
+        NativeLibrary.instance.stackAlloc<TColorGrading>(0));
   }
 }
 
@@ -11354,9 +11089,30 @@ sealed class TQualityLevel {
   static const ULTRA = 3;
 }
 
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
+}
+
 sealed class TBlendMode {
   static const OPAQUE = 0;
   static const TRANSLUCENT = 1;
+}
+
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
+  }
+}
+
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
+
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(
+        NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
+  }
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -11484,6 +11240,36 @@ final class TVsmShadowOptions extends Struct {
   static Pointer<TVsmShadowOptions> stackAlloc() {
     return Pointer<TVsmShadowOptions>(
         NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
+  }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
   }
 }
 
@@ -12034,19 +11820,510 @@ typedef DartPickCallbackFunction = void Function(
     double fragY,
     double fragZ);
 
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
   }
 }
 
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
 
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(
-        NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(
+        NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
+  }
+}
+
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
+  }
+}
+
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
+
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(
+        NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
+  }
+}
+
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
+  }
+}
+
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
+
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(
+        NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
+  }
+}
+
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(
+        NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  }
+}
+
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
+  }
+}
+
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
+
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(
+        NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
+  }
+}
+
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
+  }
+}
+
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
+
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(
+        NativeLibrary.instance.stackAlloc<TRenderManager>(0));
+  }
+}
+
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
+  }
+}
+
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
+
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  }
+}
+
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
+  }
+}
+
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
+
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(
+        NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+  }
+}
+
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
+  }
+}
+
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
+
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(
+        NativeLibrary.instance.stackAlloc<TSwapChain>(0));
+  }
+}
+
+typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
+typedef PostRenderCallback
+    = Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef DartPostRenderCallback
+    = Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
+typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
+  }
+}
+
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
+
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  }
+}
+
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
+  }
+}
+
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
+
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(
+        NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
+  }
+}
+
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback
+    = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction = void Function(
+    int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction = void Function(
+    int resultType, double x, double y, double z);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
+  }
+}
+
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
+
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(
+        NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
+  }
+}
+
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
+  }
+}
+
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
+
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(
+        NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
   }
 }
 
@@ -12113,25 +12390,35 @@ sealed class TVertexAttributeType {
   static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
+extension TVertexBufferExt on Pointer<TVertexBuffer> {
+  TVertexBuffer toDart() {
+    return TVertexBuffer(this);
   }
 }
 
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
+final class TVertexBuffer extends Struct {
+  Pointer<TVertexBuffer> get address => super.address.cast();
+  TVertexBuffer(super.address);
 
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(
-        NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
+  static Pointer<TVertexBuffer> stackAlloc() {
+    return Pointer<TVertexBuffer>(
+        NativeLibrary.instance.stackAlloc<TVertexBuffer>(0));
   }
 }
 
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
+  }
+}
+
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
+
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  }
 }
 
 extension double4x4Ext on Pointer<double4x4> {
@@ -12198,72 +12485,203 @@ final class double4x4 extends Struct {
   }
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
   }
 }
 
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
 
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(
-        NativeLibrary.instance.stackAlloc<TRenderManager>(0));
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(
+        NativeLibrary.instance.stackAlloc<TTransformManager>(0));
   }
 }
 
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
+extension Aabb3Ext on Pointer<Aabb3> {
+  Aabb3 toDart() {
+    return Aabb3(this);
   }
 }
 
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
+final class Aabb3 extends Struct {
+  Pointer<Aabb3> get address => super.address.cast();
+  double get centerX {
+    final addr = Pointer<Aabb3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(
-        NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+  set centerX(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 0), val.toJS, 'float');
+  }
+
+  double get centerY {
+    final addr = Pointer<Aabb3>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerY(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 4), val.toJS, 'float');
+  }
+
+  double get centerZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerZ(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 8), val.toJS, 'float');
+  }
+
+  double get halfExtentX {
+    final addr = Pointer<Aabb3>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentX(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 12), val.toJS, 'float');
+  }
+
+  double get halfExtentY {
+    final addr = Pointer<Aabb3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentY(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 16), val.toJS, 'float');
+  }
+
+  double get halfExtentZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 20);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentZ(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 20), val.toJS, 'float');
+  }
+
+  Aabb3(super.address);
+
+  static Pointer<Aabb3> stackAlloc() {
+    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
   }
 }
 
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
   }
 }
 
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
 
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(
-        NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(
+        NativeLibrary.instance.stackAlloc<TEntityManager>(0));
   }
 }
 
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
   }
 }
 
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
 
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
   }
+}
+
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
+  }
+}
+
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
+
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(
+        NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
+  }
+}
+
+extension TSceneAssetExt on Pointer<TSceneAsset> {
+  TSceneAsset toDart() {
+    return TSceneAsset(this);
+  }
+}
+
+final class TSceneAsset extends Struct {
+  Pointer<TSceneAsset> get address => super.address.cast();
+  TSceneAsset(super.address);
+
+  static Pointer<TSceneAsset> stackAlloc() {
+    return Pointer<TSceneAsset>(
+        NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
+  }
+}
+
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
@@ -12279,368 +12697,6 @@ final class TRenderableBuilder extends Struct {
   static Pointer<TRenderableBuilder> stackAlloc() {
     return Pointer<TRenderableBuilder>(
         NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
-  }
-}
-
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-extension double3Ext on Pointer<double3> {
-  double3 toDart() {
-    return double3(this);
-  }
-}
-
-final class double3 extends Struct {
-  Pointer<double3> get address => super.address.cast();
-  double get x {
-    final addr = Pointer<double3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set x(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
-  }
-
-  double get y {
-    final addr = Pointer<double3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set y(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
-  }
-
-  double get z {
-    final addr = Pointer<double3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set z(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
-  }
-
-  double3(super.address);
-
-  static Pointer<double3> stackAlloc() {
-    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
-  }
-}
-
-extension TShadowOptionsExt on Pointer<TShadowOptions> {
-  TShadowOptions toDart() {
-    return TShadowOptions(this);
-  }
-}
-
-final class TShadowOptions extends Struct {
-  Pointer<TShadowOptions> get address => super.address.cast();
-  int get mapSize {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set mapSize(int val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
-  }
-
-  int get shadowCascades {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set shadowCascades(int val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
-  }
-
-  Array<Float32> get cascadeSplitPositions {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float32>(
-        (numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
-  }
-
-  set cascadeSplitPositions(Array<Float32> val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 5),
-        val.internal.addr.addr.toJS,
-        '*');
-  }
-
-  double get constantBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constantBias(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
-  }
-
-  double get normalBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set normalBias(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
-  }
-
-  double get shadowFar {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFar(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
-  }
-
-  double get shadowNearHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowNearHint(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
-  }
-
-  double get shadowFarHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFarHint(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
-  }
-
-  bool get stable {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set stable(bool val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 37),
-        (val ? 1 : 0).toJS,
-        'i8');
-  }
-
-  bool get lispsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set lispsm(bool val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 38),
-        (val ? 1 : 0).toJS,
-        'i8');
-  }
-
-  double get polygonOffsetConstant {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetConstant(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
-  }
-
-  double get polygonOffsetSlope {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetSlope(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
-  }
-
-  bool get screenSpaceContactShadows {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set screenSpaceContactShadows(bool val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 47),
-        (val ? 1 : 0).toJS,
-        'i8');
-  }
-
-  int get stepCount {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set stepCount(int val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
-  }
-
-  double get maxShadowDistance {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxShadowDistance(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
-  }
-
-  bool get vsmElvsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set vsmElvsm(bool val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 53),
-        (val ? 1 : 0).toJS,
-        'i8');
-  }
-
-  double get vsmBlurWidth {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set vsmBlurWidth(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
-  }
-
-  double get shadowBulbRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowBulbRadius(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
-  }
-
-  double get transformX {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformX(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
-  }
-
-  double get transformY {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformY(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
-  }
-
-  double get transformZ {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformZ(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
-  }
-
-  double get transformW {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformW(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
-  }
-
-  TShadowOptions(super.address);
-
-  static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(
-        NativeLibrary.instance.stackAlloc<TShadowOptions>(78));
-  }
-}
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
-  }
-}
-
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
-
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(
-        NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
-  }
-}
-
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
-  }
-}
-
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
-
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(
-        NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
   }
 }
 
@@ -12715,38 +12771,15 @@ final class TGltfMeshData extends Struct {
   }
 }
 
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback
-    = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction = void Function(
-    int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction = void Function(
-    int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
-typedef PostRenderCallback
-    = Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef DartPostRenderCallback
-    = Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
   TMovementIntentExecutor toDart() {
@@ -12795,38 +12828,14 @@ const int SPRINT_INTENT_MASK = 8;
 extension StructAllocator on Struct {
   static T create<T>() {
     switch (T) {
-      case TSceneAsset:
-        final ptr = TSceneAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TEngine:
-        final ptr = TEngine.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBuffer:
-        final ptr = TVertexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
-        return ptr.toDart() as T;
       case TMaterialInstance:
         final ptr = TMaterialInstance.stackAlloc();
         return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
-        return ptr.toDart() as T;
       case TMaterial:
         final ptr = TMaterial.stackAlloc();
+        return ptr.toDart() as T;
+      case TEngine:
+        final ptr = TEngine.stackAlloc();
         return ptr.toDart() as T;
       case TTexture:
         final ptr = TTexture.stackAlloc();
@@ -12834,68 +12843,59 @@ extension StructAllocator on Struct {
       case TTextureSampler:
         final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
-      case TLinearImage:
-        final ptr = TLinearImage.stackAlloc();
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
         return ptr.toDart() as T;
-      case TKtx1Bundle:
-        final ptr = TKtx1Bundle.stackAlloc();
+      case double3:
+        final ptr = double3.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderer:
-        final ptr = TRenderer.stackAlloc();
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
         return ptr.toDart() as T;
-      case TSwapChain:
-        final ptr = TSwapChain.stackAlloc();
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
         return ptr.toDart() as T;
-      case TView:
-        final ptr = TView.stackAlloc();
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TTransformManager:
-        final ptr = TTransformManager.stackAlloc();
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableManager:
         final ptr = TRenderableManager.stackAlloc();
         return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TEntityManager:
-        final ptr = TEntityManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFence:
-        final ptr = TFence.stackAlloc();
-        return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
-      case TDebugRegistry:
-        final ptr = TDebugRegistry.stackAlloc();
-        return ptr.toDart() as T;
       case TViewport:
         final ptr = TViewport.stackAlloc();
+        return ptr.toDart() as T;
+      case TView:
+        final ptr = TView.stackAlloc();
         return ptr.toDart() as T;
       case TToneMapper:
         final ptr = TToneMapper.stackAlloc();
         return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
+        return ptr.toDart() as T;
       case TColorGradingBuilder:
         final ptr = TColorGradingBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
         return ptr.toDart() as T;
       case TSoftShadowOptions:
         final ptr = TSoftShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TVsmShadowOptions:
         final ptr = TVsmShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
+        return ptr.toDart() as T;
+      case TScene:
+        final ptr = TScene.stackAlloc();
         return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
@@ -12906,44 +12906,77 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBufferBuilder:
-        final ptr = TVertexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderManager:
-        final ptr = TRenderManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TAnimationManager:
-        final ptr = TAnimationManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderableBuilder:
-        final ptr = TRenderableBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
-        return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
       case TSurfaceOrientationBuilder:
         final ptr = TSurfaceOrientationBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TSurfaceOrientation:
         final ptr = TSurfaceOrientation.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
+      case TLinearImage:
+        final ptr = TLinearImage.stackAlloc();
+        return ptr.toDart() as T;
+      case TKtx1Bundle:
+        final ptr = TKtx1Bundle.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderManager:
+        final ptr = TRenderManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderer:
+        final ptr = TRenderer.stackAlloc();
+        return ptr.toDart() as T;
+      case TAnimationManager:
+        final ptr = TAnimationManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TSwapChain:
+        final ptr = TSwapChain.stackAlloc();
+        return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBufferBuilder:
+        final ptr = TVertexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBuffer:
+        final ptr = TVertexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
+        return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
+      case TTransformManager:
+        final ptr = TTransformManager.stackAlloc();
+        return ptr.toDart() as T;
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
+        return ptr.toDart() as T;
+      case TEntityManager:
+        final ptr = TEntityManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFence:
+        final ptr = TFence.stackAlloc();
+        return ptr.toDart() as T;
+      case TDebugRegistry:
+        final ptr = TDebugRegistry.stackAlloc();
+        return ptr.toDart() as T;
+      case TSceneAsset:
+        final ptr = TSceneAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderableBuilder:
+        final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TGltfMeshData:
         final ptr = TGltfMeshData.stackAlloc();

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -32,6 +32,106 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    bool rebuildVertices,
+  );
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _SceneAsset_getType(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_destroy(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_addToScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external void _SceneAsset_removeFromScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external EntityId _SceneAsset_getEntity(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _SceneAsset_getChildEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_getChildEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<Int32> out,
+  );
+  external Pointer<Int32> _SceneAsset_getCameraEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getCameraEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<Int32> _SceneAsset_getLightEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getLightEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+  );
+  external size_t _SceneAsset_getInstanceCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+  );
+  external void _SceneAsset_getBoundingBox(
+    Pointer<Aabb3> Aabb3_out,
+    Pointer<TSceneAsset> asset,
+  );
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external void _SceneAsset_releaseSourceData(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_setFlatShading(
+    Pointer<TSceneAsset> tSceneAsset,
+    bool flatShading,
+  );
+  external void _SceneAsset_getBones(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    Pointer<Int32> out,
+  );
+  external size_t _SceneAsset_getBoneCount(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+  );
+  external Pointer<Char> _SceneAsset_getBoneName(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    size_t boneIndex,
+  );
   external Pointer<TMaterialInstance> _Material_createInstance(
     Pointer<TMaterial> tMaterial,
   );
@@ -191,235 +291,358 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external int _Material_getBlendingMode(
     Pointer<TMaterial> material,
   );
-  external int _LightManager_createLight(
+  external Pointer<TTexture> _Texture_build(
+    Pointer<TEngine> engine,
+    int width,
+    int height,
+    int depth,
+    int levels,
+    int tUsage,
+    int import1,
+    int sampler,
+    int format,
+  );
+  external void _Texture_setExternalImage(
     Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
+    Pointer<TTexture> tTexture,
+    Pointer<Void> externalImage,
   );
-  external void _LightManager_destroyLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external size_t _Texture_getLevels(
+    Pointer<TTexture> tTexture,
   );
-  external int _LightManager_hasComponent(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external int _Texture_loadImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<TLinearImage> tImage,
+    int bufferFormat,
+    int pixelDataType,
+    int level,
   );
-  external int _LightManager_getType(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external int _Texture_setImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    int level,
+    Pointer<Uint8> data,
+    size_t size,
+    int x_offset,
+    int y_offset,
+    int z_offset,
+    int width,
+    int height,
+    int depth,
+    int bufferFormat,
+    int pixelDataType,
   );
-  external int _LightManager_isDirectional(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external int _Texture_getWidth(
+    Pointer<TTexture> tTexture,
+    int level,
   );
-  external int _LightManager_isPointLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external int _Texture_getHeight(
+    Pointer<TTexture> tTexture,
+    int level,
   );
-  external int _LightManager_isSpotLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external int _Texture_getDepth(
+    Pointer<TTexture> tTexture,
+    int level,
   );
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
+  external int _Texture_getUsage(
+    Pointer<TTexture> tTexture,
+    int level,
   );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
+  external void _Texture_generateMipMaps(
+    Pointer<TTexture> tTexture,
+    Pointer<TEngine> tEngine,
   );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
+  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(
+    Pointer<Uint8> ktxData,
+    size_t length,
   );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
+  external void _Ktx1Bundle_getSphericalHarmonics(
+    Pointer<TKtx1Bundle> tBundle,
+    Pointer<Float32> harmonics,
   );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double r,
-    double g,
-    double b,
+  external int _Ktx1Bundle_isCubemap(
+    Pointer<TKtx1Bundle> tBundle,
   );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
+  external void _Ktx1Bundle_destroy(
+    Pointer<TKtx1Bundle> tBundle,
   );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TTexture> _Ktx1Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TKtx1Bundle> tBundle,
+    int requestId,
+    VoidCallback onTextureUploadComplete,
   );
-  external void _LightManager_setIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
+  external Pointer<TTexture> _Ktx2Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> data,
+    size_t size,
   );
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double falloff,
-  );
-  external double _LightManager_getFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external double _LightManager_getSpotLightInnerCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloSize,
-  );
-  external double _LightManager_getSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    bool enabled,
-  );
-  external int _LightManager_isShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TLinearImage> _Image_createEmpty(
+    int width,
+    int height,
     int channel,
   );
-  external void _LightManager_computeUniformSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-  );
-  external void _LightManager_computeLogSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-  );
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(
-    double r,
-    double g,
-    double b,
-  );
-  external int _FilamentAsset_getEntityCount(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external void _FilamentAsset_getEntities(
-    Pointer<TFilamentAsset> filamentAsset,
-    Pointer<Int32> out,
-  );
-  external EntityId _FilamentAsset_getWireframe(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external Pointer<Void> _FilamentAsset_getSourceAsset(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
-  );
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
+  external Pointer<TLinearImage> _Image_decode(
     Pointer<Uint8> data,
     size_t length,
-    int numInstances,
+    Pointer<Char> name,
+    bool alpha,
   );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
+  external Pointer<Float32> _Image_getBytes(
+    Pointer<TLinearImage> tLinearImage,
   );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(
-    Pointer<TGltfAssetLoader> tAssetLoader,
+  external void _Image_destroy(
+    Pointer<TLinearImage> tLinearImage,
   );
-  external int _FilamentAsset_getResourceUriCount(
-    Pointer<TFilamentAsset> tFilamentAsset,
+  external int _Image_getWidth(
+    Pointer<TLinearImage> tLinearImage,
   );
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(
-    Pointer<TFilamentAsset> tFilamentAsset,
+  external int _Image_getHeight(
+    Pointer<TLinearImage> tLinearImage,
+  );
+  external int _Image_getChannels(
+    Pointer<TLinearImage> tLinearImage,
+  );
+  external Pointer<TTexture> _RenderTarget_getColorTexture(
+    Pointer<TRenderTarget> tRenderTarget,
+  );
+  external Pointer<TTexture> _RenderTarget_getDepthTexture(
+    Pointer<TRenderTarget> tRenderTarget,
+  );
+  external Pointer<TTextureSampler> _TextureSampler_create();
+  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
+    int minFilter,
+    int magFilter,
+    int wrapS,
+    int wrapT,
+    int wrapR,
+  );
+  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(
+    int compareMode,
+    int compareFunc,
+  );
+  external void _TextureSampler_setMinFilter(
+    Pointer<TTextureSampler> sampler,
+    int filter,
+  );
+  external void _TextureSampler_setMagFilter(
+    Pointer<TTextureSampler> sampler,
+    int filter,
+  );
+  external void _TextureSampler_setWrapModeS(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+  );
+  external void _TextureSampler_setWrapModeT(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+  );
+  external void _TextureSampler_setWrapModeR(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+  );
+  external void _TextureSampler_setAnisotropy(
+    Pointer<TTextureSampler> sampler,
+    double anisotropy,
+  );
+  external void _TextureSampler_setCompareMode(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+    int func,
+  );
+  external void _TextureSampler_destroy(
+    Pointer<TTextureSampler> sampler,
+  );
+  external Pointer<TEngine> _Engine_create(
+    int backend,
+    Pointer<Void> platform,
+    Pointer<Void> sharedContext,
+    int stereoscopicEyeCount,
+    bool disableHandleUseAfterFreeCheck,
+  );
+  external int _Engine_getSupportedFeatureLevel(
+    Pointer<TEngine> tEngine,
+  );
+  external void _Engine_destroy(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TRenderer> _Engine_createRenderer(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TSwapChain> _Engine_createSwapChain(
+    Pointer<TEngine> tEngine,
+    Pointer<Void> window,
+    JSBigInt flags,
+  );
+  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
+    Pointer<TEngine> tEngine,
+    int width,
+    int height,
+    JSBigInt flags,
+  );
+  external void _Engine_destroySwapChain(
+    Pointer<TEngine> tEngine,
+    Pointer<TSwapChain> tSwapChain,
+  );
+  external void _Engine_destroyView(
+    Pointer<TEngine> tEngine,
+    Pointer<TView> tView,
+  );
+  external void _Engine_destroyScene(
+    Pointer<TEngine> tEngine,
+    Pointer<TScene> tScene,
+  );
+  external void _Engine_destroyColorGrading(
+    Pointer<TEngine> tEngine,
+    Pointer<TColorGrading> tColorGrading,
+  );
+  external Pointer<TCamera> _Engine_createCamera(
+    Pointer<TEngine> tEngine,
+    EntityId entityId,
+  );
+  external void _Engine_destroyCamera(
+    Pointer<TEngine> tEngine,
+    Pointer<TCamera> tCamera,
+  );
+  external Pointer<TView> _Engine_createView(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TCamera> _Engine_getCameraComponent(
+    Pointer<TEngine> tEngine,
+    EntityId entityId,
+  );
+  external Pointer<TTransformManager> _Engine_getTransformManager(
+    Pointer<TEngine> engine,
+  );
+  external Pointer<TRenderableManager> _Engine_getRenderableManager(
+    Pointer<TEngine> engine,
+  );
+  external Pointer<TLightManager> _Engine_getLightManager(
+    Pointer<TEngine> engine,
+  );
+  external Pointer<TEntityManager> _Engine_getEntityManager(
+    Pointer<TEngine> engine,
+  );
+  external void _Engine_setAutomaticInstancingEnabled(
+    Pointer<TEngine> tEngine,
+    bool enabled,
+  );
+  external size_t _Engine_getMaxAutomaticInstances(
+    Pointer<TEngine> tEngine,
+  );
+  external void _Engine_destroyTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+  );
+  external Pointer<TFence> _Engine_createFence(
+    Pointer<TEngine> tEngine,
+  );
+  external void _Engine_destroyFence(
+    Pointer<TEngine> tEngine,
+    Pointer<TFence> tFence,
+  );
+  external void _Engine_flushAndWait(
+    Pointer<TEngine> tEngine,
+  );
+  external void _Engine_execute(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TMaterial> _Engine_buildMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> materialData,
+    size_t length,
+  );
+  external void _Engine_destroyMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterial> tMaterial,
+  );
+  external void _Engine_destroyMaterialInstance(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialInstance> tMaterialInstance,
+  );
+  external Pointer<TScene> _Engine_createScene(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TSkybox> _Engine_buildSkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+  );
+  external Pointer<TSkybox> _Engine_buildColoredSkybox(
+    Pointer<TEngine> tEngine,
+    double r,
+    double g,
+    double b,
+    double a,
+  );
+  external Pointer<TIndirectLight>
+      _Engine_buildIndirectLightFromIrradianceTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<TTexture> tIrradianceTexture,
+    double intensity,
+  );
+  external Pointer<TIndirectLight>
+      _Engine_buildIndirectLightFromIrradianceHarmonics(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<Float32> irradianceHarmonics,
+    double intensity,
+  );
+  external void _Engine_destroySkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TSkybox> tSkybox,
+  );
+  external void _Engine_destroyIndirectLight(
+    Pointer<TEngine> tEngine,
+    Pointer<TIndirectLight> tIndirectLight,
+  );
+  external EntityId _EntityManager_createEntity(
+    Pointer<TEntityManager> tEntityManager,
+  );
+  external void _EntityManager_destroyEntity(
+    Pointer<TEntityManager> tEntityManager,
+    EntityId entityId,
+  );
+  external void _Fence_waitAndDestroy(
+    Pointer<TFence> tFence,
+  );
+  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(
+    Pointer<TEngine> tEngine,
+  );
+  external int _DebugRegistry_hasProperty(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+  );
+  external int _DebugRegistry_setProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    bool value,
+  );
+  external int _DebugRegistry_setProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    int value,
+  );
+  external int _DebugRegistry_setProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    double value,
+  );
+  external int _DebugRegistry_getProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Bool> outValue,
+  );
+  external int _DebugRegistry_getProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Int32> outValue,
+  );
+  external int _DebugRegistry_getProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Float32> outValue,
   );
   external void _View_getViewport(
     Pointer<TViewport> TViewport_out,
@@ -727,339 +950,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<Char> _View_getName(
     Pointer<TView> tView,
   );
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external Pointer<TSurfaceOrientationBuilder>
-      _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
-  );
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_triangleCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
-  );
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
-  );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
-  );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
-    Pointer<TSurfaceOrientationBuilder> builder,
-  );
-  external void _SurfaceOrientationBuilder_destroy(
-    Pointer<TSurfaceOrientationBuilder> builder,
-  );
-  external size_t _SurfaceOrientation_getVertexCount(
-    Pointer<TSurfaceOrientation> orientation,
-  );
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_destroy(
-    Pointer<TSurfaceOrientation> orientation,
-  );
-  external void _IndirectLight_setRotation(
-    Pointer<TIndirectLight> tIndirectLight,
-    Pointer<Float64> rotation,
-  );
-  external Pointer<TTexture> _Texture_build(
-    Pointer<TEngine> engine,
-    int width,
-    int height,
-    int depth,
-    int levels,
-    int tUsage,
-    int import1,
-    int sampler,
-    int format,
-  );
-  external void _Texture_setExternalImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<Void> externalImage,
-  );
-  external size_t _Texture_getLevels(
-    Pointer<TTexture> tTexture,
-  );
-  external int _Texture_loadImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<TLinearImage> tImage,
-    int bufferFormat,
-    int pixelDataType,
-    int level,
-  );
-  external int _Texture_setImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    int level,
-    Pointer<Uint8> data,
-    size_t size,
-    int x_offset,
-    int y_offset,
-    int z_offset,
-    int width,
-    int height,
-    int depth,
-    int bufferFormat,
-    int pixelDataType,
-  );
-  external int _Texture_getWidth(
-    Pointer<TTexture> tTexture,
-    int level,
-  );
-  external int _Texture_getHeight(
-    Pointer<TTexture> tTexture,
-    int level,
-  );
-  external int _Texture_getDepth(
-    Pointer<TTexture> tTexture,
-    int level,
-  );
-  external int _Texture_getUsage(
-    Pointer<TTexture> tTexture,
-    int level,
-  );
-  external void _Texture_generateMipMaps(
-    Pointer<TTexture> tTexture,
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(
-    Pointer<Uint8> ktxData,
-    size_t length,
-  );
-  external void _Ktx1Bundle_getSphericalHarmonics(
-    Pointer<TKtx1Bundle> tBundle,
-    Pointer<Float32> harmonics,
-  );
-  external int _Ktx1Bundle_isCubemap(
-    Pointer<TKtx1Bundle> tBundle,
-  );
-  external void _Ktx1Bundle_destroy(
-    Pointer<TKtx1Bundle> tBundle,
-  );
-  external Pointer<TTexture> _Ktx1Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TKtx1Bundle> tBundle,
-    int requestId,
-    VoidCallback onTextureUploadComplete,
-  );
-  external Pointer<TTexture> _Ktx2Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> data,
-    size_t size,
-  );
-  external Pointer<TLinearImage> _Image_createEmpty(
-    int width,
-    int height,
-    int channel,
-  );
-  external Pointer<TLinearImage> _Image_decode(
-    Pointer<Uint8> data,
-    size_t length,
-    Pointer<Char> name,
-    bool alpha,
-  );
-  external Pointer<Float32> _Image_getBytes(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external void _Image_destroy(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external int _Image_getWidth(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external int _Image_getHeight(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external int _Image_getChannels(
-    Pointer<TLinearImage> tLinearImage,
-  );
-  external Pointer<TTexture> _RenderTarget_getColorTexture(
-    Pointer<TRenderTarget> tRenderTarget,
-  );
-  external Pointer<TTexture> _RenderTarget_getDepthTexture(
-    Pointer<TRenderTarget> tRenderTarget,
-  );
-  external Pointer<TTextureSampler> _TextureSampler_create();
-  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
-    int minFilter,
-    int magFilter,
-    int wrapS,
-    int wrapT,
-    int wrapR,
-  );
-  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(
-    int compareMode,
-    int compareFunc,
-  );
-  external void _TextureSampler_setMinFilter(
-    Pointer<TTextureSampler> sampler,
-    int filter,
-  );
-  external void _TextureSampler_setMagFilter(
-    Pointer<TTextureSampler> sampler,
-    int filter,
-  );
-  external void _TextureSampler_setWrapModeS(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-  );
-  external void _TextureSampler_setWrapModeT(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-  );
-  external void _TextureSampler_setWrapModeR(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-  );
-  external void _TextureSampler_setAnisotropy(
-    Pointer<TTextureSampler> sampler,
-    double anisotropy,
-  );
-  external void _TextureSampler_setCompareMode(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-    int func,
-  );
-  external void _TextureSampler_destroy(
-    Pointer<TTextureSampler> sampler,
-  );
-  external Pointer<TRenderManager> _RenderManager_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderer> tRenderer,
-  );
-  external void _RenderManager_destroy(
-    Pointer<TRenderManager> tRenderer,
-  );
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_render(
-    Pointer<TRenderManager> tRenderer,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
-  );
-  external void _RenderManager_removeSwapChain(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-  );
-  external void _RenderManager_requestRender(
-    Pointer<TRenderManager> tRenderer,
-  );
-  external void _RenderManager_attachToRenderThread(
-    Pointer<TRenderManager> tRenderer,
-  );
-  external void _RenderManager_setPaused(
-    Pointer<TRenderManager> tRenderer,
-    bool paused,
-  );
-  external void _FrameScheduler_start(
-    FrameCallback callback,
-    int targetFps,
-  );
-  external void _FrameScheduler_stop();
-  external void _FrameScheduler_setRenderThread(
-    Pointer<Void> renderThread,
-  );
-  external void _FrameScheduler_setRenderManager(
-    Pointer<TRenderManager> rm,
-  );
-  external void _FrameScheduler_setPostRenderCallback(
-    PostRenderCallback callback,
-    Pointer<Void> userData,
-  );
-  external void _FrameScheduler_requestRender(
-    JSBigInt frameTimeNanos,
-  );
-  external void _FrameScheduler_startNativeRenderLoop(
-    int targetFps,
-  );
-  external int _FrameScheduler_initDartApi(
-    Pointer<Void> data,
-  );
-  external void _FrameScheduler_startWithPort(
-    JSBigInt port,
-    int targetFps,
-  );
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external void _Gizmo_dummy(
-    int t,
-  );
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(
-    Pointer<TGizmo> tGizmo,
-    int x,
-    int y,
-    GizmoPickCallback callback,
-  );
-  external void _Gizmo_highlight(
-    Pointer<TGizmo> tGizmo,
-    int axis,
-  );
-  external void _Gizmo_unhighlight(
-    Pointer<TGizmo> tGizmo,
-  );
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
     bool doubleSided,
@@ -1100,36 +990,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     bool hasSheen,
     bool hasIOR,
     bool hasVolume,
-  );
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(
-    Pointer<TIndexBufferBuilder> builder,
-    int count,
-  );
-  external void _IndexBufferBuilder_bufferType(
-    Pointer<TIndexBufferBuilder> builder,
-    int indexType,
-  );
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _IndexBufferBuilder_destroy(
-    Pointer<TIndexBufferBuilder> builder,
-  );
-  external size_t _IndexBuffer_getIndexCount(
-    Pointer<TIndexBuffer> buffer,
-  );
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _IndexBuffer_destroy(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
   );
   external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
   external void _VertexBufferBuilder_bufferCount(
@@ -1175,139 +1035,35 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TEngine> engine,
     Pointer<TVertexBuffer> buffer,
   );
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(
+    Pointer<TIndexBufferBuilder> builder,
+    int count,
   );
-  external void _RenderTarget_destroy(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderTarget> tRenderTarget,
+  external void _IndexBufferBuilder_bufferType(
+    Pointer<TIndexBufferBuilder> builder,
+    int indexType,
   );
-  external void _Scene_addEntity(
-    Pointer<TScene> tScene,
-    EntityId entityId,
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  external void _Scene_removeEntity(
-    Pointer<TScene> tScene,
-    EntityId entityId,
+  external void _IndexBufferBuilder_destroy(
+    Pointer<TIndexBufferBuilder> builder,
   );
-  external void _Scene_setSkybox(
-    Pointer<TScene> tScene,
-    Pointer<TSkybox> skybox,
+  external size_t _IndexBuffer_getIndexCount(
+    Pointer<TIndexBuffer> buffer,
   );
-  external void _Scene_setIndirectLight(
-    Pointer<TScene> tScene,
-    Pointer<TIndirectLight> tIndirectLight,
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
   );
-  external void _Scene_addFilamentAsset(
-    Pointer<TScene> tScene,
-    Pointer<TFilamentAsset> asset,
-  );
-  external void _Camera_setExposure(
-    Pointer<TCamera> camera,
-    double aperture,
-    double shutterSpeed,
-    double sensitivity,
-  );
-  external double _Camera_getAperture(
-    Pointer<TCamera> camera,
-  );
-  external double _Camera_getShutterSpeed(
-    Pointer<TCamera> camera,
-  );
-  external double _Camera_getSensitivity(
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getModelMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getViewMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getCullingProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getFrustum(
-    Pointer<TCamera> camera,
-    Pointer<Float64> out,
-  );
-  external void _Camera_setProjectionMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> matrix,
-    double near,
-    double far,
-  );
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
-  );
-  external double _Camera_getFocalLength(
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(
-    Pointer<TCamera> camera,
-  );
-  external double _Camera_getCullingFar(
-    Pointer<TCamera> camera,
-  );
-  external double _Camera_getFov(
-    Pointer<TCamera> camera,
-    bool horizontal,
-  );
-  external double _Camera_getFocusDistance(
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_setFocusDistance(
-    Pointer<TCamera> camera,
-    double focusDistance,
-  );
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> tModelMatrix,
-  );
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
+  external void _IndexBuffer_destroy(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
   );
   external void _TransformManager_getLocalTransform(
     Pointer<double4x4> double4x4_out,
@@ -1376,241 +1132,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _TransformManager_commitLocalTransformTransaction(
     Pointer<TTransformManager> tTransformManager,
-  );
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(
-    Pointer<TRenderer> tRenderer,
-  );
-  external void _Renderer_render(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-  );
-  external void _Renderer_renderStandaloneView(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-  );
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
-  external Pointer<TEngine> _Engine_create(
-    int backend,
-    Pointer<Void> platform,
-    Pointer<Void> sharedContext,
-    int stereoscopicEyeCount,
-    bool disableHandleUseAfterFreeCheck,
-  );
-  external int _Engine_getSupportedFeatureLevel(
-    Pointer<TEngine> tEngine,
-  );
-  external void _Engine_destroy(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TRenderer> _Engine_createRenderer(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TSwapChain> _Engine_createSwapChain(
-    Pointer<TEngine> tEngine,
-    Pointer<Void> window,
-    JSBigInt flags,
-  );
-  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
-    Pointer<TEngine> tEngine,
-    int width,
-    int height,
-    JSBigInt flags,
-  );
-  external void _Engine_destroySwapChain(
-    Pointer<TEngine> tEngine,
-    Pointer<TSwapChain> tSwapChain,
-  );
-  external void _Engine_destroyView(
-    Pointer<TEngine> tEngine,
-    Pointer<TView> tView,
-  );
-  external void _Engine_destroyScene(
-    Pointer<TEngine> tEngine,
-    Pointer<TScene> tScene,
-  );
-  external void _Engine_destroyColorGrading(
-    Pointer<TEngine> tEngine,
-    Pointer<TColorGrading> tColorGrading,
-  );
-  external Pointer<TCamera> _Engine_createCamera(
-    Pointer<TEngine> tEngine,
-    EntityId entityId,
-  );
-  external void _Engine_destroyCamera(
-    Pointer<TEngine> tEngine,
-    Pointer<TCamera> tCamera,
-  );
-  external Pointer<TView> _Engine_createView(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TCamera> _Engine_getCameraComponent(
-    Pointer<TEngine> tEngine,
-    EntityId entityId,
-  );
-  external Pointer<TTransformManager> _Engine_getTransformManager(
-    Pointer<TEngine> engine,
-  );
-  external Pointer<TRenderableManager> _Engine_getRenderableManager(
-    Pointer<TEngine> engine,
-  );
-  external Pointer<TLightManager> _Engine_getLightManager(
-    Pointer<TEngine> engine,
-  );
-  external Pointer<TEntityManager> _Engine_getEntityManager(
-    Pointer<TEngine> engine,
-  );
-  external void _Engine_setAutomaticInstancingEnabled(
-    Pointer<TEngine> tEngine,
-    bool enabled,
-  );
-  external size_t _Engine_getMaxAutomaticInstances(
-    Pointer<TEngine> tEngine,
-  );
-  external void _Engine_destroyTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-  );
-  external Pointer<TFence> _Engine_createFence(
-    Pointer<TEngine> tEngine,
-  );
-  external void _Engine_destroyFence(
-    Pointer<TEngine> tEngine,
-    Pointer<TFence> tFence,
-  );
-  external void _Engine_flushAndWait(
-    Pointer<TEngine> tEngine,
-  );
-  external void _Engine_execute(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TMaterial> _Engine_buildMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> materialData,
-    size_t length,
-  );
-  external void _Engine_destroyMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterial> tMaterial,
-  );
-  external void _Engine_destroyMaterialInstance(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialInstance> tMaterialInstance,
-  );
-  external Pointer<TScene> _Engine_createScene(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TSkybox> _Engine_buildSkybox(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-  );
-  external Pointer<TSkybox> _Engine_buildColoredSkybox(
-    Pointer<TEngine> tEngine,
-    double r,
-    double g,
-    double b,
-    double a,
-  );
-  external Pointer<TIndirectLight>
-      _Engine_buildIndirectLightFromIrradianceTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<TTexture> tIrradianceTexture,
-    double intensity,
-  );
-  external Pointer<TIndirectLight>
-      _Engine_buildIndirectLightFromIrradianceHarmonics(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<Float32> irradianceHarmonics,
-    double intensity,
-  );
-  external void _Engine_destroySkybox(
-    Pointer<TEngine> tEngine,
-    Pointer<TSkybox> tSkybox,
-  );
-  external void _Engine_destroyIndirectLight(
-    Pointer<TEngine> tEngine,
-    Pointer<TIndirectLight> tIndirectLight,
-  );
-  external EntityId _EntityManager_createEntity(
-    Pointer<TEntityManager> tEntityManager,
-  );
-  external void _EntityManager_destroyEntity(
-    Pointer<TEntityManager> tEntityManager,
-    EntityId entityId,
-  );
-  external void _Fence_waitAndDestroy(
-    Pointer<TFence> tFence,
-  );
-  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(
-    Pointer<TEngine> tEngine,
-  );
-  external int _DebugRegistry_hasProperty(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-  );
-  external int _DebugRegistry_setProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    bool value,
-  );
-  external int _DebugRegistry_setProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    int value,
-  );
-  external int _DebugRegistry_setProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    double value,
-  );
-  external int _DebugRegistry_getProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Bool> outValue,
-  );
-  external int _DebugRegistry_getProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Int32> outValue,
-  );
-  external int _DebugRegistry_getProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Float32> outValue,
   );
   external Pointer<Void> _RenderThread_create();
   external void _RenderThread_destroy();
@@ -2610,6 +2131,307 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
+  external void _IndirectLight_setRotation(
+    Pointer<TIndirectLight> tIndirectLight,
+    Pointer<Float64> rotation,
+  );
+  external int _LightManager_createLight(
+    Pointer<TEngine> tEngine,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
+  );
+  external void _LightManager_destroyLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_hasComponent(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_getType(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isDirectional(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isPointLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isSpotLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double r,
+    double g,
+    double b,
+  );
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external double _LightManager_getIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double falloff,
+  );
+  external double _LightManager_getFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external double _LightManager_getSpotLightOuterCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external double _LightManager_getSpotLightInnerCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external double _LightManager_getSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloSize,
+  );
+  external double _LightManager_getSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external double _LightManager_getSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    bool enabled,
+  );
+  external int _LightManager_isShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external int _LightManager_getLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+  );
+  external void _LightManager_computeUniformSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+  );
+  external void _LightManager_computeLogSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+  );
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external double _LightManager_rgbToColorTemperature(
+    double r,
+    double g,
+    double b,
+  );
+  external void _Camera_setExposure(
+    Pointer<TCamera> camera,
+    double aperture,
+    double shutterSpeed,
+    double sensitivity,
+  );
+  external double _Camera_getAperture(
+    Pointer<TCamera> camera,
+  );
+  external double _Camera_getShutterSpeed(
+    Pointer<TCamera> camera,
+  );
+  external double _Camera_getSensitivity(
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getModelMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getViewMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getCullingProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getFrustum(
+    Pointer<TCamera> camera,
+    Pointer<Float64> out,
+  );
+  external void _Camera_setProjectionMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> matrix,
+    double near,
+    double far,
+  );
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
+  );
+  external double _Camera_getFocalLength(
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(
+    Pointer<TCamera> camera,
+  );
+  external double _Camera_getCullingFar(
+    Pointer<TCamera> camera,
+  );
+  external double _Camera_getFov(
+    Pointer<TCamera> camera,
+    bool horizontal,
+  );
+  external double _Camera_getFocusDistance(
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_setFocusDistance(
+    Pointer<TCamera> camera,
+    double focusDistance,
+  );
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> tModelMatrix,
+  );
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
   external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(
     Pointer<TEngine> tEngine,
   );
@@ -2643,18 +2465,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     double g,
     double b,
     double a,
-  );
-  external void _dummy(
-    Pointer<TGltfMeshData> dummyPtr,
-  );
-  external int _GltfParser_parseBuffer(
-    Pointer<Uint8> data,
-    size_t length,
-    Pointer<Char> meshName,
-    Pointer<TGltfMeshData> outMeshData,
-  );
-  external void _GltfParser_freeMeshData(
-    Pointer<TGltfMeshData> meshData,
   );
   external void _RenderableManager_destroyEntity(
     Pointer<TRenderableManager> tRenderableManager,
@@ -2934,105 +2744,282 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TEngine> engine,
     EntityId entity,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    Pointer<Aabb3> boundingBoxPtr,
+  external void _Scene_addEntity(
+    Pointer<TScene> tScene,
+    EntityId entityId,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+  external void _Scene_removeEntity(
+    Pointer<TScene> tScene,
+    EntityId entityId,
+  );
+  external void _Scene_setSkybox(
+    Pointer<TScene> tScene,
+    Pointer<TSkybox> skybox,
+  );
+  external void _Scene_setIndirectLight(
+    Pointer<TScene> tScene,
+    Pointer<TIndirectLight> tIndirectLight,
+  );
+  external void _Scene_addFilamentAsset(
+    Pointer<TScene> tScene,
+    Pointer<TFilamentAsset> asset,
+  );
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
+  );
+  external void _RenderTarget_destroy(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderTarget> tRenderTarget,
+  );
+  external Pointer<TSurfaceOrientationBuilder>
+      _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
+  );
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_triangleCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
+  );
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
+  );
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
+  );
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
+    Pointer<TSurfaceOrientationBuilder> builder,
+  );
+  external void _SurfaceOrientationBuilder_destroy(
+    Pointer<TSurfaceOrientationBuilder> builder,
+  );
+  external size_t _SurfaceOrientation_getVertexCount(
+    Pointer<TSurfaceOrientation> orientation,
+  );
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Float32> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_destroy(
+    Pointer<TSurfaceOrientation> orientation,
+  );
+  external void _dummy(
+    Pointer<TGltfMeshData> dummyPtr,
+  );
+  external int _GltfParser_parseBuffer(
+    Pointer<Uint8> data,
+    size_t length,
+    Pointer<Char> meshName,
+    Pointer<TGltfMeshData> outMeshData,
+  );
+  external void _GltfParser_freeMeshData(
+    Pointer<TGltfMeshData> meshData,
+  );
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(
+    Pointer<TRenderer> tRenderer,
+  );
+  external void _Renderer_render(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+  );
+  external void _Renderer_renderStandaloneView(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+  );
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
+  external Pointer<TRenderManager> _RenderManager_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderer> tRenderer,
+  );
+  external void _RenderManager_destroy(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_render(
+    Pointer<TRenderManager> tRenderer,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
+  );
+  external void _RenderManager_removeSwapChain(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+  );
+  external void _RenderManager_requestRender(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_attachToRenderThread(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_setPaused(
+    Pointer<TRenderManager> tRenderer,
+    bool paused,
+  );
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external void _Gizmo_dummy(
+    int t,
+  );
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+  );
+  external void _Gizmo_pick(
+    Pointer<TGizmo> tGizmo,
+    int x,
+    int y,
+    GizmoPickCallback callback,
+  );
+  external void _Gizmo_highlight(
+    Pointer<TGizmo> tGizmo,
+    int axis,
+  );
+  external void _Gizmo_unhighlight(
+    Pointer<TGizmo> tGizmo,
+  );
+  external void _FrameScheduler_start(
+    FrameCallback callback,
+    int targetFps,
+  );
+  external void _FrameScheduler_stop();
+  external void _FrameScheduler_setRenderThread(
+    Pointer<Void> renderThread,
+  );
+  external void _FrameScheduler_setRenderManager(
+    Pointer<TRenderManager> rm,
+  );
+  external void _FrameScheduler_setPostRenderCallback(
+    PostRenderCallback callback,
+    Pointer<Void> userData,
+  );
+  external void _FrameScheduler_requestRender(
+    JSBigInt frameTimeNanos,
+  );
+  external void _FrameScheduler_startNativeRenderLoop(
+    int targetFps,
+  );
+  external int _FrameScheduler_initDartApi(
+    Pointer<Void> data,
+  );
+  external void _FrameScheduler_startWithPort(
+    JSBigInt port,
+    int targetFps,
+  );
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
+  );
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
     Pointer<TEngine> tEngine,
     Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
+  );
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
+  );
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(
+    Pointer<TGltfAssetLoader> tAssetLoader,
+  );
+  external int _FilamentAsset_getResourceUriCount(
     Pointer<TFilamentAsset> tFilamentAsset,
-    bool rebuildVertices,
   );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _SceneAsset_getType(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_destroy(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_addToScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-  );
-  external void _SceneAsset_removeFromScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-  );
-  external EntityId _SceneAsset_getEntity(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _SceneAsset_getChildEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_getChildEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<Int32> out,
-  );
-  external Pointer<Int32> _SceneAsset_getCameraEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getCameraEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<Int32> _SceneAsset_getLightEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getLightEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-  );
-  external size_t _SceneAsset_getInstanceCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-  );
-  external void _SceneAsset_getBoundingBox(
-    Pointer<Aabb3> Aabb3_out,
-    Pointer<TSceneAsset> asset,
-  );
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external void _SceneAsset_releaseSourceData(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_setFlatShading(
-    Pointer<TSceneAsset> tSceneAsset,
-    bool flatShading,
-  );
-  external void _SceneAsset_getBones(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    Pointer<Int32> out,
-  );
-  external size_t _SceneAsset_getBoneCount(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-  );
-  external Pointer<Char> _SceneAsset_getBoneName(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    size_t boneIndex,
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(
+    Pointer<TFilamentAsset> tFilamentAsset,
   );
   external Pointer<TAnimationManager> _AnimationManager_create(
     Pointer<TEngine> tEngine,
@@ -3168,6 +3155,19 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int animationIndex,
     double timeInSeconds,
   );
+  external int _FilamentAsset_getEntityCount(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external void _FilamentAsset_getEntities(
+    Pointer<TFilamentAsset> filamentAsset,
+    Pointer<Int32> out,
+  );
+  external EntityId _FilamentAsset_getWireframe(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external Pointer<Void> _FilamentAsset_getSourceAsset(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
   external void _MovementIntentExecutor_destroy(
     Pointer<TMovementIntentExecutor> executor,
   );
@@ -3288,6 +3288,242 @@ BigInt get TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER {
   final value = NativeLibrary.instance.getValueBigInt(
       GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER, "i64");
   return bigIntasUintN(64, value).toDart;
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tVertexBuffer,
+  Pointer<TIndexBuffer> tIndexBuffer,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
+) {
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
+      tEngine.cast(),
+      tVertexBuffer.cast(),
+      tIndexBuffer.cast(),
+      materialInstances.cast(),
+      materialInstanceCount,
+      tPrimitiveType,
+      boundingBoxPtr.cast());
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
+      tEngine.cast(),
+      tAssetLoader.cast(),
+      tNameComponentManager.cast(),
+      tFilamentAsset.cast(),
+      rebuildVertices);
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getFilamentAsset(tSceneAsset.cast());
+  return Pointer<TFilamentAsset>(result);
+}
+
+int SceneAsset_getType(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result =
+      GeneratedBindings.instance._SceneAsset_getType(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_destroy(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result =
+      GeneratedBindings.instance._SceneAsset_destroy(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_addToScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_addToScene(tSceneAsset.cast(), tScene.cast());
+  return result;
+}
+
+void SceneAsset_removeFromScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_removeFromScene(tSceneAsset.cast(), tScene.cast());
+  return result;
+}
+
+DartEntityId SceneAsset_getEntity(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result =
+      GeneratedBindings.instance._SceneAsset_getEntity(tSceneAsset.cast());
+  return result;
+}
+
+int SceneAsset_getChildEntityCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getChildEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_getChildEntities(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getChildEntities(tSceneAsset.cast(), out);
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getCameraEntities(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getCameraEntities(tSceneAsset.cast());
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getCameraEntityCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getLightEntities(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getLightEntities(tSceneAsset.cast());
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getLightEntityCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getLightEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_getInstance(
+  Pointer<TSceneAsset> tSceneAsset,
+  int index,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getInstance(tSceneAsset.cast(), index);
+  return Pointer<TSceneAsset>(result);
+}
+
+Dartsize_t SceneAsset_getInstanceCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getInstanceCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createInstance(
+  Pointer<TSceneAsset> asset,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createInstance(
+      asset.cast(), materialInstances.cast(), materialInstanceCount);
+  return Pointer<TSceneAsset>(result);
+}
+
+Aabb3 SceneAsset_getBoundingBox(
+  Pointer<TSceneAsset> asset,
+) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getBoundingBox(Aabb3_out.cast(), asset.cast());
+  return Aabb3_out.toDart();
+}
+
+Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getVertexBuffer(tSceneAsset.cast(), primitiveIndex);
+  return Pointer<TVertexBuffer>(result);
+}
+
+Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getIndexBuffer(tSceneAsset.cast(), primitiveIndex);
+  return Pointer<TIndexBuffer>(result);
+}
+
+void SceneAsset_releaseSourceData(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_releaseSourceData(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_setFlatShading(
+  Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_setFlatShading(tSceneAsset.cast(), flatShading);
+  return result;
+}
+
+void SceneAsset_getBones(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
+  return result;
+}
+
+Dartsize_t SceneAsset_getBoneCount(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
+  return result;
+}
+
+Pointer<Char> SceneAsset_getBoneName(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+  Dartsize_t boneIndex,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
+  return Pointer<Char>(result);
 }
 
 Pointer<TMaterialInstance> Material_createInstance(
@@ -3645,482 +3881,772 @@ int Material_getBlendingMode(
   return result;
 }
 
-int LightManager_createLight(
+Pointer<TTexture> Texture_build(
+  Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import1,
+  int sampler,
+  int format,
+) {
+  final result = GeneratedBindings.instance._Texture_build(engine.cast(), width,
+      height, depth, levels, tUsage, import1, sampler, format);
+  return Pointer<TTexture>(result);
+}
+
+void Texture_setExternalImage(
   Pointer<TEngine> tEngine,
-  Pointer<TLightManager> tLightManager,
-  int tLightTtype,
+  Pointer<TTexture> tTexture,
+  Pointer<Void> externalImage,
 ) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-      tEngine.cast(), tLightManager.cast(), tLightTtype);
+  final result = GeneratedBindings.instance._Texture_setExternalImage(
+      tEngine.cast(), tTexture.cast(), externalImage);
   return result;
 }
 
-void LightManager_destroyLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+Dartsize_t Texture_getLevels(
+  Pointer<TTexture> tTexture,
 ) {
-  final result = GeneratedBindings.instance
-      ._LightManager_destroyLight(tLightManager.cast(), entity);
+  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
   return result;
 }
 
-bool LightManager_hasComponent(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+bool Texture_loadImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
 ) {
-  final result = GeneratedBindings.instance
-      ._LightManager_hasComponent(tLightManager.cast(), entity);
+  final result = GeneratedBindings.instance._Texture_loadImage(tEngine.cast(),
+      tTexture.cast(), tImage.cast(), bufferFormat, pixelDataType, level);
   return result == 1;
 }
 
-int LightManager_getType(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+bool Texture_setImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  int level,
+  Pointer<Uint8> data,
+  Dartsize_t size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
 ) {
-  final result = GeneratedBindings.instance
-      ._LightManager_getType(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_isDirectional(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_isDirectional(tLightManager.cast(), entity);
+  final result = GeneratedBindings.instance._Texture_setImage(
+      tEngine.cast(),
+      tTexture.cast(),
+      level,
+      data,
+      size,
+      x_offset,
+      y_offset,
+      z_offset,
+      width,
+      height,
+      depth,
+      bufferFormat,
+      pixelDataType);
   return result == 1;
 }
 
-bool LightManager_isPointLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+int Texture_getWidth(
+  Pointer<TTexture> tTexture,
+  int level,
+) {
+  final result =
+      GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getHeight(
+  Pointer<TTexture> tTexture,
+  int level,
+) {
+  final result =
+      GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getDepth(
+  Pointer<TTexture> tTexture,
+  int level,
+) {
+  final result =
+      GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getUsage(
+  Pointer<TTexture> tTexture,
+  int level,
+) {
+  final result =
+      GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
+  return result;
+}
+
+void Texture_generateMipMaps(
+  Pointer<TTexture> tTexture,
+  Pointer<TEngine> tEngine,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_isPointLight(tLightManager.cast(), entity);
+      ._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
+  return result;
+}
+
+Pointer<TKtx1Bundle> Ktx1Bundle_create(
+  Pointer<Uint8> ktxData,
+  Dartsize_t length,
+) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
+  return Pointer<TKtx1Bundle>(result);
+}
+
+void Ktx1Bundle_getSphericalHarmonics(
+  Pointer<TKtx1Bundle> tBundle,
+  Pointer<Float32> harmonics,
+) {
+  final result = GeneratedBindings.instance
+      ._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
+  return result;
+}
+
+bool Ktx1Bundle_isCubemap(
+  Pointer<TKtx1Bundle> tBundle,
+) {
+  final result =
+      GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
   return result == 1;
 }
 
-bool LightManager_isSpotLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+void Ktx1Bundle_destroy(
+  Pointer<TKtx1Bundle> tBundle,
+) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
+  return result;
+}
+
+Pointer<TTexture> Ktx1Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  DartVoidCallback onTextureUploadComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
+      tEngine.cast(),
+      tBundle.cast(),
+      requestId,
+      onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>);
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> Ktx2Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<Uint8> data,
+  Dartsize_t size,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_isSpotLight(tLightManager.cast(), entity);
-  return result == 1;
+      ._Ktx2Reader_createTexture(tEngine.cast(), data, size);
+  return Pointer<TTexture>(result);
 }
 
-void LightManager_setPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
+Pointer<TLinearImage> Image_createEmpty(
+  int width,
+  int height,
+  int channel,
+) {
+  final result =
+      GeneratedBindings.instance._Image_createEmpty(width, height, channel);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<TLinearImage> Image_decode(
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  Pointer<Char> name,
+  bool alpha,
+) {
+  final result =
+      GeneratedBindings.instance._Image_decode(data, length, name, alpha);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<Float32> Image_getBytes(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result =
+      GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
+  return Pointer<Float32>(result);
+}
+
+void Image_destroy(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+  return result;
+}
+
+int Image_getWidth(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result =
+      GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
+  return result;
+}
+
+int Image_getHeight(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result =
+      GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
+  return result;
+}
+
+int Image_getChannels(
+  Pointer<TLinearImage> tLinearImage,
+) {
+  final result =
+      GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
+  return result;
+}
+
+Pointer<TTexture> RenderTarget_getColorTexture(
+  Pointer<TRenderTarget> tRenderTarget,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
-  return result;
+      ._RenderTarget_getColorTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
 }
 
-double3 LightManager_getPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(
-      double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
+Pointer<TTexture> RenderTarget_getDepthTexture(
+  Pointer<TRenderTarget> tRenderTarget,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
-  return result;
+      ._RenderTarget_getDepthTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
 }
 
-double3 LightManager_getDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
+Pointer<TTextureSampler> TextureSampler_create() {
+  final result = GeneratedBindings.instance._TextureSampler_create();
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
 ) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(
-      double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
+  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
+      minFilter, magFilter, wrapS, wrapT, wrapR);
+  return Pointer<TTextureSampler>(result);
 }
 
-void LightManager_setColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double r,
-  double g,
-  double b,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-      tLightManager.cast(), entity, colorTemperature);
-  return result;
-}
-
-double3 LightManager_getColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
+Pointer<TTextureSampler> TextureSampler_createWithComparison(
+  int compareMode,
+  int compareFunc,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
-  return result;
+      ._TextureSampler_createWithComparison(compareMode, compareFunc);
+  return Pointer<TTextureSampler>(result);
 }
 
-void LightManager_setIntensityCandela(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
-      tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-      tLightManager.cast(), entity, watts, efficiency);
-  return result;
-}
-
-double LightManager_getIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+void TextureSampler_setMinFilter(
+  Pointer<TTextureSampler> sampler,
+  int filter,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_getIntensity(tLightManager.cast(), entity);
+      ._TextureSampler_setMinFilter(sampler.cast(), filter);
   return result;
 }
 
-void LightManager_setFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double falloff,
+void TextureSampler_setMagFilter(
+  Pointer<TTextureSampler> sampler,
+  int filter,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
+      ._TextureSampler_setMagFilter(sampler.cast(), filter);
   return result;
 }
 
-double LightManager_getFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+void TextureSampler_setWrapModeS(
+  Pointer<TTextureSampler> sampler,
+  int mode,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_getFalloff(tLightManager.cast(), entity);
+      ._TextureSampler_setWrapModeS(sampler.cast(), mode);
   return result;
 }
 
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
-      tLightManager.cast(), entity, inner, outer);
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+void TextureSampler_setWrapModeT(
+  Pointer<TTextureSampler> sampler,
+  int mode,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+      ._TextureSampler_setWrapModeT(sampler.cast(), mode);
   return result;
 }
 
-double LightManager_getSpotLightInnerCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+void TextureSampler_setWrapModeR(
+  Pointer<TTextureSampler> sampler,
+  int mode,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+      ._TextureSampler_setWrapModeR(sampler.cast(), mode);
   return result;
 }
 
-void LightManager_setSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double angularRadius,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-      tLightManager.cast(), entity, angularRadius);
-  return result;
-}
-
-double LightManager_getSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+void TextureSampler_setAnisotropy(
+  Pointer<TTextureSampler> sampler,
+  double anisotropy,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+      ._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
   return result;
 }
 
-void LightManager_setSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloSize,
+void TextureSampler_setCompareMode(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+  int func,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+      ._TextureSampler_setCompareMode(sampler.cast(), mode, func);
   return result;
 }
 
-double LightManager_getSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+void TextureSampler_destroy(
+  Pointer<TTextureSampler> sampler,
+) {
+  final result =
+      GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
+  return result;
+}
+
+Pointer<TEngine> Engine_create(
+  int backend,
+  Pointer<Void> platform,
+  Pointer<Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+) {
+  final result = GeneratedBindings.instance._Engine_create(backend, platform,
+      sharedContext, stereoscopicEyeCount, disableHandleUseAfterFreeCheck);
+  return Pointer<TEngine>(result);
+}
+
+int Engine_getSupportedFeatureLevel(
+  Pointer<TEngine> tEngine,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+      ._Engine_getSupportedFeatureLevel(tEngine.cast());
   return result;
 }
 
-void LightManager_setSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloFalloff,
+void Engine_destroy(
+  Pointer<TEngine> tEngine,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
-      tLightManager.cast(), entity, haloFalloff);
+  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
   return result;
 }
 
-double LightManager_getSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+Pointer<TRenderer> Engine_createRenderer(
+  Pointer<TEngine> tEngine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
+  return Pointer<TRenderer>(result);
+}
+
+Pointer<TSwapChain> Engine_createSwapChain(
+  Pointer<TEngine> tEngine,
+  Pointer<Void> window,
+  BigInt flags,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+      ._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+Pointer<TSwapChain> Engine_createHeadlessSwapChain(
+  Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  BigInt flags,
+) {
+  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
+      tEngine.cast(), width, height, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+void Engine_destroySwapChain(
+  Pointer<TEngine> tEngine,
+  Pointer<TSwapChain> tSwapChain,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
   return result;
 }
 
-void LightManager_setShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+void Engine_destroyView(
+  Pointer<TEngine> tEngine,
+  Pointer<TView> tView,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyView(tEngine.cast(), tView.cast());
+  return result;
+}
+
+void Engine_destroyScene(
+  Pointer<TEngine> tEngine,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyScene(tEngine.cast(), tScene.cast());
+  return result;
+}
+
+void Engine_destroyColorGrading(
+  Pointer<TEngine> tEngine,
+  Pointer<TColorGrading> tColorGrading,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
+  return result;
+}
+
+Pointer<TCamera> Engine_createCamera(
+  Pointer<TEngine> tEngine,
+  DartEntityId entityId,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+void Engine_destroyCamera(
+  Pointer<TEngine> tEngine,
+  Pointer<TCamera> tCamera,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
+  return result;
+}
+
+Pointer<TView> Engine_createView(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
+  return Pointer<TView>(result);
+}
+
+Pointer<TCamera> Engine_getCameraComponent(
+  Pointer<TEngine> tEngine,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_getCameraComponent(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+Pointer<TTransformManager> Engine_getTransformManager(
+  Pointer<TEngine> engine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
+  return Pointer<TTransformManager>(result);
+}
+
+Pointer<TRenderableManager> Engine_getRenderableManager(
+  Pointer<TEngine> engine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
+  return Pointer<TRenderableManager>(result);
+}
+
+Pointer<TLightManager> Engine_getLightManager(
+  Pointer<TEngine> engine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getLightManager(engine.cast());
+  return Pointer<TLightManager>(result);
+}
+
+Pointer<TEntityManager> Engine_getEntityManager(
+  Pointer<TEngine> engine,
+) {
+  final result =
+      GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
+  return Pointer<TEntityManager>(result);
+}
+
+void Engine_setAutomaticInstancingEnabled(
+  Pointer<TEngine> tEngine,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+      ._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
   return result;
 }
 
-bool LightManager_isShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
+Dartsize_t Engine_getMaxAutomaticInstances(
+  Pointer<TEngine> tEngine,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_isShadowCaster(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  TShadowOptions options,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-      tLightManager.cast(), entity, optionsPtr.cast());
+      ._Engine_getMaxAutomaticInstances(tEngine.cast());
   return result;
 }
 
-TShadowOptions LightManager_getShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-      TShadowOptions_out.cast(), tLightManager.cast(), entity);
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-      tLightManager.cast(), entity, channel, enable);
-  return result;
-}
-
-bool LightManager_getLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
+void Engine_destroyTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_computeUniformSplits(splitPositions, cascades);
+      ._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
   return result;
 }
 
-void LightManager_computeLogSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
+Pointer<TFence> Engine_createFence(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
+  return Pointer<TFence>(result);
+}
+
+void Engine_destroyFence(
+  Pointer<TEngine> tEngine,
+  Pointer<TFence> tFence,
 ) {
   final result = GeneratedBindings.instance
-      ._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+      ._Engine_destroyFence(tEngine.cast(), tFence.cast());
   return result;
 }
 
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
+void Engine_flushAndWait(
+  Pointer<TEngine> tEngine,
 ) {
-  final result = GeneratedBindings.instance
-      ._LightManager_computePracticalSplits(
-          splitPositions, cascades, near, far, lambda);
+  final result =
+      GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
   return result;
 }
 
-double LightManager_rgbToColorTemperature(
+void Engine_execute(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
+  return result;
+}
+
+Pointer<TMaterial> Engine_buildMaterial(
+  Pointer<TEngine> tEngine,
+  Pointer<Uint8> materialData,
+  Dartsize_t length,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildMaterial(tEngine.cast(), materialData, length);
+  return Pointer<TMaterial>(result);
+}
+
+void Engine_destroyMaterial(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterial> tMaterial,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
+  return result;
+}
+
+void Engine_destroyMaterialInstance(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialInstance> tMaterialInstance,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(
+      tEngine.cast(), tMaterialInstance.cast());
+  return result;
+}
+
+Pointer<TScene> Engine_createScene(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
+  return Pointer<TScene>(result);
+}
+
+Pointer<TSkybox> Engine_buildSkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildSkybox(tEngine.cast(), tTexture.cast());
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TSkybox> Engine_buildColoredSkybox(
+  Pointer<TEngine> tEngine,
   double r,
   double g,
   double b,
+  double a,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildColoredSkybox(tEngine.cast(), r, g, b, a);
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildIndirectLightFromIrradianceTexture(tEngine.cast(),
+          tReflectionsTexture.cast(), tIrradianceTexture.cast(), intensity);
+  return Pointer<TIndirectLight>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<Float32> irradianceHarmonics,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_buildIndirectLightFromIrradianceHarmonics(tEngine.cast(),
+          tReflectionsTexture.cast(), irradianceHarmonics, intensity);
+  return Pointer<TIndirectLight>(result);
+}
+
+void Engine_destroySkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TSkybox> tSkybox,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
+  return result;
+}
+
+void Engine_destroyIndirectLight(
+  Pointer<TEngine> tEngine,
+  Pointer<TIndirectLight> tIndirectLight,
+) {
+  final result = GeneratedBindings.instance
+      ._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
+  return result;
+}
+
+DartEntityId EntityManager_createEntity(
+  Pointer<TEntityManager> tEntityManager,
+) {
+  final result = GeneratedBindings.instance
+      ._EntityManager_createEntity(tEntityManager.cast());
+  return result;
+}
+
+void EntityManager_destroyEntity(
+  Pointer<TEntityManager> tEntityManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance
+      ._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
+  return result;
+}
+
+void Fence_waitAndDestroy(
+  Pointer<TFence> tFence,
 ) {
   final result =
-      GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
+      GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
   return result;
 }
 
-int FilamentAsset_getEntityCount(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getEntityCount(filamentAsset.cast());
-  return result;
-}
-
-void FilamentAsset_getEntities(
-  Pointer<TFilamentAsset> filamentAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getEntities(filamentAsset.cast(), out);
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getWireframe(filamentAsset.cast());
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._FilamentAsset_getSourceAsset(filamentAsset.cast());
-  return Pointer<Void>(result);
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+Pointer<TDebugRegistry> Engine_getDebugRegistry(
   Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
 ) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
-      tEngine.cast(), tMaterialProvider.cast(), tNameComponentManager.cast());
-  return Pointer<TGltfAssetLoader>(result);
+  final result =
+      GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
+  return Pointer<TDebugRegistry>(result);
 }
 
-Pointer<TFilamentAsset> GltfAssetLoader_load(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-  int numInstances,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
-      tEngine.cast(), tAssetLoader.cast(), data, length, numInstances);
-  return Pointer<TFilamentAsset>(result);
-}
-
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
+bool DebugRegistry_hasProperty(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
 ) {
   final result = GeneratedBindings.instance
-      ._GltfAssetLoader_getMaterialInstance(
-          tRenderableManager.cast(), tAsset.cast());
-  return Pointer<TMaterialInstance>(result);
+      ._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
+  return result == 1;
 }
 
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
-  Pointer<TGltfAssetLoader> tAssetLoader,
+bool DebugRegistry_setProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  bool value,
 ) {
   final result = GeneratedBindings.instance
-      ._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
+      ._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
+  return result == 1;
 }
 
-int FilamentAsset_getResourceUriCount(
-  Pointer<TFilamentAsset> tFilamentAsset,
+bool DebugRegistry_setProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  int value,
 ) {
   final result = GeneratedBindings.instance
-      ._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
-  return result;
+      ._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
+  return result == 1;
 }
 
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(
-  Pointer<TFilamentAsset> tFilamentAsset,
+bool DebugRegistry_setProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  double value,
 ) {
   final result = GeneratedBindings.instance
-      ._FilamentAsset_getResourceUris(tFilamentAsset.cast());
-  return Pointer<PointerClass<Char>>(result);
+      ._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Bool> outValue,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Int32> outValue,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Float32> outValue,
+) {
+  final result = GeneratedBindings.instance
+      ._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
 }
 
 TViewport View_getViewport(
@@ -4806,750 +5332,6 @@ Pointer<Char> View_getName(
   return Pointer<Char>(result);
 }
 
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-Pointer<Char> NameComponentManager_getName(
-  Pointer<TNameComponentManager> tNameComponentManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance
-      ._NameComponentManager_getName(tNameComponentManager.cast(), entity);
-  return Pointer<Char>(result);
-}
-
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint32> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_build(builder.cast());
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dart__darwin_size_t SurfaceOrientation_getVertexCount(
-  Pointer<TSurfaceOrientation> orientation,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientation_getVertexCount(orientation.cast());
-  return result;
-}
-
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-      orientation.cast(), out, quatCount, stride);
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-      orientation.cast(), out, quatCount, stride);
-  return result;
-}
-
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-      orientation.cast(), out, quatCount, stride);
-  return result;
-}
-
-void SurfaceOrientation_destroy(
-  Pointer<TSurfaceOrientation> orientation,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientation_destroy(orientation.cast());
-  return result;
-}
-
-void IndirectLight_setRotation(
-  Pointer<TIndirectLight> tIndirectLight,
-  Pointer<Float64> rotation,
-) {
-  final result = GeneratedBindings.instance
-      ._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
-  return result;
-}
-
-Pointer<TTexture> Texture_build(
-  Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import1,
-  int sampler,
-  int format,
-) {
-  final result = GeneratedBindings.instance._Texture_build(engine.cast(), width,
-      height, depth, levels, tUsage, import1, sampler, format);
-  return Pointer<TTexture>(result);
-}
-
-void Texture_setExternalImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<Void> externalImage,
-) {
-  final result = GeneratedBindings.instance._Texture_setExternalImage(
-      tEngine.cast(), tTexture.cast(), externalImage);
-  return result;
-}
-
-Dart__darwin_size_t Texture_getLevels(
-  Pointer<TTexture> tTexture,
-) {
-  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
-  return result;
-}
-
-bool Texture_loadImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-) {
-  final result = GeneratedBindings.instance._Texture_loadImage(tEngine.cast(),
-      tTexture.cast(), tImage.cast(), bufferFormat, pixelDataType, level);
-  return result == 1;
-}
-
-bool Texture_setImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  int level,
-  Pointer<Uint8> data,
-  Dart__darwin_size_t size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-) {
-  final result = GeneratedBindings.instance._Texture_setImage(
-      tEngine.cast(),
-      tTexture.cast(),
-      level,
-      data,
-      size,
-      x_offset,
-      y_offset,
-      z_offset,
-      width,
-      height,
-      depth,
-      bufferFormat,
-      pixelDataType);
-  return result == 1;
-}
-
-int Texture_getWidth(
-  Pointer<TTexture> tTexture,
-  int level,
-) {
-  final result =
-      GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getHeight(
-  Pointer<TTexture> tTexture,
-  int level,
-) {
-  final result =
-      GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getDepth(
-  Pointer<TTexture> tTexture,
-  int level,
-) {
-  final result =
-      GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getUsage(
-  Pointer<TTexture> tTexture,
-  int level,
-) {
-  final result =
-      GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
-  return result;
-}
-
-void Texture_generateMipMaps(
-  Pointer<TTexture> tTexture,
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance
-      ._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
-  return result;
-}
-
-Pointer<TKtx1Bundle> Ktx1Bundle_create(
-  Pointer<Uint8> ktxData,
-  Dart__darwin_size_t length,
-) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
-  return Pointer<TKtx1Bundle>(result);
-}
-
-void Ktx1Bundle_getSphericalHarmonics(
-  Pointer<TKtx1Bundle> tBundle,
-  Pointer<Float32> harmonics,
-) {
-  final result = GeneratedBindings.instance
-      ._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
-  return result;
-}
-
-bool Ktx1Bundle_isCubemap(
-  Pointer<TKtx1Bundle> tBundle,
-) {
-  final result =
-      GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
-  return result == 1;
-}
-
-void Ktx1Bundle_destroy(
-  Pointer<TKtx1Bundle> tBundle,
-) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
-  return result;
-}
-
-Pointer<TTexture> Ktx1Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  DartVoidCallback onTextureUploadComplete,
-) {
-  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
-      tEngine.cast(),
-      tBundle.cast(),
-      requestId,
-      onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>);
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> Ktx2Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<Uint8> data,
-  Dart__darwin_size_t size,
-) {
-  final result = GeneratedBindings.instance
-      ._Ktx2Reader_createTexture(tEngine.cast(), data, size);
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TLinearImage> Image_createEmpty(
-  int width,
-  int height,
-  int channel,
-) {
-  final result =
-      GeneratedBindings.instance._Image_createEmpty(width, height, channel);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<TLinearImage> Image_decode(
-  Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-  Pointer<Char> name,
-  bool alpha,
-) {
-  final result =
-      GeneratedBindings.instance._Image_decode(data, length, name, alpha);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<Float32> Image_getBytes(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result =
-      GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
-  return Pointer<Float32>(result);
-}
-
-void Image_destroy(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
-  return result;
-}
-
-int Image_getWidth(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result =
-      GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
-  return result;
-}
-
-int Image_getHeight(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result =
-      GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
-  return result;
-}
-
-int Image_getChannels(
-  Pointer<TLinearImage> tLinearImage,
-) {
-  final result =
-      GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
-  return result;
-}
-
-Pointer<TTexture> RenderTarget_getColorTexture(
-  Pointer<TRenderTarget> tRenderTarget,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderTarget_getColorTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> RenderTarget_getDepthTexture(
-  Pointer<TRenderTarget> tRenderTarget,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderTarget_getDepthTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_create() {
-  final result = GeneratedBindings.instance._TextureSampler_create();
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
-      minFilter, magFilter, wrapS, wrapT, wrapR);
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithComparison(
-  int compareMode,
-  int compareFunc,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_createWithComparison(compareMode, compareFunc);
-  return Pointer<TTextureSampler>(result);
-}
-
-void TextureSampler_setMinFilter(
-  Pointer<TTextureSampler> sampler,
-  int filter,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setMinFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setMagFilter(
-  Pointer<TTextureSampler> sampler,
-  int filter,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setMagFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setWrapModeS(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setWrapModeS(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeT(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setWrapModeT(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeR(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setWrapModeR(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setAnisotropy(
-  Pointer<TTextureSampler> sampler,
-  double anisotropy,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
-  return result;
-}
-
-void TextureSampler_setCompareMode(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-  int func,
-) {
-  final result = GeneratedBindings.instance
-      ._TextureSampler_setCompareMode(sampler.cast(), mode, func);
-  return result;
-}
-
-void TextureSampler_destroy(
-  Pointer<TTextureSampler> sampler,
-) {
-  final result =
-      GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
-  return result;
-}
-
-Pointer<TRenderManager> RenderManager_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderer> tRenderer,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_create(tEngine.cast(), tRenderer.cast());
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(
-  Pointer<TRenderManager> tRenderer,
-) {
-  final result =
-      GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-      tRenderer.cast(), tAnimationManager.cast());
-  return result;
-}
-
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_removeAnimationManager(
-          tRenderer.cast(), tAnimationManager.cast());
-  return result;
-}
-
-void RenderManager_render(
-  Pointer<TRenderManager> tRenderer,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-      tRenderer.cast(), swapChain.cast(), views.cast(), numViews);
-  return result;
-}
-
-void RenderManager_removeSwapChain(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
-  return result;
-}
-
-void RenderManager_requestRender(
-  Pointer<TRenderManager> tRenderer,
-) {
-  final result =
-      GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_attachToRenderThread(
-  Pointer<TRenderManager> tRenderer,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_attachToRenderThread(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_setPaused(
-  Pointer<TRenderManager> tRenderer,
-  bool paused,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_setPaused(tRenderer.cast(), paused);
-  return result;
-}
-
-void FrameScheduler_start(
-  DartFrameCallback callback,
-  int targetFps,
-) {
-  final result = GeneratedBindings.instance._FrameScheduler_start(
-      callback as Pointer<NativeFunction<FrameCallbackFunction>>, targetFps);
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-void FrameScheduler_setRenderThread(
-  Pointer<Void> renderThread,
-) {
-  final result =
-      GeneratedBindings.instance._FrameScheduler_setRenderThread(renderThread);
-  return result;
-}
-
-void FrameScheduler_setRenderManager(
-  Pointer<TRenderManager> rm,
-) {
-  final result =
-      GeneratedBindings.instance._FrameScheduler_setRenderManager(rm.cast());
-  return result;
-}
-
-void FrameScheduler_setPostRenderCallback(
-  DartPostRenderCallback callback,
-  Pointer<Void> userData,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_setPostRenderCallback(
-          callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
-          userData);
-  return result;
-}
-
-void FrameScheduler_requestRender(
-  BigInt frameTimeNanos,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_requestRender(frameTimeNanos.toJSBigInt);
-  return result;
-}
-
-void FrameScheduler_startNativeRenderLoop(
-  int targetFps,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_startNativeRenderLoop(targetFps);
-  return result;
-}
-
-int FrameScheduler_initDartApi(
-  Pointer<Void> data,
-) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(
-  BigInt port,
-  int targetFps,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-void Gizmo_dummy(
-  int t,
-) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-      tEngine.cast(),
-      assetLoader.cast(),
-      tGltfResourceLoader.cast(),
-      tNameComponentManager.cast(),
-      tView.cast(),
-      tMaterial.cast(),
-      tGizmoType);
-  return Pointer<TGizmo>(result);
-}
-
-void Gizmo_pick(
-  Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  DartGizmoPickCallback callback,
-) {
-  final result = GeneratedBindings.instance._Gizmo_pick(tGizmo.cast(), x, y,
-      callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>);
-  return result;
-}
-
-void Gizmo_highlight(
-  Pointer<TGizmo> tGizmo,
-  int axis,
-) {
-  final result =
-      GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
-  return result;
-}
-
-void Gizmo_unhighlight(
-  Pointer<TGizmo> tGizmo,
-) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
-}
-
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -5635,75 +5417,6 @@ Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   return Pointer<TMaterialInstance>(result);
 }
 
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
-}
-
-void IndexBufferBuilder_indexCount(
-  Pointer<TIndexBufferBuilder> builder,
-  int count,
-) {
-  final result = GeneratedBindings.instance
-      ._IndexBufferBuilder_indexCount(builder.cast(), count);
-  return result;
-}
-
-void IndexBufferBuilder_bufferType(
-  Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-) {
-  final result = GeneratedBindings.instance
-      ._IndexBufferBuilder_bufferType(builder.cast(), indexType);
-  return result;
-}
-
-Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  Pointer<TIndexBufferBuilder> builder,
-  Pointer<TEngine> engine,
-) {
-  final result = GeneratedBindings.instance
-      ._IndexBufferBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(
-  Pointer<TIndexBufferBuilder> builder,
-) {
-  final result =
-      GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dart__darwin_size_t IndexBuffer_getIndexCount(
-  Pointer<TIndexBuffer> buffer,
-) {
-  final result =
-      GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
-  return result;
-}
-
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-      engine.cast(), buffer.cast(), data, sizeInBytes, byteOffset);
-  return result;
-}
-
-void IndexBuffer_destroy(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-) {
-  final result = GeneratedBindings.instance
-      ._IndexBuffer_destroy(engine.cast(), buffer.cast());
-  return result;
-}
-
 Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
   final result = GeneratedBindings.instance._VertexBufferBuilder_create();
   return Pointer<TVertexBufferBuilder>(result);
@@ -5772,7 +5485,7 @@ void VertexBufferBuilder_destroy(
   return result;
 }
 
-Dart__darwin_size_t VertexBuffer_getVertexCount(
+Dartsize_t VertexBuffer_getVertexCount(
   Pointer<TVertexBuffer> buffer,
 ) {
   final result =
@@ -5785,7 +5498,7 @@ void VertexBuffer_setBufferAt(
   Pointer<TVertexBuffer> buffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
 ) {
   final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
@@ -5802,289 +5515,72 @@ void VertexBuffer_destroy(
   return result;
 }
 
-Pointer<TRenderTarget> RenderTarget_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> color,
-  Pointer<TTexture> depth,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
-  return Pointer<TRenderTarget>(result);
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
 }
 
-void RenderTarget_destroy(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderTarget> tRenderTarget,
+void IndexBufferBuilder_indexCount(
+  Pointer<TIndexBufferBuilder> builder,
+  int count,
 ) {
   final result = GeneratedBindings.instance
-      ._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
+      ._IndexBufferBuilder_indexCount(builder.cast(), count);
   return result;
 }
 
-void Scene_addEntity(
-  Pointer<TScene> tScene,
-  DartEntityId entityId,
+void IndexBufferBuilder_bufferType(
+  Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+) {
+  final result = GeneratedBindings.instance
+      ._IndexBufferBuilder_bufferType(builder.cast(), indexType);
+  return result;
+}
+
+Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  Pointer<TIndexBufferBuilder> builder,
+  Pointer<TEngine> engine,
+) {
+  final result = GeneratedBindings.instance
+      ._IndexBufferBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_destroy(
+  Pointer<TIndexBufferBuilder> builder,
 ) {
   final result =
-      GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
+      GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
   return result;
 }
 
-void Scene_removeEntity(
-  Pointer<TScene> tScene,
-  DartEntityId entityId,
+Dartsize_t IndexBuffer_getIndexCount(
+  Pointer<TIndexBuffer> buffer,
 ) {
   final result =
-      GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
+      GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
   return result;
 }
 
-void Scene_setSkybox(
-  Pointer<TScene> tScene,
-  Pointer<TSkybox> skybox,
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
 ) {
-  final result =
-      GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+      engine.cast(), buffer.cast(), data, sizeInBytes, byteOffset);
   return result;
 }
 
-void Scene_setIndirectLight(
-  Pointer<TScene> tScene,
-  Pointer<TIndirectLight> tIndirectLight,
+void IndexBuffer_destroy(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
 ) {
   final result = GeneratedBindings.instance
-      ._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
-  return result;
-}
-
-void Scene_addFilamentAsset(
-  Pointer<TScene> tScene,
-  Pointer<TFilamentAsset> asset,
-) {
-  final result = GeneratedBindings.instance
-      ._Scene_addFilamentAsset(tScene.cast(), asset.cast());
-  return result;
-}
-
-void Camera_setExposure(
-  Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
-  return result;
-}
-
-double Camera_getAperture(
-  Pointer<TCamera> camera,
-) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
-  return result;
-}
-
-double Camera_getSensitivity(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(
-  Pointer<TCamera> camera,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(
-  Pointer<TCamera> camera,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(
-  Pointer<TCamera> camera,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(
-  Pointer<TCamera> camera,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(
-  Pointer<TCamera> camera,
-  Pointer<Float64> out,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
-  return result;
-}
-
-void Camera_setProjectionMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> matrix,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-      camera.cast(), fovInDegrees, aspect, near, far, horizontal);
-  return result;
-}
-
-double Camera_getFocalLength(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
-  return result;
-}
-
-void Camera_lookAt(
-  Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(
-      camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
-  return result;
-}
-
-double Camera_getNear(
-  Pointer<TCamera> camera,
-) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
-  return result;
-}
-
-double Camera_getFov(
-  Pointer<TCamera> camera,
-  bool horizontal,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
-  return result;
-}
-
-double Camera_getFocusDistance(
-  Pointer<TCamera> camera,
-) {
-  final result =
-      GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
-  return result;
-}
-
-void Camera_setFocusDistance(
-  Pointer<TCamera> camera,
-  double focusDistance,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setFocusDistance(camera.cast(), focusDistance);
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance
-      ._Camera_setCustomProjectionWithCulling(
-          camera.cast(), projectionMatrixPtr.cast(), near, far);
-  return result;
-}
-
-void Camera_setModelMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> tModelMatrix,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setModelMatrix(camera.cast(), tModelMatrix);
-  return result;
-}
-
-void Camera_setLensProjection(
-  Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-) {
-  final result = GeneratedBindings.instance
-      ._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
-  return result;
-}
-
-DartEntityId Camera_getEntity(
-  Pointer<TCamera> camera,
-) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-      tCamera.cast(), projection, left, right, bottom, top, near, far);
+      ._IndexBuffer_destroy(engine.cast(), buffer.cast());
   return result;
 }
 
@@ -6239,517 +5735,6 @@ void TransformManager_commitLocalTransformTransaction(
       ._TransformManager_commitLocalTransformTransaction(
           tTransformManager.cast());
   return result;
-}
-
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-      tRenderer.cast(),
-      clearR,
-      clearG,
-      clearB,
-      clearA,
-      clearStencil,
-      clear,
-      discard);
-  return result;
-}
-
-bool Renderer_beginFrame(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TSwapChain> tSwapChain,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-      tRenderer.cast(), tSwapChain.cast(), frameTimeInNanos.toJSBigInt);
-  return result == 1;
-}
-
-void Renderer_endFrame(
-  Pointer<TRenderer> tRenderer,
-) {
-  final result =
-      GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
-  return result;
-}
-
-void Renderer_render(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TView> tView,
-) {
-  final result = GeneratedBindings.instance
-      ._Renderer_render(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_renderStandaloneView(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TView> tView,
-) {
-  final result = GeneratedBindings.instance
-      ._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dart__darwin_size_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-      tRenderer.cast(),
-      width,
-      height,
-      xOffset,
-      yOffset,
-      tRenderTarget.cast(),
-      tPixelBufferFormat,
-      tPixelDataType,
-      out,
-      outLength);
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-      tRenderer.cast(), headRoomRatio, scaleRate, history, interval);
-  return result;
-}
-
-Pointer<TEngine> Engine_create(
-  int backend,
-  Pointer<Void> platform,
-  Pointer<Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-) {
-  final result = GeneratedBindings.instance._Engine_create(backend, platform,
-      sharedContext, stereoscopicEyeCount, disableHandleUseAfterFreeCheck);
-  return Pointer<TEngine>(result);
-}
-
-int Engine_getSupportedFeatureLevel(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_getSupportedFeatureLevel(tEngine.cast());
-  return result;
-}
-
-void Engine_destroy(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
-  return result;
-}
-
-Pointer<TRenderer> Engine_createRenderer(
-  Pointer<TEngine> tEngine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
-  return Pointer<TRenderer>(result);
-}
-
-Pointer<TSwapChain> Engine_createSwapChain(
-  Pointer<TEngine> tEngine,
-  Pointer<Void> window,
-  BigInt flags,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-Pointer<TSwapChain> Engine_createHeadlessSwapChain(
-  Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  BigInt flags,
-) {
-  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
-      tEngine.cast(), width, height, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-void Engine_destroySwapChain(
-  Pointer<TEngine> tEngine,
-  Pointer<TSwapChain> tSwapChain,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
-  return result;
-}
-
-void Engine_destroyView(
-  Pointer<TEngine> tEngine,
-  Pointer<TView> tView,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyView(tEngine.cast(), tView.cast());
-  return result;
-}
-
-void Engine_destroyScene(
-  Pointer<TEngine> tEngine,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyScene(tEngine.cast(), tScene.cast());
-  return result;
-}
-
-void Engine_destroyColorGrading(
-  Pointer<TEngine> tEngine,
-  Pointer<TColorGrading> tColorGrading,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
-  return result;
-}
-
-Pointer<TCamera> Engine_createCamera(
-  Pointer<TEngine> tEngine,
-  DartEntityId entityId,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-void Engine_destroyCamera(
-  Pointer<TEngine> tEngine,
-  Pointer<TCamera> tCamera,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TView> Engine_createView(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
-  return Pointer<TView>(result);
-}
-
-Pointer<TCamera> Engine_getCameraComponent(
-  Pointer<TEngine> tEngine,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_getCameraComponent(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-Pointer<TTransformManager> Engine_getTransformManager(
-  Pointer<TEngine> engine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
-  return Pointer<TTransformManager>(result);
-}
-
-Pointer<TRenderableManager> Engine_getRenderableManager(
-  Pointer<TEngine> engine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
-  return Pointer<TRenderableManager>(result);
-}
-
-Pointer<TLightManager> Engine_getLightManager(
-  Pointer<TEngine> engine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getLightManager(engine.cast());
-  return Pointer<TLightManager>(result);
-}
-
-Pointer<TEntityManager> Engine_getEntityManager(
-  Pointer<TEngine> engine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
-  return Pointer<TEntityManager>(result);
-}
-
-void Engine_setAutomaticInstancingEnabled(
-  Pointer<TEngine> tEngine,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
-  return result;
-}
-
-Dart__darwin_size_t Engine_getMaxAutomaticInstances(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_getMaxAutomaticInstances(tEngine.cast());
-  return result;
-}
-
-void Engine_destroyTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
-  return result;
-}
-
-Pointer<TFence> Engine_createFence(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
-  return Pointer<TFence>(result);
-}
-
-void Engine_destroyFence(
-  Pointer<TEngine> tEngine,
-  Pointer<TFence> tFence,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyFence(tEngine.cast(), tFence.cast());
-  return result;
-}
-
-void Engine_flushAndWait(
-  Pointer<TEngine> tEngine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
-  return result;
-}
-
-void Engine_execute(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
-  return result;
-}
-
-Pointer<TMaterial> Engine_buildMaterial(
-  Pointer<TEngine> tEngine,
-  Pointer<Uint8> materialData,
-  Dart__darwin_size_t length,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_buildMaterial(tEngine.cast(), materialData, length);
-  return Pointer<TMaterial>(result);
-}
-
-void Engine_destroyMaterial(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterial> tMaterial,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
-  return result;
-}
-
-void Engine_destroyMaterialInstance(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialInstance> tMaterialInstance,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(
-      tEngine.cast(), tMaterialInstance.cast());
-  return result;
-}
-
-Pointer<TScene> Engine_createScene(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TSkybox> Engine_buildSkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_buildSkybox(tEngine.cast(), tTexture.cast());
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TSkybox> Engine_buildColoredSkybox(
-  Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_buildColoredSkybox(tEngine.cast(), r, g, b, a);
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_buildIndirectLightFromIrradianceTexture(tEngine.cast(),
-          tReflectionsTexture.cast(), tIrradianceTexture.cast(), intensity);
-  return Pointer<TIndirectLight>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<Float32> irradianceHarmonics,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_buildIndirectLightFromIrradianceHarmonics(tEngine.cast(),
-          tReflectionsTexture.cast(), irradianceHarmonics, intensity);
-  return Pointer<TIndirectLight>(result);
-}
-
-void Engine_destroySkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TSkybox> tSkybox,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
-  return result;
-}
-
-void Engine_destroyIndirectLight(
-  Pointer<TEngine> tEngine,
-  Pointer<TIndirectLight> tIndirectLight,
-) {
-  final result = GeneratedBindings.instance
-      ._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
-  return result;
-}
-
-DartEntityId EntityManager_createEntity(
-  Pointer<TEntityManager> tEntityManager,
-) {
-  final result = GeneratedBindings.instance
-      ._EntityManager_createEntity(tEntityManager.cast());
-  return result;
-}
-
-void EntityManager_destroyEntity(
-  Pointer<TEntityManager> tEntityManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance
-      ._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
-  return result;
-}
-
-void Fence_waitAndDestroy(
-  Pointer<TFence> tFence,
-) {
-  final result =
-      GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
-  return result;
-}
-
-Pointer<TDebugRegistry> Engine_getDebugRegistry(
-  Pointer<TEngine> tEngine,
-) {
-  final result =
-      GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
-  return Pointer<TDebugRegistry>(result);
-}
-
-bool DebugRegistry_hasProperty(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  bool value,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  int value,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  double value,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Bool> outValue,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Int32> outValue,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Float32> outValue,
-) {
-  final result = GeneratedBindings.instance
-      ._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
 }
 
 Pointer<Void> RenderThread_create() {
@@ -6943,7 +5928,7 @@ void Engine_createViewRenderThread(
 void Engine_buildMaterialRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
@@ -7378,7 +6363,7 @@ void Renderer_readPixelsRenderThread(
   int tPixelBufferFormat,
   int tPixelDataType,
   Pointer<Uint8> out,
-  Dart__darwin_size_t outLength,
+  Dartsize_t outLength,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -8243,7 +7228,7 @@ void Image_createEmptyRenderThread(
 
 void Image_decodeRenderThread(
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<Char> name,
   bool alpha,
   Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
@@ -8326,7 +7311,7 @@ void Texture_setImageRenderThread(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -8601,7 +7586,7 @@ void GltfResourceLoader_addResourceDataRenderThread(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -8650,7 +7635,7 @@ void GltfAssetLoader_loadRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int numInstances,
   Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
 ) {
@@ -8782,7 +7767,7 @@ void VertexBuffer_setBufferAtRenderThread(
   Pointer<TVertexBuffer> tBuffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -8829,7 +7814,7 @@ void IndexBuffer_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TIndexBuffer> tBuffer,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -8949,8 +7934,8 @@ void RenderableManager_setBonesFromMat4RenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -8970,8 +7955,8 @@ void RenderableManager_setBonesFromBoneRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -8984,6 +7969,626 @@ void RenderableManager_setBonesFromBoneRenderThread(
           offset,
           requestId,
           onComplete as Pointer<NativeFunction<VoidCallbackFunction>>);
+  return result;
+}
+
+void IndirectLight_setRotation(
+  Pointer<TIndirectLight> tIndirectLight,
+  Pointer<Float64> rotation,
+) {
+  final result = GeneratedBindings.instance
+      ._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+  return result;
+}
+
+int LightManager_createLight(
+  Pointer<TEngine> tEngine,
+  Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
+      tEngine.cast(), tLightManager.cast(), tLightTtype);
+  return result;
+}
+
+void LightManager_destroyLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_destroyLight(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_hasComponent(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_hasComponent(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+int LightManager_getType(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getType(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_isDirectional(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_isDirectional(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isPointLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_isPointLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_isSpotLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(
+      double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(
+      double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double r,
+  double g,
+  double b,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+      tLightManager.cast(), entity, colorTemperature);
+  return result;
+}
+
+double3 LightManager_getColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityCandela(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
+      tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+      tLightManager.cast(), entity, watts, efficiency);
+  return result;
+}
+
+double LightManager_getIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getIntensity(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double falloff,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
+  return result;
+}
+
+double LightManager_getFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
+      tLightManager.cast(), entity, inner, outer);
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double angularRadius,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+      tLightManager.cast(), entity, angularRadius);
+  return result;
+}
+
+double LightManager_getSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloSize,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+  return result;
+}
+
+double LightManager_getSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloFalloff,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
+      tLightManager.cast(), entity, haloFalloff);
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+  return result;
+}
+
+bool LightManager_isShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_isShadowCaster(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  TShadowOptions options,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+      tLightManager.cast(), entity, optionsPtr.cast());
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+      TShadowOptions_out.cast(), tLightManager.cast(), entity);
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+      tLightManager.cast(), entity, channel, enable);
+  return result;
+}
+
+bool LightManager_getLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_computeUniformSplits(splitPositions, cascades);
+  return result;
+}
+
+void LightManager_computeLogSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_computePracticalSplits(
+          splitPositions, cascades, near, far, lambda);
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(
+  double r,
+  double g,
+  double b,
+) {
+  final result =
+      GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
+  return result;
+}
+
+void Camera_setExposure(
+  Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
+  return result;
+}
+
+double Camera_getAperture(
+  Pointer<TCamera> camera,
+) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
+  return result;
+}
+
+double Camera_getSensitivity(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(
+  Pointer<TCamera> camera,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(
+  Pointer<TCamera> camera,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(
+  Pointer<TCamera> camera,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(
+  Pointer<TCamera> camera,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance
+      ._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(
+  Pointer<TCamera> camera,
+  Pointer<Float64> out,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
+  return result;
+}
+
+void Camera_setProjectionMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> matrix,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+      camera.cast(), fovInDegrees, aspect, near, far, horizontal);
+  return result;
+}
+
+double Camera_getFocalLength(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
+  return result;
+}
+
+void Camera_lookAt(
+  Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(
+      camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
+  return result;
+}
+
+double Camera_getNear(
+  Pointer<TCamera> camera,
+) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
+  return result;
+}
+
+double Camera_getFov(
+  Pointer<TCamera> camera,
+  bool horizontal,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
+  return result;
+}
+
+double Camera_getFocusDistance(
+  Pointer<TCamera> camera,
+) {
+  final result =
+      GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
+  return result;
+}
+
+void Camera_setFocusDistance(
+  Pointer<TCamera> camera,
+  double focusDistance,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setFocusDistance(camera.cast(), focusDistance);
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance
+      ._Camera_setCustomProjectionWithCulling(
+          camera.cast(), projectionMatrixPtr.cast(), near, far);
+  return result;
+}
+
+void Camera_setModelMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> tModelMatrix,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setModelMatrix(camera.cast(), tModelMatrix);
+  return result;
+}
+
+void Camera_setLensProjection(
+  Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+) {
+  final result = GeneratedBindings.instance
+      ._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
+  return result;
+}
+
+DartEntityId Camera_getEntity(
+  Pointer<TCamera> camera,
+) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+      tCamera.cast(), projection, left, right, bottom, top, near, far);
   return result;
 }
 
@@ -9033,7 +8638,7 @@ void GltfResourceLoader_addResourceData(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
 ) {
   final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
       tGltfResourceLoader.cast(), uri, data, length);
@@ -9058,33 +8663,6 @@ void Skybox_setColor(
 ) {
   final result =
       GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
-  return result;
-}
-
-void dummy(
-  TGltfMeshData dummy,
-) {
-  final dummyPtr = dummy.address;
-  final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-  Pointer<Char> meshName,
-  Pointer<TGltfMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance
-      ._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
-  return result;
-}
-
-void GltfParser_freeMeshData(
-  Pointer<TGltfMeshData> meshData,
-) {
-  final result =
-      GeneratedBindings.instance._GltfParser_freeMeshData(meshData.cast());
   return result;
 }
 
@@ -9123,7 +8701,7 @@ bool RenderableManager_isRenderable(
   return result == 1;
 }
 
-Dart__darwin_size_t RenderableManager_getComponentCount(
+Dartsize_t RenderableManager_getComponentCount(
   Pointer<TRenderableManager> tRenderableManager,
 ) {
   final result = GeneratedBindings.instance
@@ -9165,7 +8743,7 @@ void RenderableManager_clearMaterialInstanceAt(
   return result;
 }
 
-Dart__darwin_size_t RenderableManager_getPrimitiveCount(
+Dartsize_t RenderableManager_getPrimitiveCount(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
 ) {
@@ -9390,7 +8968,7 @@ void RenderableManager_setScreenSpaceContactShadows(
 void RenderableManager_setBlendOrderAt(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   int order,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
@@ -9401,7 +8979,7 @@ void RenderableManager_setBlendOrderAt(
 void RenderableManager_setGlobalBlendOrderEnabledAt(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
@@ -9414,15 +8992,15 @@ void RenderableManager_setMorphWeights(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> weights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t offset,
+  Dartsize_t count,
+  Dartsize_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
       tRenderableManager.cast(), entityId, weights, count, offset);
   return result;
 }
 
-Dart__darwin_size_t RenderableManager_getMorphTargetCount(
+Dartsize_t RenderableManager_getMorphTargetCount(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
 ) {
@@ -9436,8 +9014,8 @@ void RenderableManager_setBonesFromMat4(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
       tRenderableManager.cast(), entityId, transforms, boneCount, offset);
@@ -9448,8 +9026,8 @@ void RenderableManager_setBonesFromBone(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
       tRenderableManager.cast(), entityId, bones, boneCount, offset);
@@ -9457,7 +9035,7 @@ void RenderableManager_setBonesFromBone(
 }
 
 Pointer<TRenderableBuilder> RenderableBuilder_create(
-  Dart__darwin_size_t primitiveCount,
+  Dartsize_t primitiveCount,
 ) {
   final result =
       GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
@@ -9484,7 +9062,7 @@ void RenderableBuilder_boundingBox(
 
 void RenderableBuilder_material(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   Pointer<TMaterialInstance> materialInstance,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_material(
@@ -9494,12 +9072,12 @@ void RenderableBuilder_material(
 
 void RenderableBuilder_geometry(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   int type,
   Pointer<TVertexBuffer> vertices,
   Pointer<TIndexBuffer> indices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
+  Dartsize_t offset,
+  Dartsize_t count,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_geometry(
       builder.cast(),
@@ -9597,7 +9175,7 @@ void RenderableBuilder_screenSpaceContactShadows(
 
 void RenderableBuilder_blendOrder(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   int order,
 ) {
   final result = GeneratedBindings.instance
@@ -9607,7 +9185,7 @@ void RenderableBuilder_blendOrder(
 
 void RenderableBuilder_globalBlendOrderEnabled(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
@@ -9618,7 +9196,7 @@ void RenderableBuilder_globalBlendOrderEnabled(
 
 void RenderableBuilder_instances(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t instanceCount,
+  Dartsize_t instanceCount,
 ) {
   final result = GeneratedBindings.instance
       ._RenderableBuilder_instances(builder.cast(), instanceCount);
@@ -9627,7 +9205,7 @@ void RenderableBuilder_instances(
 
 void RenderableBuilder_skinningFromMat4(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t boneCount,
+  Dartsize_t boneCount,
   Pointer<Float32> transforms,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(
@@ -9637,7 +9215,7 @@ void RenderableBuilder_skinningFromMat4(
 
 void RenderableBuilder_skinningFromBone(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t boneCount,
+  Dartsize_t boneCount,
   Pointer<Float32> bones,
 ) {
   final result = GeneratedBindings.instance
@@ -9656,10 +9234,10 @@ void RenderableBuilder_enableSkinningBuffers(
 
 void RenderableBuilder_boneIndicesAndWeights(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   Pointer<Float32> indicesAndWeights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t bonesPerVertex,
+  Dartsize_t count,
+  Dartsize_t bonesPerVertex,
 ) {
   final result = GeneratedBindings.instance
       ._RenderableBuilder_boneIndicesAndWeights(builder.cast(), primitiveIndex,
@@ -9677,240 +9255,629 @@ int RenderableBuilder_build(
   return result;
 }
 
-Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tVertexBuffer,
-  Pointer<TIndexBuffer> tIndexBuffer,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
+void Scene_addEntity(
+  Pointer<TScene> tScene,
+  DartEntityId entityId,
 ) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
-      tEngine.cast(),
-      tVertexBuffer.cast(),
-      tIndexBuffer.cast(),
-      materialInstances.cast(),
-      materialInstanceCount,
-      tPrimitiveType,
-      boundingBoxPtr.cast());
-  return Pointer<TSceneAsset>(result);
+  final result =
+      GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
+  return result;
 }
 
-Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
+void Scene_removeEntity(
+  Pointer<TScene> tScene,
+  DartEntityId entityId,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
-      tEngine.cast(),
-      tAssetLoader.cast(),
-      tNameComponentManager.cast(),
-      tFilamentAsset.cast(),
-      rebuildVertices);
-  return Pointer<TSceneAsset>(result);
+  final result =
+      GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
+  return result;
 }
 
-Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  Pointer<TSceneAsset> tSceneAsset,
+void Scene_setSkybox(
+  Pointer<TScene> tScene,
+  Pointer<TSkybox> skybox,
+) {
+  final result =
+      GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
+  return result;
+}
+
+void Scene_setIndirectLight(
+  Pointer<TScene> tScene,
+  Pointer<TIndirectLight> tIndirectLight,
 ) {
   final result = GeneratedBindings.instance
-      ._SceneAsset_getFilamentAsset(tSceneAsset.cast());
+      ._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Scene_addFilamentAsset(
+  Pointer<TScene> tScene,
+  Pointer<TFilamentAsset> asset,
+) {
+  final result = GeneratedBindings.instance
+      ._Scene_addFilamentAsset(tScene.cast(), asset.cast());
+  return result;
+}
+
+Pointer<TRenderTarget> RenderTarget_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> color,
+  Pointer<TTexture> depth,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
+  return Pointer<TRenderTarget>(result);
+}
+
+void RenderTarget_destroy(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderTarget> tRenderTarget,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
+  return result;
+}
+
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint32> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_build(builder.cast());
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dartsize_t SurfaceOrientation_getVertexCount(
+  Pointer<TSurfaceOrientation> orientation,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientation_getVertexCount(orientation.cast());
+  return result;
+}
+
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+      orientation.cast(), out, quatCount, stride);
+  return result;
+}
+
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+      orientation.cast(), out, quatCount, stride);
+  return result;
+}
+
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+      orientation.cast(), out, quatCount, stride);
+  return result;
+}
+
+void SurfaceOrientation_destroy(
+  Pointer<TSurfaceOrientation> orientation,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientation_destroy(orientation.cast());
+  return result;
+}
+
+void dummy(
+  TGltfMeshData dummy,
+) {
+  final dummyPtr = dummy.address;
+  final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
+  return result;
+}
+
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  Pointer<Char> meshName,
+  Pointer<TGltfMeshData> outMeshData,
+) {
+  final result = GeneratedBindings.instance
+      ._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
+  return result;
+}
+
+void GltfParser_freeMeshData(
+  Pointer<TGltfMeshData> meshData,
+) {
+  final result =
+      GeneratedBindings.instance._GltfParser_freeMeshData(meshData.cast());
+  return result;
+}
+
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+      tRenderer.cast(),
+      clearR,
+      clearG,
+      clearB,
+      clearA,
+      clearStencil,
+      clear,
+      discard);
+  return result;
+}
+
+bool Renderer_beginFrame(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TSwapChain> tSwapChain,
+  BigInt frameTimeInNanos,
+) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+      tRenderer.cast(), tSwapChain.cast(), frameTimeInNanos.toJSBigInt);
+  return result == 1;
+}
+
+void Renderer_endFrame(
+  Pointer<TRenderer> tRenderer,
+) {
+  final result =
+      GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+  return result;
+}
+
+void Renderer_render(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TView> tView,
+) {
+  final result = GeneratedBindings.instance
+      ._Renderer_render(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderStandaloneView(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TView> tView,
+) {
+  final result = GeneratedBindings.instance
+      ._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dartsize_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+      tRenderer.cast(),
+      width,
+      height,
+      xOffset,
+      yOffset,
+      tRenderTarget.cast(),
+      tPixelBufferFormat,
+      tPixelDataType,
+      out,
+      outLength);
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+      tRenderer.cast(), headRoomRatio, scaleRate, history, interval);
+  return result;
+}
+
+Pointer<TRenderManager> RenderManager_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderer> tRenderer,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_create(tEngine.cast(), tRenderer.cast());
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(
+  Pointer<TRenderManager> tRenderer,
+) {
+  final result =
+      GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+      tRenderer.cast(), tAnimationManager.cast());
+  return result;
+}
+
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_removeAnimationManager(
+          tRenderer.cast(), tAnimationManager.cast());
+  return result;
+}
+
+void RenderManager_render(
+  Pointer<TRenderManager> tRenderer,
+  BigInt frameTimeInNanos,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+      tRenderer.cast(), swapChain.cast(), views.cast(), numViews);
+  return result;
+}
+
+void RenderManager_removeSwapChain(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_requestRender(
+  Pointer<TRenderManager> tRenderer,
+) {
+  final result =
+      GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_attachToRenderThread(
+  Pointer<TRenderManager> tRenderer,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_setPaused(
+  Pointer<TRenderManager> tRenderer,
+  bool paused,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_setPaused(tRenderer.cast(), paused);
+  return result;
+}
+
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+Pointer<Char> NameComponentManager_getName(
+  Pointer<TNameComponentManager> tNameComponentManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._NameComponentManager_getName(tNameComponentManager.cast(), entity);
+  return Pointer<Char>(result);
+}
+
+void Gizmo_dummy(
+  int t,
+) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+      tEngine.cast(),
+      assetLoader.cast(),
+      tGltfResourceLoader.cast(),
+      tNameComponentManager.cast(),
+      tView.cast(),
+      tMaterial.cast(),
+      tGizmoType);
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(
+  Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  DartGizmoPickCallback callback,
+) {
+  final result = GeneratedBindings.instance._Gizmo_pick(tGizmo.cast(), x, y,
+      callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>);
+  return result;
+}
+
+void Gizmo_highlight(
+  Pointer<TGizmo> tGizmo,
+  int axis,
+) {
+  final result =
+      GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
+  return result;
+}
+
+void Gizmo_unhighlight(
+  Pointer<TGizmo> tGizmo,
+) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
+}
+
+void FrameScheduler_start(
+  DartFrameCallback callback,
+  int targetFps,
+) {
+  final result = GeneratedBindings.instance._FrameScheduler_start(
+      callback as Pointer<NativeFunction<FrameCallbackFunction>>, targetFps);
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+void FrameScheduler_setRenderThread(
+  Pointer<Void> renderThread,
+) {
+  final result =
+      GeneratedBindings.instance._FrameScheduler_setRenderThread(renderThread);
+  return result;
+}
+
+void FrameScheduler_setRenderManager(
+  Pointer<TRenderManager> rm,
+) {
+  final result =
+      GeneratedBindings.instance._FrameScheduler_setRenderManager(rm.cast());
+  return result;
+}
+
+void FrameScheduler_setPostRenderCallback(
+  DartPostRenderCallback callback,
+  Pointer<Void> userData,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_setPostRenderCallback(
+          callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
+          userData);
+  return result;
+}
+
+void FrameScheduler_requestRender(
+  BigInt frameTimeNanos,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_requestRender(frameTimeNanos.toJSBigInt);
+  return result;
+}
+
+void FrameScheduler_startNativeRenderLoop(
+  int targetFps,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_startNativeRenderLoop(targetFps);
+  return result;
+}
+
+int FrameScheduler_initDartApi(
+  Pointer<Void> data,
+) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(
+  BigInt port,
+  int targetFps,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+      tEngine.cast(), tMaterialProvider.cast(), tNameComponentManager.cast());
+  return Pointer<TGltfAssetLoader>(result);
+}
+
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  int numInstances,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+      tEngine.cast(), tAssetLoader.cast(), data, length, numInstances);
   return Pointer<TFilamentAsset>(result);
 }
 
-int SceneAsset_getType(
-  Pointer<TSceneAsset> tSceneAsset,
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
 ) {
-  final result =
-      GeneratedBindings.instance._SceneAsset_getType(tSceneAsset.cast());
+  final result = GeneratedBindings.instance
+      ._GltfAssetLoader_getMaterialInstance(
+          tRenderableManager.cast(), tAsset.cast());
+  return Pointer<TMaterialInstance>(result);
+}
+
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
+  Pointer<TGltfAssetLoader> tAssetLoader,
+) {
+  final result = GeneratedBindings.instance
+      ._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
+}
+
+int FilamentAsset_getResourceUriCount(
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
   return result;
 }
 
-void SceneAsset_destroy(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result =
-      GeneratedBindings.instance._SceneAsset_destroy(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_addToScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(
+  Pointer<TFilamentAsset> tFilamentAsset,
 ) {
   final result = GeneratedBindings.instance
-      ._SceneAsset_addToScene(tSceneAsset.cast(), tScene.cast());
-  return result;
-}
-
-void SceneAsset_removeFromScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_removeFromScene(tSceneAsset.cast(), tScene.cast());
-  return result;
-}
-
-DartEntityId SceneAsset_getEntity(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result =
-      GeneratedBindings.instance._SceneAsset_getEntity(tSceneAsset.cast());
-  return result;
-}
-
-int SceneAsset_getChildEntityCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getChildEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_getChildEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getChildEntities(tSceneAsset.cast(), out);
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getCameraEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getCameraEntities(tSceneAsset.cast());
-  return Pointer<Int32>(result);
-}
-
-Dart__darwin_size_t SceneAsset_getCameraEntityCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getLightEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getLightEntities(tSceneAsset.cast());
-  return Pointer<Int32>(result);
-}
-
-Dart__darwin_size_t SceneAsset_getLightEntityCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getLightEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_getInstance(
-  Pointer<TSceneAsset> tSceneAsset,
-  int index,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getInstance(tSceneAsset.cast(), index);
-  return Pointer<TSceneAsset>(result);
-}
-
-Dart__darwin_size_t SceneAsset_getInstanceCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getInstanceCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_createInstance(
-  Pointer<TSceneAsset> asset,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createInstance(
-      asset.cast(), materialInstances.cast(), materialInstanceCount);
-  return Pointer<TSceneAsset>(result);
-}
-
-Aabb3 SceneAsset_getBoundingBox(
-  Pointer<TSceneAsset> asset,
-) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getBoundingBox(Aabb3_out.cast(), asset.cast());
-  return Aabb3_out.toDart();
-}
-
-Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getVertexBuffer(tSceneAsset.cast(), primitiveIndex);
-  return Pointer<TVertexBuffer>(result);
-}
-
-Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getIndexBuffer(tSceneAsset.cast(), primitiveIndex);
-  return Pointer<TIndexBuffer>(result);
-}
-
-void SceneAsset_releaseSourceData(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_releaseSourceData(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_setFlatShading(
-  Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_setFlatShading(tSceneAsset.cast(), flatShading);
-  return result;
-}
-
-void SceneAsset_getBones(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dart__darwin_size_t skinIndex,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
-  return result;
-}
-
-Dart__darwin_size_t SceneAsset_getBoneCount(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dart__darwin_size_t skinIndex,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
-  return result;
-}
-
-Pointer<Char> SceneAsset_getBoneName(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dart__darwin_size_t skinIndex,
-  Dart__darwin_size_t boneIndex,
-) {
-  final result = GeneratedBindings.instance
-      ._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
-  return Pointer<Char>(result);
+      ._FilamentAsset_getResourceUris(tFilamentAsset.cast());
+  return Pointer<PointerClass<Char>>(result);
 }
 
 Pointer<TAnimationManager> AnimationManager_create(
@@ -10208,6 +10175,39 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
+int FilamentAsset_getEntityCount(
+  Pointer<TFilamentAsset> filamentAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getEntityCount(filamentAsset.cast());
+  return result;
+}
+
+void FilamentAsset_getEntities(
+  Pointer<TFilamentAsset> filamentAsset,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getEntities(filamentAsset.cast(), out);
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(
+  Pointer<TFilamentAsset> filamentAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getWireframe(filamentAsset.cast());
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(
+  Pointer<TFilamentAsset> filamentAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._FilamentAsset_getSourceAsset(filamentAsset.cast());
+  return Pointer<Void>(result);
+}
+
 void MovementIntentExecutor_destroy(
   Pointer<TMovementIntentExecutor> executor,
 ) {
@@ -10373,6 +10373,69 @@ void TransformPipeline_setInvertMouseY(
   return result;
 }
 
+extension TSceneAssetExt on Pointer<TSceneAsset> {
+  TSceneAsset toDart() {
+    return TSceneAsset(this);
+  }
+}
+
+final class TSceneAsset extends Struct {
+  Pointer<TSceneAsset> get address => super.address.cast();
+  TSceneAsset(super.address);
+
+  static Pointer<TSceneAsset> stackAlloc() {
+    return Pointer<TSceneAsset>(
+        NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
+  }
+}
+
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
+  }
+}
+
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
+
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  }
+}
+
+extension TVertexBufferExt on Pointer<TVertexBuffer> {
+  TVertexBuffer toDart() {
+    return TVertexBuffer(this);
+  }
+}
+
+final class TVertexBuffer extends Struct {
+  Pointer<TVertexBuffer> get address => super.address.cast();
+  TVertexBuffer(super.address);
+
+  static Pointer<TVertexBuffer> stackAlloc() {
+    return Pointer<TVertexBuffer>(
+        NativeLibrary.instance.stackAlloc<TVertexBuffer>(0));
+  }
+}
+
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
+  }
+}
+
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
+
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(
+        NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
+  }
+}
+
 extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
   TMaterialInstance toDart() {
     return TMaterialInstance(this);
@@ -10388,6 +10451,182 @@ final class TMaterialInstance extends Struct {
         NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
   }
 }
+
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
+}
+
+extension Aabb3Ext on Pointer<Aabb3> {
+  Aabb3 toDart() {
+    return Aabb3(this);
+  }
+}
+
+final class Aabb3 extends Struct {
+  Pointer<Aabb3> get address => super.address.cast();
+  double get centerX {
+    final addr = Pointer<Aabb3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerX(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 0), val.toJS, 'float');
+  }
+
+  double get centerY {
+    final addr = Pointer<Aabb3>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerY(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 4), val.toJS, 'float');
+  }
+
+  double get centerZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerZ(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 8), val.toJS, 'float');
+  }
+
+  double get halfExtentX {
+    final addr = Pointer<Aabb3>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentX(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 12), val.toJS, 'float');
+  }
+
+  double get halfExtentY {
+    final addr = Pointer<Aabb3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentY(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 16), val.toJS, 'float');
+  }
+
+  double get halfExtentZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 20);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentZ(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<Aabb3>(this.address.addr + 20), val.toJS, 'float');
+  }
+
+  Aabb3(super.address);
+
+  static Pointer<Aabb3> stackAlloc() {
+    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
+  }
+}
+
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
+  }
+}
+
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
+
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(
+        NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
+  }
+}
+
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(
+        NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
+  }
+}
+
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
+  }
+}
+
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
+
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(
+        NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
+  }
+}
+
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
+  }
+}
+
+typedef EntityId = int;
+typedef DartEntityId = int;
+typedef size_t = int;
+typedef Dartsize_t = int;
 
 extension TMaterialExt on Pointer<TMaterial> {
   TMaterial toDart() {
@@ -10409,21 +10648,6 @@ sealed class TFeatureLevel {
   static const FEATURE_LEVEL_1 = 1;
   static const FEATURE_LEVEL_2 = 2;
   static const FEATURE_LEVEL_3 = 3;
-}
-
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
-  }
-}
-
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
-
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
-  }
 }
 
 sealed class TCullingMode {
@@ -10532,6 +10756,438 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(
+        NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  }
+}
+
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
+  }
+}
+
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
+
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(
+        NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
+  }
+}
+
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
+
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
+  }
+}
+
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
+
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(
+        NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
+  }
+}
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
+  }
+}
+
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
+
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  }
+}
+
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
+  }
+}
+
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
+
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(
+        NativeLibrary.instance.stackAlloc<TSwapChain>(0));
+  }
+}
+
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(
+        NativeLibrary.instance.stackAlloc<TColorGrading>(0));
+  }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
+  }
+}
+
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
+
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(
+        NativeLibrary.instance.stackAlloc<TTransformManager>(0));
+  }
+}
+
+extension TRenderableManagerExt on Pointer<TRenderableManager> {
+  TRenderableManager toDart() {
+    return TRenderableManager(this);
+  }
+}
+
+final class TRenderableManager extends Struct {
+  Pointer<TRenderableManager> get address => super.address.cast();
+  TRenderableManager(super.address);
+
+  static Pointer<TRenderableManager> stackAlloc() {
+    return Pointer<TRenderableManager>(
+        NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
+  }
+}
+
 extension TLightManagerExt on Pointer<TLightManager> {
   TLightManager toDart() {
     return TLightManager(this);
@@ -10548,415 +11204,81 @@ final class TLightManager extends Struct {
   }
 }
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-typedef EntityId = int;
-typedef DartEntityId = int;
-
-extension double3Ext on Pointer<double3> {
-  double3 toDart() {
-    return double3(this);
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
   }
 }
 
-final class double3 extends Struct {
-  Pointer<double3> get address => super.address.cast();
-  double get x {
-    final addr = Pointer<double3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
 
-  set x(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
-  }
-
-  double get y {
-    final addr = Pointer<double3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set y(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
-  }
-
-  double get z {
-    final addr = Pointer<double3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set z(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
-  }
-
-  double3(super.address);
-
-  static Pointer<double3> stackAlloc() {
-    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(
+        NativeLibrary.instance.stackAlloc<TEntityManager>(0));
   }
 }
 
-extension TShadowOptionsExt on Pointer<TShadowOptions> {
-  TShadowOptions toDart() {
-    return TShadowOptions(this);
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
   }
 }
 
-final class TShadowOptions extends Struct {
-  Pointer<TShadowOptions> get address => super.address.cast();
-  int get mapSize {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
 
-  set mapSize(int val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
-  }
-
-  int get shadowCascades {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set shadowCascades(int val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
-  }
-
-  Array<Float32> get cascadeSplitPositions {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float32>(
-        (numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
-  }
-
-  set cascadeSplitPositions(Array<Float32> val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 5),
-        val.internal.addr.addr.toJS,
-        '*');
-  }
-
-  double get constantBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constantBias(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
-  }
-
-  double get normalBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set normalBias(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
-  }
-
-  double get shadowFar {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFar(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
-  }
-
-  double get shadowNearHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowNearHint(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
-  }
-
-  double get shadowFarHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFarHint(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
-  }
-
-  bool get stable {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set stable(bool val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 37),
-        (val ? 1 : 0).toJS,
-        'i8');
-  }
-
-  bool get lispsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set lispsm(bool val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 38),
-        (val ? 1 : 0).toJS,
-        'i8');
-  }
-
-  double get polygonOffsetConstant {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetConstant(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
-  }
-
-  double get polygonOffsetSlope {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetSlope(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
-  }
-
-  bool get screenSpaceContactShadows {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set screenSpaceContactShadows(bool val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 47),
-        (val ? 1 : 0).toJS,
-        'i8');
-  }
-
-  int get stepCount {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set stepCount(int val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
-  }
-
-  double get maxShadowDistance {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxShadowDistance(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
-  }
-
-  bool get vsmElvsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set vsmElvsm(bool val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 53),
-        (val ? 1 : 0).toJS,
-        'i8');
-  }
-
-  double get vsmBlurWidth {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set vsmBlurWidth(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
-  }
-
-  double get shadowBulbRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowBulbRadius(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
-  }
-
-  double get transformX {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformX(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
-  }
-
-  double get transformY {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformY(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
-  }
-
-  double get transformZ {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformZ(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
-  }
-
-  double get transformW {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformW(double val) {
-    NativeLibrary.instance.setValue(
-        Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
-  }
-
-  TShadowOptions(super.address);
-
-  static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(
-        NativeLibrary.instance.stackAlloc<TShadowOptions>(78));
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
   }
 }
 
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(
-        NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
   }
 }
 
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
   }
 }
 
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
 
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(
-        NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(
+        NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
   }
 }
 
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
   }
 }
 
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
 
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(
-        NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
-  }
-}
-
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
-  }
-}
-
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
-
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(
-        NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
-  }
-}
-
-typedef size_t = __darwin_size_t;
-typedef __darwin_size_t = int;
-typedef Dart__darwin_size_t = int;
-
-extension TRenderableManagerExt on Pointer<TRenderableManager> {
-  TRenderableManager toDart() {
-    return TRenderableManager(this);
-  }
-}
-
-final class TRenderableManager extends Struct {
-  Pointer<TRenderableManager> get address => super.address.cast();
-  TRenderableManager(super.address);
-
-  static Pointer<TRenderableManager> stackAlloc() {
-    return Pointer<TRenderableManager>(
-        NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(
+        NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
   }
 }
 
@@ -11019,21 +11341,6 @@ final class TViewport extends Struct {
   }
 }
 
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
-}
-
 extension TToneMapperExt on Pointer<TToneMapper> {
   TToneMapper toDart() {
     return TToneMapper(this);
@@ -11047,22 +11354,6 @@ final class TToneMapper extends Struct {
   static Pointer<TToneMapper> stackAlloc() {
     return Pointer<TToneMapper>(
         NativeLibrary.instance.stackAlloc<TToneMapper>(0));
-  }
-}
-
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
-}
-
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(
-        NativeLibrary.instance.stackAlloc<TColorGrading>(0));
   }
 }
 
@@ -11097,22 +11388,6 @@ sealed class TLutFormat {
 sealed class TBlendMode {
   static const OPAQUE = 0;
   static const TRANSLUCENT = 1;
-}
-
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
-  }
-}
-
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
-
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(
-        NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
-  }
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -11240,36 +11515,6 @@ final class TVsmShadowOptions extends Struct {
   static Pointer<TVsmShadowOptions> stackAlloc() {
     return Pointer<TVsmShadowOptions>(
         NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
-
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
-
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
   }
 }
 
@@ -11820,510 +12065,19 @@ typedef DartPickCallbackFunction = void Function(
     double fragY,
     double fragZ);
 
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
   }
 }
 
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
-
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(
-        NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
-  }
-}
-
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
-  }
-}
-
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
-
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(
-        NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
-  }
-}
-
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
-  }
-}
-
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
-
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(
-        NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
-  }
-}
-
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
-  }
-}
-
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
-
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(
-        NativeLibrary.instance.stackAlloc<TLinearImage>(0));
-  }
-}
-
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
-  }
-}
-
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
-
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(
-        NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
-  }
-}
-
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
-  }
-}
-
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
-
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(
-        NativeLibrary.instance.stackAlloc<TRenderManager>(0));
-  }
-}
-
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
-  }
-}
-
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
-
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
-  }
-}
-
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
-  }
-}
-
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
-
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(
-        NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
-  }
-}
-
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
-  }
-}
-
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
-
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(
-        NativeLibrary.instance.stackAlloc<TSwapChain>(0));
-  }
-}
-
-typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
-typedef PostRenderCallback
-    = Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef DartPostRenderCallback
-    = Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
-  }
-}
-
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
-
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
-  }
-}
-
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
-  }
-}
-
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
-
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(
-        NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
-  }
-}
-
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback
-    = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction = void Function(
-    int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction = void Function(
-    int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
-  }
-}
-
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
-
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(
-        NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
-  }
-}
-
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
-  }
-}
-
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
-
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(
-        NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
+
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(
+        NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
   }
 }
 
@@ -12390,35 +12144,25 @@ sealed class TVertexAttributeType {
   static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-extension TVertexBufferExt on Pointer<TVertexBuffer> {
-  TVertexBuffer toDart() {
-    return TVertexBuffer(this);
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
   }
 }
 
-final class TVertexBuffer extends Struct {
-  Pointer<TVertexBuffer> get address => super.address.cast();
-  TVertexBuffer(super.address);
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
 
-  static Pointer<TVertexBuffer> stackAlloc() {
-    return Pointer<TVertexBuffer>(
-        NativeLibrary.instance.stackAlloc<TVertexBuffer>(0));
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(
+        NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
   }
 }
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
-  }
-}
-
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
-
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
-  }
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
 }
 
 extension double4x4Ext on Pointer<double4x4> {
@@ -12485,203 +12229,72 @@ final class double4x4 extends Struct {
   }
 }
 
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
   }
 }
 
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
 
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(
-        NativeLibrary.instance.stackAlloc<TTransformManager>(0));
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(
+        NativeLibrary.instance.stackAlloc<TRenderManager>(0));
   }
 }
 
-extension Aabb3Ext on Pointer<Aabb3> {
-  Aabb3 toDart() {
-    return Aabb3(this);
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
   }
 }
 
-final class Aabb3 extends Struct {
-  Pointer<Aabb3> get address => super.address.cast();
-  double get centerX {
-    final addr = Pointer<Aabb3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
 
-  set centerX(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 0), val.toJS, 'float');
-  }
-
-  double get centerY {
-    final addr = Pointer<Aabb3>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerY(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 4), val.toJS, 'float');
-  }
-
-  double get centerZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerZ(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 8), val.toJS, 'float');
-  }
-
-  double get halfExtentX {
-    final addr = Pointer<Aabb3>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentX(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 12), val.toJS, 'float');
-  }
-
-  double get halfExtentY {
-    final addr = Pointer<Aabb3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentY(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 16), val.toJS, 'float');
-  }
-
-  double get halfExtentZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 20);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentZ(double val) {
-    NativeLibrary.instance
-        .setValue(Pointer<Aabb3>(this.address.addr + 20), val.toJS, 'float');
-  }
-
-  Aabb3(super.address);
-
-  static Pointer<Aabb3> stackAlloc() {
-    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(
+        NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
   }
 }
 
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(
-        NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(
+        NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
   }
 }
 
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
   }
 }
 
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
 
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
   }
-}
-
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
-  }
-}
-
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
-
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(
-        NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
-  }
-}
-
-extension TSceneAssetExt on Pointer<TSceneAsset> {
-  TSceneAsset toDart() {
-    return TSceneAsset(this);
-  }
-}
-
-final class TSceneAsset extends Struct {
-  Pointer<TSceneAsset> get address => super.address.cast();
-  TSceneAsset(super.address);
-
-  static Pointer<TSceneAsset> stackAlloc() {
-    return Pointer<TSceneAsset>(
-        NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
-  }
-}
-
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
@@ -12697,6 +12310,368 @@ final class TRenderableBuilder extends Struct {
   static Pointer<TRenderableBuilder> stackAlloc() {
     return Pointer<TRenderableBuilder>(
         NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
+  }
+}
+
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+extension double3Ext on Pointer<double3> {
+  double3 toDart() {
+    return double3(this);
+  }
+}
+
+final class double3 extends Struct {
+  Pointer<double3> get address => super.address.cast();
+  double get x {
+    final addr = Pointer<double3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set x(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
+  }
+
+  double get y {
+    final addr = Pointer<double3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set y(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
+  }
+
+  double get z {
+    final addr = Pointer<double3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set z(double val) {
+    NativeLibrary.instance
+        .setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
+  }
+
+  double3(super.address);
+
+  static Pointer<double3> stackAlloc() {
+    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+  }
+}
+
+extension TShadowOptionsExt on Pointer<TShadowOptions> {
+  TShadowOptions toDart() {
+    return TShadowOptions(this);
+  }
+}
+
+final class TShadowOptions extends Struct {
+  Pointer<TShadowOptions> get address => super.address.cast();
+  int get mapSize {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set mapSize(int val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
+  }
+
+  int get shadowCascades {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set shadowCascades(int val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
+  }
+
+  Array<Float32> get cascadeSplitPositions {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float32>(
+        (numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
+  }
+
+  set cascadeSplitPositions(Array<Float32> val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 5),
+        val.internal.addr.addr.toJS,
+        '*');
+  }
+
+  double get constantBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set constantBias(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
+  }
+
+  double get normalBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set normalBias(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
+  }
+
+  double get shadowFar {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFar(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
+  }
+
+  double get shadowNearHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowNearHint(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
+  }
+
+  double get shadowFarHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFarHint(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
+  }
+
+  bool get stable {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set stable(bool val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 37),
+        (val ? 1 : 0).toJS,
+        'i8');
+  }
+
+  bool get lispsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set lispsm(bool val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 38),
+        (val ? 1 : 0).toJS,
+        'i8');
+  }
+
+  double get polygonOffsetConstant {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetConstant(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
+  }
+
+  double get polygonOffsetSlope {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetSlope(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
+  }
+
+  bool get screenSpaceContactShadows {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set screenSpaceContactShadows(bool val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 47),
+        (val ? 1 : 0).toJS,
+        'i8');
+  }
+
+  int get stepCount {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set stepCount(int val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
+  }
+
+  double get maxShadowDistance {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxShadowDistance(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
+  }
+
+  bool get vsmElvsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set vsmElvsm(bool val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 53),
+        (val ? 1 : 0).toJS,
+        'i8');
+  }
+
+  double get vsmBlurWidth {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set vsmBlurWidth(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
+  }
+
+  double get shadowBulbRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowBulbRadius(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(
+        Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
+  }
+
+  TShadowOptions(super.address);
+
+  static Pointer<TShadowOptions> stackAlloc() {
+    return Pointer<TShadowOptions>(
+        NativeLibrary.instance.stackAlloc<TShadowOptions>(78));
+  }
+}
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
+  }
+}
+
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
+
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(
+        NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
+  }
+}
+
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
+  }
+}
+
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
+
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(
+        NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
   }
 }
 
@@ -12771,15 +12746,38 @@ final class TGltfMeshData extends Struct {
   }
 }
 
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
 }
+
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback
+    = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction = void Function(
+    int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction = void Function(
+    int resultType, double x, double y, double z);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
+typedef PostRenderCallback
+    = Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef DartPostRenderCallback
+    = Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
+typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
   TMovementIntentExecutor toDart() {
@@ -12828,14 +12826,38 @@ const int SPRINT_INTENT_MASK = 8;
 extension StructAllocator on Struct {
   static T create<T>() {
     switch (T) {
-      case TMaterialInstance:
-        final ptr = TMaterialInstance.stackAlloc();
-        return ptr.toDart() as T;
-      case TMaterial:
-        final ptr = TMaterial.stackAlloc();
+      case TSceneAsset:
+        final ptr = TSceneAsset.stackAlloc();
         return ptr.toDart() as T;
       case TEngine:
         final ptr = TEngine.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBuffer:
+        final ptr = TVertexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TMaterialInstance:
+        final ptr = TMaterialInstance.stackAlloc();
+        return ptr.toDart() as T;
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TScene:
+        final ptr = TScene.stackAlloc();
+        return ptr.toDart() as T;
+      case TMaterial:
+        final ptr = TMaterial.stackAlloc();
         return ptr.toDart() as T;
       case TTexture:
         final ptr = TTexture.stackAlloc();
@@ -12843,59 +12865,68 @@ extension StructAllocator on Struct {
       case TTextureSampler:
         final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
+      case TLinearImage:
+        final ptr = TLinearImage.stackAlloc();
         return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
+      case TKtx1Bundle:
+        final ptr = TKtx1Bundle.stackAlloc();
         return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
         return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
+      case TRenderer:
+        final ptr = TRenderer.stackAlloc();
         return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
-        return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderableManager:
-        final ptr = TRenderableManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TViewport:
-        final ptr = TViewport.stackAlloc();
+      case TSwapChain:
+        final ptr = TSwapChain.stackAlloc();
         return ptr.toDart() as T;
       case TView:
         final ptr = TView.stackAlloc();
         return ptr.toDart() as T;
-      case TToneMapper:
-        final ptr = TToneMapper.stackAlloc();
-        return ptr.toDart() as T;
       case TColorGrading:
         final ptr = TColorGrading.stackAlloc();
         return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
+        return ptr.toDart() as T;
+      case TTransformManager:
+        final ptr = TTransformManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderableManager:
+        final ptr = TRenderableManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TEntityManager:
+        final ptr = TEntityManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFence:
+        final ptr = TFence.stackAlloc();
+        return ptr.toDart() as T;
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
+      case TDebugRegistry:
+        final ptr = TDebugRegistry.stackAlloc();
+        return ptr.toDart() as T;
+      case TViewport:
+        final ptr = TViewport.stackAlloc();
+        return ptr.toDart() as T;
+      case TToneMapper:
+        final ptr = TToneMapper.stackAlloc();
+        return ptr.toDart() as T;
       case TColorGradingBuilder:
         final ptr = TColorGradingBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
         return ptr.toDart() as T;
       case TSoftShadowOptions:
         final ptr = TSoftShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TVsmShadowOptions:
         final ptr = TVsmShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
         return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
@@ -12906,77 +12937,44 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBufferBuilder:
+        final ptr = TVertexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderManager:
+        final ptr = TRenderManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TAnimationManager:
+        final ptr = TAnimationManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderableBuilder:
+        final ptr = TRenderableBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case double3:
+        final ptr = double3.stackAlloc();
+        return ptr.toDart() as T;
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
       case TSurfaceOrientationBuilder:
         final ptr = TSurfaceOrientationBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TSurfaceOrientation:
         final ptr = TSurfaceOrientation.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
-      case TLinearImage:
-        final ptr = TLinearImage.stackAlloc();
-        return ptr.toDart() as T;
-      case TKtx1Bundle:
-        final ptr = TKtx1Bundle.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderManager:
-        final ptr = TRenderManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderer:
-        final ptr = TRenderer.stackAlloc();
-        return ptr.toDart() as T;
-      case TAnimationManager:
-        final ptr = TAnimationManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TSwapChain:
-        final ptr = TSwapChain.stackAlloc();
-        return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBufferBuilder:
-        final ptr = TVertexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBuffer:
-        final ptr = TVertexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case TTransformManager:
-        final ptr = TTransformManager.stackAlloc();
-        return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
-        return ptr.toDart() as T;
-      case TEntityManager:
-        final ptr = TEntityManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFence:
-        final ptr = TFence.stackAlloc();
-        return ptr.toDart() as T;
-      case TDebugRegistry:
-        final ptr = TDebugRegistry.stackAlloc();
-        return ptr.toDart() as T;
-      case TSceneAsset:
-        final ptr = TSceneAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderableBuilder:
-        final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TGltfMeshData:
         final ptr = TGltfMeshData.stackAlloc();

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
@@ -38,6 +38,20 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
   }
 
   @override
+  ColorGradingBuilder format(LutFormat format) {
+    _checkNotBuilt();
+    ColorGradingBuilder_format(_builder, format.index);
+    return this;
+  }
+
+  @override
+  ColorGradingBuilder dimensions(int dim) {
+    _checkNotBuilt();
+    ColorGradingBuilder_dimensions(_builder, dim);
+    return this;
+  }
+
+  @override
   ColorGradingBuilder toneMapper(ToneMapper mapper) {
     _checkNotBuilt();
     // Extract the native pointer from the ToneMapper object

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -111,6 +111,8 @@ class Viewport {
 
 enum QualityLevel { LOW, MEDIUM, HIGH, ULTRA }
 
+enum LutFormat { INTEGER, FLOAT }
+
 // ColorGrading object that holds color grading configuration.
 // ColorGrading is treated as const
 // Created via View.createColorGradingBuilder().build() and applied to a view.
@@ -146,6 +148,16 @@ abstract class ColorGradingBuilder {
   /// - HIGH: 32x32x32 16-bit LUT
   /// - ULTRA: 64x64x64 16-bit LUT
   ColorGradingBuilder quality(QualityLevel level);
+
+  /// Sets the internal storage format of the color grading LUT.
+  ///
+  /// Overrides the format implied by [quality]. INTEGER is 10-bit, FLOAT is 16-bit.
+  ColorGradingBuilder format(LutFormat format);
+
+  /// Sets the dimensions of the color grading LUT cube (e.g. 16, 32, 64).
+  ///
+  /// Overrides the dimensions implied by [quality]. Clamped to [8, 64] internally.
+  ColorGradingBuilder dimensions(int dim);
 
   /// Sets the tone mapping operator.
   ///

--- a/thermion_dart/native/include/c_api/TView.h
+++ b/thermion_dart/native/include/c_api/TView.h
@@ -55,6 +55,12 @@ enum TBlendMode {
 };
 typedef enum TBlendMode TBlendMode;
 
+enum TLutFormat {
+    INTEGER,
+    FLOAT
+};
+typedef enum TLutFormat TLutFormat;
+
 // View
 EMSCRIPTEN_KEEPALIVE TViewport View_getViewport(TView *view);
 EMSCRIPTEN_KEEPALIVE TToneMapper *ToneMapper_createLinear(TEngine* tEngine);
@@ -81,6 +87,8 @@ EMSCRIPTEN_KEEPALIVE void ColorGrading_destroy(TEngine* engine, TColorGrading* c
 
 // Quality and format
 EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_quality(TColorGradingBuilder* builder, TQualityLevel level);
+EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_format(TColorGradingBuilder* builder, TLutFormat format);
+EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_dimensions(TColorGradingBuilder* builder, uint8_t dim);
 EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_toneMapper(TColorGradingBuilder* builder, TToneMapper* toneMapper);
 
 // Basic adjustments

--- a/thermion_dart/native/src/c_api/TView.cpp
+++ b/thermion_dart/native/src/c_api/TView.cpp
@@ -282,6 +282,18 @@ namespace thermion
             builder->quality(static_cast<ColorGrading::QualityLevel>(level));
         }
 
+        EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_format(TColorGradingBuilder* tBuilder, TLutFormat format)
+        {
+            auto builder = reinterpret_cast<ColorGrading::Builder*>(tBuilder);
+            builder->format(static_cast<ColorGrading::LutFormat>(format));
+        }
+
+        EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_dimensions(TColorGradingBuilder* tBuilder, uint8_t dim)
+        {
+            auto builder = reinterpret_cast<ColorGrading::Builder*>(tBuilder);
+            builder->dimensions(dim);
+        }
+
         EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_toneMapper(TColorGradingBuilder* tBuilder, TToneMapper* toneMapper)
         {
             auto builder = reinterpret_cast<ColorGrading::Builder*>(tBuilder);

--- a/thermion_dart/test/color_grading_tests.dart
+++ b/thermion_dart/test/color_grading_tests.dart
@@ -114,6 +114,102 @@ void main() async {
     });
   });
 
+  test('ColorGrading LUT format and dimensions', () async {
+    await ViewerBuilder(testHelper)
+        .setCameraLookAt(Vector3(0, 2, 8), focus: Vector3.zero())
+        .setPostProcessing(true)
+        .addCube(color: kWhite, createUbershader: true)
+        .addSun()
+        .addPlane(
+            position: Vector3(0, -1.5, 0),
+            rotation: Quaternion.axisAngle(Vector3(1, 0, 0), -3.14159 / 2),
+            scale: Vector3(10, 10, 1),
+            color: kWhite,
+            createUbershader: true)
+        .execute((result) async {
+
+          await testHelper.capture(
+            result.viewer.view, "color_grading_lut_none");
+      final configs = [
+        (LutFormat.INTEGER, 16, 'integer_16'),
+        (LutFormat.INTEGER, 32, 'integer_32'),
+        (LutFormat.FLOAT, 32, 'float_32'),
+        (LutFormat.FLOAT, 64, 'float_64'),
+      ];
+
+      for (final (format, dim, name) in configs) {
+        final builder = await result.viewer.view.createColorGradingBuilder();
+        final colorGrading = await builder
+            .format(format)
+            .dimensions(dim)
+            .toneMapper(await ToneMapper.aces())
+            .saturation(1.3)
+            .contrast(1.2)
+            .build();
+
+        expect(colorGrading, isNotNull);
+        await result.viewer.view.setColorGrading(colorGrading);
+        await testHelper.capture(
+            result.viewer.view, "color_grading_lut_$name");
+      }
+    });
+  });
+
+  test('ColorGrading channelMixer', () async {
+    await ViewerBuilder(testHelper)
+        .setCameraLookAt(Vector3(0, 2, 8), focus: Vector3.zero())
+        .setPostProcessing(true)
+        .addSun()
+        .addCube(color: kRed, createUbershader: true)
+        .addPlane(
+            position: Vector3(0, -1.5, 0),
+            rotation: Quaternion.axisAngle(Vector3(1, 0, 0), -3.14159 / 2),
+            scale: Vector3(10, 10, 1),
+            color: kGreen,
+            createUbershader: true)
+        .execute((result) async {
+      final configs = <(Vector3, Vector3, Vector3, String)>[
+        (
+          Vector3(1, 0, 0),
+          Vector3(0, 1, 0),
+          Vector3(0, 0, 1),
+          'identity',
+        ),
+        (
+          Vector3(0.393, 0.769, 0.189),
+          Vector3(0.349, 0.686, 0.168),
+          Vector3(0.272, 0.534, 0.131),
+          'sepia',
+        ),
+        (
+          Vector3(0, 0, 1),
+          Vector3(0, 1, 0),
+          Vector3(1, 0, 0),
+          'swap_rb',
+        ),
+        (
+          Vector3(0.299, 0.587, 0.114),
+          Vector3(0.299, 0.587, 0.114),
+          Vector3(0.299, 0.587, 0.114),
+          'luminance',
+        ),
+      ];
+
+      for (final (outRed, outGreen, outBlue, name) in configs) {
+        final builder = await result.viewer.view.createColorGradingBuilder();
+        final colorGrading = await builder
+            .toneMapper(await ToneMapper.linear())
+            .channelMixer(outRed, outGreen, outBlue)
+            .build();
+
+        expect(colorGrading, isNotNull);
+        await result.viewer.view.setColorGrading(colorGrading);
+        await testHelper.capture(
+            result.viewer.view, "color_grading_channel_mixer_$name");
+      }
+    });
+  });
+
   test('getColorGrading - retrieve and verify color grading', () async {
     await ViewerBuilder(testHelper)
         .setCameraLookAt(Vector3(0, 2, 8), focus: Vector3.zero())


### PR DESCRIPTION
This PR  exposes Filament's `ColorGrading::Builder::format(LutFormat)` and `::dimensions(uint8_t)` through the Dart API so callers can override LUT storage format (INTEGER/FLOAT) and cube dimensions independently of the `quality()` preset.