### PR TITLE
Statically link libc++ on Android

### DIFF
--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -293,8 +293,21 @@ outputDirectory : ${outputDirectory.path}
 
       libs.addAll(["bluegl", "bluevk"]);
     } else if (targetOS == OS.android) {
+      final versionScript = File(
+        path.join(pkgRootFilePath, "native", "android", "thermion_dart.map"),
+      );
+      output.dependencies.add(versionScript.uri);
+
       libs.addAll(["GLESv3", "EGL", "bluevk", "dl", "android"]);
-      flags.add("-Wl,-z,max-page-size=16384");
+      flags.addAll([
+        "-Wl,-z,max-page-size=16384",
+        "-fvisibility=hidden",
+        // All static archives are implementation details of
+        // libthermion_dart.so. The version script retains only C entrypoints
+        // explicitly marked with default visibility.
+        "-Wl,--exclude-libs,ALL",
+        "-Wl,--version-script=${versionScript.path}",
+      ]);
     } else if (targetOS == OS.linux) {
       libs.addAll(["bluevk", "bluegl", "drm", "EGL", "GL", "gbm"]);
       flags.add("-I/usr/include/libdrm");
@@ -400,6 +413,10 @@ outputDirectory : ${outputDirectory.path}
     final cbuilder = CBuilder.library(
       name: packageName,
       language: Language.cpp,
+      // All of Thermion's C++ code, including the prebuilt Filament archives,
+      // is linked into this one shared library on Android. Keep libc++ in that
+      // library rather than shipping a separate libc++_shared.so code asset.
+      cppLinkStdLib: targetOS == OS.android ? 'c++_static' : null,
       assetName: 'thermion_dart.dart',
       sources: targetOS == OS.windows ? [] : sources,
       includes: platform == "windows" ? [] : includeDirs,
@@ -420,7 +437,7 @@ outputDirectory : ${outputDirectory.path}
             "-Wl,--no-whole-archive",
             '-lGL',
             '-lEGL',
-          ] else ...[
+          ] else if (targetOS != OS.android) ...[
             "-lc++",
             "",
           ],
@@ -428,7 +445,7 @@ outputDirectory : ${outputDirectory.path}
         ],
         if (targetOS == OS.linux)
           '-Wl,--no-as-needed'
-        else if (targetOS != OS.windows)
+        else if (targetOS != OS.windows && targetOS != OS.android)
           '-lc++',
         if (platform == "windows") ...[
           ...includeDirs.map((d) => "/I${path.join(pkgRootFilePath, d)}"),
@@ -450,44 +467,6 @@ outputDirectory : ${outputDirectory.path}
     );
 
     await cbuilder.run(input: input, output: output, logger: logger);
