### PR TITLE
Android: recover SurfaceProducer swapchains after surface replacement

### DIFF
--- a/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
+++ b/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
@@ -47,7 +47,7 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   // SurfaceProducer path composites premultiplied alpha correctly.
   private data class TextureEntry(
       val surfaceProducer: TextureRegistry.SurfaceProducer,
-      val surface: Surface
+      var surface: Surface?
   )
 
   var _surface: Surface? = null
@@ -83,12 +83,12 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
                 Log.d("thermion_flutter", "Creating SurfaceProducer ${width}x${height}")
 
-                // Thermion recreates the texture and Filament swapchain when
-                // its size changes. Keep this producer's surface stable until
-                // that explicit teardown instead of resetting it in the
-                // background.
+                // Allow Flutter to release the ImageReader-backed surface
+                // while the app is backgrounded. The callback below notifies
+                // Dart to destroy and recreate the Filament swapchain around
+                // the replacement surface.
                 val producer = flutterPluginBinding.textureRegistry.createSurfaceProducer(
-                    TextureRegistry.SurfaceLifecycle.manual
+                    TextureRegistry.SurfaceLifecycle.resetInBackground
                 )
                 producer.setSize(width, height)
                 val surface = producer.getSurface()
@@ -115,16 +115,60 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
 
                 val flutterTextureId = producer.id()
