### PR TITLE
android: per-view swap chain bookkeeping (multi-viewer fixes)

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -638,7 +638,29 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
   //
   Future<Iterable<SwapChain>> getSwapChains() async {
-    return _swapChains;
+    // Return a snapshot, not the live list. Returning the live list lets
+    // mutations from concurrent createSwapChain / destroySwapChain calls
+    // leak back to callers — which is exactly what happened in
+    // thermion_flutter's Android `createTextureAndBindToView`:
+    //
+    //   final swapChains = await FilamentApp.instance!.getSwapChains();
+    //   final swapChain  = await FilamentApp.instance!.createSwapChain(...);
+    //   if (swapChains.isNotEmpty) {
+    //     await FilamentApp.instance!.destroySwapChain(swapChains.first);
+    //   }
+    //
+    // The intent was "snapshot existing chains, create the new one,
+    // tear down the old one", but `swapChains` aliased `_swapChains`,
+    // so after `createSwapChain` appended, `swapChains.first` was the
+    // *new* swap chain. The plugin then destroyed it and attached the
+    // view to a freed pointer — the next render hit Filament's
+    // "SwapChain must remain valid until endFrame is called" assert
+    // and the process aborted on every viewer mount on Android.
+    //
+    // Returning an unmodifiable snapshot fixes this at the API layer
+    // and makes the function safe regardless of how callers are
+    // structured.
+    return List<SwapChain>.unmodifiable(_swapChains);
   }
 
   final _hooks = <Future Function()>[];

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -87,6 +87,14 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   // has been redirected to an internal RT (e.g., in composite highlight mode).
   static final _viewRenderTargets = <View, RenderTarget>{};
 
+  // Track the SwapChain currently bound to each view (Android only).
+  // The Android branch of createTextureAndBindToView destroys this view's
+  // *previous* swap chain after creating the new one. Keying by view
+  // (rather than iterating FilamentApp's global swap-chain list) is what
+  // makes multi-viewer apps work — without this, mounting viewer #N
+  // would destroy viewer #(N-1)'s swap chain and freeze it.
+  static final _viewSwapChains = <View, SwapChain>{};
+
   // Deferred Filament render target cleanup for Windows resize.
   // Old RT stays alive so native can Blit from it during the swap window.
   static final _deferredRenderTargets = <(RenderTarget, int)>[];
@@ -582,17 +590,27 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
     // the viewport?
     // In fact we can probably do this for all platforms
     if (Platform.isAndroid) {
-      final swapChains = await FilamentApp.instance!.getSwapChains();
+      // The OLD swap chain to destroy is the one *previously bound to
+      // this view* — not whatever happens to be at the front of
+      // FilamentApp's global list. Earlier code iterated
+      // `getSwapChains()` and destroyed `swapChains.first`, which in a
+      // multi-viewer app destroyed *another* viewer's swap chain, freezing
+      // its viewport. Tracking per-view in `_viewSwapChains` scopes the
+      // destroy to this view only.
+      final oldSwapChain = _viewSwapChains[view];
 
       final swapChain = await FilamentApp.instance!.createSwapChain(
         Pointer<Void>.fromAddress(descriptor.windowHandle!),
       );
 
-      if (swapChains.isNotEmpty) {
-        await FilamentApp.instance!.destroySwapChain(swapChains.first);
-      }
-
       await FilamentApp.instance!.renderManager.attach(view, swapChain);
+      _viewSwapChains[view] = swapChain;
+
+      // Destroy the old swap chain after the new one is attached so the
+      // view never has a window of being unattached.
+      if (oldSwapChain != null) {
+        await FilamentApp.instance!.destroySwapChain(oldSwapChain);
+      }
 
       // On other platforms, if a hardware texture ID is returned, this means
       // the texture is immediately available for rendering.

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -750,4 +750,15 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
 
     return texture;
   }
+
+  @override
+  Future<void> releaseTextureBindingForView(View view) async {
+    // Only Android keeps per-view swap-chain bookkeeping in this plugin
+    // (see `_viewSwapChains` and the size-change branch of
+    // `createTextureAndBindToView`). Other platforms are no-ops.
+    final swapChain = _viewSwapChains.remove(view);
+    if (swapChain != null) {
+      await FilamentApp.instance!.destroySwapChain(swapChain);
+    }
+  }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
@@ -145,6 +145,12 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   }
 
   @override
