### PR TITLE
Fix duplicate texture destruction during resize

### DIFF
--- a/examples/flutter/quickstart/integration_test/texture_resize_test.dart
+++ b/examples/flutter/quickstart/integration_test/texture_resize_test.dart
@@ -1,0 +1,160 @@
+// Regression test for duplicate destruction of a texture descriptor during a
+// widget resize.
+//
+// Run on a real target:
+//
+//   flutter test integration_test/texture_resize_test.dart -d macos
+//   flutter test integration_test/texture_resize_test.dart -d linux
+//   flutter test integration_test/texture_resize_test.dart -d <device-id>
+//
+// Windows updates its descriptor in place while other platforms replace it;
+// teardown must serialize correctly with either resize strategy.
+import 'dart:async';
+
+import 'package:flutter/material.dart' hide View;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:thermion_flutter/thermion_flutter.dart' hide Texture;
+// ignore: implementation_imports
+import 'package:thermion_flutter/src/platform/src/frame_scheduler.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'resize and teardown destroy each texture exactly once',
+    (tester) async {
+      final viewer = await ThermionFlutterPlugin.createViewer();
+      final size = ValueNotifier<Size>(const Size(160, 120));
+      var textureUpdateCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: ValueListenableBuilder<Size>(
+              valueListenable: size,
+              builder: (context, value, child) {
+                return SizedBox(
+                  width: value.width,
+                  height: value.height,
+                  child: ThermionWidgetInternal(
+                    key: const ValueKey('resizable-thermion-surface'),
+                    view: viewer.view,
+                    surfaceWidgetBuilder: (descriptor) {
+                      if (descriptor == null) {
+                        return const SizedBox.expand();
+                      }
+                      return Texture(
+                        textureId: descriptor.flutterTextureId,
+                      );
+                    },
+                    onTextureUpdated: (descriptor) {
+                      if (descriptor != null) {
+                        textureUpdateCount++;
+                      }
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await _pumpUntil(
+        tester,
+        () => textureUpdateCount == 1,
+        'the initial texture allocation',
+      );
+
+      size.value = const Size(240, 180);
+      await tester.pump();
+      await _pumpUntil(
+        tester,
+        () => textureUpdateCount == 2,
+        'the resized texture allocation',
+      );
+
+      // Let errors from unawaited descriptor cleanup reach the test binding.
+      // Before the fix, Darwin throws here because resizeTexture() has already
+      // destroyed the descriptor and ThermionWidgetInternal destroys it again.
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+
+      // Hold one scheduler frame open so resizeTexture() deterministically
+      // remains in flight until teardown has been queued behind it.
+      final scheduler = FrameScheduler.instance;
+      final renderGate = Completer<void>();
+      scheduler.pause();
+      await _pumpUntil(
+        tester,
+        () => !scheduler.isRendering,
+        'the current frame to finish',
+      );
+      scheduler.setOnFrame(() async {
+        await renderGate.future;
+        await FilamentApp.instance?.render();
+      });
+      scheduler.resume();
+      await _pumpUntil(
+        tester,
+        () => scheduler.isRendering,
+        'the controlled frame to start',
+      );
+
+      // Start another resize, then unmount while the native operation is in
+      // flight. Teardown must wait for it, release the final platform binding,
+      // and destroy only the final descriptor.
+      size.value = const Size(320, 240);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 101));
+      await _pumpUntil(
+        tester,
+        () => scheduler.isPaused,
+        'resizeTexture to pause behind the controlled frame',
+      );
+      final updatesAtUnmount = textureUpdateCount;
+      expect(
+        updatesAtUnmount,
+        2,
+        reason: 'the native resize must still be in flight at unmount',
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      renderGate.complete();
+      await _pumpUntil(
+        tester,
+        () => !scheduler.isPaused,
+        'the in-flight resize to complete',
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await tester.pump();
+
+      expect(
+        textureUpdateCount,
+        updatesAtUnmount,
+        reason: 'an allocation completing after dispose must not notify',
+      );
+      expect(tester.takeException(), isNull);
+
+      scheduler.stop();
+      await viewer.dispose();
+      size.dispose();
+    },
+  );
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition,
+  String operation,
+) async {
+  final stopwatch = Stopwatch()..start();
+  while (!condition()) {
+    if (stopwatch.elapsed > const Duration(seconds: 15)) {
+      throw TestFailure('Timed out waiting for $operation');
+    }
+    await tester.pump(const Duration(milliseconds: 20));
+  }
+}

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -69,6 +69,8 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
 
   PlatformTextureDescriptor? _texture;
   Timer? _debounceTimer;
+  Future<void> _textureOperations = Future<void>.value();
+  bool _disposing = false;
 
   // The current texture size (what's actually allocated)
   int _currentWidth = 0;
@@ -80,24 +82,26 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
 
   @override
   void dispose() {
-    super.dispose();
+    _disposing = true;
     _debounceTimer?.cancel();
-    var texture = _texture;
-    _texture = null;
-    // Tear down per-view plugin bindings (Android: SwapChain bound to
-    // this view) BEFORE releasing the underlying texture. The
-    // SurfaceTexture release frees the swap chain's native window, so
-    // if the swap chain is still attached to the RenderManager when
-    // that happens Filament's next render fires `eglSwapBuffers` on a
-    // null buffer and the emulator/EGL stack logs `EGL_BAD_SURFACE`
-    // until the widget unmount finishes propagating. Sequencing the
-    // two awaits inside an unawaited closure keeps `dispose()` synchronous
-    // for the framework while still ordering the calls.
     final view = widget.view;
-    () async {
+    _enqueueTextureOperation(() async {
+      // Tear down per-view plugin bindings (Android: SwapChain bound to
+      // this view) BEFORE releasing the underlying texture. Releasing the
+      // SurfaceProducer texture entry invalidates the swap chain's native
+      // window, so if the swap chain is still attached to the RenderManager,
+      // Filament's next render can call eglSwapBuffers on an invalid surface
+      // and log EGL_BAD_SURFACE until widget teardown finishes propagating.
+      //
+      // Queueing this teardown after any in-flight allocation or resize also
+      // ensures that it releases the final binding and destroys the final
+      // descriptor exactly once.
       await ThermionFlutterPlugin.instance.releaseTextureBindingForView(view);
+      final texture = _texture;
+      _texture = null;
       await texture?.destroy();
-    }();
+    }, 'disposing a Thermion widget texture');
+    super.dispose();
   }
 
   @override
@@ -132,18 +136,29 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
   }
 
   void _scheduleTextureAllocation(int width, int height) {
+    if (_disposing) return;
+
     _pendingWidth = width;
     _pendingHeight = height;
 
     _debounceTimer?.cancel();
     _debounceTimer = Timer(_debounceDuration, () {
-      if (_pendingWidth != null && _pendingHeight != null) {
+      if (!_disposing && _pendingWidth != null && _pendingHeight != null) {
         _allocateTexture(_pendingWidth!, _pendingHeight!);
       }
     });
   }
 
-  void _allocateTexture(int width, int height) async {
+  void _allocateTexture(int width, int height) {
+    _enqueueTextureOperation(
+      () => _performTextureAllocation(width, height),
+      'allocating a Thermion widget texture',
+    );
+  }
+
+  Future<void> _performTextureAllocation(int width, int height) async {
+    if (_disposing) return;
+
     PlatformTextureDescriptor? texture;
 
     if (_texture != null) {
@@ -163,25 +178,49 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
       );
     }
 
-    widget.onTextureUpdated?.call(texture);
-
-    if (!mounted) {
-      texture?.destroy();
-      return;
-    }
-
     if (texture == null) return;
 
-    setState(() {
-      // On Windows resize, texture is the same object (same flutterTextureId),
-      // so old?.destroy() is skipped to avoid destroying the live texture.
-      final old = _texture;
+    if (_disposing || !mounted) {
+      // Publish the result even if dispose() ran while the platform operation
+      // was awaiting. The queued teardown operation owns releasing this final
+      // descriptor and its per-view binding.
       _texture = texture;
       _currentWidth = width;
       _currentHeight = height;
-      if (old != null && old != texture) {
-        old.destroy();
-      }
+      return;
+    }
+
+    setState(() {
+      // resizeTexture owns disposal of the superseded descriptor. On Windows
+      // it returns the existing descriptor after updating it in place.
+      _texture = texture;
+      _currentWidth = width;
+      _currentHeight = height;
     });
+
+    widget.onTextureUpdated?.call(texture);
+  }
+
+  void _enqueueTextureOperation(
+    Future<void> Function() operation,
+    String context,
+  ) {
+    final previous = _textureOperations;
+    _textureOperations = () async {
+      await previous;
+      try {
+        await operation();
+      } catch (exception, stack) {
+        FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: exception,
+            stack: stack,
+            library: 'thermion_flutter',
+            context: ErrorDescription('while $context'),
+          ),
+        );
+      }
+    }();
+    unawaited(_textureOperations);
   }
 }


### PR DESCRIPTION
ThermionWidget and ThermionFlutterPlugin had overlapping ownership of texture disposal.  On non-Windows platforms, resizeTexture() creates the replacement and destroys the superseded descriptor before returning. ThermionWidgetInternal then destroyed that same  descriptor again when installing the replacement. This caused a deterministic exception on Darwin and TEXTURE_NOT_FOUND on Android.

Teardown exposed a related race. Cancelling the debounce timer only prevents work that has not started; it does not cancel an allocation or resize already in flight.  dispose() could therefore release the view binding and destroy the current descriptor while resizeTexture() was still using it. When resize resumed, it could destroy the descriptor again or establish a replacement binding after teardown had already run.

This PR adds a single serialized ownership boundary to ensure that allocation, resize, and teardown occur on one path only (`resizeTexture())