### PR TITLE
mobile: eager-accept the scale gesture; synthesize tap/double-tap

### DIFF
--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -99,6 +99,14 @@ outputDirectory : ${outputDirectory.path}
       sources = sources.where((p) => !p.contains("linux")).toList();
     }
 
+    // iOS is Metal-only — exclude Vulkan-utility sources whose symbols
+    // resolve through `bluevk` (which iOS does not link). Without this
+    // exclusion, linking fails with "Undefined symbols: bluevk::vk*".
+    // See native/src/vulkan/{VulkanUtils,BaseVulkanTexture}.cpp.
+    if (targetOS == OS.iOS) {
+      sources = sources.where((p) => !p.contains("vulkan")).toList();
+    }
+
     // Material source paths (used by _processMaterials below)
     final materialSources = <String, String>{
       'capture_uv': 'native/include/material/capture_uv.c',

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_listener_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_listener_widget.dart
@@ -322,47 +322,132 @@ class _MobileListenerWidget extends StatefulWidget {
 }
 
 class _MobileListenerWidgetState extends State<_MobileListenerWidget> {
+  // Tap/double-tap detection state. We synthesize taps from the eager
+  // scale recognizer's start/update/end callbacks because the eager
+  // recognizer claims the gesture arena on PointerDown — separate
+  // TapGestureRecognizer / DoubleTapGestureRecognizer entries can no
+  // longer win. See `_EagerScaleGestureRecognizer` below.
+  Offset? _scaleStartFocal;
+  DateTime? _scaleStartTime;
+  double _scaleMaxMovement = 0;
+  Offset? _lastTapPosition;
+  DateTime? _lastTapTime;
+
+  static const _kTapMaxMovement = 8.0;
+  static const _kTapMaxDuration = Duration(milliseconds: 250);
+  static const _kDoubleTapInterval = Duration(milliseconds: 300);
+
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onTapDown: (details) {
-          widget.inputHandler.handle(TouchEvent(TouchEventType.tap,
-              details.localPosition.toVector2() * widget.pixelRatio, null));
-        },
-        onDoubleTap: () {
-          widget.inputHandler
-              .handle(TouchEvent(TouchEventType.doubleTap, null, null));
-        },
-        onScaleStart: (ScaleStartDetails event) async {
-          widget.inputHandler.handle(ScaleStartEvent(
-              numPointers: event.pointerCount,
-              localFocalPoint: (
-                event.focalPoint.dx * widget.pixelRatio,
-                event.focalPoint.dy * widget.pixelRatio
-              )));
-        },
-        onScaleUpdate: (ScaleUpdateDetails event) async {
-          widget.inputHandler.handle(ScaleUpdateEvent(
-            numPointers: event.pointerCount,
-            localFocalPoint: (
-              event.focalPoint.dx * widget.pixelRatio,
-              event.focalPoint.dy * widget.pixelRatio
-            ),
-            localFocalPointDelta: (
-              event.focalPointDelta.dx * widget.pixelRatio,
-              event.focalPointDelta.dy * widget.pixelRatio
-            ),
-            rotation: event.rotation,
-            horizontalScale: event.horizontalScale,
-            verticalScale: event.verticalScale,
-            scale: event.scale,
-          ));
-        },
-        onScaleEnd: (details) async {
-          widget.inputHandler
-              .handle(ScaleEndEvent(numPointers: details.pointerCount));
-        },
-        child: widget.child);
+    return RawGestureDetector(
+      behavior: HitTestBehavior.translucent,
+      gestures: <Type, GestureRecognizerFactory>{
+        _EagerScaleGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<_EagerScaleGestureRecognizer>(
+          () => _EagerScaleGestureRecognizer(),
+          (_EagerScaleGestureRecognizer instance) {
+            instance
+              ..onStart = (ScaleStartDetails event) {
+                _scaleStartFocal = event.focalPoint;
+                _scaleStartTime = DateTime.now();
+                _scaleMaxMovement = 0;
+                widget.inputHandler.handle(ScaleStartEvent(
+                    numPointers: event.pointerCount,
+                    localFocalPoint: (
+                      event.focalPoint.dx * widget.pixelRatio,
+                      event.focalPoint.dy * widget.pixelRatio
+                    )));
+              }
+              ..onUpdate = (ScaleUpdateDetails event) {
+                if (_scaleStartFocal != null) {
+                  final movement =
+                      (event.focalPoint - _scaleStartFocal!).distance;
+                  if (movement > _scaleMaxMovement) {
+                    _scaleMaxMovement = movement;
+                  }
+                }
+                widget.inputHandler.handle(ScaleUpdateEvent(
+                  numPointers: event.pointerCount,
+                  localFocalPoint: (
+                    event.focalPoint.dx * widget.pixelRatio,
+                    event.focalPoint.dy * widget.pixelRatio
+                  ),
+                  localFocalPointDelta: (
+                    event.focalPointDelta.dx * widget.pixelRatio,
+                    event.focalPointDelta.dy * widget.pixelRatio
+                  ),
+                  rotation: event.rotation,
+                  horizontalScale: event.horizontalScale,
+                  verticalScale: event.verticalScale,
+                  scale: event.scale,
+                ));
+              }
+              ..onEnd = (ScaleEndDetails event) {
+                final now = DateTime.now();
+                final wasTap = _scaleStartTime != null &&
+                    _scaleStartFocal != null &&
+                    now.difference(_scaleStartTime!) < _kTapMaxDuration &&
+                    _scaleMaxMovement < _kTapMaxMovement &&
+                    event.pointerCount == 0;
+                if (wasTap) {
+                  final tapPosition = _scaleStartFocal!;
+                  final isDoubleTap = _lastTapPosition != null &&
+                      _lastTapTime != null &&
+                      now.difference(_lastTapTime!) < _kDoubleTapInterval &&
+                      (tapPosition - _lastTapPosition!).distance <
+                          _kTapMaxMovement;
+                  if (isDoubleTap) {
+                    widget.inputHandler.handle(
+                        TouchEvent(TouchEventType.doubleTap, null, null));
+                    _lastTapPosition = null;
+                    _lastTapTime = null;
+                  } else {
+                    widget.inputHandler.handle(TouchEvent(
+                        TouchEventType.tap,
+                        tapPosition.toVector2() * widget.pixelRatio,
+                        null));
+                    _lastTapPosition = tapPosition;
+                    _lastTapTime = now;
+                  }
+                }
+                widget.inputHandler
+                    .handle(ScaleEndEvent(numPointers: event.pointerCount));
+                _scaleStartFocal = null;
+                _scaleStartTime = null;
+                _scaleMaxMovement = 0;
+              };
+          },
+        ),
+      },
+      child: widget.child,
+    );
+  }
+}
+
+/// Variant of [ScaleGestureRecognizer] that claims the gesture arena
+/// the moment a pointer is added, instead of waiting for displacement
+/// to cross [kPanSlop].
+///
+/// Why: the default recognizer waits to disambiguate a one-finger pan
+/// from a two-finger pinch. While it waits, an ancestor `Scrollable`'s
+/// `VerticalDragGestureRecognizer` reaches its acceptance threshold
+/// first and wins the arena — the touch is interpreted as a page
+/// scroll instead of a viewport gesture. With this eager subclass,
+/// ancestors lose the arena on the first PointerDown inside the
+/// Thermion view, so single-finger orbit and pinch-zoom both resolve
+/// to the viewport regardless of what scrollable wraps it.
+///
+/// Tradeoff: separate `TapGestureRecognizer` /
+/// `DoubleTapGestureRecognizer` entries can no longer participate
+/// (eager scale wins arena before they ever accept). The mobile
+/// listener compensates by synthesizing tap and double-tap events
+/// from the scale callbacks — a "tap" is a scale gesture whose total
+/// focal-point movement stays below 8px and whose total duration
+/// stays below 250 ms; "double-tap" is two such taps within 300 ms.
+class _EagerScaleGestureRecognizer extends ScaleGestureRecognizer {
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    super.addAllowedPointer(event);
+    resolve(GestureDisposition.accepted);
   }
 }