-    if (targetOS == OS.android) {
-      final archExtension = switch (targetArchitecture) {
-        Architecture.arm => "arm-linux-androideabi",
-        Architecture.arm64 => "aarch64-linux-android",
-        Architecture.x64 => "x86_64-linux-android",
-        Architecture.ia32 => "i686-linux-android",
-        _ => throw FormatException('Invalid'),
-      };
-
-      var compilerPath = config.code.cCompiler!.compiler.path;
-
-      if (Platform.isWindows && compilerPath.startsWith("/")) {
-        compilerPath = compilerPath.substring(1);
-      }
-
-      var ndkRoot = File(
-        compilerPath,
-      ).parent.parent.uri.toFilePath(windows: Platform.isWindows);
-
-      var stlPath = File(
-        [
-          ndkRoot,
-          "sysroot",
-          "usr",
-          "lib",
-          archExtension,
-          "libc++_shared.so",
-        ].join(Platform.pathSeparator),
-      );
-      final libcpp = CodeAsset(
-        package: "thermion_dart",
-        name: "libc++_shared.so",
-        linkMode: DynamicLoadingBundled(),
-        file: stlPath.uri,
-      );
-
-      output.assets.addEncodedAsset(libcpp.encode());
-    }
 
     output.metadata.addAll({
       "includeDirs": includeDirs

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -19,6 +19,1267 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 @ffi.Native<ffi.Uint64>()
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)
+>(isLeaf: true)
+external void Camera_setExposure(
+  ffi.Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+  isLeaf: true,
+)
+external void Camera_getFrustum(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> out,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.Pointer<ffi.Double>,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
+  isLeaf: true,
+)
+external void Camera_lookAt(
+  ffi.Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(
+  ffi.Pointer<TCamera> camera,
+  double focusDistance,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)
+>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+  isLeaf: true,
+)
+external void Camera_setModelMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> tModelMatrix,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.UnsignedInt,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.UnsignedInt,
+    Aabb3,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tVertexBuffer,
+  ffi.Pointer<TIndexBuffer> tIndexBuffer,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
+);
+
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+  isLeaf: true,
+)
+external void SceneAsset_addToScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+  isLeaf: true,
+)
+external void SceneAsset_removeFromScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getChildEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
+  isLeaf: true,
+)
+external void SceneAsset_getChildEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getCameraEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getLightEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int index,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
+  ffi.Pointer<TSceneAsset> asset,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
+
+@ffi.Native<
+  ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<
+  ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
+external int SceneAsset_getPrimitiveOffsetForEntity(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_releaseSourceData(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
+external void SceneAsset_setFlatShading(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)
+>(isLeaf: true)
+external void SceneAsset_getBones(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
+external int SceneAsset_getBoneCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+);
+
+@ffi.Native<
+  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)
+>(isLeaf: true)
+external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+);
+
+@ffi.Native<
+  ffi.Pointer<TGltfAssetLoader> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Pointer<TNameComponentManager>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external void GltfAssetLoader_destroy(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+);
+
+@ffi.Native<
+  ffi.Pointer<TFilamentAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+);
+
+@ffi.Native<
+  ffi.Pointer<TMaterialInstance> Function(
+    ffi.Pointer<TRenderableManager>,
+    ffi.Pointer<TFilamentAsset>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  ffi.Pointer<TFilamentAsset> tAsset,
+);
+
+@ffi.Native<
+  ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)
+>(isLeaf: true)
+external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getResourceUriCount(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+  ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)
+>(isLeaf: true)
+external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external void NameComponentManager_destroy(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<
+  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)
+>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientationBuilder>
+SurfaceOrientationBuilder_create();
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_vertexCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_normals(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> normals,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_tangents(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> tangents,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_uvs(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> uvs,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_positions(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> positions,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangleCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Uint32>,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_uint(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint32> triangles,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Uint16>,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_ushort(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint16> triangles,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSurfaceOrientation> Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
+  isLeaf: true,
+)
+external void SurfaceOrientationBuilder_destroy(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external int SurfaceOrientation_getVertexCount(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientation_getQuats_float4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Float> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Int16>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientation_getQuats_short4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Int16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Uint16>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientation_getQuats_half4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Uint16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external void SurfaceOrientation_destroy(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)
+>(isLeaf: true)
+external void FilamentAsset_getEntities(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TViewport View_getViewport(ffi.Pointer<TView> view);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createLinear(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createACES(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGX(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(
+  ffi.Pointer<TEngine> tEngine,
+  int look,
+);
+
+@ffi.Native<
+  ffi.Pointer<TToneMapper> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
+  ffi.Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
+external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
+
+@ffi.Native<
+  ffi.Pointer<TColorGrading> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TToneMapper>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TColorGrading> ColorGrading_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TToneMapper> toneMapper,
+);
+
+@ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
+
+@ffi.Native<
+  ffi.Pointer<TColorGrading> Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Pointer<TEngine>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
+external void ColorGradingBuilder_destroy(
+  ffi.Pointer<TColorGradingBuilder> builder,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)
+>(isLeaf: true)
+external void ColorGrading_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TColorGrading> colorGrading,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)
+>(isLeaf: true)
+external void ColorGradingBuilder_quality(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int level,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)
+>(isLeaf: true)
+external void ColorGradingBuilder_format(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int format,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_dimensions(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int dim,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)
+>(isLeaf: true)
+external void ColorGradingBuilder_toneMapper(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  ffi.Pointer<TToneMapper> toneMapper,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_exposure(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double exposure,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_nightAdaptation(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double adaptation,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)
+>(isLeaf: true)
+external void ColorGradingBuilder_whiteBalance(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double temperature,
+  double tint,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_contrast(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double contrast,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_vibrance(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double vibrance,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_saturation(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double saturation,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_channelMixer(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double outRedR,
+  double outRedG,
+  double outRedB,
+  double outGreenR,
+  double outGreenG,
+  double outGreenB,
+  double outBlueR,
+  double outBlueG,
+  double outBlueB,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_shadowsMidtonesHighlights(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double shadowsR,
+  double shadowsG,
+  double shadowsB,
+  double shadowsW,
+  double midtonesR,
+  double midtonesG,
+  double midtonesB,
+  double midtonesW,
+  double highlightsR,
+  double highlightsG,
+  double highlightsB,
+  double highlightsW,
+  double rangesX,
+  double rangesY,
+  double rangesZ,
+  double rangesW,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_slopeOffsetPower(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double slopeR,
+  double slopeG,
+  double slopeB,
+  double offsetR,
+  double offsetG,
+  double offsetB,
+  double powerR,
+  double powerG,
+  double powerB,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_curves(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double shadowGammaR,
+  double shadowGammaG,
+  double shadowGammaB,
+  double midPointR,
+  double midPointG,
+  double midPointB,
+  double highlightScaleR,
+  double highlightScaleG,
+  double highlightScaleB,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_luminanceScaling(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_gamutMapping(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(
+  isLeaf: true,
+)
+external void View_setColorGrading(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TColorGrading> tColorGrading,
+);
+
+@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TColorGrading> View_getColorGrading(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
+  isLeaf: true,
+)
+external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(
+  isLeaf: true,
+)
+external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(
+  isLeaf: true,
+)
+external void View_setRenderTarget(
+  ffi.Pointer<TView> view,
+  ffi.Pointer<TRenderTarget> renderTarget,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrustumCullingEnabled(
+  ffi.Pointer<TView> view,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TRenderTarget> View_getRenderTarget(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
+external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
+external int View_getShadowType(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(
+  isLeaf: true,
+)
+external void View_setSoftShadowOptions(
+  ffi.Pointer<TView> tView,
+  TSoftShadowOptions options,
+);
+
+@ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(
+  isLeaf: true,
+)
+external void View_setVsmShadowOptions(
+  ffi.Pointer<TView> tView,
+  TVsmShadowOptions options,
+);
+
+@ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(
+  isLeaf: true,
+)
+external void View_setBloom(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  double strength,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
+  isLeaf: true,
+)
+external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)
+>(isLeaf: true)
+external void View_setAntiAliasing(
+  ffi.Pointer<TView> tView,
+  bool msaa,
+  bool fxaa,
+  bool taa,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(
+  isLeaf: true,
+)
+external void View_setLayerEnabled(
+  ffi.Pointer<TView> tView,
+  int layer,
+  bool visible,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(
+  isLeaf: true,
+)
+external void View_setCamera(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TCamera> tCamera,
+);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setStencilBufferEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(
+  isLeaf: true,
+)
+external void View_setScene(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrontFaceWindingInverted(
+  ffi.Pointer<TView> tView,
+  bool inverted,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(
+  isLeaf: true,
+)
+external void View_setAmbientOcclusionOptions(
+  ffi.Pointer<TView> tView,
+  TAmbientOcclusionOptions options,
+);
+
+@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
+external void View_setFogOptions(
+  ffi.Pointer<TView> tView,
+  TFogOptions tFogOptions,
+);
+
+@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setTransparentPickingEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    PickCallback,
+  )
+>(isLeaf: true)
+external void View_pick(
+  ffi.Pointer<TView> tView,
+  int requestId,
+  int x,
+  int y,
+  PickCallback callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(
+  isLeaf: true,
+)
+external void View_setName(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<ffi.Char> name,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSkybox>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void Skybox_setColor(
+  ffi.Pointer<TSkybox> tSkybox,
+  double r,
+  double g,
+  double b,
+  double a,
+);
+
+@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
+  isLeaf: true,
+)
+external void IndexBufferBuilder_indexCount(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)
+>(isLeaf: true)
+external void IndexBufferBuilder_bufferType(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+);
+
+@ffi.Native<
+  ffi.Pointer<TIndexBuffer> Function(
+    ffi.Pointer<TIndexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
+external void IndexBufferBuilder_destroy(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external void IndexBuffer_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
+  isLeaf: true,
+)
+external void IndexBuffer_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+);
+
 @ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
   isLeaf: true,
 )
@@ -370,27 +1631,6 @@ external int MaterialInstance_getTransparencyMode(
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
 external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
-
-@ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
-external void dummy(TGltfMeshData dummy);
-
-@ffi.Native<
-  ffi.Int Function(
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<TGltfMeshData>,
-  )
->(isLeaf: true)
-external int GltfParser_parseBuffer(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> meshName,
-  ffi.Pointer<TGltfMeshData> outMeshData,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
-external void GltfParser_freeMeshData(ffi.Pointer<TGltfMeshData> meshData);
 
 @ffi.Native<
   ffi.Pointer<TTexture> Function(
@@ -1110,558 +2350,6 @@ external bool DebugRegistry_getProperty_float(
   ffi.Pointer<ffi.Float> outValue,
 );
 
-@ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TViewport View_getViewport(ffi.Pointer<TView> view);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createLinear(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createACES(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGX(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(
-  ffi.Pointer<TEngine> tEngine,
-  int look,
-);
-
-@ffi.Native<
-  ffi.Pointer<TToneMapper> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
-  ffi.Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
-
-@ffi.Native<
-  ffi.Pointer<TColorGrading> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TToneMapper>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TColorGrading> ColorGrading_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TToneMapper> toneMapper,
-);
-
-@ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
-
-@ffi.Native<
-  ffi.Pointer<TColorGrading> Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Pointer<TEngine>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
-external void ColorGradingBuilder_destroy(
-  ffi.Pointer<TColorGradingBuilder> builder,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)
->(isLeaf: true)
-external void ColorGrading_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TColorGrading> colorGrading,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)
->(isLeaf: true)
-external void ColorGradingBuilder_quality(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int level,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)
->(isLeaf: true)
-external void ColorGradingBuilder_format(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int format,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_dimensions(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int dim,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)
->(isLeaf: true)
-external void ColorGradingBuilder_toneMapper(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  ffi.Pointer<TToneMapper> toneMapper,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_exposure(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double exposure,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_nightAdaptation(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double adaptation,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)
->(isLeaf: true)
-external void ColorGradingBuilder_whiteBalance(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double temperature,
-  double tint,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_contrast(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double contrast,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_vibrance(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double vibrance,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_saturation(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double saturation,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_channelMixer(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double outRedR,
-  double outRedG,
-  double outRedB,
-  double outGreenR,
-  double outGreenG,
-  double outGreenB,
-  double outBlueR,
-  double outBlueG,
-  double outBlueB,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_shadowsMidtonesHighlights(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double shadowsR,
-  double shadowsG,
-  double shadowsB,
-  double shadowsW,
-  double midtonesR,
-  double midtonesG,
-  double midtonesB,
-  double midtonesW,
-  double highlightsR,
-  double highlightsG,
-  double highlightsB,
-  double highlightsW,
-  double rangesX,
-  double rangesY,
-  double rangesZ,
-  double rangesW,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_slopeOffsetPower(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double slopeR,
-  double slopeG,
-  double slopeB,
-  double offsetR,
-  double offsetG,
-  double offsetB,
-  double powerR,
-  double powerG,
-  double powerB,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_curves(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double shadowGammaR,
-  double shadowGammaG,
-  double shadowGammaB,
-  double midPointR,
-  double midPointG,
-  double midPointB,
-  double highlightScaleR,
-  double highlightScaleG,
-  double highlightScaleB,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_luminanceScaling(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_gamutMapping(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(
-  isLeaf: true,
-)
-external void View_setColorGrading(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TColorGrading> tColorGrading,
-);
-
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TColorGrading> View_getColorGrading(
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(
-  isLeaf: true,
-)
-external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(
-  isLeaf: true,
-)
-external void View_setRenderTarget(
-  ffi.Pointer<TView> view,
-  ffi.Pointer<TRenderTarget> renderTarget,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrustumCullingEnabled(
-  ffi.Pointer<TView> view,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TRenderTarget> View_getRenderTarget(
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
-external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getShadowType(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(
-  isLeaf: true,
-)
-external void View_setSoftShadowOptions(
-  ffi.Pointer<TView> tView,
-  TSoftShadowOptions options,
-);
-
-@ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(
-  isLeaf: true,
-)
-external void View_setVsmShadowOptions(
-  ffi.Pointer<TView> tView,
-  TVsmShadowOptions options,
-);
-
-@ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(
-  isLeaf: true,
-)
-external void View_setBloom(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  double strength,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)
->(isLeaf: true)
-external void View_setAntiAliasing(
-  ffi.Pointer<TView> tView,
-  bool msaa,
-  bool fxaa,
-  bool taa,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(
-  isLeaf: true,
-)
-external void View_setLayerEnabled(
-  ffi.Pointer<TView> tView,
-  int layer,
-  bool visible,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(
-  isLeaf: true,
-)
-external void View_setCamera(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TCamera> tCamera,
-);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setStencilBufferEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void View_setScene(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrontFaceWindingInverted(
-  ffi.Pointer<TView> tView,
-  bool inverted,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(
-  isLeaf: true,
-)
-external void View_setAmbientOcclusionOptions(
-  ffi.Pointer<TView> tView,
-  TAmbientOcclusionOptions options,
-);
-
-@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
-external void View_setFogOptions(
-  ffi.Pointer<TView> tView,
-  TFogOptions tFogOptions,
-);
-
-@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setTransparentPickingEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    PickCallback,
-  )
->(isLeaf: true)
-external void View_pick(
-  ffi.Pointer<TView> tView,
-  int requestId,
-  int x,
-  int y,
-  PickCallback callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(
-  isLeaf: true,
-)
-external void View_setName(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<ffi.Char> name,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
-
 @ffi.Native<
   ffi.Pointer<TMaterialInstance> Function(
     ffi.Pointer<TMaterialProvider>,
@@ -1842,69 +2530,6 @@ external void VertexBuffer_setBufferAt(
 external void VertexBuffer_destroy(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
-);
-
-@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
-  isLeaf: true,
-)
-external void IndexBufferBuilder_indexCount(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)
->(isLeaf: true)
-external void IndexBufferBuilder_bufferType(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndexBuffer> Function(
-    ffi.Pointer<TIndexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
-external void IndexBufferBuilder_destroy(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external void IndexBuffer_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
-  isLeaf: true,
-)
-external void IndexBuffer_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
 );
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
@@ -4585,195 +5210,440 @@ external void RenderableManager_setBonesFromBoneRenderThread(
   VoidCallback onComplete,
 );
 
+@ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
+external void dummy(TGltfMeshData dummy);
+
 @ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
+  ffi.Int Function(
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TGltfMeshData>,
+  )
+>(isLeaf: true)
+external int GltfParser_parseBuffer(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> meshName,
+  ffi.Pointer<TGltfMeshData> outMeshData,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
+external void GltfParser_freeMeshData(ffi.Pointer<TGltfMeshData> meshData);
+
+@ffi.Native<
+  ffi.Int Function(
     ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
+    ffi.Pointer<TLightManager>,
     ffi.UnsignedInt,
-    Aabb3,
   )
 >(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+external int LightManager_createLight(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tVertexBuffer,
-  ffi.Pointer<TIndexBuffer> tIndexBuffer,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
 );
 
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
-);
-
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
   isLeaf: true,
 )
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void SceneAsset_addToScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void SceneAsset_removeFromScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
-  isLeaf: true,
-)
-external void SceneAsset_getChildEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int index,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
-  ffi.Pointer<TSceneAsset> asset,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
-
-@ffi.Native<
-  ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int SceneAsset_getPrimitiveOffsetForEntity(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
+external void LightManager_destroyLight(
+  ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_hasComponent(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external int LightManager_getType(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_isDirectional(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_isPointLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_isSpotLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
 >(isLeaf: true)
-external void SceneAsset_getBones(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  ffi.Pointer<EntityId> out,
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
 );
 
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double3 LightManager_getPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
 );
 
 @ffi.Native<
-  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
 >(isLeaf: true)
-external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double3 LightManager_getDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void LightManager_setColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double3 LightManager_getColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
+external void LightManager_setIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
+external void LightManager_setIntensityCandela(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
+external void LightManager_setFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double falloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSpotLightOuterCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSpotLightInnerCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+  isLeaf: true,
+)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+  isLeaf: true,
+)
+external void LightManager_setSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloSize,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+  isLeaf: true,
+)
+external void LightManager_setSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloFalloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
+  isLeaf: true,
+)
+external void LightManager_setShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_isShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)
+>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external TShadowOptions LightManager_getShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.UnsignedInt,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<
+  ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)
+>(isLeaf: true)
+external bool LightManager_getLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)
+>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<ffi.Float>,
+    ffi.Uint8,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
+  isLeaf: true,
+)
+external double LightManager_rgbToColorTemperature(
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
+  isLeaf: true,
+)
+external void Scene_setSkybox(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TSkybox> skybox,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)
+>(isLeaf: true)
+external void Scene_setIndirectLight(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)
+>(isLeaf: true)
+external void Scene_addFilamentAsset(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TFilamentAsset> asset,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(
@@ -5352,294 +6222,114 @@ external int RenderableBuilder_build(
   int entity,
 );
 
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)
->(isLeaf: true)
-external void Camera_setExposure(
-  ffi.Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
   isLeaf: true,
 )
-external void Camera_getFrustum(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> out,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Pointer<ffi.Double>,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
-  isLeaf: true,
-)
-external void Camera_lookAt(
-  ffi.Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(
-  ffi.Pointer<TCamera> camera,
-  double focusDistance,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)
->(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-  isLeaf: true,
-)
-external void Camera_setModelMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> tModelMatrix,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.UnsignedInt,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-  ffi.Pointer<TRenderManager> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TRenderer>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
+external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
->(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)
 >(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
+external void GltfResourceLoader_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
-  isLeaf: true,
-)
-external void RenderManager_render(
-  ffi.Pointer<TRenderManager> tRenderer,
-  int frameTimeInNanos,
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+  )
+>(isLeaf: true)
+external bool GltfResourceLoader_asyncBeginLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_asyncUpdateLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external double GltfResourceLoader_asyncGetLoadProgress(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
 );
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Pointer<ffi.Pointer<TView>>,
-    ffi.Uint8,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
   )
 >(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
+external void GltfResourceLoader_addResourceData(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.Char> uri,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)
+  ffi.Bool Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+  )
 >(isLeaf: true)
-external void RenderManager_removeSwapChain(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
+external bool GltfResourceLoader_loadResources(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(
-  ffi.Pointer<TRenderManager> tRenderer,
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(int t);
+
+@ffi.Native<
+  ffi.Pointer<TGizmo> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TView>,
+    ffi.Pointer<TMaterial>,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TGizmo> Gizmo_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> assetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(
-  ffi.Pointer<TRenderManager> tRenderer,
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TGizmo>,
+    ffi.Uint32,
+    ffi.Uint32,
+    GizmoPickCallback,
+  )
+>(isLeaf: true)
+external void Gizmo_pick(
+  ffi.Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  GizmoPickCallback callback,
 );
 
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
-external void RenderManager_detachFromRenderThread();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
   isLeaf: true,
 )
-external void RenderManager_setPaused(
-  ffi.Pointer<TRenderManager> tRenderer,
-  bool paused,
-);
+external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
 
-@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_start(FrameCallback callback, int targetFps);
-
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void FrameScheduler_setRenderThread(
-  ffi.Pointer<ffi.Void> renderThread,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void FrameScheduler_setRenderManager(ffi.Pointer<TRenderManager> rm);
-
-@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
-  isLeaf: true,
-)
-external void FrameScheduler_setPostRenderCallback(
-  PostRenderCallback callback,
-  ffi.Pointer<ffi.Void> userData,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Uint64)>(isLeaf: true)
-external bool FrameScheduler_requestRender(int frameTimeNanos);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startNativeRenderLoop(int targetFps);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(int port, int targetFps);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_setTargetFps(int fps);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
+external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
 
 @ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(
   isLeaf: true,
@@ -5951,97 +6641,156 @@ external bool AnimationManager_setGltfAnimationTime(
   double timeInSeconds,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
-  isLeaf: true,
-)
-external void Scene_setSkybox(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TSkybox> skybox,
-);
-
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)
->(isLeaf: true)
-external void Scene_setIndirectLight(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)
->(isLeaf: true)
-external void Scene_addFilamentAsset(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TFilamentAsset> asset,
-);
-
-@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)
->(isLeaf: true)
-external void GltfResourceLoader_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
+  ffi.Pointer<TRenderTarget> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
   )
 >(isLeaf: true)
-external bool GltfResourceLoader_asyncBeginLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+external ffi.Pointer<TRenderTarget> RenderTarget_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> color,
+  ffi.Pointer<TTexture> depth,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)
+>(isLeaf: true)
+external void RenderTarget_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
 );
 
-@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external double GltfResourceLoader_asyncGetLoadProgress(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)
+>(isLeaf: true)
+external void IndirectLight_setRotation(
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+  ffi.Pointer<ffi.Double> rotation,
+);
+
+@ffi.Native<
+  ffi.Pointer<TRenderManager> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TRenderer>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
+>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
+>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
+  isLeaf: true,
+)
+external void RenderManager_render(
+  ffi.Pointer<TRenderManager> tRenderer,
+  int frameTimeInNanos,
 );
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Pointer<ffi.Pointer<TView>>,
+    ffi.Uint8,
   )
 >(isLeaf: true)
-external void GltfResourceLoader_addResourceData(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.Char> uri,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-  )
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)
 >(isLeaf: true)
-external bool GltfResourceLoader_loadResources(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+external void RenderManager_removeSwapChain(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
 );
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function()>(isLeaf: true)
+external void RenderManager_detachFromRenderThread();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+  isLeaf: true,
+)
+external void RenderManager_setPaused(
+  ffi.Pointer<TRenderManager> tRenderer,
+  bool paused,
+);
+
+@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_start(FrameCallback callback, int targetFps);
+
+@ffi.Native<ffi.Void Function()>(isLeaf: true)
+external void FrameScheduler_stop();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void FrameScheduler_setRenderThread(
+  ffi.Pointer<ffi.Void> renderThread,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void FrameScheduler_setRenderManager(ffi.Pointer<TRenderManager> rm);
+
+@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
+  isLeaf: true,
+)
+external void FrameScheduler_setPostRenderCallback(
+  PostRenderCallback callback,
+  ffi.Pointer<ffi.Void> userData,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Uint64)>(isLeaf: true)
+external bool FrameScheduler_requestRender(int frameTimeNanos);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startNativeRenderLoop(int targetFps);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(int port, int targetFps);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_setTargetFps(int fps);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
 
 @ffi.Native<
   ffi.Void Function(
@@ -6137,755 +6886,6 @@ external void Renderer_setFrameInterval(
   int history,
   int interval,
 );
-
-@ffi.Native<
-  ffi.Pointer<TRenderTarget> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TRenderTarget> RenderTarget_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> color,
-  ffi.Pointer<TTexture> depth,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)
->(isLeaf: true)
-external void RenderTarget_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)
->(isLeaf: true)
-external void FilamentAsset_getEntities(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<
-  ffi.Int Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TLightManager>,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external int LightManager_createLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external void LightManager_destroyLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_hasComponent(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external int LightManager_getType(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isDirectional(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isPointLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isSpotLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setIntensityCandela(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double falloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSpotLightOuterCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSpotLightInnerCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloSize,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloFalloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
-  isLeaf: true,
-)
-external void LightManager_setShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)
->(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-);
-
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external TShadowOptions LightManager_getShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.UnsignedInt,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)
->(isLeaf: true)
-external bool LightManager_getLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)
->(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<ffi.Float>,
-    ffi.Uint8,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
-  isLeaf: true,
-)
-external double LightManager_rgbToColorTemperature(
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external void NameComponentManager_destroy(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
-
-@ffi.Native<
-  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)
->(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)
->(isLeaf: true)
-external void IndirectLight_setRotation(
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-  ffi.Pointer<ffi.Double> rotation,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSkybox>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Skybox_setColor(
-  ffi.Pointer<TSkybox> tSkybox,
-  double r,
-  double g,
-  double b,
-  double a,
-);
-
-@ffi.Native<
-  ffi.Pointer<TGltfAssetLoader> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Pointer<TNameComponentManager>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external void GltfAssetLoader_destroy(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-);
-
-@ffi.Native<
-  ffi.Pointer<TFilamentAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int numInstances,
-);
-
-@ffi.Native<
-  ffi.Pointer<TMaterialInstance> Function(
-    ffi.Pointer<TRenderableManager>,
-    ffi.Pointer<TFilamentAsset>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  ffi.Pointer<TFilamentAsset> tAsset,
-);
-
-@ffi.Native<
-  ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)
->(isLeaf: true)
-external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getResourceUriCount(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<
-  ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)
->(isLeaf: true)
-external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientationBuilder>
-SurfaceOrientationBuilder_create();
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
->(isLeaf: true)
-external void SurfaceOrientationBuilder_vertexCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_normals(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> normals,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_tangents(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> tangents,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_uvs(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> uvs,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_positions(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> positions,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangleCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Uint32>,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_uint(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint32> triangles,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Uint16>,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_ushort(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint16> triangles,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSurfaceOrientation> Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
-  isLeaf: true,
-)
-external void SurfaceOrientationBuilder_destroy(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external int SurfaceOrientation_getVertexCount(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientation_getQuats_float4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Float> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Int16>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientation_getQuats_short4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Int16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Uint16>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientation_getQuats_half4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Uint16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external void SurfaceOrientation_destroy(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(int t);
-
-@ffi.Native<
-  ffi.Pointer<TGizmo> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TView>,
-    ffi.Pointer<TMaterial>,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGizmo> Gizmo_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> assetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGizmo>,
-    ffi.Uint32,
-    ffi.Uint32,
-    GizmoPickCallback,
-  )
->(isLeaf: true)
-external void Gizmo_pick(
-  ffi.Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  GizmoPickCallback callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
   isLeaf: true,
@@ -7262,6 +7262,245 @@ sealed class TIndexType {
   static const TINDEX_TYPE_UINT = 1;
 }
 
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+final class TViewport extends ffi.Struct {
+  @ffi.Int32()
+  external int left;
+
+  @ffi.Int32()
+  external int bottom;
+
+  @ffi.Uint32()
+  external int width;
+
+  @ffi.Uint32()
+  external int height;
+}
+
+/// Copied from FogOptions in View.h
+final class TFogOptions extends ffi.Struct {
+  @ffi.Float()
+  external double distance;
+
+  @ffi.Float()
+  external double cutOffDistance;
+
+  @ffi.Float()
+  external double maximumOpacity;
+
+  @ffi.Float()
+  external double height;
+
+  @ffi.Float()
+  external double heightFalloff;
+
+  @ffi.Float()
+  external double density;
+
+  @ffi.Float()
+  external double inScatteringStart;
+
+  @ffi.Float()
+  external double inScatteringSize;
+
+  external ffi.Pointer<TTexture> skyColor;
+
+  @ffi.Float()
+  external double linearColorR;
+
+  @ffi.Float()
+  external double linearColorG;
+
+  @ffi.Float()
+  external double linearColorB;
+
+  @ffi.Bool()
+  external bool fogColorFromIbl;
+
+  @ffi.Bool()
+  external bool enabled;
+}
+
+final class TToneMapper extends ffi.Opaque {}
+
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
+}
+
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
+}
+
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
+}
+
+final class TColorGradingBuilder extends ffi.Opaque {}
+
+/// Options for DPCF and PCSS Shadowing.
+final class TSoftShadowOptions extends ffi.Struct {
+  @ffi.Float()
+  external double penumbraScale;
+
+  @ffi.Float()
+  external double penumbraRatioScale;
+}
+
+/// Options for VSM Shadowing.
+final class TVsmShadowOptions extends ffi.Struct {
+  @ffi.Uint8()
+  external int anisotropy;
+
+  @ffi.Bool()
+  external bool mipmapping;
+
+  @ffi.Uint8()
+  external int msaaSamples;
+
+  @ffi.Bool()
+  external bool highPrecision;
+
+  @ffi.Float()
+  external double minVarianceScale;
+
+  @ffi.Float()
+  external double lightBleedReduction;
+}
+
+/// Screen Space Cone Tracing (SSCT) options
+/// Ambient shadows from dominant light
+final class TSsct extends ffi.Struct {
+  /// !< full cone angle in radian, between 0 and pi/2
+  @ffi.Float()
+  external double lightConeRad;
+
+  /// !< how far shadows can be cast
+  @ffi.Float()
+  external double shadowDistance;
+
+  /// !< max distance for contact
+  @ffi.Float()
+  external double contactDistanceMax;
+
+  /// !< intensity
+  @ffi.Float()
+  external double intensity;
+
+  /// !< light direction X
+  @ffi.Float()
+  external double lightDirectionX;
+
+  /// !< light direction Y
+  @ffi.Float()
+  external double lightDirectionY;
+
+  /// !< light direction Z
+  @ffi.Float()
+  external double lightDirectionZ;
+
+  /// !< depth bias in world units (mitigate self shadowing)
+  @ffi.Float()
+  external double depthBias;
+
+  /// !< depth slope bias (mitigate self shadowing)
+  @ffi.Float()
+  external double depthSlopeBias;
+
+  /// !< tracing sample count, between 1 and 255
+  @ffi.Uint8()
+  external int sampleCount;
+
+  /// !< # of rays to trace, between 1 and 255
+  @ffi.Uint8()
+  external int rayCount;
+
+  /// !< enables or disables SSCT
+  @ffi.Bool()
+  external bool enabled;
+}
+
+/// Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+final class TAmbientOcclusionOptions extends ffi.Struct {
+  /// !< Ambient Occlusion radius in meters, between 0 and ~10
+  @ffi.Float()
+  external double radius;
+
+  /// !< Controls ambient occlusion's contrast. Must be positive
+  @ffi.Float()
+  external double power;
+
+  /// !< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm
+  @ffi.Float()
+  external double bias;
+
+  /// !< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0
+  @ffi.Float()
+  external double resolution;
+
+  /// !< Strength of the Ambient Occlusion effect
+  @ffi.Float()
+  external double intensity;
+
+  /// !< depth distance that constitute an edge for filtering
+  @ffi.Float()
+  external double bilateralThreshold;
+
+  /// !< affects # of samples used for AO
+  @ffi.UnsignedInt()
+  external int quality;
+
+  /// !< affects AO smoothness
+  @ffi.UnsignedInt()
+  external int lowPassFilter;
+
+  /// !< affects AO buffer upsampling quality
+  @ffi.UnsignedInt()
+  external int upsampling;
+
+  /// !< enables or disables screen-space ambient occlusion
+  @ffi.Bool()
+  external bool enabled;
+
+  /// !< enables bent normals computation from AO, and specular AO
+  @ffi.Bool()
+  external bool bentNormals;
+
+  /// !< min angle in radian to consider
+  @ffi.Float()
+  external double minHorizonAngleRad;
+
+  external TSsct ssct;
+}
+
+typedef PickCallbackFunction =
+    ffi.Void Function(
+      ffi.Uint32 requestId,
+      EntityId entityId,
+      ffi.Float depth,
+      ffi.Float fragX,
+      ffi.Float fragY,
+      ffi.Float fragZ,
+    );
+typedef DartPickCallbackFunction =
+    void Function(
+      int requestId,
+      DartEntityId entityId,
+      double depth,
+      double fragX,
+      double fragY,
+      double fragZ,
+    );
+typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
+
 sealed class TSamplerCompareFunc {
   /// !< Less or equal
   static const LE = 0;
@@ -7335,21 +7574,6 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_MULTIPLY = 5;
   static const BLENDING_MODE_SCREEN = 6;
   static const BLENDING_MODE_CUSTOM = 7;
-}
-
-final class TGltfMeshData extends ffi.Struct {
-  external ffi.Pointer<ffi.Float> vertices;
-
-  @ffi.Uint32()
-  external int vertexCount;
-
-  external ffi.Pointer<ffi.Uint32> indices;
-
-  @ffi.Uint32()
-  external int indexCount;
-
-  @ffi.UnsignedInt()
-  external int primitiveType;
 }
 
 sealed class TTextureSamplerType {
@@ -7625,239 +7849,6 @@ sealed class TBackend {
   static const BACKEND_NOOP = 4;
 }
 
-final class TViewport extends ffi.Struct {
-  @ffi.Int32()
-  external int left;
-
-  @ffi.Int32()
-  external int bottom;
-
-  @ffi.Uint32()
-  external int width;
-
-  @ffi.Uint32()
-  external int height;
-}
-
-/// Copied from FogOptions in View.h
-final class TFogOptions extends ffi.Struct {
-  @ffi.Float()
-  external double distance;
-
-  @ffi.Float()
-  external double cutOffDistance;
-
-  @ffi.Float()
-  external double maximumOpacity;
-
-  @ffi.Float()
-  external double height;
-
-  @ffi.Float()
-  external double heightFalloff;
-
-  @ffi.Float()
-  external double density;
-
-  @ffi.Float()
-  external double inScatteringStart;
-
-  @ffi.Float()
-  external double inScatteringSize;
-
-  external ffi.Pointer<TTexture> skyColor;
-
-  @ffi.Float()
-  external double linearColorR;
-
-  @ffi.Float()
-  external double linearColorG;
-
-  @ffi.Float()
-  external double linearColorB;
-
-  @ffi.Bool()
-  external bool fogColorFromIbl;
-
-  @ffi.Bool()
-  external bool enabled;
-}
-
-final class TToneMapper extends ffi.Opaque {}
-
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
-}
-
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
-}
-
-sealed class TLutFormat {
-  static const INTEGER = 0;
-  static const FLOAT = 1;
-}
-
-final class TColorGradingBuilder extends ffi.Opaque {}
-
-/// Options for DPCF and PCSS Shadowing.
-final class TSoftShadowOptions extends ffi.Struct {
-  @ffi.Float()
-  external double penumbraScale;
-
-  @ffi.Float()
-  external double penumbraRatioScale;
-}
-
-/// Options for VSM Shadowing.
-final class TVsmShadowOptions extends ffi.Struct {
-  @ffi.Uint8()
-  external int anisotropy;
-
-  @ffi.Bool()
-  external bool mipmapping;
-
-  @ffi.Uint8()
-  external int msaaSamples;
-
-  @ffi.Bool()
-  external bool highPrecision;
-
-  @ffi.Float()
-  external double minVarianceScale;
-
-  @ffi.Float()
-  external double lightBleedReduction;
-}
-
-/// Screen Space Cone Tracing (SSCT) options
-/// Ambient shadows from dominant light
-final class TSsct extends ffi.Struct {
-  /// !< full cone angle in radian, between 0 and pi/2
-  @ffi.Float()
-  external double lightConeRad;
-
-  /// !< how far shadows can be cast
-  @ffi.Float()
-  external double shadowDistance;
-
-  /// !< max distance for contact
-  @ffi.Float()
-  external double contactDistanceMax;
-
-  /// !< intensity
-  @ffi.Float()
-  external double intensity;
-
-  /// !< light direction X
-  @ffi.Float()
-  external double lightDirectionX;
-
-  /// !< light direction Y
-  @ffi.Float()
-  external double lightDirectionY;
-
-  /// !< light direction Z
-  @ffi.Float()
-  external double lightDirectionZ;
-
-  /// !< depth bias in world units (mitigate self shadowing)
-  @ffi.Float()
-  external double depthBias;
-
-  /// !< depth slope bias (mitigate self shadowing)
-  @ffi.Float()
-  external double depthSlopeBias;
-
-  /// !< tracing sample count, between 1 and 255
-  @ffi.Uint8()
-  external int sampleCount;
-
-  /// !< # of rays to trace, between 1 and 255
-  @ffi.Uint8()
-  external int rayCount;
-
-  /// !< enables or disables SSCT
-  @ffi.Bool()
-  external bool enabled;
-}
-
-/// Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
-final class TAmbientOcclusionOptions extends ffi.Struct {
-  /// !< Ambient Occlusion radius in meters, between 0 and ~10
-  @ffi.Float()
-  external double radius;
-
-  /// !< Controls ambient occlusion's contrast. Must be positive
-  @ffi.Float()
-  external double power;
-
-  /// !< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm
-  @ffi.Float()
-  external double bias;
-
-  /// !< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0
-  @ffi.Float()
-  external double resolution;
-
-  /// !< Strength of the Ambient Occlusion effect
-  @ffi.Float()
-  external double intensity;
-
-  /// !< depth distance that constitute an edge for filtering
-  @ffi.Float()
-  external double bilateralThreshold;
-
-  /// !< affects # of samples used for AO
-  @ffi.UnsignedInt()
-  external int quality;
-
-  /// !< affects AO smoothness
-  @ffi.UnsignedInt()
-  external int lowPassFilter;
-
-  /// !< affects AO buffer upsampling quality
-  @ffi.UnsignedInt()
-  external int upsampling;
-
-  /// !< enables or disables screen-space ambient occlusion
-  @ffi.Bool()
-  external bool enabled;
-
-  /// !< enables bent normals computation from AO, and specular AO
-  @ffi.Bool()
-  external bool bentNormals;
-
-  /// !< min angle in radian to consider
-  @ffi.Float()
-  external double minHorizonAngleRad;
-
-  external TSsct ssct;
-}
-
-typedef PickCallbackFunction =
-    ffi.Void Function(
-      ffi.Uint32 requestId,
-      EntityId entityId,
-      ffi.Float depth,
-      ffi.Float fragX,
-      ffi.Float fragY,
-      ffi.Float fragZ,
-    );
-typedef DartPickCallbackFunction =
-    void Function(
-      int requestId,
-      DartEntityId entityId,
-      double depth,
-      double fragX,
-      double fragY,
-      double fragZ,
-    );
-typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
 typedef FilamentRenderCallbackFunction =
     ffi.Void Function(ffi.Pointer<ffi.Void> owner);
 typedef DartFilamentRenderCallbackFunction =
@@ -7865,20 +7856,20 @@ typedef DartFilamentRenderCallbackFunction =
 typedef FilamentRenderCallback =
     ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
 
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
+final class TGltfMeshData extends ffi.Struct {
+  external ffi.Pointer<ffi.Float> vertices;
 
-typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
-typedef PostRenderCallbackFunction =
-    ffi.Void Function(ffi.Pointer<ffi.Void> userData);
-typedef DartPostRenderCallbackFunction =
-    void Function(ffi.Pointer<ffi.Void> userData);
-typedef PostRenderCallback =
-    ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
+  @ffi.Uint32()
+  external int vertexCount;
+
+  external ffi.Pointer<ffi.Uint32> indices;
+
+  @ffi.Uint32()
+  external int indexCount;
+
+  @ffi.UnsignedInt()
+  external int primitiveType;
+}
 
 sealed class TLightType {
   static const LIGHT_TYPE_SUN = 0;
@@ -7981,6 +7972,15 @@ typedef DartGizmoPickCallbackFunction =
     void Function(int resultType, double x, double y, double z);
 typedef GizmoPickCallback =
     ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
+typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
+typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
+typedef PostRenderCallbackFunction =
+    ffi.Void Function(ffi.Pointer<ffi.Void> userData);
+typedef DartPostRenderCallbackFunction =
+    void Function(ffi.Pointer<ffi.Void> userData);
+typedef PostRenderCallback =
+    ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
 
 final class TMovementIntentCalculator extends ffi.Opaque {}
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -32,6 +32,593 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
+  external void _Camera_setExposure(
+    Pointer<TCamera> camera,
+    double aperture,
+    double shutterSpeed,
+    double sensitivity,
+  );
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external void _Camera_getModelMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getViewMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getCullingProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getFrustum(
+    Pointer<TCamera> camera,
+    Pointer<Float64> out,
+  );
+  external void _Camera_setProjectionMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> matrix,
+    double near,
+    double far,
+  );
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
+  );
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external void _Camera_setFocusDistance(
+    Pointer<TCamera> camera,
+    double focusDistance,
+  );
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> tModelMatrix,
+  );
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    bool rebuildVertices,
+  );
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_addToScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external void _SceneAsset_removeFromScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getChildEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_getChildEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<Int32> out,
+  );
+  external Pointer<Int32> _SceneAsset_getCameraEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getCameraEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<Int32> _SceneAsset_getLightEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getLightEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+  );
+  external size_t _SceneAsset_getInstanceCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+  );
+  external void _SceneAsset_getBoundingBox(
+    Pointer<Aabb3> Aabb3_out,
+    Pointer<TSceneAsset> asset,
+  );
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external int _SceneAsset_getPrimitiveOffsetForEntity(
+    Pointer<TSceneAsset> tSceneAsset,
+    EntityId entity,
+  );
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_setFlatShading(
+    Pointer<TSceneAsset> tSceneAsset,
+    bool flatShading,
+  );
+  external void _SceneAsset_getBones(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    Pointer<Int32> out,
+  );
+  external size_t _SceneAsset_getBoneCount(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+  );
+  external Pointer<Char> _SceneAsset_getBoneName(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    size_t boneIndex,
+  );
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
+  );
+  external void _GltfAssetLoader_destroy(
+    Pointer<TGltfAssetLoader> tAssetLoader,
+  );
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
+  );
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
+  );
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(
+    Pointer<TGltfAssetLoader> tAssetLoader,
+  );
+  external int _FilamentAsset_getResourceUriCount(
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(
+    Pointer<TNameComponentManager> tNameComponentManager,
+  );
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external Pointer<TSurfaceOrientationBuilder>
+  _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
+  );
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_triangleCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
+  );
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
+  );
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
+  );
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
+    Pointer<TSurfaceOrientationBuilder> builder,
+  );
+  external void _SurfaceOrientationBuilder_destroy(
+    Pointer<TSurfaceOrientationBuilder> builder,
+  );
+  external size_t _SurfaceOrientation_getVertexCount(
+    Pointer<TSurfaceOrientation> orientation,
+  );
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Float32> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_destroy(
+    Pointer<TSurfaceOrientation> orientation,
+  );
+  external int _FilamentAsset_getEntityCount(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external void _FilamentAsset_getEntities(
+    Pointer<TFilamentAsset> filamentAsset,
+    Pointer<Int32> out,
+  );
+  external EntityId _FilamentAsset_getWireframe(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external Pointer<Void> _FilamentAsset_getSourceAsset(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external void _View_getViewport(
+    Pointer<TViewport> TViewport_out,
+    Pointer<TView> view,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createLinear(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createACES(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createACESLegacy(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createFilmic(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createPBRNeutral(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createAGX(Pointer<TEngine> tEngine);
+  external Pointer<TToneMapper> _ToneMapper_createAGXWithLook(
+    Pointer<TEngine> tEngine,
+    int look,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createGeneric(
+    Pointer<TEngine> tEngine,
+    double contrast,
+    double midGrayIn,
+    double midGrayOut,
+    double hdrMax,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createDisplayRange(
+    Pointer<TEngine> tEngine,
+  );
+  external void _ToneMapper_destroy(Pointer<TToneMapper> toneMapper);
+  external Pointer<TColorGrading> _ColorGrading_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TToneMapper> toneMapper,
+  );
+  external Pointer<TColorGradingBuilder> _ColorGradingBuilder_create();
+  external Pointer<TColorGrading> _ColorGradingBuilder_build(
+    Pointer<TColorGradingBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _ColorGradingBuilder_destroy(
+    Pointer<TColorGradingBuilder> builder,
+  );
+  external void _ColorGrading_destroy(
+    Pointer<TEngine> engine,
+    Pointer<TColorGrading> colorGrading,
+  );
+  external void _ColorGradingBuilder_quality(
+    Pointer<TColorGradingBuilder> builder,
+    int level,
+  );
+  external void _ColorGradingBuilder_format(
+    Pointer<TColorGradingBuilder> builder,
+    int format,
+  );
+  external void _ColorGradingBuilder_dimensions(
+    Pointer<TColorGradingBuilder> builder,
+    int dim,
+  );
+  external void _ColorGradingBuilder_toneMapper(
+    Pointer<TColorGradingBuilder> builder,
+    Pointer<TToneMapper> toneMapper,
+  );
+  external void _ColorGradingBuilder_exposure(
+    Pointer<TColorGradingBuilder> builder,
+    double exposure,
+  );
+  external void _ColorGradingBuilder_nightAdaptation(
+    Pointer<TColorGradingBuilder> builder,
+    double adaptation,
+  );
+  external void _ColorGradingBuilder_whiteBalance(
+    Pointer<TColorGradingBuilder> builder,
+    double temperature,
+    double tint,
+  );
+  external void _ColorGradingBuilder_contrast(
+    Pointer<TColorGradingBuilder> builder,
+    double contrast,
+  );
+  external void _ColorGradingBuilder_vibrance(
+    Pointer<TColorGradingBuilder> builder,
+    double vibrance,
+  );
+  external void _ColorGradingBuilder_saturation(
+    Pointer<TColorGradingBuilder> builder,
+    double saturation,
+  );
+  external void _ColorGradingBuilder_channelMixer(
+    Pointer<TColorGradingBuilder> builder,
+    double outRedR,
+    double outRedG,
+    double outRedB,
+    double outGreenR,
+    double outGreenG,
+    double outGreenB,
+    double outBlueR,
+    double outBlueG,
+    double outBlueB,
+  );
+  external void _ColorGradingBuilder_shadowsMidtonesHighlights(
+    Pointer<TColorGradingBuilder> builder,
+    double shadowsR,
+    double shadowsG,
+    double shadowsB,
+    double shadowsW,
+    double midtonesR,
+    double midtonesG,
+    double midtonesB,
+    double midtonesW,
+    double highlightsR,
+    double highlightsG,
+    double highlightsB,
+    double highlightsW,
+    double rangesX,
+    double rangesY,
+    double rangesZ,
+    double rangesW,
+  );
+  external void _ColorGradingBuilder_slopeOffsetPower(
+    Pointer<TColorGradingBuilder> builder,
+    double slopeR,
+    double slopeG,
+    double slopeB,
+    double offsetR,
+    double offsetG,
+    double offsetB,
+    double powerR,
+    double powerG,
+    double powerB,
+  );
+  external void _ColorGradingBuilder_curves(
+    Pointer<TColorGradingBuilder> builder,
+    double shadowGammaR,
+    double shadowGammaG,
+    double shadowGammaB,
+    double midPointR,
+    double midPointG,
+    double midPointB,
+    double highlightScaleR,
+    double highlightScaleG,
+    double highlightScaleB,
+  );
+  external void _ColorGradingBuilder_luminanceScaling(
+    Pointer<TColorGradingBuilder> builder,
+    bool enabled,
+  );
+  external void _ColorGradingBuilder_gamutMapping(
+    Pointer<TColorGradingBuilder> builder,
+    bool enabled,
+  );
+  external void _View_setColorGrading(
+    Pointer<TView> tView,
+    Pointer<TColorGrading> tColorGrading,
+  );
+  external Pointer<TColorGrading> _View_getColorGrading(Pointer<TView> tView);
+  external void _View_setBlendMode(Pointer<TView> view, int blendMode);
+  external void _View_setViewport(Pointer<TView> view, int width, int height);
+  external void _View_setRenderTarget(
+    Pointer<TView> view,
+    Pointer<TRenderTarget> renderTarget,
+  );
+  external void _View_setFrustumCullingEnabled(
+    Pointer<TView> view,
+    bool enabled,
+  );
+  external Pointer<TRenderTarget> _View_getRenderTarget(Pointer<TView> tView);
+  external void _View_setPostProcessing(Pointer<TView> tView, bool enabled);
+  external void _View_setShadowsEnabled(Pointer<TView> tView, bool enabled);
+  external void _View_setShadowType(Pointer<TView> tView, int shadowType);
+  external int _View_getShadowType(Pointer<TView> tView);
+  external void _View_setSoftShadowOptions(
+    Pointer<TView> tView,
+    Pointer<TSoftShadowOptions> optionsPtr,
+  );
+  external void _View_getSoftShadowOptions(
+    Pointer<TSoftShadowOptions> TSoftShadowOptions_out,
+    Pointer<TView> tView,
+  );
+  external void _View_setVsmShadowOptions(
+    Pointer<TView> tView,
+    Pointer<TVsmShadowOptions> optionsPtr,
+  );
+  external void _View_getVsmShadowOptions(
+    Pointer<TVsmShadowOptions> TVsmShadowOptions_out,
+    Pointer<TView> tView,
+  );
+  external void _View_setBloom(
+    Pointer<TView> tView,
+    bool enabled,
+    double strength,
+  );
+  external void _View_setRenderQuality(Pointer<TView> tView, int qualityLevel);
+  external void _View_setAntiAliasing(
+    Pointer<TView> tView,
+    bool msaa,
+    bool fxaa,
+    bool taa,
+  );
+  external void _View_setLayerEnabled(
+    Pointer<TView> tView,
+    int layer,
+    bool visible,
+  );
+  external void _View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera);
+  external Pointer<TScene> _View_getScene(Pointer<TView> tView);
+  external Pointer<TCamera> _View_getCamera(Pointer<TView> tView);
+  external void _View_setStencilBufferEnabled(
+    Pointer<TView> tView,
+    bool enabled,
+  );
+  external int _View_isStencilBufferEnabled(Pointer<TView> tView);
+  external void _View_setDitheringEnabled(Pointer<TView> tView, bool enabled);
+  external int _View_isDitheringEnabled(Pointer<TView> tView);
+  external void _View_setScene(Pointer<TView> tView, Pointer<TScene> tScene);
+  external void _View_setFrontFaceWindingInverted(
+    Pointer<TView> tView,
+    bool inverted,
+  );
+  external void _View_setAmbientOcclusionOptions(
+    Pointer<TView> tView,
+    Pointer<TAmbientOcclusionOptions> optionsPtr,
+  );
+  external void _View_getAmbientOcclusionOptions(
+    Pointer<TAmbientOcclusionOptions> TAmbientOcclusionOptions_out,
+    Pointer<TView> tView,
+  );
+  external void _View_setFogOptions(
+    Pointer<TView> tView,
+    Pointer<TFogOptions> tFogOptionsPtr,
+  );
+  external void _View_getFogOptions(
+    Pointer<TFogOptions> TFogOptions_out,
+    Pointer<TView> tView,
+  );
+  external void _View_setTransparentPickingEnabled(
+    Pointer<TView> tView,
+    bool enabled,
+  );
+  external int _View_isTransparentPickingEnabled(Pointer<TView> tView);
+  external void _View_pick(
+    Pointer<TView> tView,
+    int requestId,
+    int x,
+    int y,
+    PickCallback callback,
+  );
+  external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
+  external Pointer<Char> _View_getName(Pointer<TView> tView);
+  external void _Skybox_setColor(
+    Pointer<TSkybox> tSkybox,
+    double r,
+    double g,
+    double b,
+    double a,
+  );
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(
+    Pointer<TIndexBufferBuilder> builder,
+    int count,
+  );
+  external void _IndexBufferBuilder_bufferType(
+    Pointer<TIndexBufferBuilder> builder,
+    int indexType,
+  );
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _IndexBufferBuilder_destroy(
+    Pointer<TIndexBufferBuilder> builder,
+  );
+  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _IndexBuffer_destroy(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+  );
   external Pointer<TMaterialInstance> _Material_createInstance(
     Pointer<TMaterial> tMaterial,
   );
@@ -190,14 +777,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TMaterialInstance> materialInstance,
   );
   external int _Material_getBlendingMode(Pointer<TMaterial> material);
-  external void _dummy(Pointer<TGltfMeshData> dummyPtr);
-  external int _GltfParser_parseBuffer(
-    Pointer<Uint8> data,
-    size_t length,
-    Pointer<Char> meshName,
-    Pointer<TGltfMeshData> outMeshData,
-  );
-  external void _GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData);
   external Pointer<TTexture> _Texture_build(
     Pointer<TEngine> engine,
     int width,
@@ -506,259 +1085,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<Char> name,
     Pointer<Float32> outValue,
   );
-  external void _View_getViewport(
-    Pointer<TViewport> TViewport_out,
-    Pointer<TView> view,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createLinear(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createACES(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createACESLegacy(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createFilmic(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createPBRNeutral(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createAGX(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createAGXWithLook(
-    Pointer<TEngine> tEngine,
-    int look,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createGeneric(
-    Pointer<TEngine> tEngine,
-    double contrast,
-    double midGrayIn,
-    double midGrayOut,
-    double hdrMax,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createDisplayRange(
-    Pointer<TEngine> tEngine,
-  );
-  external void _ToneMapper_destroy(Pointer<TToneMapper> toneMapper);
-  external Pointer<TColorGrading> _ColorGrading_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TToneMapper> toneMapper,
-  );
-  external Pointer<TColorGradingBuilder> _ColorGradingBuilder_create();
-  external Pointer<TColorGrading> _ColorGradingBuilder_build(
-    Pointer<TColorGradingBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _ColorGradingBuilder_destroy(
-    Pointer<TColorGradingBuilder> builder,
-  );
-  external void _ColorGrading_destroy(
-    Pointer<TEngine> engine,
-    Pointer<TColorGrading> colorGrading,
-  );
-  external void _ColorGradingBuilder_quality(
-    Pointer<TColorGradingBuilder> builder,
-    int level,
-  );
-  external void _ColorGradingBuilder_format(
-    Pointer<TColorGradingBuilder> builder,
-    int format,
-  );
-  external void _ColorGradingBuilder_dimensions(
-    Pointer<TColorGradingBuilder> builder,
-    int dim,
-  );
-  external void _ColorGradingBuilder_toneMapper(
-    Pointer<TColorGradingBuilder> builder,
-    Pointer<TToneMapper> toneMapper,
-  );
-  external void _ColorGradingBuilder_exposure(
-    Pointer<TColorGradingBuilder> builder,
-    double exposure,
-  );
-  external void _ColorGradingBuilder_nightAdaptation(
-    Pointer<TColorGradingBuilder> builder,
-    double adaptation,
-  );
-  external void _ColorGradingBuilder_whiteBalance(
-    Pointer<TColorGradingBuilder> builder,
-    double temperature,
-    double tint,
-  );
-  external void _ColorGradingBuilder_contrast(
-    Pointer<TColorGradingBuilder> builder,
-    double contrast,
-  );
-  external void _ColorGradingBuilder_vibrance(
-    Pointer<TColorGradingBuilder> builder,
-    double vibrance,
-  );
-  external void _ColorGradingBuilder_saturation(
-    Pointer<TColorGradingBuilder> builder,
-    double saturation,
-  );
-  external void _ColorGradingBuilder_channelMixer(
-    Pointer<TColorGradingBuilder> builder,
-    double outRedR,
-    double outRedG,
-    double outRedB,
-    double outGreenR,
-    double outGreenG,
-    double outGreenB,
-    double outBlueR,
-    double outBlueG,
-    double outBlueB,
-  );
-  external void _ColorGradingBuilder_shadowsMidtonesHighlights(
-    Pointer<TColorGradingBuilder> builder,
-    double shadowsR,
-    double shadowsG,
-    double shadowsB,
-    double shadowsW,
-    double midtonesR,
-    double midtonesG,
-    double midtonesB,
-    double midtonesW,
-    double highlightsR,
-    double highlightsG,
-    double highlightsB,
-    double highlightsW,
-    double rangesX,
-    double rangesY,
-    double rangesZ,
-    double rangesW,
-  );
-  external void _ColorGradingBuilder_slopeOffsetPower(
-    Pointer<TColorGradingBuilder> builder,
-    double slopeR,
-    double slopeG,
-    double slopeB,
-    double offsetR,
-    double offsetG,
-    double offsetB,
-    double powerR,
-    double powerG,
-    double powerB,
-  );
-  external void _ColorGradingBuilder_curves(
-    Pointer<TColorGradingBuilder> builder,
-    double shadowGammaR,
-    double shadowGammaG,
-    double shadowGammaB,
-    double midPointR,
-    double midPointG,
-    double midPointB,
-    double highlightScaleR,
-    double highlightScaleG,
-    double highlightScaleB,
-  );
-  external void _ColorGradingBuilder_luminanceScaling(
-    Pointer<TColorGradingBuilder> builder,
-    bool enabled,
-  );
-  external void _ColorGradingBuilder_gamutMapping(
-    Pointer<TColorGradingBuilder> builder,
-    bool enabled,
-  );
-  external void _View_setColorGrading(
-    Pointer<TView> tView,
-    Pointer<TColorGrading> tColorGrading,
-  );
-  external Pointer<TColorGrading> _View_getColorGrading(Pointer<TView> tView);
-  external void _View_setBlendMode(Pointer<TView> view, int blendMode);
-  external void _View_setViewport(Pointer<TView> view, int width, int height);
-  external void _View_setRenderTarget(
-    Pointer<TView> view,
-    Pointer<TRenderTarget> renderTarget,
-  );
-  external void _View_setFrustumCullingEnabled(
-    Pointer<TView> view,
-    bool enabled,
-  );
-  external Pointer<TRenderTarget> _View_getRenderTarget(Pointer<TView> tView);
-  external void _View_setPostProcessing(Pointer<TView> tView, bool enabled);
-  external void _View_setShadowsEnabled(Pointer<TView> tView, bool enabled);
-  external void _View_setShadowType(Pointer<TView> tView, int shadowType);
-  external int _View_getShadowType(Pointer<TView> tView);
-  external void _View_setSoftShadowOptions(
-    Pointer<TView> tView,
-    Pointer<TSoftShadowOptions> optionsPtr,
-  );
-  external void _View_getSoftShadowOptions(
-    Pointer<TSoftShadowOptions> TSoftShadowOptions_out,
-    Pointer<TView> tView,
-  );
-  external void _View_setVsmShadowOptions(
-    Pointer<TView> tView,
-    Pointer<TVsmShadowOptions> optionsPtr,
-  );
-  external void _View_getVsmShadowOptions(
-    Pointer<TVsmShadowOptions> TVsmShadowOptions_out,
-    Pointer<TView> tView,
-  );
-  external void _View_setBloom(
-    Pointer<TView> tView,
-    bool enabled,
-    double strength,
-  );
-  external void _View_setRenderQuality(Pointer<TView> tView, int qualityLevel);
-  external void _View_setAntiAliasing(
-    Pointer<TView> tView,
-    bool msaa,
-    bool fxaa,
-    bool taa,
-  );
-  external void _View_setLayerEnabled(
-    Pointer<TView> tView,
-    int layer,
-    bool visible,
-  );
-  external void _View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera);
-  external Pointer<TScene> _View_getScene(Pointer<TView> tView);
-  external Pointer<TCamera> _View_getCamera(Pointer<TView> tView);
-  external void _View_setStencilBufferEnabled(
-    Pointer<TView> tView,
-    bool enabled,
-  );
-  external int _View_isStencilBufferEnabled(Pointer<TView> tView);
-  external void _View_setDitheringEnabled(Pointer<TView> tView, bool enabled);
-  external int _View_isDitheringEnabled(Pointer<TView> tView);
-  external void _View_setScene(Pointer<TView> tView, Pointer<TScene> tScene);
-  external void _View_setFrontFaceWindingInverted(
-    Pointer<TView> tView,
-    bool inverted,
-  );
-  external void _View_setAmbientOcclusionOptions(
-    Pointer<TView> tView,
-    Pointer<TAmbientOcclusionOptions> optionsPtr,
-  );
-  external void _View_getAmbientOcclusionOptions(
-    Pointer<TAmbientOcclusionOptions> TAmbientOcclusionOptions_out,
-    Pointer<TView> tView,
-  );
-  external void _View_setFogOptions(
-    Pointer<TView> tView,
-    Pointer<TFogOptions> tFogOptionsPtr,
-  );
-  external void _View_getFogOptions(
-    Pointer<TFogOptions> TFogOptions_out,
-    Pointer<TView> tView,
-  );
-  external void _View_setTransparentPickingEnabled(
-    Pointer<TView> tView,
-    bool enabled,
-  );
-  external int _View_isTransparentPickingEnabled(Pointer<TView> tView);
-  external void _View_pick(
-    Pointer<TView> tView,
-    int requestId,
-    int x,
-    int y,
-    PickCallback callback,
-  );
-  external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
-  external Pointer<Char> _View_getName(Pointer<TView> tView);
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
     bool doubleSided,
@@ -841,34 +1167,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _VertexBuffer_destroy(
     Pointer<TEngine> engine,
     Pointer<TVertexBuffer> buffer,
-  );
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(
-    Pointer<TIndexBufferBuilder> builder,
-    int count,
-  );
-  external void _IndexBufferBuilder_bufferType(
-    Pointer<TIndexBufferBuilder> builder,
-    int indexType,
-  );
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _IndexBufferBuilder_destroy(
-    Pointer<TIndexBufferBuilder> builder,
-  );
-  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _IndexBuffer_destroy(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
   );
   external void _TransformManager_getLocalTransform(
     Pointer<double4x4> double4x4_out,
@@ -1984,101 +2282,219 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+  external void _dummy(Pointer<TGltfMeshData> dummyPtr);
+  external int _GltfParser_parseBuffer(
+    Pointer<Uint8> data,
+    size_t length,
+    Pointer<Char> meshName,
+    Pointer<TGltfMeshData> outMeshData,
+  );
+  external void _GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData);
+  external int _LightManager_createLight(
     Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    Pointer<Aabb3> boundingBoxPtr,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TFilamentAsset> tFilamentAsset,
-    bool rebuildVertices,
-  );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-  );
-  external void _SceneAsset_removeFromScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-  );
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_getChildEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<Int32> out,
-  );
-  external Pointer<Int32> _SceneAsset_getCameraEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getCameraEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<Int32> _SceneAsset_getLightEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getLightEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-  );
-  external size_t _SceneAsset_getInstanceCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-  );
-  external void _SceneAsset_getBoundingBox(
-    Pointer<Aabb3> Aabb3_out,
-    Pointer<TSceneAsset> asset,
-  );
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external int _SceneAsset_getPrimitiveOffsetForEntity(
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _LightManager_destroyLight(
+    Pointer<TLightManager> tLightManager,
     EntityId entity,
   );
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(
-    Pointer<TSceneAsset> tSceneAsset,
-    bool flatShading,
+  external int _LightManager_hasComponent(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
   );
-  external void _SceneAsset_getBones(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    Pointer<Int32> out,
+  external int _LightManager_getType(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
   );
-  external size_t _SceneAsset_getBoneCount(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
+  external int _LightManager_isDirectional(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
   );
-  external Pointer<Char> _SceneAsset_getBoneName(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    size_t boneIndex,
+  external int _LightManager_isPointLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isSpotLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double r,
+    double g,
+    double b,
+  );
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external double _LightManager_getIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double falloff,
+  );
+  external double _LightManager_getFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external double _LightManager_getSpotLightOuterCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external double _LightManager_getSpotLightInnerCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external double _LightManager_getSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloSize,
+  );
+  external double _LightManager_getSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external double _LightManager_getSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    bool enabled,
+  );
+  external int _LightManager_isShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external int _LightManager_getLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+  );
+  external void _LightManager_computeUniformSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+  );
+  external void _LightManager_computeLogSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+  );
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external double _LightManager_rgbToColorTemperature(
+    double r,
+    double g,
+    double b,
+  );
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_setSkybox(
+    Pointer<TScene> tScene,
+    Pointer<TSkybox> skybox,
+  );
+  external void _Scene_setIndirectLight(
+    Pointer<TScene> tScene,
+    Pointer<TIndirectLight> tIndirectLight,
+  );
+  external void _Scene_addFilamentAsset(
+    Pointer<TScene> tScene,
+    Pointer<TFilamentAsset> asset,
   );
   external void _RenderableManager_destroyEntity(
     Pointer<TRenderableManager> tRenderableManager,
@@ -2356,142 +2772,51 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TEngine> engine,
     EntityId entity,
   );
-  external void _Camera_setExposure(
-    Pointer<TCamera> camera,
-    double aperture,
-    double shutterSpeed,
-    double sensitivity,
-  );
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getViewMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getCullingProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getFrustum(
-    Pointer<TCamera> camera,
-    Pointer<Float64> out,
-  );
-  external void _Camera_setProjectionMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> matrix,
-    double near,
-    double far,
-  );
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
-  );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(
-    Pointer<TCamera> camera,
-    double focusDistance,
-  );
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> tModelMatrix,
-  );
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
-  external Pointer<TRenderManager> _RenderManager_create(
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(
     Pointer<TEngine> tEngine,
-    Pointer<TRenderer> tRenderer,
   );
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
+  external void _GltfResourceLoader_destroy(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
   );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
   );
-  external void _RenderManager_render(
-    Pointer<TRenderManager> tRenderer,
-    JSBigInt frameTimeInNanos,
+  external void _GltfResourceLoader_asyncUpdateLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
   );
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
+  external double _GltfResourceLoader_asyncGetLoadProgress(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
   );
-  external void _RenderManager_removeSwapChain(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
   );
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(
-    Pointer<TRenderManager> tRenderer,
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
   );
-  external void _RenderManager_detachFromRenderThread();
-  external void _RenderManager_setPaused(
-    Pointer<TRenderManager> tRenderer,
-    bool paused,
+  external void _Gizmo_dummy(int t);
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
   );
-  external void _FrameScheduler_start(FrameCallback callback, int targetFps);
-  external void _FrameScheduler_stop();
-  external void _FrameScheduler_setRenderThread(Pointer<Void> renderThread);
-  external void _FrameScheduler_setRenderManager(Pointer<TRenderManager> rm);
-  external void _FrameScheduler_setPostRenderCallback(
-    PostRenderCallback callback,
-    Pointer<Void> userData,
+  external void _Gizmo_pick(
+    Pointer<TGizmo> tGizmo,
+    int x,
+    int y,
+    GizmoPickCallback callback,
   );
-  external int _FrameScheduler_requestRender(JSBigInt frameTimeNanos);
-  external void _FrameScheduler_startNativeRenderLoop(int targetFps);
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
   external Pointer<TAnimationManager> _AnimationManager_create(
     Pointer<TEngine> tEngine,
   );
@@ -2629,47 +2954,69 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int animationIndex,
     double timeInSeconds,
   );
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(
-    Pointer<TScene> tScene,
-    Pointer<TSkybox> skybox,
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
   );
-  external void _Scene_setIndirectLight(
-    Pointer<TScene> tScene,
+  external void _RenderTarget_destroy(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderTarget> tRenderTarget,
+  );
+  external void _IndirectLight_setRotation(
     Pointer<TIndirectLight> tIndirectLight,
+    Pointer<Float64> rotation,
   );
-  external void _Scene_addFilamentAsset(
-    Pointer<TScene> tScene,
-    Pointer<TFilamentAsset> asset,
-  );
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(
+  external Pointer<TRenderManager> _RenderManager_create(
     Pointer<TEngine> tEngine,
+    Pointer<TRenderer> tRenderer,
   );
-  external void _GltfResourceLoader_destroy(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
   );
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
   );
-  external void _GltfResourceLoader_asyncUpdateLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  external void _RenderManager_render(
+    Pointer<TRenderManager> tRenderer,
+    JSBigInt frameTimeInNanos,
   );
-  external double _GltfResourceLoader_asyncGetLoadProgress(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
   );
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
+  external void _RenderManager_removeSwapChain(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
   );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_attachToRenderThread(
+    Pointer<TRenderManager> tRenderer,
   );
+  external void _RenderManager_detachFromRenderThread();
+  external void _RenderManager_setPaused(
+    Pointer<TRenderManager> tRenderer,
+    bool paused,
+  );
+  external void _FrameScheduler_start(FrameCallback callback, int targetFps);
+  external void _FrameScheduler_stop();
+  external void _FrameScheduler_setRenderThread(Pointer<Void> renderThread);
+  external void _FrameScheduler_setRenderManager(Pointer<TRenderManager> rm);
+  external void _FrameScheduler_setPostRenderCallback(
+    PostRenderCallback callback,
+    Pointer<Void> userData,
+  );
+  external int _FrameScheduler_requestRender(JSBigInt frameTimeNanos);
+  external void _FrameScheduler_startNativeRenderLoop(int targetFps);
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
   external void _Renderer_setClearOptions(
     Pointer<TRenderer> tRenderer,
     double clearR,
@@ -2713,353 +3060,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int history,
     int interval,
   );
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
-  );
-  external void _RenderTarget_destroy(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderTarget> tRenderTarget,
-  );
-  external int _FilamentAsset_getEntityCount(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external void _FilamentAsset_getEntities(
-    Pointer<TFilamentAsset> filamentAsset,
-    Pointer<Int32> out,
-  );
-  external EntityId _FilamentAsset_getWireframe(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external Pointer<Void> _FilamentAsset_getSourceAsset(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external int _LightManager_createLight(
-    Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
-  );
-  external void _LightManager_destroyLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_hasComponent(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_getType(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isDirectional(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isPointLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isSpotLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double r,
-    double g,
-    double b,
-  );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double falloff,
-  );
-  external double _LightManager_getFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external double _LightManager_getSpotLightInnerCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloSize,
-  );
-  external double _LightManager_getSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    bool enabled,
-  );
-  external int _LightManager_isShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-  );
-  external void _LightManager_computeUniformSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-  );
-  external void _LightManager_computeLogSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-  );
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(
-    double r,
-    double g,
-    double b,
-  );
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(
-    Pointer<TNameComponentManager> tNameComponentManager,
-  );
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external void _IndirectLight_setRotation(
-    Pointer<TIndirectLight> tIndirectLight,
-    Pointer<Float64> rotation,
-  );
-  external void _Skybox_setColor(
-    Pointer<TSkybox> tSkybox,
-    double r,
-    double g,
-    double b,
-    double a,
-  );
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
-  );
-  external void _GltfAssetLoader_destroy(
-    Pointer<TGltfAssetLoader> tAssetLoader,
-  );
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
-  );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
-  );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(
-    Pointer<TGltfAssetLoader> tAssetLoader,
-  );
-  external int _FilamentAsset_getResourceUriCount(
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external Pointer<TSurfaceOrientationBuilder>
-  _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
-  );
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_triangleCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
-  );
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
-  );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
-  );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
-    Pointer<TSurfaceOrientationBuilder> builder,
-  );
-  external void _SurfaceOrientationBuilder_destroy(
-    Pointer<TSurfaceOrientationBuilder> builder,
-  );
-  external size_t _SurfaceOrientation_getVertexCount(
-    Pointer<TSurfaceOrientation> orientation,
-  );
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_destroy(
-    Pointer<TSurfaceOrientation> orientation,
-  );
-  external void _Gizmo_dummy(int t);
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(
-    Pointer<TGizmo> tGizmo,
-    int x,
-    int y,
-    GizmoPickCallback callback,
-  );
-  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
-  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
   external void _MovementIntentExecutor_destroy(
     Pointer<TMovementIntentExecutor> executor,
   );
@@ -3172,6 +3172,1615 @@ BigInt get TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER {
     "i64",
   );
   return bigIntasUintN(64, value).toDart;
+}
+
+void Camera_setExposure(
+  Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+) {
+  final result = GeneratedBindings.instance._Camera_setExposure(
+    camera.cast(),
+    aperture,
+    shutterSpeed,
+    sensitivity,
+  );
+  return result;
+}
+
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(
+    camera.cast(),
+  );
+  return result;
+}
+
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(
+    camera.cast(),
+  );
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(
+    camera.cast(),
+    out,
+  );
+  return result;
+}
+
+void Camera_setProjectionMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> matrix,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(
+    camera.cast(),
+    matrix,
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(
+    camera.cast(),
+  );
+  return result;
+}
+
+void Camera_lookAt(
+  Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(
+    camera.cast(),
+    eyePtr.cast(),
+    focusPtr.cast(),
+    upPtr.cast(),
+  );
+  return result;
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(
+    camera.cast(),
+  );
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(
+    camera.cast(),
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(
+    camera.cast(),
+  );
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(
+    camera.cast(),
+    focusDistance,
+  );
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance
+      ._Camera_setCustomProjectionWithCulling(
+        camera.cast(),
+        projectionMatrixPtr.cast(),
+        near,
+        far,
+      );
+  return result;
+}
+
+void Camera_setModelMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> tModelMatrix,
+) {
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(
+    camera.cast(),
+    tModelMatrix,
+  );
+  return result;
+}
+
+void Camera_setLensProjection(
+  Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(
+    camera.cast(),
+    near,
+    far,
+    aspect,
+    focalLength,
+  );
+  return result;
+}
+
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tVertexBuffer,
+  Pointer<TIndexBuffer> tIndexBuffer,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
+) {
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
+    tEngine.cast(),
+    tVertexBuffer.cast(),
+    tIndexBuffer.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+    tPrimitiveType,
+    boundingBoxPtr.cast(),
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    tNameComponentManager.cast(),
+    tFilamentAsset.cast(),
+    rebuildVertices,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(
+    tSceneAsset.cast(),
+  );
+  return Pointer<TFilamentAsset>(result);
+}
+
+int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getType(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_destroy(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_addToScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_addToScene(
+    tSceneAsset.cast(),
+    tScene.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_removeFromScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(
+    tSceneAsset.cast(),
+    tScene.cast(),
+  );
+  return result;
+}
+
+DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getEntity(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_getChildEntities(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(
+    tSceneAsset.cast(),
+    out,
+  );
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(
+    tSceneAsset.cast(),
+  );
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(
+    tSceneAsset.cast(),
+  );
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_getInstance(
+  Pointer<TSceneAsset> tSceneAsset,
+  int index,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstance(
+    tSceneAsset.cast(),
+    index,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createInstance(
+  Pointer<TSceneAsset> asset,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createInstance(
+    asset.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(
+    Aabb3_out.cast(),
+    asset.cast(),
+  );
+  return Aabb3_out.toDart();
+}
+
+Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(
+    tSceneAsset.cast(),
+    primitiveIndex,
+  );
+  return Pointer<TVertexBuffer>(result);
+}
+
+Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(
+    tSceneAsset.cast(),
+    primitiveIndex,
+  );
+  return Pointer<TIndexBuffer>(result);
+}
+
+int SceneAsset_getPrimitiveOffsetForEntity(
+  Pointer<TSceneAsset> tSceneAsset,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
+  return result;
+}
+
+void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_setFlatShading(
+  Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(
+    tSceneAsset.cast(),
+    flatShading,
+  );
+  return result;
+}
+
+void SceneAsset_getBones(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getBones(
+    tSceneAsset.cast(),
+    skinIndex,
+    out,
+  );
+  return result;
+}
+
+Dartsize_t SceneAsset_getBoneCount(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(
+    tSceneAsset.cast(),
+    skinIndex,
+  );
+  return result;
+}
+
+Pointer<Char> SceneAsset_getBoneName(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+  Dartsize_t boneIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getBoneName(
+    tSceneAsset.cast(),
+    skinIndex,
+    boneIndex,
+  );
+  return Pointer<Char>(result);
+}
+
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+    tEngine.cast(),
+    tMaterialProvider.cast(),
+    tNameComponentManager.cast(),
+  );
+  return Pointer<TGltfAssetLoader>(result);
+}
+
+void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(
+    tAssetLoader.cast(),
+  );
+  return result;
+}
+
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  int numInstances,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    data,
+    length,
+    numInstances,
+  );
+  return Pointer<TFilamentAsset>(result);
+}
+
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
+) {
+  final result = GeneratedBindings.instance
+      ._GltfAssetLoader_getMaterialInstance(
+        tRenderableManager.cast(),
+        tAsset.cast(),
+      );
+  return Pointer<TMaterialInstance>(result);
+}
+
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
+  Pointer<TGltfAssetLoader> tAssetLoader,
+) {
+  final result = GeneratedBindings.instance
+      ._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
+}
+
+int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(
+    tFilamentAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(
+    tFilamentAsset.cast(),
+  );
+  return Pointer<PointerClass<Char>>(result);
+}
+
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(
+    tNameComponentManager.cast(),
+  );
+  return result;
+}
+
+Pointer<Char> NameComponentManager_getName(
+  Pointer<TNameComponentManager> tNameComponentManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(
+    tNameComponentManager.cast(),
+    entity,
+  );
+  return Pointer<Char>(result);
+}
+
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(
+    builder.cast(),
+    normals,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(
+    builder.cast(),
+    tangents,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(
+    builder.cast(),
+    uvs,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint32> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(
+    builder.cast(),
+  );
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(
+    builder.cast(),
+  );
+  return result;
+}
+
+Dartsize_t SurfaceOrientation_getVertexCount(
+  Pointer<TSurfaceOrientation> orientation,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(
+    orientation.cast(),
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(
+    orientation.cast(),
+  );
+  return result;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(
+    filamentAsset.cast(),
+  );
+  return result;
+}
+
+void FilamentAsset_getEntities(
+  Pointer<TFilamentAsset> filamentAsset,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(
+    filamentAsset.cast(),
+    out,
+  );
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(
+    filamentAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(
+  Pointer<TFilamentAsset> filamentAsset,
+) {
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(
+    filamentAsset.cast(),
+  );
+  return Pointer<Void>(result);
+}
+
+TViewport View_getViewport(Pointer<TView> view) {
+  final TViewport_out = TViewport.stackAlloc();
+  final result = GeneratedBindings.instance._View_getViewport(
+    TViewport_out.cast(),
+    view.cast(),
+  );
+  return TViewport_out.toDart();
+}
+
+Pointer<TToneMapper> ToneMapper_createLinear(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createLinear(
+    tEngine.cast(),
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createACES(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createACES(
+    tEngine.cast(),
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createACESLegacy(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createACESLegacy(
+    tEngine.cast(),
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createFilmic(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createFilmic(
+    tEngine.cast(),
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createPBRNeutral(
+    tEngine.cast(),
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createAGX(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createAGX(
+    tEngine.cast(),
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createAGXWithLook(
+  Pointer<TEngine> tEngine,
+  int look,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createAGXWithLook(
+    tEngine.cast(),
+    look,
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createGeneric(
+  Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createGeneric(
+    tEngine.cast(),
+    contrast,
+    midGrayIn,
+    midGrayOut,
+    hdrMax,
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createDisplayRange(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createDisplayRange(
+    tEngine.cast(),
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_destroy(Pointer<TToneMapper> toneMapper) {
+  final result = GeneratedBindings.instance._ToneMapper_destroy(
+    toneMapper.cast(),
+  );
+  return result;
+}
+
+Pointer<TColorGrading> ColorGrading_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TToneMapper> toneMapper,
+) {
+  final result = GeneratedBindings.instance._ColorGrading_create(
+    tEngine.cast(),
+    toneMapper.cast(),
+  );
+  return Pointer<TColorGrading>(result);
+}
+
+Pointer<TColorGradingBuilder> ColorGradingBuilder_create() {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_create();
+  return Pointer<TColorGradingBuilder>(result);
+}
+
+Pointer<TColorGrading> ColorGradingBuilder_build(
+  Pointer<TColorGradingBuilder> builder,
+  Pointer<TEngine> engine,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_build(
+    builder.cast(),
+    engine.cast(),
+  );
+  return Pointer<TColorGrading>(result);
+}
+
+void ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_destroy(
+    builder.cast(),
+  );
+  return result;
+}
+
+void ColorGrading_destroy(
+  Pointer<TEngine> engine,
+  Pointer<TColorGrading> colorGrading,
+) {
+  final result = GeneratedBindings.instance._ColorGrading_destroy(
+    engine.cast(),
+    colorGrading.cast(),
+  );
+  return result;
+}
+
+void ColorGradingBuilder_quality(
+  Pointer<TColorGradingBuilder> builder,
+  int level,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_quality(
+    builder.cast(),
+    level,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_format(
+  Pointer<TColorGradingBuilder> builder,
+  int format,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_format(
+    builder.cast(),
+    format,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_dimensions(
+  Pointer<TColorGradingBuilder> builder,
+  int dim,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_dimensions(
+    builder.cast(),
+    dim,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_toneMapper(
+  Pointer<TColorGradingBuilder> builder,
+  Pointer<TToneMapper> toneMapper,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_toneMapper(
+    builder.cast(),
+    toneMapper.cast(),
+  );
+  return result;
+}
+
+void ColorGradingBuilder_exposure(
+  Pointer<TColorGradingBuilder> builder,
+  double exposure,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_exposure(
+    builder.cast(),
+    exposure,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_nightAdaptation(
+  Pointer<TColorGradingBuilder> builder,
+  double adaptation,
+) {
+  final result = GeneratedBindings.instance
+      ._ColorGradingBuilder_nightAdaptation(builder.cast(), adaptation);
+  return result;
+}
+
+void ColorGradingBuilder_whiteBalance(
+  Pointer<TColorGradingBuilder> builder,
+  double temperature,
+  double tint,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_whiteBalance(
+    builder.cast(),
+    temperature,
+    tint,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_contrast(
+  Pointer<TColorGradingBuilder> builder,
+  double contrast,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_contrast(
+    builder.cast(),
+    contrast,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_vibrance(
+  Pointer<TColorGradingBuilder> builder,
+  double vibrance,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_vibrance(
+    builder.cast(),
+    vibrance,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_saturation(
+  Pointer<TColorGradingBuilder> builder,
+  double saturation,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_saturation(
+    builder.cast(),
+    saturation,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_channelMixer(
+  Pointer<TColorGradingBuilder> builder,
+  double outRedR,
+  double outRedG,
+  double outRedB,
+  double outGreenR,
+  double outGreenG,
+  double outGreenB,
+  double outBlueR,
+  double outBlueG,
+  double outBlueB,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_channelMixer(
+    builder.cast(),
+    outRedR,
+    outRedG,
+    outRedB,
+    outGreenR,
+    outGreenG,
+    outGreenB,
+    outBlueR,
+    outBlueG,
+    outBlueB,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_shadowsMidtonesHighlights(
+  Pointer<TColorGradingBuilder> builder,
+  double shadowsR,
+  double shadowsG,
+  double shadowsB,
+  double shadowsW,
+  double midtonesR,
+  double midtonesG,
+  double midtonesB,
+  double midtonesW,
+  double highlightsR,
+  double highlightsG,
+  double highlightsB,
+  double highlightsW,
+  double rangesX,
+  double rangesY,
+  double rangesZ,
+  double rangesW,
+) {
+  final result = GeneratedBindings.instance
+      ._ColorGradingBuilder_shadowsMidtonesHighlights(
+        builder.cast(),
+        shadowsR,
+        shadowsG,
+        shadowsB,
+        shadowsW,
+        midtonesR,
+        midtonesG,
+        midtonesB,
+        midtonesW,
+        highlightsR,
+        highlightsG,
+        highlightsB,
+        highlightsW,
+        rangesX,
+        rangesY,
+        rangesZ,
+        rangesW,
+      );
+  return result;
+}
+
+void ColorGradingBuilder_slopeOffsetPower(
+  Pointer<TColorGradingBuilder> builder,
+  double slopeR,
+  double slopeG,
+  double slopeB,
+  double offsetR,
+  double offsetG,
+  double offsetB,
+  double powerR,
+  double powerG,
+  double powerB,
+) {
+  final result = GeneratedBindings.instance
+      ._ColorGradingBuilder_slopeOffsetPower(
+        builder.cast(),
+        slopeR,
+        slopeG,
+        slopeB,
+        offsetR,
+        offsetG,
+        offsetB,
+        powerR,
+        powerG,
+        powerB,
+      );
+  return result;
+}
+
+void ColorGradingBuilder_curves(
+  Pointer<TColorGradingBuilder> builder,
+  double shadowGammaR,
+  double shadowGammaG,
+  double shadowGammaB,
+  double midPointR,
+  double midPointG,
+  double midPointB,
+  double highlightScaleR,
+  double highlightScaleG,
+  double highlightScaleB,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_curves(
+    builder.cast(),
+    shadowGammaR,
+    shadowGammaG,
+    shadowGammaB,
+    midPointR,
+    midPointG,
+    midPointB,
+    highlightScaleR,
+    highlightScaleG,
+    highlightScaleB,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_luminanceScaling(
+  Pointer<TColorGradingBuilder> builder,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance
+      ._ColorGradingBuilder_luminanceScaling(builder.cast(), enabled);
+  return result;
+}
+
+void ColorGradingBuilder_gamutMapping(
+  Pointer<TColorGradingBuilder> builder,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_gamutMapping(
+    builder.cast(),
+    enabled,
+  );
+  return result;
+}
+
+void View_setColorGrading(
+  Pointer<TView> tView,
+  Pointer<TColorGrading> tColorGrading,
+) {
+  final result = GeneratedBindings.instance._View_setColorGrading(
+    tView.cast(),
+    tColorGrading.cast(),
+  );
+  return result;
+}
+
+Pointer<TColorGrading> View_getColorGrading(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getColorGrading(tView.cast());
+  return Pointer<TColorGrading>(result);
+}
+
+void View_setBlendMode(Pointer<TView> view, int blendMode) {
+  final result = GeneratedBindings.instance._View_setBlendMode(
+    view.cast(),
+    blendMode,
+  );
+  return result;
+}
+
+void View_setViewport(Pointer<TView> view, int width, int height) {
+  final result = GeneratedBindings.instance._View_setViewport(
+    view.cast(),
+    width,
+    height,
+  );
+  return result;
+}
+
+void View_setRenderTarget(
+  Pointer<TView> view,
+  Pointer<TRenderTarget> renderTarget,
+) {
+  final result = GeneratedBindings.instance._View_setRenderTarget(
+    view.cast(),
+    renderTarget.cast(),
+  );
+  return result;
+}
+
+void View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled) {
+  final result = GeneratedBindings.instance._View_setFrustumCullingEnabled(
+    view.cast(),
+    enabled,
+  );
+  return result;
+}
+
+Pointer<TRenderTarget> View_getRenderTarget(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getRenderTarget(tView.cast());
+  return Pointer<TRenderTarget>(result);
+}
+
+void View_setPostProcessing(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setPostProcessing(
+    tView.cast(),
+    enabled,
+  );
+  return result;
+}
+
+void View_setShadowsEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setShadowsEnabled(
+    tView.cast(),
+    enabled,
+  );
+  return result;
+}
+
+void View_setShadowType(Pointer<TView> tView, int shadowType) {
+  final result = GeneratedBindings.instance._View_setShadowType(
+    tView.cast(),
+    shadowType,
+  );
+  return result;
+}
+
+int View_getShadowType(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getShadowType(tView.cast());
+  return result;
+}
+
+void View_setSoftShadowOptions(
+  Pointer<TView> tView,
+  TSoftShadowOptions options,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setSoftShadowOptions(
+    tView.cast(),
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TSoftShadowOptions View_getSoftShadowOptions(Pointer<TView> tView) {
+  final TSoftShadowOptions_out = TSoftShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getSoftShadowOptions(
+    TSoftShadowOptions_out.cast(),
+    tView.cast(),
+  );
+  return TSoftShadowOptions_out.toDart();
+}
+
+void View_setVsmShadowOptions(Pointer<TView> tView, TVsmShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setVsmShadowOptions(
+    tView.cast(),
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TVsmShadowOptions View_getVsmShadowOptions(Pointer<TView> tView) {
+  final TVsmShadowOptions_out = TVsmShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getVsmShadowOptions(
+    TVsmShadowOptions_out.cast(),
+    tView.cast(),
+  );
+  return TVsmShadowOptions_out.toDart();
+}
+
+void View_setBloom(Pointer<TView> tView, bool enabled, double strength) {
+  final result = GeneratedBindings.instance._View_setBloom(
+    tView.cast(),
+    enabled,
+    strength,
+  );
+  return result;
+}
+
+void View_setRenderQuality(Pointer<TView> tView, int qualityLevel) {
+  final result = GeneratedBindings.instance._View_setRenderQuality(
+    tView.cast(),
+    qualityLevel,
+  );
+  return result;
+}
+
+void View_setAntiAliasing(
+  Pointer<TView> tView,
+  bool msaa,
+  bool fxaa,
+  bool taa,
+) {
+  final result = GeneratedBindings.instance._View_setAntiAliasing(
+    tView.cast(),
+    msaa,
+    fxaa,
+    taa,
+  );
+  return result;
+}
+
+void View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible) {
+  final result = GeneratedBindings.instance._View_setLayerEnabled(
+    tView.cast(),
+    layer,
+    visible,
+  );
+  return result;
+}
+
+void View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera) {
+  final result = GeneratedBindings.instance._View_setCamera(
+    tView.cast(),
+    tCamera.cast(),
+  );
+  return result;
+}
+
+Pointer<TScene> View_getScene(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getScene(tView.cast());
+  return Pointer<TScene>(result);
+}
+
+Pointer<TCamera> View_getCamera(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getCamera(tView.cast());
+  return Pointer<TCamera>(result);
+}
+
+void View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setStencilBufferEnabled(
+    tView.cast(),
+    enabled,
+  );
+  return result;
+}
+
+bool View_isStencilBufferEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isStencilBufferEnabled(
+    tView.cast(),
+  );
+  return result == 1;
+}
+
+void View_setDitheringEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setDitheringEnabled(
+    tView.cast(),
+    enabled,
+  );
+  return result;
+}
+
+bool View_isDitheringEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isDitheringEnabled(
+    tView.cast(),
+  );
+  return result == 1;
+}
+
+void View_setScene(Pointer<TView> tView, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._View_setScene(
+    tView.cast(),
+    tScene.cast(),
+  );
+  return result;
+}
+
+void View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted) {
+  final result = GeneratedBindings.instance._View_setFrontFaceWindingInverted(
+    tView.cast(),
+    inverted,
+  );
+  return result;
+}
+
+void View_setAmbientOcclusionOptions(
+  Pointer<TView> tView,
+  TAmbientOcclusionOptions options,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setAmbientOcclusionOptions(
+    tView.cast(),
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TAmbientOcclusionOptions View_getAmbientOcclusionOptions(Pointer<TView> tView) {
+  final TAmbientOcclusionOptions_out = TAmbientOcclusionOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getAmbientOcclusionOptions(
+    TAmbientOcclusionOptions_out.cast(),
+    tView.cast(),
+  );
+  return TAmbientOcclusionOptions_out.toDart();
+}
+
+void View_setFogOptions(Pointer<TView> tView, TFogOptions tFogOptions) {
+  final tFogOptionsPtr = tFogOptions.address;
+  final result = GeneratedBindings.instance._View_setFogOptions(
+    tView.cast(),
+    tFogOptionsPtr.cast(),
+  );
+  return result;
+}
+
+TFogOptions View_getFogOptions(Pointer<TView> tView) {
+  final TFogOptions_out = TFogOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getFogOptions(
+    TFogOptions_out.cast(),
+    tView.cast(),
+  );
+  return TFogOptions_out.toDart();
+}
+
+void View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setTransparentPickingEnabled(
+    tView.cast(),
+    enabled,
+  );
+  return result;
+}
+
+bool View_isTransparentPickingEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isTransparentPickingEnabled(
+    tView.cast(),
+  );
+  return result == 1;
+}
+
+void View_pick(
+  Pointer<TView> tView,
+  int requestId,
+  int x,
+  int y,
+  DartPickCallback callback,
+) {
+  final result = GeneratedBindings.instance._View_pick(
+    tView.cast(),
+    requestId,
+    x,
+    y,
+    callback as Pointer<NativeFunction<PickCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setName(Pointer<TView> tView, Pointer<Char> name) {
+  final result = GeneratedBindings.instance._View_setName(tView.cast(), name);
+  return result;
+}
+
+Pointer<Char> View_getName(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getName(tView.cast());
+  return Pointer<Char>(result);
+}
+
+void Skybox_setColor(
+  Pointer<TSkybox> tSkybox,
+  double r,
+  double g,
+  double b,
+  double a,
+) {
+  final result = GeneratedBindings.instance._Skybox_setColor(
+    tSkybox.cast(),
+    r,
+    g,
+    b,
+    a,
+  );
+  return result;
+}
+
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
+}
+
+void IndexBufferBuilder_indexCount(
+  Pointer<TIndexBufferBuilder> builder,
+  int count,
+) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(
+    builder.cast(),
+    count,
+  );
+  return result;
+}
+
+void IndexBufferBuilder_bufferType(
+  Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(
+    builder.cast(),
+    indexType,
+  );
+  return result;
+}
+
+Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  Pointer<TIndexBufferBuilder> builder,
+  Pointer<TEngine> engine,
+) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_build(
+    builder.cast(),
+    engine.cast(),
+  );
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(
+    builder.cast(),
+  );
+  return result;
+}
+
+Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(
+    buffer.cast(),
+  );
+  return result;
+}
+
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void IndexBuffer_destroy(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_destroy(
+    engine.cast(),
+    buffer.cast(),
+  );
+  return result;
 }
 
 Pointer<TMaterialInstance> Material_createInstance(
@@ -3598,34 +5207,6 @@ int MaterialInstance_getTransparencyMode(
 int Material_getBlendingMode(Pointer<TMaterial> material) {
   final result = GeneratedBindings.instance._Material_getBlendingMode(
     material.cast(),
-  );
-  return result;
-}
-
-void dummy(TGltfMeshData dummy) {
-  final dummyPtr = dummy.address;
-  final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  Pointer<Char> meshName,
-  Pointer<TGltfMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance._GltfParser_parseBuffer(
-    data,
-    length,
-    meshName,
-    outMeshData.cast(),
-  );
-  return result;
-}
-
-void GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData) {
-  final result = GeneratedBindings.instance._GltfParser_freeMeshData(
-    meshData.cast(),
   );
   return result;
 }
@@ -4481,709 +6062,6 @@ bool DebugRegistry_getProperty_float(
   return result == 1;
 }
 
-TViewport View_getViewport(Pointer<TView> view) {
-  final TViewport_out = TViewport.stackAlloc();
-  final result = GeneratedBindings.instance._View_getViewport(
-    TViewport_out.cast(),
-    view.cast(),
-  );
-  return TViewport_out.toDart();
-}
-
-Pointer<TToneMapper> ToneMapper_createLinear(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createLinear(
-    tEngine.cast(),
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createACES(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createACES(
-    tEngine.cast(),
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createACESLegacy(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createACESLegacy(
-    tEngine.cast(),
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createFilmic(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createFilmic(
-    tEngine.cast(),
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createPBRNeutral(
-    tEngine.cast(),
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createAGX(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createAGX(
-    tEngine.cast(),
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createAGXWithLook(
-  Pointer<TEngine> tEngine,
-  int look,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createAGXWithLook(
-    tEngine.cast(),
-    look,
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createGeneric(
-  Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createGeneric(
-    tEngine.cast(),
-    contrast,
-    midGrayIn,
-    midGrayOut,
-    hdrMax,
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createDisplayRange(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createDisplayRange(
-    tEngine.cast(),
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-void ToneMapper_destroy(Pointer<TToneMapper> toneMapper) {
-  final result = GeneratedBindings.instance._ToneMapper_destroy(
-    toneMapper.cast(),
-  );
-  return result;
-}
-
-Pointer<TColorGrading> ColorGrading_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TToneMapper> toneMapper,
-) {
-  final result = GeneratedBindings.instance._ColorGrading_create(
-    tEngine.cast(),
-    toneMapper.cast(),
-  );
-  return Pointer<TColorGrading>(result);
-}
-
-Pointer<TColorGradingBuilder> ColorGradingBuilder_create() {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_create();
-  return Pointer<TColorGradingBuilder>(result);
-}
-
-Pointer<TColorGrading> ColorGradingBuilder_build(
-  Pointer<TColorGradingBuilder> builder,
-  Pointer<TEngine> engine,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_build(
-    builder.cast(),
-    engine.cast(),
-  );
-  return Pointer<TColorGrading>(result);
-}
-
-void ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_destroy(
-    builder.cast(),
-  );
-  return result;
-}
-
-void ColorGrading_destroy(
-  Pointer<TEngine> engine,
-  Pointer<TColorGrading> colorGrading,
-) {
-  final result = GeneratedBindings.instance._ColorGrading_destroy(
-    engine.cast(),
-    colorGrading.cast(),
-  );
-  return result;
-}
-
-void ColorGradingBuilder_quality(
-  Pointer<TColorGradingBuilder> builder,
-  int level,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_quality(
-    builder.cast(),
-    level,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_format(
-  Pointer<TColorGradingBuilder> builder,
-  int format,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_format(
-    builder.cast(),
-    format,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_dimensions(
-  Pointer<TColorGradingBuilder> builder,
-  int dim,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_dimensions(
-    builder.cast(),
-    dim,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_toneMapper(
-  Pointer<TColorGradingBuilder> builder,
-  Pointer<TToneMapper> toneMapper,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_toneMapper(
-    builder.cast(),
-    toneMapper.cast(),
-  );
-  return result;
-}
-
-void ColorGradingBuilder_exposure(
-  Pointer<TColorGradingBuilder> builder,
-  double exposure,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_exposure(
-    builder.cast(),
-    exposure,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_nightAdaptation(
-  Pointer<TColorGradingBuilder> builder,
-  double adaptation,
-) {
-  final result = GeneratedBindings.instance
-      ._ColorGradingBuilder_nightAdaptation(builder.cast(), adaptation);
-  return result;
-}
-
-void ColorGradingBuilder_whiteBalance(
-  Pointer<TColorGradingBuilder> builder,
-  double temperature,
-  double tint,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_whiteBalance(
-    builder.cast(),
-    temperature,
-    tint,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_contrast(
-  Pointer<TColorGradingBuilder> builder,
-  double contrast,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_contrast(
-    builder.cast(),
-    contrast,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_vibrance(
-  Pointer<TColorGradingBuilder> builder,
-  double vibrance,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_vibrance(
-    builder.cast(),
-    vibrance,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_saturation(
-  Pointer<TColorGradingBuilder> builder,
-  double saturation,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_saturation(
-    builder.cast(),
-    saturation,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_channelMixer(
-  Pointer<TColorGradingBuilder> builder,
-  double outRedR,
-  double outRedG,
-  double outRedB,
-  double outGreenR,
-  double outGreenG,
-  double outGreenB,
-  double outBlueR,
-  double outBlueG,
-  double outBlueB,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_channelMixer(
-    builder.cast(),
-    outRedR,
-    outRedG,
-    outRedB,
-    outGreenR,
-    outGreenG,
-    outGreenB,
-    outBlueR,
-    outBlueG,
-    outBlueB,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_shadowsMidtonesHighlights(
-  Pointer<TColorGradingBuilder> builder,
-  double shadowsR,
-  double shadowsG,
-  double shadowsB,
-  double shadowsW,
-  double midtonesR,
-  double midtonesG,
-  double midtonesB,
-  double midtonesW,
-  double highlightsR,
-  double highlightsG,
-  double highlightsB,
-  double highlightsW,
-  double rangesX,
-  double rangesY,
-  double rangesZ,
-  double rangesW,
-) {
-  final result = GeneratedBindings.instance
-      ._ColorGradingBuilder_shadowsMidtonesHighlights(
-        builder.cast(),
-        shadowsR,
-        shadowsG,
-        shadowsB,
-        shadowsW,
-        midtonesR,
-        midtonesG,
-        midtonesB,
-        midtonesW,
-        highlightsR,
-        highlightsG,
-        highlightsB,
-        highlightsW,
-        rangesX,
-        rangesY,
-        rangesZ,
-        rangesW,
-      );
-  return result;
-}
-
-void ColorGradingBuilder_slopeOffsetPower(
-  Pointer<TColorGradingBuilder> builder,
-  double slopeR,
-  double slopeG,
-  double slopeB,
-  double offsetR,
-  double offsetG,
-  double offsetB,
-  double powerR,
-  double powerG,
-  double powerB,
-) {
-  final result = GeneratedBindings.instance
-      ._ColorGradingBuilder_slopeOffsetPower(
-        builder.cast(),
-        slopeR,
-        slopeG,
-        slopeB,
-        offsetR,
-        offsetG,
-        offsetB,
-        powerR,
-        powerG,
-        powerB,
-      );
-  return result;
-}
-
-void ColorGradingBuilder_curves(
-  Pointer<TColorGradingBuilder> builder,
-  double shadowGammaR,
-  double shadowGammaG,
-  double shadowGammaB,
-  double midPointR,
-  double midPointG,
-  double midPointB,
-  double highlightScaleR,
-  double highlightScaleG,
-  double highlightScaleB,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_curves(
-    builder.cast(),
-    shadowGammaR,
-    shadowGammaG,
-    shadowGammaB,
-    midPointR,
-    midPointG,
-    midPointB,
-    highlightScaleR,
-    highlightScaleG,
-    highlightScaleB,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_luminanceScaling(
-  Pointer<TColorGradingBuilder> builder,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance
-      ._ColorGradingBuilder_luminanceScaling(builder.cast(), enabled);
-  return result;
-}
-
-void ColorGradingBuilder_gamutMapping(
-  Pointer<TColorGradingBuilder> builder,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_gamutMapping(
-    builder.cast(),
-    enabled,
-  );
-  return result;
-}
-
-void View_setColorGrading(
-  Pointer<TView> tView,
-  Pointer<TColorGrading> tColorGrading,
-) {
-  final result = GeneratedBindings.instance._View_setColorGrading(
-    tView.cast(),
-    tColorGrading.cast(),
-  );
-  return result;
-}
-
-Pointer<TColorGrading> View_getColorGrading(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getColorGrading(tView.cast());
-  return Pointer<TColorGrading>(result);
-}
-
-void View_setBlendMode(Pointer<TView> view, int blendMode) {
-  final result = GeneratedBindings.instance._View_setBlendMode(
-    view.cast(),
-    blendMode,
-  );
-  return result;
-}
-
-void View_setViewport(Pointer<TView> view, int width, int height) {
-  final result = GeneratedBindings.instance._View_setViewport(
-    view.cast(),
-    width,
-    height,
-  );
-  return result;
-}
-
-void View_setRenderTarget(
-  Pointer<TView> view,
-  Pointer<TRenderTarget> renderTarget,
-) {
-  final result = GeneratedBindings.instance._View_setRenderTarget(
-    view.cast(),
-    renderTarget.cast(),
-  );
-  return result;
-}
-
-void View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled) {
-  final result = GeneratedBindings.instance._View_setFrustumCullingEnabled(
-    view.cast(),
-    enabled,
-  );
-  return result;
-}
-
-Pointer<TRenderTarget> View_getRenderTarget(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getRenderTarget(tView.cast());
-  return Pointer<TRenderTarget>(result);
-}
-
-void View_setPostProcessing(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setPostProcessing(
-    tView.cast(),
-    enabled,
-  );
-  return result;
-}
-
-void View_setShadowsEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setShadowsEnabled(
-    tView.cast(),
-    enabled,
-  );
-  return result;
-}
-
-void View_setShadowType(Pointer<TView> tView, int shadowType) {
-  final result = GeneratedBindings.instance._View_setShadowType(
-    tView.cast(),
-    shadowType,
-  );
-  return result;
-}
-
-int View_getShadowType(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getShadowType(tView.cast());
-  return result;
-}
-
-void View_setSoftShadowOptions(
-  Pointer<TView> tView,
-  TSoftShadowOptions options,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setSoftShadowOptions(
-    tView.cast(),
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TSoftShadowOptions View_getSoftShadowOptions(Pointer<TView> tView) {
-  final TSoftShadowOptions_out = TSoftShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getSoftShadowOptions(
-    TSoftShadowOptions_out.cast(),
-    tView.cast(),
-  );
-  return TSoftShadowOptions_out.toDart();
-}
-
-void View_setVsmShadowOptions(Pointer<TView> tView, TVsmShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setVsmShadowOptions(
-    tView.cast(),
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TVsmShadowOptions View_getVsmShadowOptions(Pointer<TView> tView) {
-  final TVsmShadowOptions_out = TVsmShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getVsmShadowOptions(
-    TVsmShadowOptions_out.cast(),
-    tView.cast(),
-  );
-  return TVsmShadowOptions_out.toDart();
-}
-
-void View_setBloom(Pointer<TView> tView, bool enabled, double strength) {
-  final result = GeneratedBindings.instance._View_setBloom(
-    tView.cast(),
-    enabled,
-    strength,
-  );
-  return result;
-}
-
-void View_setRenderQuality(Pointer<TView> tView, int qualityLevel) {
-  final result = GeneratedBindings.instance._View_setRenderQuality(
-    tView.cast(),
-    qualityLevel,
-  );
-  return result;
-}
-
-void View_setAntiAliasing(
-  Pointer<TView> tView,
-  bool msaa,
-  bool fxaa,
-  bool taa,
-) {
-  final result = GeneratedBindings.instance._View_setAntiAliasing(
-    tView.cast(),
-    msaa,
-    fxaa,
-    taa,
-  );
-  return result;
-}
-
-void View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible) {
-  final result = GeneratedBindings.instance._View_setLayerEnabled(
-    tView.cast(),
-    layer,
-    visible,
-  );
-  return result;
-}
-
-void View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera) {
-  final result = GeneratedBindings.instance._View_setCamera(
-    tView.cast(),
-    tCamera.cast(),
-  );
-  return result;
-}
-
-Pointer<TScene> View_getScene(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getScene(tView.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TCamera> View_getCamera(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getCamera(tView.cast());
-  return Pointer<TCamera>(result);
-}
-
-void View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setStencilBufferEnabled(
-    tView.cast(),
-    enabled,
-  );
-  return result;
-}
-
-bool View_isStencilBufferEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isStencilBufferEnabled(
-    tView.cast(),
-  );
-  return result == 1;
-}
-
-void View_setDitheringEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setDitheringEnabled(
-    tView.cast(),
-    enabled,
-  );
-  return result;
-}
-
-bool View_isDitheringEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isDitheringEnabled(
-    tView.cast(),
-  );
-  return result == 1;
-}
-
-void View_setScene(Pointer<TView> tView, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._View_setScene(
-    tView.cast(),
-    tScene.cast(),
-  );
-  return result;
-}
-
-void View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted) {
-  final result = GeneratedBindings.instance._View_setFrontFaceWindingInverted(
-    tView.cast(),
-    inverted,
-  );
-  return result;
-}
-
-void View_setAmbientOcclusionOptions(
-  Pointer<TView> tView,
-  TAmbientOcclusionOptions options,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setAmbientOcclusionOptions(
-    tView.cast(),
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TAmbientOcclusionOptions View_getAmbientOcclusionOptions(Pointer<TView> tView) {
-  final TAmbientOcclusionOptions_out = TAmbientOcclusionOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getAmbientOcclusionOptions(
-    TAmbientOcclusionOptions_out.cast(),
-    tView.cast(),
-  );
-  return TAmbientOcclusionOptions_out.toDart();
-}
-
-void View_setFogOptions(Pointer<TView> tView, TFogOptions tFogOptions) {
-  final tFogOptionsPtr = tFogOptions.address;
-  final result = GeneratedBindings.instance._View_setFogOptions(
-    tView.cast(),
-    tFogOptionsPtr.cast(),
-  );
-  return result;
-}
-
-TFogOptions View_getFogOptions(Pointer<TView> tView) {
-  final TFogOptions_out = TFogOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getFogOptions(
-    TFogOptions_out.cast(),
-    tView.cast(),
-  );
-  return TFogOptions_out.toDart();
-}
-
-void View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setTransparentPickingEnabled(
-    tView.cast(),
-    enabled,
-  );
-  return result;
-}
-
-bool View_isTransparentPickingEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isTransparentPickingEnabled(
-    tView.cast(),
-  );
-  return result == 1;
-}
-
-void View_pick(
-  Pointer<TView> tView,
-  int requestId,
-  int x,
-  int y,
-  DartPickCallback callback,
-) {
-  final result = GeneratedBindings.instance._View_pick(
-    tView.cast(),
-    requestId,
-    x,
-    y,
-    callback as Pointer<NativeFunction<PickCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setName(Pointer<TView> tView, Pointer<Char> name) {
-  final result = GeneratedBindings.instance._View_setName(tView.cast(), name);
-  return result;
-}
-
-Pointer<Char> View_getName(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getName(tView.cast());
-  return Pointer<Char>(result);
-}
-
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -5378,86 +6256,6 @@ void VertexBuffer_destroy(
   Pointer<TVertexBuffer> buffer,
 ) {
   final result = GeneratedBindings.instance._VertexBuffer_destroy(
-    engine.cast(),
-    buffer.cast(),
-  );
-  return result;
-}
-
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
-}
-
-void IndexBufferBuilder_indexCount(
-  Pointer<TIndexBufferBuilder> builder,
-  int count,
-) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(
-    builder.cast(),
-    count,
-  );
-  return result;
-}
-
-void IndexBufferBuilder_bufferType(
-  Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(
-    builder.cast(),
-    indexType,
-  );
-  return result;
-}
-
-Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  Pointer<TIndexBufferBuilder> builder,
-  Pointer<TEngine> engine,
-) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_build(
-    builder.cast(),
-    engine.cast(),
-  );
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(
-    builder.cast(),
-  );
-  return result;
-}
-
-Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(
-    buffer.cast(),
-  );
-  return result;
-}
-
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void IndexBuffer_destroy(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroy(
     engine.cast(),
     buffer.cast(),
   );
@@ -8263,267 +9061,577 @@ void RenderableManager_setBonesFromBoneRenderThread(
   return result;
 }
 
-Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+void dummy(TGltfMeshData dummy) {
+  final dummyPtr = dummy.address;
+  final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
+  return result;
+}
+
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  Pointer<Char> meshName,
+  Pointer<TGltfMeshData> outMeshData,
+) {
+  final result = GeneratedBindings.instance._GltfParser_parseBuffer(
+    data,
+    length,
+    meshName,
+    outMeshData.cast(),
+  );
+  return result;
+}
+
+void GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData) {
+  final result = GeneratedBindings.instance._GltfParser_freeMeshData(
+    meshData.cast(),
+  );
+  return result;
+}
+
+int LightManager_createLight(
   Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tVertexBuffer,
-  Pointer<TIndexBuffer> tIndexBuffer,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
+  Pointer<TLightManager> tLightManager,
+  int tLightTtype,
 ) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
+  final result = GeneratedBindings.instance._LightManager_createLight(
     tEngine.cast(),
-    tVertexBuffer.cast(),
-    tIndexBuffer.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-    tPrimitiveType,
-    boundingBoxPtr.cast(),
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    tNameComponentManager.cast(),
-    tFilamentAsset.cast(),
-    rebuildVertices,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(
-    tSceneAsset.cast(),
-  );
-  return Pointer<TFilamentAsset>(result);
-}
-
-int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getType(
-    tSceneAsset.cast(),
+    tLightManager.cast(),
+    tLightTtype,
   );
   return result;
 }
 
-void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_destroy(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_addToScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_addToScene(
-    tSceneAsset.cast(),
-    tScene.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_removeFromScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(
-    tSceneAsset.cast(),
-    tScene.cast(),
-  );
-  return result;
-}
-
-DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getEntity(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_getChildEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(
-    tSceneAsset.cast(),
-    out,
-  );
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(
-    tSceneAsset.cast(),
-  );
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(
-    tSceneAsset.cast(),
-  );
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_getInstance(
-  Pointer<TSceneAsset> tSceneAsset,
-  int index,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstance(
-    tSceneAsset.cast(),
-    index,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_createInstance(
-  Pointer<TSceneAsset> asset,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createInstance(
-    asset.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(
-    Aabb3_out.cast(),
-    asset.cast(),
-  );
-  return Aabb3_out.toDart();
-}
-
-Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(
-    tSceneAsset.cast(),
-    primitiveIndex,
-  );
-  return Pointer<TVertexBuffer>(result);
-}
-
-Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(
-    tSceneAsset.cast(),
-    primitiveIndex,
-  );
-  return Pointer<TIndexBuffer>(result);
-}
-
-int SceneAsset_getPrimitiveOffsetForEntity(
-  Pointer<TSceneAsset> tSceneAsset,
+void LightManager_destroyLight(
+  Pointer<TLightManager> tLightManager,
   DartEntityId entity,
 ) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+bool LightManager_hasComponent(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+int LightManager_getType(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getType(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+bool LightManager_isDirectional(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+bool LightManager_isPointLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+void LightManager_setPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(
+    tLightManager.cast(),
+    light,
+    x,
+    y,
+    z,
+  );
+  return result;
+}
+
+double3 LightManager_getPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(
+    double3_out.cast(),
+    tLightManager.cast(),
+    light,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(
+    tLightManager.cast(),
+    light,
+    x,
+    y,
+    z,
+  );
+  return result;
+}
+
+double3 LightManager_getDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(
+    double3_out.cast(),
+    tLightManager.cast(),
+    light,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double r,
+  double g,
+  double b,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColor(
+    tLightManager.cast(),
+    entity,
+    r,
+    g,
+    b,
+  );
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+double3 LightManager_getColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(
+    double3_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(
+    tLightManager.cast(),
+    entity,
+    intensity,
+  );
+  return result;
+}
+
+void LightManager_setIntensityCandela(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
+    tLightManager.cast(),
+    entity,
+    intensity,
+  );
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+double LightManager_getIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double falloff,
+) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(
+    tLightManager.cast(),
+    entity,
+    falloff,
+  );
+  return result;
+}
+
+double LightManager_getFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
+    tLightManager.cast(),
+    entity,
+    inner,
+    outer,
+  );
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double angularRadius,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+double LightManager_getSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloSize,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(
+    tLightManager.cast(),
+    entity,
+    haloSize,
+  );
+  return result;
+}
+
+double LightManager_getSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloFalloff,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
+    tLightManager.cast(),
+    entity,
+    haloFalloff,
+  );
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(
+    tLightManager.cast(),
+    entity,
+    enabled,
+  );
+  return result;
+}
+
+bool LightManager_isShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  TShadowOptions options,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool LightManager_getLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+  );
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(
+    splitPositions,
+    cascades,
+  );
+  return result;
+}
+
+void LightManager_computeLogSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+  );
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
   final result = GeneratedBindings.instance
-      ._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
+      ._LightManager_computePracticalSplits(
+        splitPositions,
+        cascades,
+        near,
+        far,
+        lambda,
+      );
   return result;
 }
 
-void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(
-    tSceneAsset.cast(),
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(
+    r,
+    g,
+    b,
   );
   return result;
 }
 
-void SceneAsset_setFlatShading(
-  Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(
+    tScene.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(
+    tScene.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(
+    tScene.cast(),
+    skybox.cast(),
+  );
+  return result;
+}
+
+void Scene_setIndirectLight(
+  Pointer<TScene> tScene,
+  Pointer<TIndirectLight> tIndirectLight,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(
-    tSceneAsset.cast(),
-    flatShading,
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(
+    tScene.cast(),
+    tIndirectLight.cast(),
   );
   return result;
 }
 
-void SceneAsset_getBones(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
-  Pointer<Int32> out,
+void Scene_addFilamentAsset(
+  Pointer<TScene> tScene,
+  Pointer<TFilamentAsset> asset,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_getBones(
-    tSceneAsset.cast(),
-    skinIndex,
-    out,
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(
+    tScene.cast(),
+    asset.cast(),
   );
   return result;
-}
-
-Dartsize_t SceneAsset_getBoneCount(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(
-    tSceneAsset.cast(),
-    skinIndex,
-  );
-  return result;
-}
-
-Pointer<Char> SceneAsset_getBoneName(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
-  Dartsize_t boneIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneName(
-    tSceneAsset.cast(),
-    skinIndex,
-    boneIndex,
-  );
-  return Pointer<Char>(result);
 }
 
 void RenderableManager_destroyEntity(
@@ -9259,430 +10367,132 @@ int RenderableBuilder_build(
   return result;
 }
 
-void Camera_setExposure(
-  Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-) {
-  final result = GeneratedBindings.instance._Camera_setExposure(
-    camera.cast(),
-    aperture,
-    shutterSpeed,
-    sensitivity,
-  );
-  return result;
-}
-
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(
-    camera.cast(),
-  );
-  return result;
-}
-
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(
-    camera.cast(),
-  );
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(
-    camera.cast(),
-    out,
-  );
-  return result;
-}
-
-void Camera_setProjectionMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> matrix,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(
-    camera.cast(),
-    matrix,
-    near,
-    far,
-  );
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(
-    camera.cast(),
-  );
-  return result;
-}
-
-void Camera_lookAt(
-  Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(
-    camera.cast(),
-    eyePtr.cast(),
-    focusPtr.cast(),
-    upPtr.cast(),
-  );
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(
-    camera.cast(),
-  );
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(
-    camera.cast(),
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(
-    camera.cast(),
-  );
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(
-    camera.cast(),
-    focusDistance,
-  );
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance
-      ._Camera_setCustomProjectionWithCulling(
-        camera.cast(),
-        projectionMatrixPtr.cast(),
-        near,
-        far,
-      );
-  return result;
-}
-
-void Camera_setModelMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> tModelMatrix,
-) {
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(
-    camera.cast(),
-    tModelMatrix,
-  );
-  return result;
-}
-
-void Camera_setLensProjection(
-  Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(
-    camera.cast(),
-    near,
-    far,
-    aspect,
-    focalLength,
-  );
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
-  return result;
-}
-
-Pointer<TRenderManager> RenderManager_create(
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(
   Pointer<TEngine> tEngine,
-  Pointer<TRenderer> tRenderer,
 ) {
-  final result = GeneratedBindings.instance._RenderManager_create(
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(
     tEngine.cast(),
-    tRenderer.cast(),
   );
-  return Pointer<TRenderManager>(result);
+  return Pointer<TGltfResourceLoader>(result);
 }
 
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
+void GltfResourceLoader_destroy(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
 ) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(
+    tEngine.cast(),
+    tGltfResourceLoader.cast(),
   );
   return result;
 }
 
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
 ) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_removeAnimationManager(
-        tRenderer.cast(),
-        tAnimationManager.cast(),
-      );
-  return result;
-}
-
-void RenderManager_render(
-  Pointer<TRenderManager> tRenderer,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance._RenderManager_render(
-    tRenderer.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(
-    tRenderer.cast(),
-    swapChain.cast(),
-  );
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_detachFromRenderThread() {
-  final result = GeneratedBindings.instance
-      ._RenderManager_detachFromRenderThread();
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(
-    tRenderer.cast(),
-    paused,
-  );
-  return result;
-}
-
-void FrameScheduler_start(DartFrameCallback callback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_start(
-    callback as Pointer<NativeFunction<FrameCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-void FrameScheduler_setRenderThread(Pointer<Void> renderThread) {
-  final result = GeneratedBindings.instance._FrameScheduler_setRenderThread(
-    renderThread,
-  );
-  return result;
-}
-
-void FrameScheduler_setRenderManager(Pointer<TRenderManager> rm) {
-  final result = GeneratedBindings.instance._FrameScheduler_setRenderManager(
-    rm.cast(),
-  );
-  return result;
-}
-
-void FrameScheduler_setPostRenderCallback(
-  DartPostRenderCallback callback,
-  Pointer<Void> userData,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_setPostRenderCallback(
-        callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
-        userData,
-      );
-  return result;
-}
-
-bool FrameScheduler_requestRender(BigInt frameTimeNanos) {
-  final result = GeneratedBindings.instance._FrameScheduler_requestRender(
-    frameTimeNanos.toJSBigInt,
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
   );
   return result == 1;
 }
 
-void FrameScheduler_startNativeRenderLoop(int targetFps) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_startNativeRenderLoop(targetFps);
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(
-    port.toJSBigInt,
-    targetFps,
+void GltfResourceLoader_asyncUpdateLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(
+    tGltfResourceLoader.cast(),
   );
   return result;
 }
 
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+double GltfResourceLoader_asyncGetLoadProgress(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+) {
+  final result = GeneratedBindings.instance
+      ._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
   return result;
 }
 
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+    tEngine.cast(),
+    assetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+  );
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(
+  Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  DartGizmoPickCallback callback,
+) {
+  final result = GeneratedBindings.instance._Gizmo_pick(
+    tGizmo.cast(),
+    x,
+    y,
+    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
+  );
+  return result;
+}
+
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(
+    tGizmo.cast(),
+    axis,
+  );
+  return result;
+}
+
+void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
 }
 
 Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
@@ -10047,124 +10857,220 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(
-    tScene.cast(),
-    entityId,
+Pointer<TRenderTarget> RenderTarget_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> color,
+  Pointer<TTexture> depth,
+) {
+  final result = GeneratedBindings.instance._RenderTarget_create(
+    tEngine.cast(),
+    color.cast(),
+    depth.cast(),
+  );
+  return Pointer<TRenderTarget>(result);
+}
+
+void RenderTarget_destroy(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderTarget> tRenderTarget,
+) {
+  final result = GeneratedBindings.instance._RenderTarget_destroy(
+    tEngine.cast(),
+    tRenderTarget.cast(),
   );
   return result;
 }
 
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(
-    tScene.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(
-    tScene.cast(),
-    skybox.cast(),
-  );
-  return result;
-}
-
-void Scene_setIndirectLight(
-  Pointer<TScene> tScene,
+void IndirectLight_setRotation(
   Pointer<TIndirectLight> tIndirectLight,
+  Pointer<Float64> rotation,
 ) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(
-    tScene.cast(),
+  final result = GeneratedBindings.instance._IndirectLight_setRotation(
     tIndirectLight.cast(),
+    rotation,
   );
   return result;
 }
 
-void Scene_addFilamentAsset(
-  Pointer<TScene> tScene,
-  Pointer<TFilamentAsset> asset,
-) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(
-    tScene.cast(),
-    asset.cast(),
-  );
-  return result;
-}
-
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(
+Pointer<TRenderManager> RenderManager_create(
   Pointer<TEngine> tEngine,
+  Pointer<TRenderer> tRenderer,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(
+  final result = GeneratedBindings.instance._RenderManager_create(
     tEngine.cast(),
+    tRenderer.cast(),
   );
-  return Pointer<TGltfResourceLoader>(result);
+  return Pointer<TRenderManager>(result);
 }
 
-void GltfResourceLoader_destroy(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(
-    tEngine.cast(),
-    tGltfResourceLoader.cast(),
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(
+    tRenderer.cast(),
   );
   return result;
 }
 
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void GltfResourceLoader_asyncUpdateLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(
-    tGltfResourceLoader.cast(),
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
   );
   return result;
 }
 
-double GltfResourceLoader_asyncGetLoadProgress(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
 ) {
   final result = GeneratedBindings.instance
-      ._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+      ._RenderManager_removeAnimationManager(
+        tRenderer.cast(),
+        tAnimationManager.cast(),
+      );
   return result;
 }
 
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dartsize_t length,
+void RenderManager_render(
+  Pointer<TRenderManager> tRenderer,
+  BigInt frameTimeInNanos,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
+  final result = GeneratedBindings.instance._RenderManager_render(
+    tRenderer.cast(),
+    frameTimeInNanos.toJSBigInt,
   );
   return result;
 }
 
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(
+    tRenderer.cast(),
+    swapChain.cast(),
+  );
+  return result;
+}
+
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void RenderManager_detachFromRenderThread() {
+  final result = GeneratedBindings.instance
+      ._RenderManager_detachFromRenderThread();
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(
+    tRenderer.cast(),
+    paused,
+  );
+  return result;
+}
+
+void FrameScheduler_start(DartFrameCallback callback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_start(
+    callback as Pointer<NativeFunction<FrameCallbackFunction>>,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+void FrameScheduler_setRenderThread(Pointer<Void> renderThread) {
+  final result = GeneratedBindings.instance._FrameScheduler_setRenderThread(
+    renderThread,
+  );
+  return result;
+}
+
+void FrameScheduler_setRenderManager(Pointer<TRenderManager> rm) {
+  final result = GeneratedBindings.instance._FrameScheduler_setRenderManager(
+    rm.cast(),
+  );
+  return result;
+}
+
+void FrameScheduler_setPostRenderCallback(
+  DartPostRenderCallback callback,
+  Pointer<Void> userData,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_setPostRenderCallback(
+        callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
+        userData,
+      );
+  return result;
+}
+
+bool FrameScheduler_requestRender(BigInt frameTimeNanos) {
+  final result = GeneratedBindings.instance._FrameScheduler_requestRender(
+    frameTimeNanos.toJSBigInt,
   );
   return result == 1;
+}
+
+void FrameScheduler_startNativeRenderLoop(int targetFps) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_startNativeRenderLoop(targetFps);
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(
+    port.toJSBigInt,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
 }
 
 void Renderer_setClearOptions(
@@ -10270,912 +11176,6 @@ void Renderer_setFrameInterval(
     history,
     interval,
   );
-  return result;
-}
-
-Pointer<TRenderTarget> RenderTarget_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> color,
-  Pointer<TTexture> depth,
-) {
-  final result = GeneratedBindings.instance._RenderTarget_create(
-    tEngine.cast(),
-    color.cast(),
-    depth.cast(),
-  );
-  return Pointer<TRenderTarget>(result);
-}
-
-void RenderTarget_destroy(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderTarget> tRenderTarget,
-) {
-  final result = GeneratedBindings.instance._RenderTarget_destroy(
-    tEngine.cast(),
-    tRenderTarget.cast(),
-  );
-  return result;
-}
-
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(
-    filamentAsset.cast(),
-  );
-  return result;
-}
-
-void FilamentAsset_getEntities(
-  Pointer<TFilamentAsset> filamentAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(
-    filamentAsset.cast(),
-    out,
-  );
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(
-    filamentAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(
-    filamentAsset.cast(),
-  );
-  return Pointer<Void>(result);
-}
-
-int LightManager_createLight(
-  Pointer<TEngine> tEngine,
-  Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-    tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
-  );
-  return result;
-}
-
-void LightManager_destroyLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-bool LightManager_hasComponent(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-int LightManager_getType(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getType(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-bool LightManager_isDirectional(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-bool LightManager_isPointLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-void LightManager_setPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(
-    tLightManager.cast(),
-    light,
-    x,
-    y,
-    z,
-  );
-  return result;
-}
-
-double3 LightManager_getPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(
-    double3_out.cast(),
-    tLightManager.cast(),
-    light,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(
-    tLightManager.cast(),
-    light,
-    x,
-    y,
-    z,
-  );
-  return result;
-}
-
-double3 LightManager_getDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(
-    double3_out.cast(),
-    tLightManager.cast(),
-    light,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double r,
-  double g,
-  double b,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColor(
-    tLightManager.cast(),
-    entity,
-    r,
-    g,
-    b,
-  );
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
-  );
-  return result;
-}
-
-double3 LightManager_getColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(
-    double3_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(
-    tLightManager.cast(),
-    entity,
-    intensity,
-  );
-  return result;
-}
-
-void LightManager_setIntensityCandela(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
-    tLightManager.cast(),
-    entity,
-    intensity,
-  );
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
-  );
-  return result;
-}
-
-double LightManager_getIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double falloff,
-) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(
-    tLightManager.cast(),
-    entity,
-    falloff,
-  );
-  return result;
-}
-
-double LightManager_getFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
-    tLightManager.cast(),
-    entity,
-    inner,
-    outer,
-  );
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double angularRadius,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
-  );
-  return result;
-}
-
-double LightManager_getSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloSize,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(
-    tLightManager.cast(),
-    entity,
-    haloSize,
-  );
-  return result;
-}
-
-double LightManager_getSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloFalloff,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
-    tLightManager.cast(),
-    entity,
-    haloFalloff,
-  );
-  return result;
-}
-
-double LightManager_getSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(
-    tLightManager.cast(),
-    entity,
-    enabled,
-  );
-  return result;
-}
-
-bool LightManager_isShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  TShadowOptions options,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-  );
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(
-    splitPositions,
-    cascades,
-  );
-  return result;
-}
-
-void LightManager_computeLogSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(
-    splitPositions,
-    cascades,
-    near,
-    far,
-  );
-  return result;
-}
-
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_computePracticalSplits(
-        splitPositions,
-        cascades,
-        near,
-        far,
-        lambda,
-      );
-  return result;
-}
-
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(
-    r,
-    g,
-    b,
-  );
-  return result;
-}
-
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(
-  Pointer<TNameComponentManager> tNameComponentManager,
-) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(
-    tNameComponentManager.cast(),
-  );
-  return result;
-}
-
-Pointer<Char> NameComponentManager_getName(
-  Pointer<TNameComponentManager> tNameComponentManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(
-    tNameComponentManager.cast(),
-    entity,
-  );
-  return Pointer<Char>(result);
-}
-
-void IndirectLight_setRotation(
-  Pointer<TIndirectLight> tIndirectLight,
-  Pointer<Float64> rotation,
-) {
-  final result = GeneratedBindings.instance._IndirectLight_setRotation(
-    tIndirectLight.cast(),
-    rotation,
-  );
-  return result;
-}
-
-void Skybox_setColor(
-  Pointer<TSkybox> tSkybox,
-  double r,
-  double g,
-  double b,
-  double a,
-) {
-  final result = GeneratedBindings.instance._Skybox_setColor(
-    tSkybox.cast(),
-    r,
-    g,
-    b,
-    a,
-  );
-  return result;
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
-    tEngine.cast(),
-    tMaterialProvider.cast(),
-    tNameComponentManager.cast(),
-  );
-  return Pointer<TGltfAssetLoader>(result);
-}
-
-void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(
-    tAssetLoader.cast(),
-  );
-  return result;
-}
-
-Pointer<TFilamentAsset> GltfAssetLoader_load(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  int numInstances,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    data,
-    length,
-    numInstances,
-  );
-  return Pointer<TFilamentAsset>(result);
-}
-
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
-) {
-  final result = GeneratedBindings.instance
-      ._GltfAssetLoader_getMaterialInstance(
-        tRenderableManager.cast(),
-        tAsset.cast(),
-      );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
-  Pointer<TGltfAssetLoader> tAssetLoader,
-) {
-  final result = GeneratedBindings.instance
-      ._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
-}
-
-int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(
-    tFilamentAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(
-    tFilamentAsset.cast(),
-  );
-  return Pointer<PointerClass<Char>>(result);
-}
-
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(
-    builder.cast(),
-    normals,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(
-    builder.cast(),
-    tangents,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(
-    builder.cast(),
-    uvs,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint32> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(
-    builder.cast(),
-  );
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(
-    builder.cast(),
-  );
-  return result;
-}
-
-Dartsize_t SurfaceOrientation_getVertexCount(
-  Pointer<TSurfaceOrientation> orientation,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(
-    orientation.cast(),
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(
-    orientation.cast(),
-  );
-  return result;
-}
-
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-    tEngine.cast(),
-    assetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
-  );
-  return Pointer<TGizmo>(result);
-}
-
-void Gizmo_pick(
-  Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  DartGizmoPickCallback callback,
-) {
-  final result = GeneratedBindings.instance._Gizmo_pick(
-    tGizmo.cast(),
-    x,
-    y,
-    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
-  );
-  return result;
-}
-
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(
-    tGizmo.cast(),
-    axis,
-  );
-  return result;
-}
-
-void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
   return result;
 }
 
@@ -11354,43 +11354,186 @@ void TransformPipeline_setInvertMouseY(int invert) {
   return result;
 }
 
-extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
-  TMaterialInstance toDart() {
-    return TMaterialInstance(this);
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
   }
 }
 
-final class TMaterialInstance extends Struct {
-  Pointer<TMaterialInstance> get address => super.address.cast();
-  TMaterialInstance(super.address);
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
 
-  static Pointer<TMaterialInstance> stackAlloc() {
-    return Pointer<TMaterialInstance>(
-      NativeLibrary.instance.stackAlloc<TMaterialInstance>(0),
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+extension double4x4Ext on Pointer<double4x4> {
+  double4x4 toDart() {
+    return double4x4(this);
+  }
+}
+
+final class double4x4 extends Struct {
+  Pointer<double4x4> get address => super.address.cast();
+  Array<Float64> get col1 {
+    final addr = Pointer<double4x4>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 0),
+    ));
+  }
+
+  set col1(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 0),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col2 {
+    final addr = Pointer<double4x4>(this.address.addr + 32);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 32),
+    ));
+  }
+
+  set col2(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 32),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col3 {
+    final addr = Pointer<double4x4>(this.address.addr + 64);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 64),
+    ));
+  }
+
+  set col3(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 64),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col4 {
+    final addr = Pointer<double4x4>(this.address.addr + 96);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 96),
+    ));
+  }
+
+  set col4(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 96),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  double4x4(super.address);
+
+  static Pointer<double4x4> stackAlloc() {
+    return Pointer<double4x4>(
+      NativeLibrary.instance.stackAlloc<double4x4>(128),
     );
   }
 }
 
-extension TMaterialExt on Pointer<TMaterial> {
-  TMaterial toDart() {
-    return TMaterial(this);
+extension double3Ext on Pointer<double3> {
+  double3 toDart() {
+    return double3(this);
   }
 }
 
-final class TMaterial extends Struct {
-  Pointer<TMaterial> get address => super.address.cast();
-  TMaterial(super.address);
+final class double3 extends Struct {
+  Pointer<double3> get address => super.address.cast();
+  double get x {
+    final addr = Pointer<double3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TMaterial> stackAlloc() {
-    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  set x(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double3>(this.address.addr + 0),
+      val.toJS,
+      'double',
+    );
+  }
+
+  double get y {
+    final addr = Pointer<double3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set y(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double3>(this.address.addr + 8),
+      val.toJS,
+      'double',
+    );
+  }
+
+  double get z {
+    final addr = Pointer<double3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set z(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double3>(this.address.addr + 16),
+      val.toJS,
+      'double',
+    );
+  }
+
+  double3(super.address);
+
+  static Pointer<double3> stackAlloc() {
+    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
   }
 }
 
-sealed class TFeatureLevel {
-  static const FEATURE_LEVEL_0 = 0;
-  static const FEATURE_LEVEL_1 = 1;
-  static const FEATURE_LEVEL_2 = 2;
-  static const FEATURE_LEVEL_3 = 3;
+typedef EntityId = int;
+typedef DartEntityId = int;
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+extension TSceneAssetExt on Pointer<TSceneAsset> {
+  TSceneAsset toDart() {
+    return TSceneAsset(this);
+  }
+}
+
+final class TSceneAsset extends Struct {
+  Pointer<TSceneAsset> get address => super.address.cast();
+  TSceneAsset(super.address);
+
+  static Pointer<TSceneAsset> stackAlloc() {
+    return Pointer<TSceneAsset>(
+      NativeLibrary.instance.stackAlloc<TSceneAsset>(0),
+    );
+  }
 }
 
 extension TEngineExt on Pointer<TEngine> {
@@ -11408,196 +11551,53 @@ final class TEngine extends Struct {
   }
 }
 
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
-}
-
-extension TTextureExt on Pointer<TTexture> {
-  TTexture toDart() {
-    return TTexture(this);
+extension TVertexBufferExt on Pointer<TVertexBuffer> {
+  TVertexBuffer toDart() {
+    return TVertexBuffer(this);
   }
 }
 
-final class TTexture extends Struct {
-  Pointer<TTexture> get address => super.address.cast();
-  TTexture(super.address);
+final class TVertexBuffer extends Struct {
+  Pointer<TVertexBuffer> get address => super.address.cast();
+  TVertexBuffer(super.address);
 
-  static Pointer<TTexture> stackAlloc() {
-    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
-  }
-}
-
-extension TTextureSamplerExt on Pointer<TTextureSampler> {
-  TTextureSampler toDart() {
-    return TTextureSampler(this);
-  }
-}
-
-final class TTextureSampler extends Struct {
-  Pointer<TTextureSampler> get address => super.address.cast();
-  TTextureSampler(super.address);
-
-  static Pointer<TTextureSampler> stackAlloc() {
-    return Pointer<TTextureSampler>(
-      NativeLibrary.instance.stackAlloc<TTextureSampler>(0),
+  static Pointer<TVertexBuffer> stackAlloc() {
+    return Pointer<TVertexBuffer>(
+      NativeLibrary.instance.stackAlloc<TVertexBuffer>(0),
     );
   }
 }
 
-sealed class TSamplerCompareFunc {
-  /// !< Less or equal
-  static const LE = 0;
-
-  /// !< Greater or equal
-  static const GE = 1;
-
-  /// !< Strictly less than
-  static const L = 2;
-
-  /// !< Strictly greater than
-  static const G = 3;
-
-  /// !< Equal
-  static const E = 4;
-
-  /// !< Not equal
-  static const NE = 5;
-
-  /// !< Always. Depth / stencil testing is deactivated.
-  static const A = 6;
-
-  /// !< Never. The depth / stencil test always fails.
-  static const N = 7;
-}
-
-sealed class TStencilOperation {
-  static const KEEP = 0;
-  static const ZERO = 1;
-  static const REPLACE = 2;
-  static const INCR = 3;
-  static const INCR_WRAP = 4;
-  static const DECR = 5;
-  static const DECR_WRAP = 6;
-  static const INVERT = 7;
-}
-
-sealed class TStencilFace {
-  static const STENCIL_FACE_FRONT = 1;
-  static const STENCIL_FACE_BACK = 2;
-  static const STENCIL_FACE_FRONT_AND_BACK = 3;
-}
-
-sealed class TTransparencyMode {
-  /// ! the transparent object is drawn honoring the raster state
-  static const DEFAULT = 0;
-
-  /// the transparent object is first drawn in the depth buffer,
-  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
-  static const TWO_PASSES_ONE_SIDE = 1;
-
-  /// the transparent object is drawn twice in the color buffer,
-  /// first with back faces only, then with front faces; the culling
-  /// mode is ignored. Can be combined with two-sided lighting
-  static const TWO_PASSES_TWO_SIDES = 2;
-}
-
-sealed class TBlendingMode {
-  static const BLENDING_MODE_OPAQUE = 0;
-  static const BLENDING_MODE_TRANSPARENT = 1;
-  static const BLENDING_MODE_ADD = 2;
-  static const BLENDING_MODE_MASKED = 3;
-  static const BLENDING_MODE_FADE = 4;
-  static const BLENDING_MODE_MULTIPLY = 5;
-  static const BLENDING_MODE_SCREEN = 6;
-  static const BLENDING_MODE_CUSTOM = 7;
-}
-
-extension TGltfMeshDataExt on Pointer<TGltfMeshData> {
-  TGltfMeshData toDart() {
-    return TGltfMeshData(this);
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
   }
 }
 
-final class TGltfMeshData extends Struct {
-  Pointer<TGltfMeshData> get address => super.address.cast();
-  Pointer<Float32> get vertices {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Pointer<Float32>(value.toDartInt);
-  }
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
 
-  set vertices(Pointer<Float32> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TGltfMeshData>(this.address.addr + 0),
-      val.toJS,
-      '*',
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(
+      NativeLibrary.instance.stackAlloc<TIndexBuffer>(0),
     );
   }
+}
 
-  int get vertexCount {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
+extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
+  TMaterialInstance toDart() {
+    return TMaterialInstance(this);
   }
+}
 
-  set vertexCount(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TGltfMeshData>(this.address.addr + 4),
-      val.toJS,
-      'i32',
-    );
-  }
+final class TMaterialInstance extends Struct {
+  Pointer<TMaterialInstance> get address => super.address.cast();
+  TMaterialInstance(super.address);
 
-  Pointer<Uint32> get indices {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Pointer<Uint32>(value.toDartInt);
-  }
-
-  set indices(Pointer<Uint32> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TGltfMeshData>(this.address.addr + 8),
-      val.toJS,
-      '*',
-    );
-  }
-
-  int get indexCount {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set indexCount(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TGltfMeshData>(this.address.addr + 12),
-      val.toJS,
-      'i32',
-    );
-  }
-
-  int get primitiveType {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set primitiveType(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TGltfMeshData>(this.address.addr + 16),
-      val.toJS,
-      'i32',
-    );
-  }
-
-  TGltfMeshData(super.address);
-
-  static Pointer<TGltfMeshData> stackAlloc() {
-    return Pointer<TGltfMeshData>(
-      NativeLibrary.instance.stackAlloc<TGltfMeshData>(20),
+  static Pointer<TMaterialInstance> stackAlloc() {
+    return Pointer<TMaterialInstance>(
+      NativeLibrary.instance.stackAlloc<TMaterialInstance>(0),
     );
   }
 }
@@ -11619,383 +11619,164 @@ sealed class TPrimitiveType {
   static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
-typedef size_t = int;
-typedef Dartsize_t = int;
-
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
+extension Aabb3Ext on Pointer<Aabb3> {
+  Aabb3 toDart() {
+    return Aabb3(this);
   }
 }
 
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
+final class Aabb3 extends Struct {
+  Pointer<Aabb3> get address => super.address.cast();
+  double get centerX {
+    final addr = Pointer<Aabb3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(
-      NativeLibrary.instance.stackAlloc<TLinearImage>(0),
+  set centerX(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 0),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get centerY {
+    final addr = Pointer<Aabb3>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerY(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 4),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get centerZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerZ(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 8),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentX {
+    final addr = Pointer<Aabb3>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentX(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 12),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentY {
+    final addr = Pointer<Aabb3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentY(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 16),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 20);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentZ(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 20),
+      val.toJS,
+      'float',
+    );
+  }
+
+  Aabb3(super.address);
+
+  static Pointer<Aabb3> stackAlloc() {
+    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
+  }
+}
+
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
+  }
+}
+
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
+
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(
+      NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0),
     );
   }
 }
 
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
   }
 }
 
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
 
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(
-      NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0),
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(
+      NativeLibrary.instance.stackAlloc<TNameComponentManager>(0),
     );
   }
 }
 
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
   }
 }
 
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
 
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(
-      NativeLibrary.instance.stackAlloc<TRenderTarget>(0),
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(
+      NativeLibrary.instance.stackAlloc<TFilamentAsset>(0),
     );
   }
 }
 
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
-  }
-}
-
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
-
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
-  }
-}
-
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
-  }
-}
-
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
-
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(
-      NativeLibrary.instance.stackAlloc<TSwapChain>(0),
-    );
-  }
-}
-
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
 extension TSceneExt on Pointer<TScene> {
@@ -12013,54 +11794,22 @@ final class TScene extends Struct {
   }
 }
 
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
+typedef size_t = int;
+typedef Dartsize_t = int;
+
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
   }
 }
 
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
 
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(
-      NativeLibrary.instance.stackAlloc<TColorGrading>(0),
-    );
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-typedef EntityId = int;
-typedef DartEntityId = int;
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
-  }
-}
-
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
-
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(
-      NativeLibrary.instance.stackAlloc<TTransformManager>(0),
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(
+      NativeLibrary.instance.stackAlloc<TMaterialProvider>(0),
     );
   }
 }
@@ -12082,100 +11831,36 @@ final class TRenderableManager extends Struct {
   }
 }
 
-extension TLightManagerExt on Pointer<TLightManager> {
-  TLightManager toDart() {
-    return TLightManager(this);
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
   }
 }
 
-final class TLightManager extends Struct {
-  Pointer<TLightManager> get address => super.address.cast();
-  TLightManager(super.address);
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
 
-  static Pointer<TLightManager> stackAlloc() {
-    return Pointer<TLightManager>(
-      NativeLibrary.instance.stackAlloc<TLightManager>(0),
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(
+      NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0),
     );
   }
 }
 
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(
-      NativeLibrary.instance.stackAlloc<TEntityManager>(0),
-    );
-  }
-}
-
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
-  }
-}
-
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
-
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
-  }
-}
-
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
-  }
-}
-
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
-
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
-  }
-}
-
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
-  }
-}
-
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
-
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(
-      NativeLibrary.instance.stackAlloc<TIndirectLight>(0),
-    );
-  }
-}
-
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
-  }
-}
-
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
-
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(
-      NativeLibrary.instance.stackAlloc<TDebugRegistry>(0),
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(
+      NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0),
     );
   }
 }
@@ -12251,6 +11936,21 @@ final class TViewport extends Struct {
   }
 }
 
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
 extension TToneMapperExt on Pointer<TToneMapper> {
   TToneMapper toDart() {
     return TToneMapper(this);
@@ -12264,6 +11964,23 @@ final class TToneMapper extends Struct {
   static Pointer<TToneMapper> stackAlloc() {
     return Pointer<TToneMapper>(
       NativeLibrary.instance.stackAlloc<TToneMapper>(0),
+    );
+  }
+}
+
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(
+      NativeLibrary.instance.stackAlloc<TColorGrading>(0),
     );
   }
 }
@@ -12300,6 +12017,23 @@ sealed class TLutFormat {
 sealed class TBlendMode {
   static const OPAQUE = 0;
   static const TRANSLUCENT = 1;
+}
+
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
+  }
+}
+
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
+
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(
+      NativeLibrary.instance.stackAlloc<TRenderTarget>(0),
+    );
+  }
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -13080,6 +12814,21 @@ final class TFogOptions extends Struct {
   }
 }
 
+extension TTextureExt on Pointer<TTexture> {
+  TTexture toDart() {
+    return TTexture(this);
+  }
+}
+
+final class TTexture extends Struct {
+  Pointer<TTexture> get address => super.address.cast();
+  TTexture(super.address);
+
+  static Pointer<TTexture> stackAlloc() {
+    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
+  }
+}
+
 typedef PickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
 typedef DartPickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
 typedef PickCallbackFunction =
@@ -13101,19 +12850,597 @@ typedef DartPickCallbackFunction =
       double fragZ,
     );
 
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(
-      NativeLibrary.instance.stackAlloc<TMaterialProvider>(0),
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  }
+}
+
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
+  }
+}
+
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
+
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(
+      NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0),
+    );
+  }
+}
+
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
+extension TMaterialExt on Pointer<TMaterial> {
+  TMaterial toDart() {
+    return TMaterial(this);
+  }
+}
+
+final class TMaterial extends Struct {
+  Pointer<TMaterial> get address => super.address.cast();
+  TMaterial(super.address);
+
+  static Pointer<TMaterial> stackAlloc() {
+    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  }
+}
+
+sealed class TFeatureLevel {
+  static const FEATURE_LEVEL_0 = 0;
+  static const FEATURE_LEVEL_1 = 1;
+  static const FEATURE_LEVEL_2 = 2;
+  static const FEATURE_LEVEL_3 = 3;
+}
+
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
+extension TTextureSamplerExt on Pointer<TTextureSampler> {
+  TTextureSampler toDart() {
+    return TTextureSampler(this);
+  }
+}
+
+final class TTextureSampler extends Struct {
+  Pointer<TTextureSampler> get address => super.address.cast();
+  TTextureSampler(super.address);
+
+  static Pointer<TTextureSampler> stackAlloc() {
+    return Pointer<TTextureSampler>(
+      NativeLibrary.instance.stackAlloc<TTextureSampler>(0),
+    );
+  }
+}
+
+sealed class TSamplerCompareFunc {
+  /// !< Less or equal
+  static const LE = 0;
+
+  /// !< Greater or equal
+  static const GE = 1;
+
+  /// !< Strictly less than
+  static const L = 2;
+
+  /// !< Strictly greater than
+  static const G = 3;
+
+  /// !< Equal
+  static const E = 4;
+
+  /// !< Not equal
+  static const NE = 5;
+
+  /// !< Always. Depth / stencil testing is deactivated.
+  static const A = 6;
+
+  /// !< Never. The depth / stencil test always fails.
+  static const N = 7;
+}
+
+sealed class TStencilOperation {
+  static const KEEP = 0;
+  static const ZERO = 1;
+  static const REPLACE = 2;
+  static const INCR = 3;
+  static const INCR_WRAP = 4;
+  static const DECR = 5;
+  static const DECR_WRAP = 6;
+  static const INVERT = 7;
+}
+
+sealed class TStencilFace {
+  static const STENCIL_FACE_FRONT = 1;
+  static const STENCIL_FACE_BACK = 2;
+  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+}
+
+sealed class TTransparencyMode {
+  /// ! the transparent object is drawn honoring the raster state
+  static const DEFAULT = 0;
+
+  /// the transparent object is first drawn in the depth buffer,
+  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
+  static const TWO_PASSES_ONE_SIDE = 1;
+
+  /// the transparent object is drawn twice in the color buffer,
+  /// first with back faces only, then with front faces; the culling
+  /// mode is ignored. Can be combined with two-sided lighting
+  static const TWO_PASSES_TWO_SIDES = 2;
+}
+
+sealed class TBlendingMode {
+  static const BLENDING_MODE_OPAQUE = 0;
+  static const BLENDING_MODE_TRANSPARENT = 1;
+  static const BLENDING_MODE_ADD = 2;
+  static const BLENDING_MODE_MASKED = 3;
+  static const BLENDING_MODE_FADE = 4;
+  static const BLENDING_MODE_MULTIPLY = 5;
+  static const BLENDING_MODE_SCREEN = 6;
+  static const BLENDING_MODE_CUSTOM = 7;
+}
+
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(
+      NativeLibrary.instance.stackAlloc<TLinearImage>(0),
+    );
+  }
+}
+
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
+  }
+}
+
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
+
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(
+      NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0),
+    );
+  }
+}
+
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
+  }
+}
+
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
+
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  }
+}
+
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
+  }
+}
+
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
+
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(
+      NativeLibrary.instance.stackAlloc<TSwapChain>(0),
+    );
+  }
+}
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
+  }
+}
+
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
+
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(
+      NativeLibrary.instance.stackAlloc<TTransformManager>(0),
+    );
+  }
+}
+
+extension TLightManagerExt on Pointer<TLightManager> {
+  TLightManager toDart() {
+    return TLightManager(this);
+  }
+}
+
+final class TLightManager extends Struct {
+  Pointer<TLightManager> get address => super.address.cast();
+  TLightManager(super.address);
+
+  static Pointer<TLightManager> stackAlloc() {
+    return Pointer<TLightManager>(
+      NativeLibrary.instance.stackAlloc<TLightManager>(0),
+    );
+  }
+}
+
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
+  }
+}
+
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
+
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(
+      NativeLibrary.instance.stackAlloc<TEntityManager>(0),
+    );
+  }
+}
+
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
+  }
+}
+
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
+
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  }
+}
+
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
+  }
+}
+
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
+
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(
+      NativeLibrary.instance.stackAlloc<TIndirectLight>(0),
+    );
+  }
+}
+
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
+  }
+}
+
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
+
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(
+      NativeLibrary.instance.stackAlloc<TDebugRegistry>(0),
     );
   }
 }
