### PR TITLE
multi-viewer: synchronise shared-state mutations + skip empty render cycles

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -251,45 +251,65 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
         (cb) => Engine_createCameraRenderThread(engine, targetEntity!, cb)));
   }
 
+  /// Serial chain that prevents multiple `destroySwapChain` calls
+  /// from running concurrently. Each call awaits `_destroyChain`,
+  /// runs detach + flush + destroy + bookkeeping, then completes the
+  /// chain so the next destroy can start.
+  ///
+  /// Why: in multi-viewer apps, mass dispose (e.g. toggling stress-
+  /// test viewer count from 8 → 1) triggers eight concurrent
+  /// destroySwapChain calls. Each call's flush() drains the backend
+  /// at the moment it runs — but if other concurrent destroys are
+  /// queueing new commands on the backend at the same time, no
+  /// individual flush guarantees the backend is empty afterwards.
+  /// Filament's internal Renderer mSwapChain state can end up
+  /// pointing at a SwapChain that another destroy is in the middle
+  /// of freeing, tripping the `endFrame:490` precondition.
+  ///
+  /// Serialising destroys gives flush() a stable target: nothing
+  /// else is queueing destroy work, so the flush truly drains and
+  /// the synchronous engine->destroy can proceed safely.
+  static Future<void> _destroyChain = Future.value();
+
   //
   Future destroySwapChain(SwapChain swapChain) async {
-    _logger.info("Destroying swapchain");
-    await renderManager.detachAll(swapChain);
+    final completer = Completer<void>();
+    final prev = _destroyChain;
+    _destroyChain = completer.future;
+    await prev;
+    try {
+      _logger.info("Destroying swapchain");
+      await renderManager.detachAll(swapChain);
 
-    // Drain Filament's backend command queue before releasing the
-    // SwapChain. `RenderManager::removeSwapChain` (called inside
-    // detachAll) takes Thermion's render-manager mutex and finishes
-    // synchronously, so no future RenderManager::render iteration
-    // will touch this swap chain. But Filament has its own internal
-    // command stream that processes BEGIN_FRAME / render / END_FRAME
-    // on its backend thread, independently of Thermion's render
-    // thread. If a frame's endFrame is still queued on that backend
-    // when `engine->destroy(swapChain)` runs synchronously on our
-    // thread, the SwapChain memory is freed before endFrame
-    // executes — and Filament aborts at Renderer.cpp:490 with
-    // "SwapChain must remain valid until endFrame is called."
-    //
-    // `flushAndWait()` blocks until the backend has processed every
-    // command submitted up to this point, guaranteeing the pending
-    // endFrame ran on a still-valid swap chain. Filament's docs for
-    // `Engine::destroy(SwapChain*)` explicitly recommend this when a
-    // frame might be in flight; the upstream pattern wasn't enforcing
-    // it because the implicit-drain-by-luck in single-viewer apps
-    // hid the requirement.
-    //
-    // Surfaced in multi-viewer Flutter apps: with one viewer
-    // disposing while another mounts, the frame scheduler keeps
-    // firing renders, and Filament's backend has commands in flight
-    // from the very recent renders when our destroy runs.
-    await flush();
+      // Drain Filament's backend command queue before releasing the
+      // SwapChain. `RenderManager::removeSwapChain` (called inside
+      // detachAll) takes Thermion's render-manager mutex and finishes
+      // synchronously, so no future RenderManager::render iteration
+      // will touch this swap chain. But Filament has its own internal
+      // command stream that processes BEGIN_FRAME / render / END_FRAME
+      // on its backend thread, independently of Thermion's render
+      // thread. If a frame's endFrame is still queued on that backend
+      // when `engine->destroy(swapChain)` runs synchronously on our
+      // thread, the SwapChain memory is freed before endFrame
+      // executes — and Filament aborts at Renderer.cpp:490 with
+      // "SwapChain must remain valid until endFrame is called."
+      //
+      // `flushAndWait()` blocks until the backend has processed every
+      // command submitted up to this point. Combined with the destroy
+      // serialisation above, this guarantees a quiet backend at the
+      // moment we synchronously call engine->destroy.
+      await flush();
 
-    await withVoidCallback((requestId, callback) {
-      Engine_destroySwapChainRenderThread(
-          engine, swapChain.getNativeHandle(), requestId, callback);
-    });
+      await withVoidCallback((requestId, callback) {
+        Engine_destroySwapChainRenderThread(
+            engine, swapChain.getNativeHandle(), requestId, callback);
+      });
 
-    _swapChains.remove(swapChain);
-    _logger.info("Destroyed swapchain");
+      _swapChains.remove(swapChain);
+      _logger.info("Destroyed swapchain");
+    } finally {
+      completer.complete();
+    }
   }
 
   // Destroys the specified entity. You must ensure that the entity has already

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -256,6 +256,33 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     _logger.info("Destroying swapchain");
     await renderManager.detachAll(swapChain);
 
