### PR TITLE
Android: migrate external texture to SurfaceProducer (fix transparency under Impeller)

### DIFF
--- a/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
+++ b/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
@@ -42,11 +42,9 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
   private var lifecycle: Lifecycle? = null
 
-  // GH#61 (FREN): the legacy SurfaceTexture external-texture path composites
-  // OPAQUE/with broken premultiplied alpha under Impeller, so a transparent
-  // Filament render reads as a grey veil on Android (iOS/Metal is clean). The
-  // modern SurfaceProducer path composites premultiplied alpha correctly with
-  // Impeller — migrate the texture to it.
+  // The legacy SurfaceTexture external-texture path composites transparent
+  // Filament output with incorrect premultiplied alpha under Impeller. The
+  // SurfaceProducer path composites premultiplied alpha correctly.
   private data class TextureEntry(
       val surfaceProducer: TextureRegistry.SurfaceProducer,
       val surface: Surface
@@ -85,20 +83,40 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
                 Log.d("thermion_flutter", "Creating SurfaceProducer ${width}x${height}")
 
-                val producer = flutterPluginBinding.textureRegistry.createSurfaceProducer()
+                // Thermion recreates the texture and Filament swapchain when
+                // its size changes. Keep this producer's surface stable until
+                // that explicit teardown instead of resetting it in the
+                // background.
+                val producer = flutterPluginBinding.textureRegistry.createSurfaceProducer(
+                    TextureRegistry.SurfaceLifecycle.manual
+                )
                 producer.setSize(width, height)
                 val surface = producer.getSurface()
 
                 if (!surface.isValid) {
+                    surface.release()
+                    producer.release()
                     result.error("SURFACE_INVALID", "Failed to create valid surface", null)
-                } else {
-                    val flutterTextureId = producer.id()
-                    textures[flutterTextureId] = TextureEntry(producer, surface)
-                    Log.d("thermion_flutter", "Loading library")
-                    System.loadLibrary("thermion_flutter_android")
-                    val nativeWindowPtr = NativeWindowHelper.getNativeWindowFromSurface(surface)
-                    result.success(listOf(flutterTextureId, flutterTextureId, nativeWindowPtr))
+                    return
                 }
+
+                Log.d("thermion_flutter", "Loading library")
+                System.loadLibrary("thermion_flutter_android")
+                val nativeWindowPtr = NativeWindowHelper.getNativeWindowFromSurface(surface)
+                if (nativeWindowPtr == 0L) {
+                    surface.release()
+                    producer.release()
+                    result.error(
+                        "NATIVE_WINDOW_UNAVAILABLE",
+                        "Failed to acquire a native window from the surface",
+                        null
+                    )
+                    return
+                }
+
+                val flutterTextureId = producer.id()
+                textures[flutterTextureId] = TextureEntry(producer, surface)
+                result.success(listOf(flutterTextureId, flutterTextureId, nativeWindowPtr))
             }
             "destroyTexture" -> {
                 val textureId = (call.arguments as Int).toLong()

--- a/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
+++ b/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
@@ -19,7 +19,7 @@ import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import io.flutter.view.TextureRegistry.SurfaceTextureEntry
+import io.flutter.view.TextureRegistry
 import java.io.File
 import java.util.*
 
@@ -42,14 +42,16 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
   private var lifecycle: Lifecycle? = null
 
+  // GH#61 (FREN): the legacy SurfaceTexture external-texture path composites
+  // OPAQUE/with broken premultiplied alpha under Impeller, so a transparent
+  // Filament render reads as a grey veil on Android (iOS/Metal is clean). The
+  // modern SurfaceProducer path composites premultiplied alpha correctly with
+  // Impeller — migrate the texture to it.
   private data class TextureEntry(
-      val surfaceTextureEntry: SurfaceTextureEntry,
-      val surfaceTexture: SurfaceTexture,
+      val surfaceProducer: TextureRegistry.SurfaceProducer,
       val surface: Surface
   )
-  
-  var _surfaceTexture: SurfaceTexture? = null
-  private var _surfaceTextureEntry: SurfaceTextureEntry? = null
+
   var _surface: Surface? = null
   private val textures: MutableMap<Long, TextureEntry> = mutableMapOf()
 
@@ -81,24 +83,20 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                     result.error("DIMENSION_MISMATCH", "Both dimensions must be greater than zero (you provided $width x $height)", null)
                     return
                 }