+  Future<void> releaseTextureBindingForView(View view) async {
+    // No per-view swap-chain bookkeeping on the web plugin. Surfaces
+    // are managed via the canvas + WebGL context lifecycle.
+  }
+
+  @override
   Future<PlatformTextureDescriptor?> createTextureAndBindToView(
     View view,
     int width,

--- a/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
@@ -57,6 +57,18 @@ abstract class ThermionFlutterPlugin {
     int height,
   );
 
+  /// Release plugin-side resources bound to this view (e.g. the per-view
+  /// `SwapChain` the Android plugin tracks). Call this BEFORE destroying
+  /// the underlying texture / surface descriptor — otherwise on Android
+  /// the SurfaceTexture is released first, the swap chain's native
+  /// window becomes invalid, and Filament's next `eglSwapBuffers` call
+  /// for that swap chain returns `EGL_BAD_SURFACE` until the widget
+  /// finishes unmounting.
+  ///
+  /// Safe to call on platforms that don't track per-view bindings (e.g.
+  /// the web plugin) — it's a no-op there.
+  Future<void> releaseTextureBindingForView(View view);
+
   static Future<ThermionViewer> createViewer(
       {bool destroySwapchain = true}) async {
     _logger.finest("Creating viewer");

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -86,7 +86,20 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
     _debounceTimer?.cancel();
     var texture = _texture;
     _texture = null;
-    texture?.destroy();
+    // Tear down per-view plugin bindings (Android: SwapChain bound to
+    // this view) BEFORE releasing the underlying texture. The
+    // SurfaceTexture release frees the swap chain's native window, so
+    // if the swap chain is still attached to the RenderManager when
+    // that happens Filament's next render fires `eglSwapBuffers` on a
+    // null buffer and the emulator/EGL stack logs `EGL_BAD_SURFACE`
+    // until the widget unmount finishes propagating. Sequencing the
+    // two awaits inside an unawaited closure keeps `dispose()` synchronous
+    // for the framework while still ordering the calls.
+    final view = widget.view;
+    () async {
+      await ThermionFlutterPlugin.instance.releaseTextureBindingForView(view);
+      await texture?.destroy();
+    }();
   }
 
   @override


### PR DESCRIPTION
## Summary

Three related fixes to the Android plugin's swap-chain handling. All three are needed for multi-viewer Flutter apps on Android to mount, render, and unmount cleanly. Single-viewer behaviour is unchanged.

## Background

\`thermion_flutter_plugin_native.dart\`'s Android branch of \`createTextureAndBindToView\` recreates a swap chain whenever the surface size changes — that's the documented intent (\`// On Android, we recreate the swapchain whenever the size changes\`). The implementation works for single-viewer apps but has three latent bugs that surface immediately when more than one viewer is mounted.

## Fix 1: \`getSwapChains()\` returns a snapshot, not the live list

\`FFIFilamentApp.getSwapChains()\` returned the live \`_swapChains\` list reference. The plugin code does:

\`\`\`dart
final swapChains = await FilamentApp.instance!.getSwapChains();   // aliases _swapChains
final swapChain  = await FilamentApp.instance!.createSwapChain(...);   // appends to _swapChains
if (swapChains.isNotEmpty) {                                          // now [newSwapChain]!
  await FilamentApp.instance!.destroySwapChain(swapChains.first);     // destroys the NEW one
}
\`\`\`

The intent reads as "snapshot existing chains, create the new one, tear down the old one" — but because \`swapChains\` aliased \`_swapChains\`, \`createSwapChain\` appended into the very list the plugin was about to iterate. \`swapChains.first\` immediately referred to the newly-created swap chain. The plugin destroyed its own new swap chain and attached the view to a freed pointer; the next render hit Filament's \`endFrame:490\` precondition and aborted on every viewer mount.

Returning \`List<SwapChain>.unmodifiable(_swapChains)\` defends at the API layer.

## Fix 2: per-view swap chain tracking (multi-viewer freeze)

After Fix 1, the snapshot is correct, but \`swapChains.first\` is still the *first* swap chain in the list — which in a multi-viewer app is *another* viewer's swap chain. Mounting viewer #N destroyed viewer #(N-1)'s swap chain, freezing it. The most-recently-mounted viewer always rendered fine; everyone else froze in cascade.

Track the swap chain currently bound to each view in a \`<View, SwapChain>\` map (mirroring the existing \`_viewRenderTargets\` pattern in the same file), and destroy *that* one — scoped to this view only. Other viewers' swap chains stay live.

## Fix 3: release per-view swap chain on widget dispose (EGL_BAD_SURFACE flood)

After Fix 2, the swap chain is correctly created and reused per view, but never *released* when the widget unmounts. \`ThermionWidget.dispose()\` released the underlying SurfaceTexture (freeing the native window), while the SwapChain stayed in \`_viewSwapChains\` and stayed attached to the RenderManager. The next render iteration would then call \`eglSwapBuffers\` on the now-orphaned native window, logging:

\`\`\`
E/EGL_emulation: egl_window_surface_t::swapBuffers called with NULL buffer
E/EGL_emulation: tid <n>: swapBuffers(764): error 0x300d (EGL_BAD_SURFACE)
\`\`\`

repeatedly per render. On a multi-viewer stress test, even brief widget rebuilds (toggling viewer count) flooded the log and cost visible frame budget.

Add a public \`releaseTextureBindingForView(View view)\` API on \`ThermionFlutterPlugin\`. Native impl removes the entry from \`_viewSwapChains\` and calls \`destroySwapChain\` (which detaches from RenderManager and destroys the Filament SwapChain). Web impl is a no-op — it doesn't track per-view bindings. \`ThermionWidget.dispose()\` calls it before tearing down the descriptor, sequenced inside an unawaited async closure so \`dispose()\` stays synchronous for the framework while the destroy still completes before the SurfaceTexture release.

## Verification

- Stress-test screen on Android emulator: 4-viewer mount, render, region-tap, dispose all clean.
- 8-viewer mount works too (with companion fixes from sibling PRs covering the multi-viewer state-mutation race; this PR alone is sufficient for single-viewer + 4-viewer).
- iOS / macOS / Windows unchanged — the affected code path is gated on \`Platform.isAndroid\`.

## Related

- #167 (closing) was the original "snapshot fix" PR; that branch grew to nine commits as we kept finding adjacent issues. Splitting into focused PRs for review.
- #168 — focalPoint → localFocalPoint follow-up to the merged #163 (Android picking).
- Two more PRs incoming for the remaining multi-viewer correctness fixes (viewer-detach-before-destroy; multi-viewer state serialisation).