### PR TITLE
Pin Flutter example toolchain

### DIFF
--- a/.github/workflows/run-flutter-builds.yml
+++ b/.github/workflows/run-flutter-builds.yml
@@ -23,15 +23,15 @@ jobs:
         include:
           - name: macOS
             os: macos-latest
-            flutter-channel: beta
+            flutter-channel: stable
             flutter-arch: ARM64
           - name: Windows
             os: windows-latest
-            flutter-channel: beta
+            flutter-channel: stable
             flutter-arch: X64
           - name: Linux
             os: ubuntu-22.04
-            flutter-channel: beta
+            flutter-channel: stable
             flutter-arch: X64
     runs-on: ${{ matrix.os }}
     defaults:
@@ -45,6 +45,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.8'
           channel: ${{ matrix.flutter-channel }}
           architecture: ${{ matrix.flutter-arch }}
 

--- a/examples/flutter/picking/android/app/build.gradle
+++ b/examples/flutter/picking/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
         applicationId = "com.example.quickstart"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 22
+        minSdkVersion = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/examples/flutter/picking/android/gradle.properties
+++ b/examples/flutter/picking/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/examples/flutter/picking/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/flutter/picking/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/examples/flutter/picking/android/settings.gradle
+++ b/examples/flutter/picking/android/settings.gradle
@@ -17,9 +17,9 @@ pluginManagement {
 }
 
 plugins {
-    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.6.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include ":app"

--- a/examples/flutter/quickstart/android/gradle.properties
+++ b/examples/flutter/quickstart/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/examples/flutter/quickstart/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/flutter/quickstart/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/examples/flutter/quickstart/android/settings.gradle
+++ b/examples/flutter/quickstart/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include ":app"

--- a/examples/flutter/viewer/android/app/build.gradle
+++ b/examples/flutter/viewer/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
         applicationId = "com.example.quickstart"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 22
+        minSdkVersion = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/examples/flutter/viewer/android/gradle.properties
+++ b/examples/flutter/viewer/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/examples/flutter/viewer/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/flutter/viewer/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/examples/flutter/viewer/android/settings.gradle
+++ b/examples/flutter/viewer/android/settings.gradle
@@ -17,9 +17,9 @@ pluginManagement {
 }
 
 plugins {
-    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.6.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
The CI Flutter Examples workflow was previously pinned to Flutter beta, this PR pins to stable `3.44.8`.
Also updates example Flutter apps to the appropriate Gradle 8.14, AGP 8.11.1, and Kotlin 2.2.20.