### PR TITLE
ios: exclude vulkan sources from native build hook

### DIFF
--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -99,6 +99,14 @@ outputDirectory : ${outputDirectory.path}
       sources = sources.where((p) => !p.contains("linux")).toList();
     }
 
+    // iOS is Metal-only — exclude Vulkan-utility sources whose symbols
+    // resolve through `bluevk` (which iOS does not link). Without this
+    // exclusion, linking fails with "Undefined symbols: bluevk::vk*".
+    // See native/src/vulkan/{VulkanUtils,BaseVulkanTexture}.cpp.
+    if (targetOS == OS.iOS) {
+      sources = sources.where((p) => !p.contains("vulkan")).toList();
+    }
+
     // Material source paths (used by _processMaterials below)
     final materialSources = <String, String>{
       'capture_uv': 'native/include/material/capture_uv.c',


### PR DESCRIPTION
## Problem

`thermion_dart/hook/build.dart` recursively gathers every `.cpp` under `native/src/` for the native-assets build, then excludes platform-specific paths (`windows` / `d3d` / `linux`). There is no analogous exclusion for `vulkan/`, so on iOS the hook compiles `native/src/vulkan/VulkanUtils.cpp` and `native/src/vulkan/BaseVulkanTexture.cpp`. Both reference symbols in the `bluevk::` namespace, but the iOS branch (Metal-only) never adds `bluevk` to its `libs` list — see lines ~280-285:

\`\`\`dart
} else if (targetOS == OS.macOS) {
  // ...
  libs.addAll([\"bluegl\", \"bluevk\"]);   // ← macOS links bluevk
} else if (targetOS == OS.android) {
  libs.addAll([\"GLESv3\", \"EGL\", \"bluevk\", \"dl\", \"android\"]);
} else if (targetOS == OS.linux) {
  libs.addAll([\"bluevk\", \"bluegl\", \"drm\", \"EGL\", \"GL\", \"gbm\"]);
}
// iOS branch sets only frameworks, never `bluevk`.
\`\`\`

## Symptom

\`flutter build ios --debug --no-codesign\` (Xcode 15, Flutter master / native-assets enabled, Thermion at \`develop\`) fails inside dart_build:

\`\`\`
Undefined symbols for architecture arm64:
  \"bluevk::vkMapMemory\", referenced from:
      thermion::vulkan::readVkImageToBitmap(...) in VulkanUtils-*.o
  \"bluevk::vkFreeMemory\", referenced from: ...
  \"bluevk::vkCreateFence\", referenced from: ...
  ... (~50 more bluevk:: symbols, all from VulkanUtils.cpp)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1
\`\`\`

The whole flutter build then aborts with \`Building assets for package:thermion_dart failed\`.

## Fix

Skip \`vulkan/\` source paths when \`targetOS == OS.iOS\`, mirroring the structure of the existing \`windows\` / \`linux\` exclusions a few lines above. Three lines.

## What's affected

| Platform | Before | After | Reason |
|---|---|---|---|
| iOS | broken (link error) | builds | Metal-only, doesn't link bluevk |
| macOS | works | works (unchanged) | links bluevk |
| Android | works | works (unchanged) | links bluevk |
| Linux | works | works (unchanged) | links bluevk |
| Windows | works | works (unchanged) | doesn't reach this code path |

## Verification

\`\`\`
flutter build ios --debug --no-codesign
...
✓ Built build/ios/iphoneos/Runner.app
\`\`\`

Reproduced both before (failure) and after (success) on macOS 15.x with Xcode 15, Flutter master, in an app pinning \`thermion_flutter\` + \`thermion_dart\` to upstream develop. Happy to share a minimal repro if useful.

---

Found while spiking Thermion as a cross-platform replacement for our existing WebView+Three.js 3D viewer. Filing two related issues separately (AGX texture-region OOB on macOS, and a concurrent-modification race in \`FFIRenderManager._syncViews\` when several viewers mount in parallel).