@@ -13182,246 +13509,6 @@ sealed class TVertexAttributeType {
   static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-extension TVertexBufferExt on Pointer<TVertexBuffer> {
-  TVertexBuffer toDart() {
-    return TVertexBuffer(this);
-  }
-}
-
-final class TVertexBuffer extends Struct {
-  Pointer<TVertexBuffer> get address => super.address.cast();
-  TVertexBuffer(super.address);
-
-  static Pointer<TVertexBuffer> stackAlloc() {
-    return Pointer<TVertexBuffer>(
-      NativeLibrary.instance.stackAlloc<TVertexBuffer>(0),
-    );
-  }
-}
-
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
-  }
-}
-
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
-
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(
-      NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0),
-    );
-  }
-}
-
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
-  }
-}
-
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
-
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(
-      NativeLibrary.instance.stackAlloc<TIndexBuffer>(0),
-    );
-  }
-}
-
-extension double4x4Ext on Pointer<double4x4> {
-  double4x4 toDart() {
-    return double4x4(this);
-  }
-}
-
-final class double4x4 extends Struct {
-  Pointer<double4x4> get address => super.address.cast();
-  Array<Float64> get col1 {
-    final addr = Pointer<double4x4>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 0),
-    ));
-  }
-
-  set col1(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 0),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col2 {
-    final addr = Pointer<double4x4>(this.address.addr + 32);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 32),
-    ));
-  }
-
-  set col2(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 32),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col3 {
-    final addr = Pointer<double4x4>(this.address.addr + 64);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 64),
-    ));
-  }
-
-  set col3(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 64),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col4 {
-    final addr = Pointer<double4x4>(this.address.addr + 96);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 96),
-    ));
-  }
-
-  set col4(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 96),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  double4x4(super.address);
-
-  static Pointer<double4x4> stackAlloc() {
-    return Pointer<double4x4>(
-      NativeLibrary.instance.stackAlloc<double4x4>(128),
-    );
-  }
-}
-
-extension Aabb3Ext on Pointer<Aabb3> {
-  Aabb3 toDart() {
-    return Aabb3(this);
-  }
-}
-
-final class Aabb3 extends Struct {
-  Pointer<Aabb3> get address => super.address.cast();
-  double get centerX {
-    final addr = Pointer<Aabb3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerX(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 0),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get centerY {
-    final addr = Pointer<Aabb3>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerY(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 4),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get centerZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerZ(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 8),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get halfExtentX {
-    final addr = Pointer<Aabb3>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentX(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 12),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get halfExtentY {
-    final addr = Pointer<Aabb3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentY(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 16),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get halfExtentZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 20);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentZ(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 20),
-      val.toJS,
-      'float',
-    );
-  }
-
-  Aabb3(super.address);
-
-  static Pointer<Aabb3> stackAlloc() {
-    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
-  }
-}
-
 extension TRenderManagerExt on Pointer<TRenderManager> {
   TRenderManager toDart() {
     return TRenderManager(this);
@@ -13452,74 +13539,6 @@ final class TAnimationManager extends Struct {
   static Pointer<TAnimationManager> stackAlloc() {
     return Pointer<TAnimationManager>(
       NativeLibrary.instance.stackAlloc<TAnimationManager>(0),
-    );
-  }
-}
-
-extension TSceneAssetExt on Pointer<TSceneAsset> {
-  TSceneAsset toDart() {
-    return TSceneAsset(this);
-  }
-}
-
-final class TSceneAsset extends Struct {
-  Pointer<TSceneAsset> get address => super.address.cast();
-  TSceneAsset(super.address);
-
-  static Pointer<TSceneAsset> stackAlloc() {
-    return Pointer<TSceneAsset>(
-      NativeLibrary.instance.stackAlloc<TSceneAsset>(0),
-    );
-  }
-}
-
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
-  }
-}
-
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
-
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(
-      NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0),
-    );
-  }
-}
-
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
-  }
-}
-
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
-
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(
-      NativeLibrary.instance.stackAlloc<TNameComponentManager>(0),
-    );
-  }
-}
-
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
-  }
-}
-
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
-
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(
-      NativeLibrary.instance.stackAlloc<TFilamentAsset>(0),
     );
   }
 }
