### PR TITLE
windows: fix VK_ERROR_DEVICE_LOST - give the D3D-interop blit its own VkQueue

### DIFF
--- a/thermion_dart/native/src/vulkan/VulkanUtils.cpp
+++ b/thermion_dart/native/src/vulkan/VulkanUtils.cpp
@@ -271,10 +271,24 @@ CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physic
     // 1. Find a suitable queue family
     resources.queueFamilyIndex = findGraphicsQueueFamily(physicalDevice);
 
-    // 2. Get the queue handle
+    // 2. Get the queue handle. Use the SECOND queue in the family when the
+    //    hardware has one (the device requests two — see createLogicalDevice):
+    //    queue 0 belongs to Filament's render thread via VulkanSharedContext,
+    //    and submitting to it concurrently from the platform thread is a
+    //    data race (VK_ERROR_DEVICE_LOST on newer NVIDIA drivers). Fall back
+    //    to queue 0 only on hardware exposing a single graphics queue.
+    uint32_t familyCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, nullptr);
+    std::vector<VkQueueFamilyProperties> families(familyCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, families.data());
+    const uint32_t queueIndex =
+        families[resources.queueFamilyIndex].queueCount >= 2 ? 1u : 0u;
+    std::cout << "[INFO] Blit/command queue: family " << resources.queueFamilyIndex
+              << ", queue index " << queueIndex << std::endl;
+
     vkGetDeviceQueue(device,
         resources.queueFamilyIndex,
-        0,  // First queue in family
+        queueIndex,
         &resources.queue);
 
     // 3. Create command pool
@@ -591,12 +605,27 @@ VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevi
         #endif
         VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME, };
 
-    float queuePriority = 1.0f;
+    // Request a second queue in the family when the hardware exposes one.
+    // Queue 0 is handed to Filament via VulkanSharedContext (render thread);
+    // the D3D-interop Blit submits from the Flutter platform thread. VkQueue
+    // access is externally synchronized, so sharing one queue across those
+    // two threads is a data race — tolerated by some drivers, but newer
+    // NVIDIA drivers (observed on RTX 5090 / 610.62) fail the first
+    // concurrent submission with VK_ERROR_DEVICE_LOST. With two queues the
+    // blit gets its own (see createCommandResources).
+    uint32_t familyCount = 0;
+    bluevk::vkGetPhysicalDeviceQueueFamilyProperties(*physicalDevice, &familyCount, nullptr);
+    std::vector<VkQueueFamilyProperties> families(familyCount);
+    bluevk::vkGetPhysicalDeviceQueueFamilyProperties(*physicalDevice, &familyCount, families.data());
+    const uint32_t queueCount =
+        families[*queueFamilyIndex].queueCount >= 2 ? 2u : 1u;
+
+    float queuePriorities[2] = {1.0f, 1.0f};
     VkDeviceQueueCreateInfo queueCreateInfo = {};
     queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
     queueCreateInfo.queueFamilyIndex = *queueFamilyIndex;
-    queueCreateInfo.queueCount = 1;
-    queueCreateInfo.pQueuePriorities = &queuePriority;
+    queueCreateInfo.queueCount = queueCount;
+    queueCreateInfo.pQueuePriorities = queuePriorities;
 
     VkDeviceCreateInfo deviceCreateInfo = {};
     deviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;

--- a/thermion_dart/native/src/vulkan/VulkanUtils.cpp
+++ b/thermion_dart/native/src/vulkan/VulkanUtils.cpp
@@ -1,5 +1,7 @@
 #include "vulkan/VulkanUtils.h"
 
+#include "Log.hpp"
+
 #include <fstream>
 
 #include <iostream>
@@ -278,13 +280,13 @@ CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physic
     //    data race (VK_ERROR_DEVICE_LOST on newer NVIDIA drivers). Fall back
     //    to queue 0 only on hardware exposing a single graphics queue.
     uint32_t familyCount = 0;
-    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, nullptr);
+    bluevk::vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, nullptr);
     std::vector<VkQueueFamilyProperties> families(familyCount);
-    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, families.data());
+    bluevk::vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, families.data());
     const uint32_t queueIndex =
         families[resources.queueFamilyIndex].queueCount >= 2 ? 1u : 0u;
