### PR TITLE
mobile: synthesised tap uses localFocalPoint, not focalPoint (follow-up to #163)

### DIFF
--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_listener_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_listener_widget.dart
@@ -348,7 +348,16 @@ class _MobileListenerWidgetState extends State<_MobileListenerWidget> {
           (_EagerScaleGestureRecognizer instance) {
             instance
               ..onStart = (ScaleStartDetails event) {
-                _scaleStartFocal = event.focalPoint;
+                // Capture the *local* focal point (widget-relative) for
+                // tap synthesis. The synthesised tap dispatches via
+                // TouchEvent.localPosition, which is what
+                // `View.pick(x, y, ...)` consumes — pick wants viewport-
+                // relative pixels, not screen-global. Using
+                // `event.focalPoint` (global) here was wrong: picks
+                // landed outside the rendered viewport whenever the
+                // widget wasn't at (0,0) on the screen, which is
+                // basically every real layout.
+                _scaleStartFocal = event.localFocalPoint;
                 _scaleStartTime = DateTime.now();
                 _scaleMaxMovement = 0;
                 widget.inputHandler.handle(ScaleStartEvent(
@@ -360,8 +369,12 @@ class _MobileListenerWidgetState extends State<_MobileListenerWidget> {
               }
               ..onUpdate = (ScaleUpdateDetails event) {
                 if (_scaleStartFocal != null) {
+                  // Compare local-to-local for the tap-vs-drag movement
+                  // threshold. Mixing global with local would inflate
+                  // the distance by the widget's screen position and
+                  // misclassify static taps as drags.
                   final movement =
-                      (event.focalPoint - _scaleStartFocal!).distance;
+                      (event.localFocalPoint - _scaleStartFocal!).distance;
                   if (movement > _scaleMaxMovement) {
                     _scaleMaxMovement = movement;
                   }


### PR DESCRIPTION
## Follow-up to #163

\`#163\` introduced the eager-scale gesture recognizer that synthesises tap and double-tap from the scale callbacks. The synthesis captured \`event.focalPoint\` from \`ScaleStartDetails\` and dispatched it as \`TouchEvent.localPosition\`. Flutter documents \`focalPoint\` as **global** (screen) coordinates; \`TouchEvent.localPosition\` consumers — most importantly \`View.pick(x, y, …)\` — expect coordinates relative to the viewport.

The result: in any layout where the Thermion widget isn't anchored at the screen origin (anything inside an AppBar / inside a list / inside padding), picks land outside the rendered viewport and Filament returns the background entity. Reproduced reliably on Android — the spike author's downstream app couldn't get region-tap to work in any non-trivial composition.

## Fix

Capture \`event.localFocalPoint\` (widget-relative) into \`_scaleStartFocal\`, and use \`event.localFocalPoint\` in the onUpdate movement-distance comparison so the tap-vs-drag threshold is also computed in widget-local space.

The other places that pass \`event.focalPoint\` to \`inputHandler.handle(ScaleStart/UpdateEvent(localFocalPoint: …))\` keep using \`event.focalPoint\` (global) — that's the existing upstream convention for those events, and they're consumed by orbit-camera code that uses deltas, not absolute positions, so the global/local distinction doesn't affect them.

## Why it didn't surface earlier

Initial testing happened in layouts where the viewer sat near the screen origin (top-left, full-width column). Global ≈ local in that case, picks landed on the right entity by coincidence. Moving the viewer into a real composition (e.g., a stress-test ListView on Android) immediately exposed the bug.

## Verification

- Spike app on Android emulator: region picking now resolves correctly inside a 220-px-tall ListView item with surrounding padding.
- Single-viewer behaviour unchanged in flush-to-origin layouts (where global == local).
- Orbit / pinch / double-tap all unchanged (they don't depend on absolute position).