### PR TITLE
Refactor platform texture binding ownership

### DIFF
--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/services.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+
+import 'method_channel_platform_texture_descriptor.dart';
+
+/// Describes an Android SurfaceProducer texture and its native window.
+class AndroidPlatformTextureDescriptor
+    extends MethodChannelPlatformTextureDescriptor {
+  AndroidPlatformTextureDescriptor(
+    super.channel, {
+    required super.flutterTextureId,
+    required super.hardwareId,
+    required super.windowHandle,
+    required super.width,
+    required super.height,
+  });
+
+  _AndroidPlatformTextureBinding? _binding;
+
+  @override
+  View? get boundView => _binding?.view;
+
+  /// Android gets its SurfaceProducer surface synchronously, so it is not
+  /// deferred despite extending the (Linux-oriented) method-channel base.
+  @override
+  bool get deferred => false;
+
+  static Future<AndroidPlatformTextureDescriptor> allocate(
+    MethodChannel channel,
+    int width,
+    int height,
+  ) async {
+    final allocation = await allocateMethodChannelTexture(
+      channel,
+      width,
+      height,
+    );
+    final windowHandle = allocation.windowHandle;
+    if (windowHandle == null || windowHandle == 0) {
+      throw StateError('Android texture has no native window');
+    }
+    return AndroidPlatformTextureDescriptor(
+      channel,
+      flutterTextureId: allocation.flutterTextureId,
+      hardwareId: allocation.hardwareTextureId,
+      windowHandle: windowHandle,
+      width: width,
+      height: height,
+    );
+  }
+
+  @override
+  Future<bool> bindToView(View view) async {
+    final replacement = _AndroidPlatformTextureBinding(this, view);
+    await replacement.bind();
+
+    final previous = _binding;
+    _binding = replacement;
+    await previous?.release();
+    return true;
+  }
+
+  @override
+  Future<void> releaseBinding() async {
+    final binding = _binding;
+    _binding = null;
+    await binding?.release();
+  }
+}
+
+class _AndroidPlatformTextureBinding {
+  _AndroidPlatformTextureBinding(this.descriptor, this.view);
+
+  final AndroidPlatformTextureDescriptor descriptor;
+  final View view;
+
+  SwapChain? _swapChain;
+
+  Future<void> bind() async {
+    if (descriptor.destroyed) {
+      throw StateError('Cannot bind a destroyed texture descriptor');
+    }
+    final windowHandle = descriptor.windowHandle;
+    if (windowHandle == null || windowHandle == 0) {
+      throw StateError('Android texture has no native window');
+    }
+
+    final app = FilamentApp.instance;
+    if (app == null) {
+      throw StateError('Cannot bind a surface after Filament shutdown');
+    }
+
+    final swapChain = await app.createSwapChain(
+      Pointer<Void>.fromAddress(windowHandle),
+    );
+    await app.renderManager.attach(view, swapChain);
+    _swapChain = swapChain;
+  }
+
+  Future<void> release() async {
+    final swapChain = _swapChain;
+    _swapChain = null;
+    final app = FilamentApp.instance;
+    if (swapChain != null && app != null) {
+      await app.destroySwapChain(swapChain);
+    }
+  }
+}

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/darwin_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/darwin_platform_texture_descriptor.dart
@@ -6,6 +6,9 @@ class DarwinPlatformTextureDescriptorImpl extends PlatformTextureDescriptor {
 
   bool _destroyed = false;
 
+  @override
+  bool get destroyed => _destroyed;
+
   DarwinPlatformTextureDescriptorImpl(
     this.texture, {
     required super.flutterTextureId,

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
@@ -31,23 +31,16 @@ class MethodChannelPlatformTextureDescriptor extends PlatformTextureDescriptor {
     int width,
     int height,
   ) async {
-    final result = await channel.invokeMethod("createTexture", [
+    final allocation = await allocateMethodChannelTexture(
+      channel,
       width,
       height,
-      0,
-      0,
-    ]);
-    if (result == null || (result[0] == -1)) {
-      throw Exception("Failed to create texture");
-    }
-    final flutterTextureId = result[0] as int;
-    final hardwareTextureId = result[1] as int;
-    final windowHandle = result[2] as int?; // usually 0 for nullptr
+    );
     return MethodChannelPlatformTextureDescriptor(
       channel,
-      flutterTextureId: flutterTextureId,
-      hardwareId: hardwareTextureId,
-      windowHandle: windowHandle,
+      flutterTextureId: allocation.flutterTextureId,
+      hardwareId: allocation.hardwareTextureId,
+      windowHandle: allocation.windowHandle,
       width: width,
       height: height,
     );
@@ -55,6 +48,7 @@ class MethodChannelPlatformTextureDescriptor extends PlatformTextureDescriptor {
 
   /// Waits for populate() to create the GL texture (deferred path).
   /// Returns the hardware texture ID once ready.
+  @override
   Future<int> awaitTextureReady() async {
     final result = await channel.invokeMethod(
       "awaitTextureReady",
@@ -63,5 +57,39 @@ class MethodChannelPlatformTextureDescriptor extends PlatformTextureDescriptor {
     return result as int;
   }
 
+  @override
+  bool get deferred => true;
+
+  @override
   bool destroyed = false;
+}
+
+typedef MethodChannelTextureAllocation = ({
+  int flutterTextureId,
+  int hardwareTextureId,
+  int? windowHandle,
+});
+
+Future<MethodChannelTextureAllocation> allocateMethodChannelTexture(
+  MethodChannel channel,
+  int width,
+  int height,
+) async {
+  final result = await channel.invokeMethod("createTexture", [
+    width,
+    height,
+    0,
+    0,
+  ]);
+  if (result == null || (result[0] == -1)) {
+    throw Exception("Failed to create texture");
+  }
+  final flutterTextureId = result[0] as int;
+  final hardwareTextureId = result[1] as int;
+  final windowHandle = result[2] as int?; // usually 0 for nullptr
+  return (
+    flutterTextureId: flutterTextureId,
+    hardwareTextureId: hardwareTextureId,
+    windowHandle: windowHandle,
+  );
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
@@ -1,3 +1,5 @@
+import 'package:thermion_dart/thermion_dart.dart';
+
 abstract class PlatformTextureDescriptor {
   final int flutterTextureId;
   int hardwareId;
@@ -5,16 +7,43 @@ abstract class PlatformTextureDescriptor {
   int width;
   int height;
 
+  View? get boundView => null;
+
   PlatformTextureDescriptor({
     required this.flutterTextureId,
     required this.hardwareId,
-    this.windowHandle,
     required this.width,
     required this.height,
+    this.windowHandle,
   });
+
+  /// Descriptors are identified by their Flutter texture id — the stable
+  /// reference that maps to the backing native surface/producer.
+  @override
+  bool operator ==(Object other) =>
+      other is PlatformTextureDescriptor &&
+      other.flutterTextureId == flutterTextureId;
+
+  @override
+  int get hashCode => flutterTextureId.hashCode;
 
   void markTextureFrameAvailable();
   Future destroy();
+
+  Future<bool> bindToView(View view) async => false;
+
+  Future<void> releaseBinding() async {}
+
+  /// Whether [destroy] has run.
+  bool get destroyed => false;
+
+  /// True when the backing GL texture is created asynchronously; callers must
+  /// await [awaitTextureReady] before using [hardwareId].
+  bool get deferred => false;
+
+  /// Completes with the hardware texture id. Synchronous descriptors resolve
+  /// immediately with the current [hardwareId].
+  Future<int> awaitTextureReady() async => hardwareId;
 
   Future Function(Duration timestamp)? onBeginFrame;
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_factory.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_factory.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'android_platform_texture_descriptor.dart';
+import 'darwin_platform_texture_descriptor.dart';
+import 'method_channel_platform_texture_descriptor.dart';
+import 'platform_texture_descriptor.dart';
+
+Future<PlatformTextureDescriptor> createPlatformTextureDescriptor(
+  MethodChannel channel,
+  int width,
+  int height,
+) async {
+  if (Platform.isMacOS || Platform.isIOS) {
+    return DarwinPlatformTextureDescriptorImpl.allocate(width, height);
+  }
+  if (Platform.isAndroid) {
+    return AndroidPlatformTextureDescriptor.allocate(channel, width, height);
+  }
+  return MethodChannelPlatformTextureDescriptor.allocate(
+    channel,
+    width,
+    height,
+  );
+}

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -4,9 +4,8 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart' hide View;
 import 'package:logging/logging.dart';
-import 'package:thermion_flutter/src/platform/src/darwin_platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/platform/src/frame_scheduler.dart';
-import 'package:thermion_flutter/src/platform/src/method_channel_platform_texture_descriptor.dart';
+import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor_factory.dart';
 import '../../../thermion_flutter.dart';
 import 'platform_texture_descriptor.dart';
 // ignore: implementation_imports
@@ -46,14 +45,6 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
   // This allows us to destroy the correct RT on resize, even when the view
   // has been redirected to an internal RT (e.g. in composite highlight mode).
   static final _viewRenderTargets = <View, RenderTarget>{};
-
-  // Track the SwapChain currently bound to each view (Android only).
-  // The Android branch of createTextureAndBindToView destroys this view's
-  // *previous* swap chain after creating the new one. Keying by view
-  // (rather than iterating FilamentApp's global swap-chain list) is what
-  // makes multi-viewer apps work — without this, mounting viewer #N
-  // would destroy viewer #(N-1)'s swap chain and freeze it.
-  static final _viewSwapChains = <View, SwapChain>{};
 
   // Deferred Filament render target cleanup for Windows resize.
   // Old RT stays alive so native can Blit from it during the swap window.
@@ -409,7 +400,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
   /// then creates Filament resources. Runs after createTextureAndBindToView
   /// returns so the Texture widget can be built first.
   static void _scheduleDeferredBinding(
-    MethodChannelPlatformTextureDescriptor descriptor,
+    PlatformTextureDescriptor descriptor,
     View view,
     int width,
     int height,
@@ -439,52 +430,20 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
       );
     }
 
-    late PlatformTextureDescriptor descriptor;
-
-    if (Platform.isMacOS || Platform.isIOS) {
-      descriptor = DarwinPlatformTextureDescriptorImpl.allocate(width, height);
-    } else {
-      descriptor = await MethodChannelPlatformTextureDescriptor.allocate(
-        channel,
-        width,
-        height,
-      );
-    }
+    final descriptor = await createPlatformTextureDescriptor(
+      channel,
+      width,
+      height,
+    );
 
     // Add to descriptors early so markTextureFrameAvailable is called
     // (triggers populate() which creates the deferred GL texture)
     _descriptors.add(descriptor);
 
-    // On Android, we recreate the swapchain whenever the size changes
-    // TODO - why not allocate a larger swapchain initially and just change
-    // the viewport?
-    // In fact we can probably do this for all platforms
-    if (Platform.isAndroid) {
-      // The OLD swap chain to destroy is the one *previously bound to
-      // this view* — not whatever happens to be at the front of
-      // FilamentApp's global list. Earlier code iterated
-      // `getSwapChains()` and destroyed `swapChains.first`, which in a
-      // multi-viewer app destroyed *another* viewer's swap chain, freezing
-      // its viewport. Tracking per-view in `_viewSwapChains` scopes the
-      // destroy to this view only.
-      final oldSwapChain = _viewSwapChains[view];
-
-      final swapChain = await FilamentApp.instance!.createSwapChain(
-        Pointer<Void>.fromAddress(descriptor.windowHandle!),
-      );
-
-      await FilamentApp.instance!.renderManager.attach(view, swapChain);
-      _viewSwapChains[view] = swapChain;
-
-      // Destroy the old swap chain after the new one is attached so the
-      // view never has a window of being unattached.
-      if (oldSwapChain != null) {
-        await FilamentApp.instance!.destroySwapChain(oldSwapChain);
-      }
-
-      // On other platforms, if a hardware texture ID is returned, this means
-      // the texture is immediately available for rendering.
-    } else if (descriptor.hardwareId != 0) {
+    final bound = await _bindDescriptorToView(descriptor, view);
+    if (!bound && descriptor.hardwareId != 0) {
+      // If a hardware texture ID is returned, the texture is immediately
+      // available for rendering.
       await _createFilamentResources(descriptor, view, width, height);
 
       // On Linux, when running via EGL/OpenGL backend (Wayland),
@@ -493,12 +452,12 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
       // We need to defer binding the surface.
       //
     } else if (Platform.isLinux) {
-      _scheduleDeferredBinding(
-        descriptor as MethodChannelPlatformTextureDescriptor,
-        view,
-        width,
-        height,
-      );
+      if (!descriptor.deferred) {
+        throw StateError(
+          'Deferred texture creation requires a deferred descriptor',
+        );
+      }
+      _scheduleDeferredBinding(descriptor, view, width, height);
     }
 
     await view.setViewport(width, height);
@@ -529,7 +488,9 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
         return await _resizeTextureWindows(texture, view, width, height);
       }
 
-      // Non-Windows: full destroy + recreate (existing path)
+      // Non-Windows: full destroy + recreate (existing path).
+      // TODO: alternatively, allocate a larger swapchain up front and just
+      // change the viewport on resize, avoiding the destroy/recreate.
       var newTexture = await createTextureAndBindToView(view, width, height);
       if (newTexture == null) {
         throw Exception('Failed to create texture during resize');
@@ -628,14 +589,33 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     return texture;
   }
 
+  /// Binds [descriptor] to [view], then releases any *other* descriptor still
+  /// bound to the same view, so a view never holds two active bindings.
+  ///
+  /// Scoping the release to descriptors on *this* view (matched via
+  /// [PlatformTextureDescriptor.boundView]) — rather than touching every swap
+  /// chain in FilamentApp's global list — is what makes multi-viewer apps
+  /// work: without the per-view scoping, mounting viewer #N would release
+  /// viewer #(N-1)'s swap chain and freeze it.
+  Future<bool> _bindDescriptorToView(
+    PlatformTextureDescriptor descriptor,
+    View view,
+  ) async {
+    if (!await descriptor.bindToView(view)) return false;
+    for (final other in _descriptors) {
+      if (other != descriptor && other.boundView == view) {
+        await other.releaseBinding();
+      }
+    }
+    return true;
+  }
+
   @override
   Future<void> releaseTextureBindingForView(View view) async {
-    // Only Android keeps per-view swap-chain bookkeeping in this plugin
-    // (see `_viewSwapChains` and the size-change branch of
-    // `createTextureAndBindToView`). Other platforms are no-ops.
-    final swapChain = _viewSwapChains.remove(view);
-    if (swapChain != null) {
-      await FilamentApp.instance!.destroySwapChain(swapChain);
+    for (final descriptor in _descriptors) {
+      if (descriptor.boundView == view) {
+        await descriptor.releaseBinding();
+      }
     }
   }
 }

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
+
+// ignore: implementation_imports
+import 'package:thermion_dart/src/filament/src/interface/native_handle.dart';
+
+void main() {
+  group('PlatformTextureDescriptor equality', () {
+    test(
+      'descriptors with the same flutterTextureId match (== and hashCode)',
+      () {
+        // Two distinct instances that differ in every other field — only the
+        // stable native reference (flutterTextureId) is shared.
+        final a = _TestDescriptor(flutterTextureId: 1, hardwareId: 10);
+        final b = _TestDescriptor(flutterTextureId: 1, hardwareId: 99);
+
+        expect(a == b, isTrue);
+        expect(a.hashCode, b.hashCode);
+      },
+    );
+
+    test('descriptors with different flutterTextureIds do not match', () {
+      expect(
+        _TestDescriptor(flutterTextureId: 1) ==
+            _TestDescriptor(flutterTextureId: 2),
+        isFalse,
+      );
+    });
+  });
+
+  // [View] inherits its equality from [NativeHandle] (compare-by-native-handle),
+  // so this group verifies the mechanism `descriptor.boundView` relies on for
+  // matching distinct Dart wrappers around the same native view.
+  group('NativeHandle equality (inherited by View)', () {
+    test('handles with the same native reference match', () {
+      final a = _TestNativeHandle(42);
+      final b = _TestNativeHandle(42);
+
+      expect(a == b, isTrue);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('handles with different native references do not match', () {
+      expect(_TestNativeHandle(42) == _TestNativeHandle(43), isFalse);
+    });
+  });
+}
+
+class _TestDescriptor extends PlatformTextureDescriptor {
+  _TestDescriptor({
+    required int flutterTextureId,
+    int hardwareId = 0,
+  }) : super(
+          flutterTextureId: flutterTextureId,
+          hardwareId: hardwareId,
+          width: 1,
+          height: 1,
+        );
+
+  @override
+  void markTextureFrameAvailable() {}
+
+  @override
+  Future destroy() async {}
+}
+
+class _TestNativeHandle extends NativeHandle<int> {
+  _TestNativeHandle(this.handle);
+
+  final int handle;
+
+  @override
+  int getNativeHandle() => handle;
+}


### PR DESCRIPTION
Adds a `AndroidPlatformTextureDescriptor` class responsible for requesting a new SwapChain (and binding to the relevant `View`) before the old SwapChain is destroyed.

This is preparatory work for a follow-up PR to recover a SwapChain when the app is foregrounded.