@@ -13578,88 +13597,92 @@ final class TRenderableBuilder extends Struct {
   }
 }
 
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
-}
-
-extension double3Ext on Pointer<double3> {
-  double3 toDart() {
-    return double3(this);
+extension TGltfMeshDataExt on Pointer<TGltfMeshData> {
+  TGltfMeshData toDart() {
+    return TGltfMeshData(this);
   }
 }
 
-final class double3 extends Struct {
-  Pointer<double3> get address => super.address.cast();
-  double get x {
-    final addr = Pointer<double3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
+final class TGltfMeshData extends Struct {
+  Pointer<TGltfMeshData> get address => super.address.cast();
+  Pointer<Float32> get vertices {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Pointer<Float32>(value.toDartInt);
   }
 
-  set x(double val) {
+  set vertices(Pointer<Float32> val) {
     NativeLibrary.instance.setValue(
-      Pointer<double3>(this.address.addr + 0),
+      Pointer<TGltfMeshData>(this.address.addr + 0),
       val.toJS,
-      'double',
+      '*',
     );
   }
 
-  double get y {
-    final addr = Pointer<double3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+  int get vertexCount {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
     return value;
   }
 
-  set y(double val) {
+  set vertexCount(int val) {
     NativeLibrary.instance.setValue(
-      Pointer<double3>(this.address.addr + 8),
+      Pointer<TGltfMeshData>(this.address.addr + 4),
       val.toJS,
-      'double',
+      'i32',
     );
   }
 
-  double get z {
-    final addr = Pointer<double3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+  Pointer<Uint32> get indices {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Pointer<Uint32>(value.toDartInt);
+  }
+
+  set indices(Pointer<Uint32> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TGltfMeshData>(this.address.addr + 8),
+      val.toJS,
+      '*',
+    );
+  }
+
+  int get indexCount {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
     return value;
   }
 
-  set z(double val) {
+  set indexCount(int val) {
     NativeLibrary.instance.setValue(
-      Pointer<double3>(this.address.addr + 16),
+      Pointer<TGltfMeshData>(this.address.addr + 12),
       val.toJS,
-      'double',
+      'i32',
     );
   }
 
-  double3(super.address);
+  int get primitiveType {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
 
-  static Pointer<double3> stackAlloc() {
-    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+  set primitiveType(int val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TGltfMeshData>(this.address.addr + 16),
+      val.toJS,
+      'i32',
+    );
+  }
+
+  TGltfMeshData(super.address);
+
+  static Pointer<TGltfMeshData> stackAlloc() {
+    return Pointer<TGltfMeshData>(
+      NativeLibrary.instance.stackAlloc<TGltfMeshData>(20),
+    );
   }
 }
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
-typedef PostRenderCallback =
-    Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef DartPostRenderCallback =
-    Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
 
 sealed class TLightType {
   static const LIGHT_TYPE_SUN = 0;
@@ -13997,40 +14020,6 @@ final class TShadowOptions extends Struct {
   }
 }
 
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
-  }
-}
-
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
-
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(
-      NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0),
-    );
-  }
-}
-
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
-  }
-}
-
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
-
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(
-      NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0),
-    );
-  }
-}
-
 sealed class TGizmoPickResultType {
   static const AxisX = 0;
   static const AxisY = 1;
@@ -14052,6 +14041,17 @@ sealed class TGizmoAxis {
   static const Y = 1;
   static const Z = 2;
 }
+
+typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
+typedef PostRenderCallback =
+    Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef DartPostRenderCallback =
+    Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
+typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
   TMovementIntentExecutor toDart() {
@@ -14102,83 +14102,74 @@ const int SPRINT_INTENT_MASK = 8;
 extension StructAllocator on Struct {
   static T create<T>() {
     switch (T) {
-      case TMaterialInstance:
-        final ptr = TMaterialInstance.stackAlloc();
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterial:
-        final ptr = TMaterial.stackAlloc();
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
+      case double3:
+        final ptr = double3.stackAlloc();
+        return ptr.toDart() as T;
+      case TSceneAsset:
+        final ptr = TSceneAsset.stackAlloc();
         return ptr.toDart() as T;
       case TEngine:
         final ptr = TEngine.stackAlloc();
         return ptr.toDart() as T;
-      case TTexture:
-        final ptr = TTexture.stackAlloc();
+      case TVertexBuffer:
+        final ptr = TVertexBuffer.stackAlloc();
         return ptr.toDart() as T;
-      case TTextureSampler:
-        final ptr = TTextureSampler.stackAlloc();
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
         return ptr.toDart() as T;
-      case TGltfMeshData:
-        final ptr = TGltfMeshData.stackAlloc();
+      case TMaterialInstance:
+        final ptr = TMaterialInstance.stackAlloc();
         return ptr.toDart() as T;
-      case TLinearImage:
-        final ptr = TLinearImage.stackAlloc();
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
         return ptr.toDart() as T;
-      case TKtx1Bundle:
-        final ptr = TKtx1Bundle.stackAlloc();
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderer:
-        final ptr = TRenderer.stackAlloc();
-        return ptr.toDart() as T;
-      case TSwapChain:
-        final ptr = TSwapChain.stackAlloc();
-        return ptr.toDart() as T;
-      case TView:
-        final ptr = TView.stackAlloc();
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
         return ptr.toDart() as T;
       case TScene:
         final ptr = TScene.stackAlloc();
         return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TTransformManager:
-        final ptr = TTransformManager.stackAlloc();
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableManager:
         final ptr = TRenderableManager.stackAlloc();
         return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
+      case TSurfaceOrientationBuilder:
+        final ptr = TSurfaceOrientationBuilder.stackAlloc();
         return ptr.toDart() as T;
-      case TEntityManager:
-        final ptr = TEntityManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFence:
-        final ptr = TFence.stackAlloc();
-        return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
-      case TDebugRegistry:
-        final ptr = TDebugRegistry.stackAlloc();
+      case TSurfaceOrientation:
+        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
       case TViewport:
         final ptr = TViewport.stackAlloc();
         return ptr.toDart() as T;
+      case TView:
+        final ptr = TView.stackAlloc();
+        return ptr.toDart() as T;
       case TToneMapper:
         final ptr = TToneMapper.stackAlloc();
         return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
+        return ptr.toDart() as T;
       case TColorGradingBuilder:
         final ptr = TColorGradingBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
         return ptr.toDart() as T;
       case TSoftShadowOptions:
         final ptr = TSoftShadowOptions.stackAlloc();
@@ -14195,44 +14186,59 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
+      case TTexture:
+        final ptr = TTexture.stackAlloc();
         return ptr.toDart() as T;
-      case TVertexBufferBuilder:
-        final ptr = TVertexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBuffer:
-        final ptr = TVertexBuffer.stackAlloc();
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
         return ptr.toDart() as T;
       case TIndexBufferBuilder:
         final ptr = TIndexBufferBuilder.stackAlloc();
         return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
+      case TMaterial:
+        final ptr = TMaterial.stackAlloc();
         return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
+      case TTextureSampler:
+        final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
+      case TLinearImage:
+        final ptr = TLinearImage.stackAlloc();
+        return ptr.toDart() as T;
+      case TKtx1Bundle:
+        final ptr = TKtx1Bundle.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderer:
+        final ptr = TRenderer.stackAlloc();
+        return ptr.toDart() as T;
+      case TSwapChain:
+        final ptr = TSwapChain.stackAlloc();
+        return ptr.toDart() as T;
+      case TTransformManager:
+        final ptr = TTransformManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TEntityManager:
+        final ptr = TEntityManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFence:
+        final ptr = TFence.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
+      case TDebugRegistry:
+        final ptr = TDebugRegistry.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBufferBuilder:
+        final ptr = TVertexBufferBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TRenderManager:
         final ptr = TRenderManager.stackAlloc();
         return ptr.toDart() as T;
       case TAnimationManager:
         final ptr = TAnimationManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TSceneAsset:
-        final ptr = TSceneAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
         return ptr.toDart() as T;
       case TGltfResourceLoader:
         final ptr = TGltfResourceLoader.stackAlloc();
@@ -14243,17 +14249,11 @@ extension StructAllocator on Struct {
       case TRenderableBuilder:
         final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
+      case TGltfMeshData:
+        final ptr = TGltfMeshData.stackAlloc();
         return ptr.toDart() as T;
       case TShadowOptions:
         final ptr = TShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientationBuilder:
-        final ptr = TSurfaceOrientationBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientation:
-        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();

--- a/thermion_dart/native/android/thermion_dart.map
+++ b/thermion_dart/native/android/thermion_dart.map
@@ -1,0 +1,6 @@
+THERMION_DART {
+  global:
+    [A-Za-z]*;
+  local:
+    *;
+};

--- a/thermion_dart/native/src/c_api/TAndroid.cpp
+++ b/thermion_dart/native/src/c_api/TAndroid.cpp
@@ -1,0 +1,18 @@
+#ifdef __ANDROID__
+
+#include "c_api/APIExport.h"
+
+#include <jni.h>
+
+// Filament does not publish a header for this Android initialization hook.
+// Give its existing C++ symbol a local C identifier without duplicating
+// Filament's private VirtualMachineEnv class definition.
+extern "C" void filamentVirtualMachineEnvOnLoad(JavaVM* vm)
+        __asm__("_ZN8filament17VirtualMachineEnv10JNI_OnLoadEP7_JavaVM");
+
+extern "C" EMSCRIPTEN_KEEPALIVE void
+Thermion_filament_JNI_OnLoad(JavaVM* vm) noexcept {
+    filamentVirtualMachineEnvOnLoad(vm);
+}
+
+#endif

--- a/thermion_dart/native/src/c_api/TMaterialInstance.cpp
+++ b/thermion_dart/native/src/c_api/TMaterialInstance.cpp
@@ -249,7 +249,9 @@ namespace thermion
                 case STENCIL_FACE_FRONT: return filament::MaterialInstance::StencilFace::FRONT;
                 case STENCIL_FACE_BACK: return filament::MaterialInstance::StencilFace::BACK;
                 case STENCIL_FACE_FRONT_AND_BACK: return filament::MaterialInstance::StencilFace::FRONT_AND_BACK;
-                default: throw std::invalid_argument("Invalid TStencilFace value");
+                default:
+                    ERROR("Invalid TStencilFace value: %d", static_cast<int>(tface));
+                    return filament::MaterialInstance::StencilFace::FRONT_AND_BACK;
             }
         }
 

--- a/thermion_dart/pubspec.yaml
+++ b/thermion_dart/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   ffi: ^2.1.2
   code_assets: ^1.0.0
   hooks: ^1.0.0
-  native_toolchain_c: ^0.17.1
+  native_toolchain_c: ^0.17.6
   archive: ^4.0.0
   web: ^1.0.0
   logging: ^1.2.0

--- a/thermion_flutter/thermion_flutter/android/CMakeLists.txt
+++ b/thermion_flutter/thermion_flutter/android/CMakeLists.txt
@@ -1,9 +1,12 @@
-cmake_minimum_required(VERSION 3.10)  
+cmake_minimum_required(VERSION 3.10)
+
+# This JNI shim only uses C/JNI/Android APIs. Thermion's sole C++ runtime is
+# linked statically into libthermion_dart.so by its native-assets build hook.
+project(thermion_flutter_android LANGUAGES C CXX)
 
 include_directories(src/main/include)
 include_directories(src/main/cpp)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-set(ANDROID_STL c++_shared)
 add_compile_definitions(ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES ON)
 
 add_library(thermion_flutter_android SHARED

--- a/thermion_flutter/thermion_flutter/android/build.gradle
+++ b/thermion_flutter/thermion_flutter/android/build.gradle
@@ -43,6 +43,11 @@ android {
 
     defaultConfig {
         minSdkVersion 22
+        externalNativeBuild {
+            cmake {
+                arguments "-DANDROID_STL=none"
+            }
+        }
     }
     
     externalNativeBuild {

--- a/thermion_flutter/thermion_flutter/android/src/main/cpp/ThermionFlutterAndroid.cpp
+++ b/thermion_flutter/thermion_flutter/android/src/main/cpp/ThermionFlutterAndroid.cpp
@@ -27,14 +27,14 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
      
      dlerror();
      
-     JNI_OnLoad_Func vmEnvOnLoad = (JNI_OnLoad_Func)dlsym(filamentLib, 
-                                   "_ZN8filament17VirtualMachineEnv10JNI_OnLoadEP7_JavaVM");
+     JNI_OnLoad_Func vmEnvOnLoad = (JNI_OnLoad_Func)dlsym(
+         filamentLib, "Thermion_filament_JNI_OnLoad");
      
      // Check for errors
      const char* dlsym_error = dlerror();
      if (dlsym_error) {
          __android_log_print(ANDROID_LOG_ERROR, "thermion_android", 
-                            "Failed to find VirtualMachineEnv::JNI_OnLoad: %s", dlsym_error);
+                            "Failed to find Thermion_filament_JNI_OnLoad: %s", dlsym_error);
          dlclose(filamentLib);
          return false;
      }


### PR DESCRIPTION
This PR statically links libc++ into libthermion_dart and stops packaging libc++_shared.so.
This is the [official recommended method](https://developer.android.com/ndk/guides/cpp-support#sr) for linking libc++.

To support this, the Android JNI shim is now built without STL and Filament initialization is exposed through a stable C wrapper. We also hide C++ implementation symbols and removed an errant C++ exception that could be thrown in the C API.

This surfaced due to a [recent Flutter change](https://github.com/flutter/flutter/commit/6efbbadd2ee7921be6135990dd6bfee856fb4d1e) to bundled native assets that were included in jniLibs. 