-    std::cout << "[INFO] Blit/command queue: family " << resources.queueFamilyIndex
-              << ", queue index " << queueIndex << std::endl;
+    Log("[INFO] Blit/command queue: family %d, queue index %d",
+        (int)resources.queueFamilyIndex, (int)queueIndex);
 
     vkGetDeviceQueue(device,
         resources.queueFamilyIndex,

--- a/thermion_dart/native/src/vulkan/windows/WindowsVulkanContext.cpp
+++ b/thermion_dart/native/src/vulkan/windows/WindowsVulkanContext.cpp
@@ -78,15 +78,15 @@ class WindowsVulkanContext::Impl {
             _sharedContext.debugMarkersSupported = false;
             _sharedContext.multiviewSupported = false;
 
-            std::cout << "[INFO] Vulkan logical device created with queue family index "
-                      << queueFamilyIndex << std::endl;
+            Log("[INFO] Vulkan logical device created with queue family index %d",
+                (int)queueFamilyIndex);
 
             CommandResources cmdResources = createCommandResources(device, physicalDevice);
 
             commandPool = cmdResources.commandPool;
             queue = cmdResources.queue;
-            std::cout << "[INFO] Vulkan command resources using queue family index "
-                      << cmdResources.queueFamilyIndex << std::endl;
+            Log("[INFO] Vulkan command resources using queue family index %d",
+                (int)cmdResources.queueFamilyIndex);
 
             VkPhysicalDeviceExternalImageFormatInfo externFormatInfo = {
                 .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO,


### PR DESCRIPTION
## Problem

On Windows with newer NVIDIA hardware/drivers, any Thermion app dies as soon as rendering starts:

```
Initializing WindowsVulkanContext
vkQueueSubmit failed: -4          <- VK_ERROR_DEVICE_LOST
vkWaitForFences failed: -4        <- repeats every frame afterwards
```

sometimes followed by a native abort through Filament's timer-query postcondition (`vkGetQueryPoolResults error=-4`). Reproduced with the unmodified `examples/flutter/quickstart` at `89c135b` on:

- **GPU:** NVIDIA GeForce RTX 5090 (Blackwell)
- **Driver:** 610.62 (32.0.16.1062, 2026-06), Vulkan API 1.4.341
- **OS:** Windows 11 Pro 26200

The device is lost on the *first* frame; the viewport stays blank (or shows the app's clear color) and the app eventually aborts.

## Root cause

`createLogicalDevice` requests a single queue (`queueCount = 1`) in the graphics family. Two independent code paths then fetch **the same `VkQueue`**:

1. Filament, via `VulkanSharedContext` (`graphicsQueueFamilyIndex`, `graphicsQueueIndex = 0`), submitting from its **render thread**;
2. `createCommandResources` (`vkGetDeviceQueue(device, family, 0)`), used by the D3D-interop `Blit()` submitting from the **Flutter platform thread**.

Per the Vulkan spec, queue access is *externally synchronized* — `vkQueueSubmit` on the same queue from two threads without host synchronization is invalid. Many driver generations happen to tolerate it, which is why this hasn't bitten on existing hardware; the current NVIDIA driver for Blackwell rejects the first concurrent submission with `VK_ERROR_DEVICE_LOST`.

## Fix

Request **two queues** from the graphics family when the hardware exposes more than one (NVIDIA exposes 16; the request is clamped to the family's `queueCount`):

- queue **0** remains exclusively Filament's, exactly as before;
- queue **1** is used by `createCommandResources` for the blit/command path.

Both queues are in the same family, so no queue-family ownership transfers are needed and the existing barriers/fences are unchanged. On hardware exposing a single graphics queue (`queueCount == 1`) the behavior is byte-for-byte the old one, so nothing regresses on platforms where the shared queue happened to work.

## Validation

- Before: `examples/flutter/quickstart` reproduces the device loss on the first frame (hardware above).
- After: quickstart and a full app (113 MB character glTF with skin + morph targets) render correctly; no Vulkan errors across repeated runs, window resizes, and viewer re-creation.
- A diagnostic line logs the chosen queue at startup: `[INFO] Blit/command queue: family 0, queue index 1`.

Happy to adjust if you'd prefer a different split (e.g. a dedicated transfer-family queue) — this is the minimal change that makes the existing design valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