-                textures[flutterTextureId] = TextureEntry(producer, surface)
+                val textureEntry = TextureEntry(producer, surface)
+                textures[flutterTextureId] = textureEntry
+                producer.setCallback(object : TextureRegistry.SurfaceProducer.Callback {
+                    override fun onSurfaceCleanup() {
+                        val entry = textures[flutterTextureId] ?: return
+                        entry.surface?.release()
+                        entry.surface = null
+                        channel.invokeMethod("onSurfaceCleanup", flutterTextureId)
+                    }
+
+                    override fun onSurfaceAvailable() {
+                        val entry = textures[flutterTextureId] ?: return
+                        val newSurface = producer.getSurface()
+                        if (!newSurface.isValid) {
+                            newSurface.release()
+                            channel.invokeMethod(
+                                "onSurfaceError",
+                                listOf(flutterTextureId, "Replacement surface is invalid")
+                            )
+                            return
+                        }
+
+                        val newNativeWindowPtr =
+                            NativeWindowHelper.getNativeWindowFromSurface(newSurface)
+                        if (newNativeWindowPtr == 0L) {
+                            newSurface.release()
+                            channel.invokeMethod(
+                                "onSurfaceError",
+                                listOf(
+                                    flutterTextureId,
+                                    "Failed to acquire replacement native window"
+                                )
+                            )
+                            return
+                        }
+
+                        entry.surface?.release()
+                        entry.surface = newSurface
+                        channel.invokeMethod(
+                            "onSurfaceAvailable",
+                            listOf(flutterTextureId, newNativeWindowPtr)
+                        )
+                    }
+                })
                 result.success(listOf(flutterTextureId, flutterTextureId, nativeWindowPtr))
             }
             "destroyTexture" -> {
                 val textureId = (call.arguments as Int).toLong()
-                val textureEntry = textures[textureId]
+                val textureEntry = textures.remove(textureId)
                 if (textureEntry != null) {
-                    textureEntry.surface.release()
+                    textureEntry.surfaceProducer.setCallback(null)
+                    textureEntry.surface?.release()
+                    textureEntry.surface = null
                     textureEntry.surfaceProducer.release()
-                    textures.remove(textureId)
                     result.success(true)
                 } else {
                     result.error("TEXTURE_NOT_FOUND", "Texture with id $textureId not found", null)
@@ -155,7 +199,9 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       channel.setMethodCallHandler(null)
         // Release all textures
         for ((_, textureEntry) in textures) {
-            textureEntry.surface.release()
+            textureEntry.surfaceProducer.setCallback(null)
+            textureEntry.surface?.release()
+            textureEntry.surface = null
             textureEntry.surfaceProducer.release()
         }
         textures.clear()

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 
 import 'method_channel_platform_texture_descriptor.dart';
+import 'platform_texture_descriptor.dart';
 
 /// Describes an Android SurfaceProducer texture and its native window.
 class AndroidPlatformTextureDescriptor
-    extends MethodChannelPlatformTextureDescriptor {
+    extends MethodChannelPlatformTextureDescriptor
+    with ReplaceablePlatformTextureDescriptorMixin {
   AndroidPlatformTextureDescriptor(
     super.channel, {
     required super.flutterTextureId,
@@ -66,6 +69,24 @@ class AndroidPlatformTextureDescriptor
     _binding = null;
     await binding?.release();
   }
+
+  @override
+  Future<void> cleanupSurface() async {
+    await _binding?.onSurfaceCleanup();
+  }
+
+  @override
+  Future<void> restoreSurface(int nativeWindowHandle) async {
+    updateSurfaceHandle(nativeWindowHandle);
+    await _binding?.onSurfaceAvailable(nativeWindowHandle);
+    markSurfaceRestored();
+  }
+
+  @override
+  Future<void> destroy() async {
+    markSurfaceError();
+    await super.destroy();
+  }
 }
 
 class _AndroidPlatformTextureBinding {
@@ -74,13 +95,40 @@ class _AndroidPlatformTextureBinding {
   final AndroidPlatformTextureDescriptor descriptor;
   final View view;
 
+  static final _logger = Logger('AndroidPlatformTextureBinding');
+
   SwapChain? _swapChain;
 
-  Future<void> bind() async {
+  Future<void> bind() => _replaceSwapChain();
+
+  Future<void> onSurfaceCleanup() async {
+    // The plugin pauses the frame scheduler before invoking cleanup, so the
+    // render loop is already drained by the time we reach here.
+    await release();
+    _logger.info(
+      'Released swapchain for Android texture '
+      '${descriptor.flutterTextureId}',
+    );
+  }
+
+  Future<void> onSurfaceAvailable(int nativeWindowHandle) async {
+    await _replaceSwapChain(nativeWindowHandle);
+    _logger.info(
+      'Recreated swapchain for Android texture '
+      '${descriptor.flutterTextureId}',
+    );
+  }
+
+  /// Creates and attaches the replacement [SwapChain] for [view] *before*
+  /// destroying the previous one, so there is never a frame with no swap
+  /// chain attached (which would render into a freed surface). On failure to
+  /// attach, the replacement is destroyed and the previous chain is left
+  /// attached.
+  Future<void> _replaceSwapChain([int? nativeWindowHandle]) async {
     if (descriptor.destroyed) {
       throw StateError('Cannot bind a destroyed texture descriptor');
     }
-    final windowHandle = descriptor.windowHandle;
+    final windowHandle = nativeWindowHandle ?? descriptor.windowHandle;
     if (windowHandle == null || windowHandle == 0) {
       throw StateError('Android texture has no native window');
     }
@@ -90,11 +138,23 @@ class _AndroidPlatformTextureBinding {
       throw StateError('Cannot bind a surface after Filament shutdown');
     }
 
-    final swapChain = await app.createSwapChain(
+    final previous = _swapChain;
+    final replacement = await app.createSwapChain(
       Pointer<Void>.fromAddress(windowHandle),
     );
-    await app.renderManager.attach(view, swapChain);
-    _swapChain = swapChain;
+    try {
+      await app.renderManager.attach(view, replacement);
+    } catch (error, stackTrace) {
+      // attach failed — destroy the orphaned replacement so it doesn't leak,
+      // leaving any previous swapchain still attached, then rethrow.
+      await app.destroySwapChain(replacement);
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+    _swapChain = replacement;
+
+    if (previous != null) {
+      await app.destroySwapChain(previous);
+    }
   }
 
   Future<void> release() async {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
@@ -9,6 +9,8 @@ abstract class PlatformTextureDescriptor {
 
   View? get boundView => null;
 
+  bool get isSurfaceAvailable => true;
+
   PlatformTextureDescriptor({
     required this.flutterTextureId,
     required this.hardwareId,
@@ -34,6 +36,14 @@ abstract class PlatformTextureDescriptor {
 
   Future<void> releaseBinding() async {}
 
+  void markSurfaceUnavailable() {}
+
+  Future<void> cleanupSurface() async {}
+
+  Future<void> restoreSurface(int nativeWindowHandle) async {}
+
+  void markSurfaceError() {}
+
   /// Whether [destroy] has run.
   bool get destroyed => false;
 
@@ -46,4 +56,36 @@ abstract class PlatformTextureDescriptor {
   Future<int> awaitTextureReady() async => hardwareId;
 
   Future Function(Duration timestamp)? onBeginFrame;
+}
+
+mixin ReplaceablePlatformTextureDescriptorMixin on PlatformTextureDescriptor {
+  bool _isSurfaceAvailable = true;
+
+  @override
+  bool get isSurfaceAvailable => _isSurfaceAvailable;
+
+  @override
+  void markSurfaceUnavailable() {
+    _isSurfaceAvailable = false;
+  }
+
+  void updateSurfaceHandle(int nativeWindowHandle) {
+    if (nativeWindowHandle == 0) {
+      throw ArgumentError.value(
+        nativeWindowHandle,
+        'nativeWindowHandle',
+        'must not be zero',
+      );
+    }
+    _isSurfaceAvailable = false;
+  }
+
+  void markSurfaceRestored() {
+    _isSurfaceAvailable = true;
+  }
+
+  @override
+  void markSurfaceError() {
+    _isSurfaceAvailable = false;
+  }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -22,6 +22,10 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     with WidgetsBindingObserver {
   final channel = const MethodChannel("dev.thermion.flutter/event");
 
+  ThermionFlutterPluginImpl() {
+    channel.setMethodCallHandler(_handlePlatformMethodCall);
+  }
+
   static final _logger = Logger("ThermionFlutterPluginImpl");
 
   static ThermionFlutterPluginImpl get instance =>
@@ -46,6 +50,8 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
   // has been redirected to an internal RT (e.g. in composite highlight mode).
   static final _viewRenderTargets = <View, RenderTarget>{};
 
+  Future<void> _textureOperationChain = Future<void>.value();
+
   // Deferred Filament render target cleanup for Windows resize.
   // Old RT stays alive so native can Blit from it during the swap window.
   static final _deferredRenderTargets = <(RenderTarget, int)>[];
@@ -55,7 +61,91 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
   bool _resizing = false;
 
   bool get _pauseRequested =>
-      _explicitlyPaused || _lifecycleSuspended || _resizing;
+      _explicitlyPaused ||
+      _lifecycleSuspended ||
+      _resizing ||
+      _descriptors.any((descriptor) => !descriptor.isSurfaceAvailable);
+
+  PlatformTextureDescriptor? _descriptorForTextureId(int textureId) {
+    for (final descriptor in _descriptors) {
+      if (descriptor.flutterTextureId == textureId) return descriptor;
+    }
+    return null;
+  }
+
+  Future<Object?> _handlePlatformMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'onSurfaceCleanup':
+        final descriptor = _descriptorForTextureId(call.arguments as int);
+        if (descriptor == null) return null;
+        descriptor.markSurfaceUnavailable();
+        FrameScheduler.instance.pause();
+        await _serializeTextureOperation(() async {
+          if (_descriptors.contains(descriptor)) {
+            await descriptor.cleanupSurface();
+          }
+        });
+        return null;
+      case 'onSurfaceAvailable':
+        final arguments = call.arguments as List<Object?>;
+        final textureId = arguments[0] as int;
+        final descriptor = _descriptorForTextureId(textureId);
+        if (descriptor == null) return null;
+        final wasAvailable = descriptor.isSurfaceAvailable;
+        descriptor.markSurfaceUnavailable();
+        if (wasAvailable) {
+          FrameScheduler.instance.pause();
+        }
+        try {
+          await _serializeTextureOperation(() async {
+            if (!_descriptors.contains(descriptor)) return;
+            await descriptor.restoreSurface(arguments[1] as int);
+            _resumeTextureRenderingIfReady();
+          });
+        } catch (error, stackTrace) {
+          _logger.severe(
+            'Failed to restore texture surface $textureId',
+            error,
+            stackTrace,
+          );
+          rethrow;
+        }
+        return null;
+      case 'onSurfaceError':
+        final arguments = call.arguments as List<Object?>;
+        final textureId = arguments[0] as int;
+        final descriptor = _descriptorForTextureId(textureId);
+        if (descriptor == null) return null;
+        descriptor.markSurfaceError();
+        FrameScheduler.instance.pause();
+        _logger.severe(
+          'Surface recovery failed for texture $textureId: ${arguments[1]}',
+        );
+        return null;
+      default:
+        throw MissingPluginException(
+          'Unknown platform callback ${call.method}',
+        );
+    }
+  }
+
+  Future<R> _serializeTextureOperation<R>(Future<R> Function() operation) {
+    final completer = Completer<R>();
+    _textureOperationChain = _textureOperationChain.then((_) async {
+      try {
+        completer.complete(await operation());
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      }
+    });
+    return completer.future;
+  }
+
+  void _resumeTextureRenderingIfReady() {
+    if (!_pauseRequested) {
+      FrameScheduler.instance.resume();
+    }
+  }
 
   bool _suspendForLifecycle() {
     if (_lifecycleSuspended) return false;
@@ -423,6 +513,16 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     View view,
     int width,
     int height,
+  ) {
+    return _serializeTextureOperation(
+      () => _createTextureAndBindToView(view, width, height),
+    );
+  }
+
+  Future<PlatformTextureDescriptor?> _createTextureAndBindToView(
+    View view,
+    int width,
+    int height,
   ) async {
     if (width == 0 || height == 0) {
       throw Exception(
@@ -471,6 +571,17 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     View view,
     int width,
     int height,
+  ) {
+    return _serializeTextureOperation(
+      () => _resizeTexture(texture, view, width, height),
+    );
+  }
+
+  Future<PlatformTextureDescriptor> _resizeTexture(
+    PlatformTextureDescriptor texture,
+    View view,
+    int width,
+    int height,
   ) async {
     // Block new frames while we swap textures, then wait for any in-flight
     // frame to finish before we touch render targets.
@@ -491,7 +602,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
       // Non-Windows: full destroy + recreate (existing path).
       // TODO: alternatively, allocate a larger swapchain up front and just
       // change the viewport on resize, avoiding the destroy/recreate.
-      var newTexture = await createTextureAndBindToView(view, width, height);
+      var newTexture = await _createTextureAndBindToView(view, width, height);
       if (newTexture == null) {
         throw Exception('Failed to create texture during resize');
       }
@@ -611,11 +722,18 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
   }
 
   @override
-  Future<void> releaseTextureBindingForView(View view) async {
-    for (final descriptor in _descriptors) {
-      if (descriptor.boundView == view) {
-        await descriptor.releaseBinding();
-      }
+  Future<void> releaseTextureBindingForView(View view) {
+    return _serializeTextureOperation(() => _releaseBindingForView(view));
+  }
+
+  Future<void> _releaseBindingForView(View view) async {
+    final released = _descriptors
+        .where((descriptor) => descriptor.boundView == view)
+        .toList();
+    for (final descriptor in released) {
+      await descriptor.releaseBinding();
+      _descriptors.remove(descriptor);
     }
+    _resumeTextureRenderingIfReady();
   }
 }


### PR DESCRIPTION
This PR allows Flutter to release the ImageReader-backed surface on Android while the app is backgrounded. The callback notifies the Dart layer to destroy and recreate the Filament swapchain when the surface replacement is available.