### PR DESCRIPTION
## Problem

\`_MobileListenerWidget\` in \`thermion_listener_widget.dart\` uses a default \`GestureDetector(onScaleStart/Update/End, onTapDown, onDoubleTap, ...)\`. Under the hood that registers a regular \`ScaleGestureRecognizer\` which waits past \`kPanSlop\` (~18 px) to disambiguate one-finger pan from two-finger pinch.

When a Thermion view is mounted inside an ancestor \`Scrollable\` (a \`ListView\`, \`PageView\`, \`CustomScrollView\`, scrollable bottom-sheet body, etc.), the ancestor's \`VerticalDragGestureRecognizer\` reaches its acceptance threshold first and wins the gesture arena. Touches that started on the viewer get interpreted as page scrolls instead of orbit / pinch.

Symptom on iOS, reproduced reliably with 8 \`ThermionViewer\`s in a vertical \`ListView\`:

- Drag down across the viewport → page scrolls. No orbit.
- Drag mostly horizontally → orbit fires. As expected.
- Drag at an angle → a coin flip; sometimes orbit, sometimes scroll. Feels broken.

Single-viewer / no-ancestor-scrollable layouts are unaffected because nothing competes with Thermion's recognizer in the arena.

## Fix

Replace the default \`GestureDetector\` with a \`RawGestureDetector\` that uses a custom \`_EagerScaleGestureRecognizer\` — a one-line subclass of \`ScaleGestureRecognizer\` that calls \`resolve(GestureDisposition.accepted)\` inside \`addAllowedPointer\`. The arena is claimed on the first PointerDown inside the viewer, so ancestors lose the arena unconditionally. Single-finger orbit, two-finger pinch, and rotation all resolve to the viewport regardless of how the viewer is composed.

\`\`\`dart
class _EagerScaleGestureRecognizer extends ScaleGestureRecognizer {
  @override
  void addAllowedPointer(PointerDownEvent event) {
    super.addAllowedPointer(event);
    resolve(GestureDisposition.accepted);
  }
}
\`\`\`

## Tap & double-tap synthesis

Separate \`TapGestureRecognizer\` and \`DoubleTapGestureRecognizer\` entries can no longer participate (eager scale claims arena before they accept), so I synthesised both inside the scale callbacks:

- **Tap**: scale-end fires with \`pointerCount == 0\`, total focal-point movement < 8 px, and total duration < 250 ms.
- **Double-tap**: two consecutive synthetic taps within 300 ms of each other and within 8 px of each other.

Thresholds are at the top of \`_MobileListenerWidgetState\` so they're easy to tune. Both fire the existing \`TouchEvent(TouchEventType.tap, ...)\` / \`TouchEvent(TouchEventType.doubleTap, ...)\` events on \`InputHandler\`, so callers see no API change. \`TGizmo\`-style picking via \`view.pick\` continues to work.

## Trade-off

\`onScaleStart\` now fires on PointerDown rather than after movement crosses \`kPanSlop\`. For pure-tap cases (touch + lift, no movement) this means \`InputHandler\` receives a \`ScaleStartEvent\` immediately followed by \`ScaleEndEvent\` with no \`ScaleUpdateEvent\` between them. Existing \`OrbitInputHandlerDelegate\` / picking delegates handle this gracefully — they're idempotent on no-motion start/end pairs — but custom delegates that assume scale events imply motion may need a guard. If anyone has a strong case against this change, an alternative is to leave the recognizer non-eager and accept arena from \`handleEvent\` once movement crosses a smaller threshold than \`kPanSlop\`; happy to refactor.

## Verification

- \`flutter build ios --debug --no-codesign\` succeeds on top of develop with this change applied (combined with [#160](https://github.com/nmfisher/thermion/pull/160) which is needed for iOS to build at all).
- On a physical iPhone with 8 \`ThermionViewer\`s in a \`ListView.separated\`: drags starting in the parent's scroll-gutter padding scroll the page; drags starting on a viewer always orbit / pinch; tap-to-pick still resolves to the right entity.
- macOS desktop \`_desktop()\` path is untouched (\`Listener\`-based, not GestureDetector).
- Android single-viewer and macOS single-viewer behaviour unchanged.

## Related

- [#160](https://github.com/nmfisher/thermion/pull/160) — companion fix for iOS link error (vulkan-source exclusion). Both are needed to build a working multi-viewer Thermion app on iOS today; #160 is independent and could merge first.
- [#161](https://github.com/nmfisher/thermion/issues/161) — macOS AGX texture-region OOB crash. Separate issue; this PR doesn't address it.
- [#162](https://github.com/nmfisher/thermion/issues/162) — \`FFIRenderManager._syncViews\` concurrent-modification race. Separate issue.