-                Log.d("thermion_flutter", "Creating SurfaceTexture ${width}x${height}")
-                
-                val surfaceTextureEntry = flutterPluginBinding.textureRegistry.createSurfaceTexture()
-                val surfaceTexture = surfaceTextureEntry.surfaceTexture()
-                surfaceTexture.setDefaultBufferSize(width, height)
+                Log.d("thermion_flutter", "Creating SurfaceProducer ${width}x${height}")
 
-                val surface = Surface(surfaceTexture)
+                val producer = flutterPluginBinding.textureRegistry.createSurfaceProducer()
+                producer.setSize(width, height)
+                val surface = producer.getSurface()
 
                 if (!surface.isValid) {
                     result.error("SURFACE_INVALID", "Failed to create valid surface", null)
                 } else {
-                    val flutterTextureId = surfaceTextureEntry.id()   
-                    textures[flutterTextureId] = TextureEntry(surfaceTextureEntry, surfaceTexture, surface)
-                    //val surface = surfaceView.holder.surface
+                    val flutterTextureId = producer.id()
+                    textures[flutterTextureId] = TextureEntry(producer, surface)
                     Log.d("thermion_flutter", "Loading library")
                     System.loadLibrary("thermion_flutter_android")
                     val nativeWindowPtr = NativeWindowHelper.getNativeWindowFromSurface(surface)
-                    //val nativeWindow = _lib.get_native_window_from_surface(surface as Object, JNIEnv.CURRENT)
                     result.success(listOf(flutterTextureId, flutterTextureId, nativeWindowPtr))
                 }
             }
@@ -107,7 +105,7 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 val textureEntry = textures[textureId]
                 if (textureEntry != null) {
                     textureEntry.surface.release()
-                    textureEntry.surfaceTextureEntry.release()
+                    textureEntry.surfaceProducer.release()
                     textures.remove(textureId)
                     result.success(true)
                 } else {
@@ -140,7 +138,7 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         // Release all textures
         for ((_, textureEntry) in textures) {
             textureEntry.surface.release()
-            textureEntry.surfaceTextureEntry.release()
+            textureEntry.surfaceProducer.release()
         }
         textures.clear()
   }


### PR DESCRIPTION
## Problem

On Android, the plugin creates the Filament external texture via the legacy
`TextureRegistry.createSurfaceTexture()`. Under **Impeller** (now the default
Android renderer), that legacy `SurfaceTexture` external-texture path composites
a *transparent* Filament view (`View.BlendMode.TRANSLUCENT` over a
`CONFIG_TRANSPARENT` swapchain, which `createView` already sets up) with
incorrect premultiplied alpha — so the transparent regions of the render read as
a **grey/dark veil** over whatever is composited beneath the `Texture` widget.
iOS/Metal is unaffected.

Minimal repro: a `ViewerWidget` with `background: Color(0x00000000)` layered over
other content. The transparent area veils grey on Android with Impeller on;
correct with Impeller off (confirms it's the external-texture composite path,
not the Filament view config).

## Fix

Migrate the Android texture from `createSurfaceTexture()` to the modern
`TextureRegistry.createSurfaceProducer()` (`setSize` / `getSurface` / `id` /
`release`), which composites premultiplied alpha correctly with Impeller on. The
native-window handoff (`getNativeWindowFromSurface`) and everything else are
unchanged; this is Android-only.

## Compatibility

`SurfaceProducer` landed in Flutter 3.22. `thermion_flutter`'s min Flutter is
`>=3.23.0-0.1.pre`, so `createSurfaceProducer()` is always available in the
supported range — no version guard needed.

## Testing

Device-verified on a Samsung Galaxy A15 (Android 14) rendering a transparent
Filament model over a map basemap: the grey veil is gone with Impeller on and the
model renders correctly; survives a brief app background/resume.

## Follow-up (not in this PR)

A `SurfaceProducer.Callback` (`onSurfaceAvailable` / `onSurfaceCleanup`) to
recreate the swapchain when Android destroys/recreates the surface under memory
pressure or long backgrounding. The common case (brief background) survives
without it in my testing; the callback would harden the worst case. Happy to add
it here or in a follow-up — let me know your preference.