+    // Drain Filament's backend command queue before releasing the
+    // SwapChain. `RenderManager::removeSwapChain` (called inside
+    // detachAll) takes Thermion's render-manager mutex and finishes
+    // synchronously, so no future RenderManager::render iteration
+    // will touch this swap chain. But Filament has its own internal
+    // command stream that processes BEGIN_FRAME / render / END_FRAME
+    // on its backend thread, independently of Thermion's render
+    // thread. If a frame's endFrame is still queued on that backend
+    // when `engine->destroy(swapChain)` runs synchronously on our
+    // thread, the SwapChain memory is freed before endFrame
+    // executes — and Filament aborts at Renderer.cpp:490 with
+    // "SwapChain must remain valid until endFrame is called."
+    //
+    // `flushAndWait()` blocks until the backend has processed every
+    // command submitted up to this point, guaranteeing the pending
+    // endFrame ran on a still-valid swap chain. Filament's docs for
+    // `Engine::destroy(SwapChain*)` explicitly recommend this when a
+    // frame might be in flight; the upstream pattern wasn't enforcing
+    // it because the implicit-drain-by-luck in single-viewer apps
+    // hid the requirement.
+    //
+    // Surfaced in multi-viewer Flutter apps: with one viewer
+    // disposing while another mounts, the frame scheduler keeps
+    // firing renders, and Filament's backend has commands in flight
+    // from the very recent renders when our destroy runs.
+    await flush();
+
     await withVoidCallback((requestId, callback) {
       Engine_destroySwapChainRenderThread(
           engine, swapChain.getNativeHandle(), requestId, callback);

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
@@ -47,8 +47,30 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
   }
 
   Future _syncViews() async {
-    for (final swapChainHandle in _attachments.keys) {
-      final views = _attachments[swapChainHandle]!;
+    // Snapshot the keys and the per-key view list BEFORE iterating.
+    // Concurrent `attach` / `detach` calls (common in multi-viewer
+    // apps where multiple viewers mount or dispose at the same time)
+    // mutate `_attachments` while we await on the render thread
+    // round-trip. A naive `for (final h in _attachments.keys) { … }`
+    // loop yields to the event loop on the await, lets a concurrent
+    // attach/detach modify the live map, then resumes with stale
+    // iterator state — `_syncViews` ends up pushing inconsistent
+    // view lists to C++ RenderManager (some swap chains skipped,
+    // others written with old data). The downstream symptom is the
+    // `endFrame:490 — SwapChain must remain valid` precondition
+    // when the render iteration touches the inconsistent state.
+    //
+    // Snapshotting also tolerates removal: if an entry was deleted
+    // by the time we get back to it, the views list will be null
+    // and we skip it.
+    final snapshot = <Pointer<TSwapChain>, List<(int, View)>>{};
+    for (final entry in _attachments.entries) {
+      snapshot[entry.key] = List.of(entry.value);
+    }
+
+    for (final swapChainHandle in snapshot.keys) {
+      final views = snapshot[swapChainHandle];
+      if (views == null) continue;
       final pointers = allocate<PointerClass>(views.length);
       for (int i = 0; i < views.length; i++) {
         pointers[i] = views[i].$2.getNativeHandle();

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:logging/logging.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_swapchain.dart';
 import 'package:thermion_dart/src/filament/src/interface/render_manager.dart';
@@ -16,34 +18,70 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
 
   static final _attachments = <Pointer<TSwapChain>, List<(int, View)>>{};
 
-  @override
-  Future attach(View view, SwapChain swapChain, {int renderOrder = 0}) async {
-    final handle = swapChain.getNativeHandle();
-    if (!_attachments.containsKey(handle)) {
-      _attachments[handle] = [];
-    }
+  /// Serialises every operation that mutates `_attachments` and runs
+  /// `_syncViews` (attach / detach / detachAll). Concurrent calls from
+  /// sibling viewers in multi-viewer apps were running in parallel,
+  /// each taking its own `_syncViews` snapshot at a different moment.
+  /// One viewer's snapshot could include another viewer's view that
+  /// was being concurrently destroyed via `destroyView`; the
+  /// `setRenderable` call then passed a dangling native pointer to
+  /// Filament and the process took a SIGSEGV at the next access.
+  ///
+  /// Serialising means each attach/detach/_syncViews completes before
+  /// the next can begin — the snapshot it takes is always a stable
+  /// view of the world for the duration of its setRenderable round-
+  /// trips. View destruction (which awaits `detach(view)` first via
+  /// `destroyView`) cannot interleave inside another viewer's sync.
+  static Future<void> _opChain = Future.value();
 
-    _attachments[handle]!.removeWhere((v) => v.$2 == view);
-    _attachments[handle]!.add((renderOrder, view));
-    _attachments[handle]!.sort((a, b) => a.$1.compareTo(b.$1));
-    await _syncViews();
+  Future<T> _serialize<T>(Future<T> Function() op) {
+    final completer = Completer<T>();
+    final prev = _opChain;
+    _opChain = completer.future.then((_) {}, onError: (_) {});
+    return prev.then((_) async {
+      try {
+        final result = await op();
+        completer.complete(result);
+        return result;
+      } catch (e, st) {
+        completer.completeError(e, st);
+        rethrow;
+      }
+    });
   }
 
   @override
-  Future detach(View view, {SwapChain? swapChain}) async {
-    if (swapChain == null) {
-      for (final swapChainHandle in _attachments.keys) {
-        _attachments[swapChainHandle]!.removeWhere((v) => v.$2 == view);
-      }
-    } else {
-      if (!_attachments.containsKey(swapChain.getNativeHandle())) {
-        _attachments[swapChain.getNativeHandle()] = [];
+  Future attach(View view, SwapChain swapChain, {int renderOrder = 0}) {
+    return _serialize(() async {
+      final handle = swapChain.getNativeHandle();
+      if (!_attachments.containsKey(handle)) {
+        _attachments[handle] = [];
       }
 
-      _attachments[swapChain.getNativeHandle()]!
-          .removeWhere((v) => v.$2 == view);
-    }
-    await _syncViews();
+      _attachments[handle]!.removeWhere((v) => v.$2 == view);
+      _attachments[handle]!.add((renderOrder, view));
+      _attachments[handle]!.sort((a, b) => a.$1.compareTo(b.$1));
+      await _syncViews();
+    });
+  }
+
+  @override
+  Future detach(View view, {SwapChain? swapChain}) {
+    return _serialize(() async {
+      if (swapChain == null) {
+        for (final swapChainHandle in _attachments.keys) {
+          _attachments[swapChainHandle]!.removeWhere((v) => v.$2 == view);
+        }
+      } else {
+        if (!_attachments.containsKey(swapChain.getNativeHandle())) {
+          _attachments[swapChain.getNativeHandle()] = [];
+        }
+
+        _attachments[swapChain.getNativeHandle()]!
+            .removeWhere((v) => v.$2 == view);
+      }
+      await _syncViews();
+    });
   }
 
   Future _syncViews() async {
@@ -86,11 +124,13 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
     }
   }
 
-  Future detachAll(SwapChain swapChain) async {
-    await withVoidCallback((requestId, cb) =>
-        RenderManager_removeSwapChainRenderThread(
-            pointer, swapChain.getNativeHandle(), requestId, cb));
-    _attachments.remove(swapChain.getNativeHandle());
+  Future detachAll(SwapChain swapChain) {
+    return _serialize(() async {
+      await withVoidCallback((requestId, cb) =>
+          RenderManager_removeSwapChainRenderThread(
+              pointer, swapChain.getNativeHandle(), requestId, cb));
+      _attachments.remove(swapChain.getNativeHandle());
+    });
   }
 
   void destroy() {

--- a/thermion_dart/native/src/rendering/RenderManager.cpp
+++ b/thermion_dart/native/src/rendering/RenderManager.cpp
@@ -114,6 +114,35 @@ namespace thermion
       return false;
     }
 
+    // Skip the entire begin/render/end cycle if no views are
+    // attached. setRendering(false) and detach(view) both remove the
+    // view from this entry's view list but leave the swap chain
+    // entry behind for later reattachment, so we can land in this
+    // function with the swap chain still in `mViewAttachments` but
+    // nothing to render. Calling beginFrame / endFrame on a swap
+    // chain that has no work is wasteful in single-viewer apps and
+    // dangerous in multi-viewer ones: Filament's Renderer is
+    // documented as one-Renderer-per-one-window, but Thermion shares
+    // a single Renderer across every swap chain in the engine, so
+    // its `mSwapChain` member gets set/cleared rapidly across the
+    // iteration. An empty-views begin/end fires the same internal
+    // state machine as a real frame, opening a window for the
+    // SwapChain validity assertion at endFrame:490 to trip during
+    // dispose / mount transitions.
+    bool hasAnyView = false;
+    for (int i = 0; i < numViewAttachments; i++)
+    {
+      if (attachment.views[i])
+      {
+        hasAnyView = true;
+        break;
+      }
+    }
+    if (!hasAnyView)
+    {
+      return false;
+    }
+
     auto beforeBegin = std::chrono::high_resolution_clock::now();
     bool beginFrame = mRenderer->beginFrame(attachment.swapChain, frameTimeInNanos);
     auto afterBegin = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
## Summary

Four fixes that together make Thermion's multi-viewer pipeline (multiple \`SwapChain\`s sharing one \`Engine\` / \`Renderer\`) safe under contention. Each addresses a distinct race exposed when several viewers mount, dispose, or render concurrently. Single-viewer is unaffected.

## Background

Filament documents \`Renderer\` as a per-window primitive — the example in \`Engine.h\` shows one \`Engine\` ↔ one \`SwapChain\` ↔ one \`Renderer\` ↔ one \`View\`, and \`Renderer.h:343\` says *"It is recommended to use the same swapChain for every call to beginFrame, failing to do so can result is losing all or part of the FrameInfo history."* Thermion shares a single \`mRenderer\` across every \`SwapChain\` in the engine and calls \`beginFrame(SC_i)\` / \`endFrame()\` for each entry in \`mViewAttachments\` inside one \`render()\` call. That pattern works in single-viewer apps but has multiple race windows the moment more than one viewer is involved.

This PR closes those windows. (Filament's per-window assumption is itself worth addressing long-term via per-SwapChain Renderers, but the changes below make the shared-Renderer-with-multiple-SwapChains pattern reliable in the meantime.)

## Fix 1 — \`flushAndWait\` before destroying a SwapChain

\`Engine::destroy(SwapChain*)\` is documented as not synchronising with the GPU; explicit guidance is to call \`flushAndWait()\` first if a frame might still be in flight. \`destroySwapChain\` previously called \`detachAll\` (which removes the swap chain from \`mViewAttachments\` synchronously) and then immediately \`Engine_destroySwapChainRenderThread\`. Filament's *backend* command queue could still have a \`BEGIN_FRAME\` / \`END_FRAME\` pair referencing the swap chain when the synchronous \`engine->destroy(swapChain)\` frees the underlying object. The backend then runs endFrame on freed memory and aborts at \`Renderer.cpp:490\` — *"SwapChain must remain valid until endFrame is called."*

Insert \`await flush()\` between \`detachAll\` and \`Engine_destroySwapChainRenderThread\`.

## Fix 2 — skip begin/end cycle when SwapChain has no attached views

Both \`setRendering(false)\` and \`renderManager.detach(view)\` remove the view from a swap chain entry's view list but leave the swap chain entry itself in \`mViewAttachments\` for later reattachment. When \`renderSwapChainAt\` then iterates that entry, it called \`mRenderer->beginFrame(...)\` / \`endFrame()\` with no actual rendering work in between — wasted in single-viewer apps, dangerous in multi-viewer ones because the per-pair internal state on Filament's \`mSwapChain\` gets set/cleared rapidly across the iteration, opening a race window for the validity assertion when concurrent destroy/attach traffic from a sibling viewer hits Filament's internal state.

Scan \`attachment.views\` before calling \`beginFrame\`. Return false if all are null. The begin/end pair only happens when there's actual rendering work — which is what Filament's Renderer expects.

## Fix 3 — serialise \`destroySwapChain\` + snapshot \`_syncViews\` iteration

Two changes in one commit because they address overlapping symptoms in the same dispose path:

(a) **\`destroySwapChain\` serialisation**: in mass-dispose scenarios (e.g., a stress-test screen toggling 8 viewers down to 1), eight concurrent \`destroySwapChain\` calls each ran their own \`detachAll → flush → destroy\` sequence in unsynchronised parallel. Each call's \`flush()\` had no stable target — other destroys were concurrently queueing fresh commands on Filament's backend, so no individual flush guaranteed a quiet backend. The shared Renderer's \`mSwapChain\` could end up pointing at a SwapChain another destroy was in the middle of freeing. Add a \`static Future<void> _destroyChain\` to \`FFIFilamentApp\` so each \`destroySwapChain\` awaits the previous one — flush() now has a quiet backend at the moment it runs.

(b) **\`_syncViews\` iteration snapshot**: the loop iterated \`_attachments.keys\` directly, awaiting a render-thread round-trip on each iteration. Concurrent \`attach\` / \`detach\` from sibling viewers mutated the live map across the await, leaving the iterator with stale state — \`_syncViews\` then pushed inconsistent view lists to C++ RenderManager. Snapshot keys + per-key views at function entry; iterate the snapshot.

## Fix 4 — serialise \`attach\` / \`detach\` / \`detachAll\` through a static Future chain

Fix 3 kept iteration self-consistent across its own awaits, but didn't synchronise *between* sibling viewers' attach/detach calls. Each viewer's snapshot was taken at its own moment; one viewer's snapshot could capture another viewer's view that was being concurrently destroyed via \`destroyView\` (which itself awaits \`detach(view)\`). By the time the snapshot's \`_syncViews\` reached \`RenderManager_setRenderableRenderThread\`, the captured view's native handle had been freed — Filament dereferenced the dangling pointer and the process took a SIGSEGV (past the precondition checks).

Introduce a static \`_opChain\` Future and a \`_serialize\` helper in \`FFIRenderManager\`. \`attach\`, \`detach\`, and \`detachAll\` now each await the previous op before running. Concurrent calls queue cleanly; view destruction can no longer interleave inside another viewer's sync.

## Result

Combined, every shared-state mutation in the multi-viewer pipeline runs serially. The spike app's stress-test screen on Android — which previously crashed on every viewer-count toggle — now mounts, renders, region-picks, and disposes cleanly across 1 / 4 / 8 viewer counts and arbitrary toggle sequences.

## Verification

- 1 → 4 → 8 → 4 → 1 → 4 toggle sequence on Android emulator: stable. No SIGABRT, no SIGSEGV, no \`endFrame:490\` precondition.
- iOS, macOS, Windows: existing test paths pass — no new locks introduced where none were needed.

## Related

- Sibling PRs in this series: #169 (Android per-view swap chains), #170 (viewer detach-before-destroy). All three are independently mergeable; together they cover every distinct race we've found.
- #168 — focalPoint follow-up to merged #163.