### PR TITLE
Harden platform texture replacement and teardown

### DIFF
--- a/examples/flutter/quickstart/integration_test/darwin_texture_leak_test.dart
+++ b/examples/flutter/quickstart/integration_test/darwin_texture_leak_test.dart
@@ -1,0 +1,282 @@
+// Regression test for the iOS/macOS IOSurface leak described in
+// https://github.com/nmfisher/thermion/issues/178.
+//
+// Every time a ThermionWidget is mounted and unmounted, the darwin plugin
+// allocates a full-screen BGRA IOSurface (CVPixelBuffer + CVMetalTexture +
+// the +1-retained MTLTexture handed to Filament as the hardware id). On
+// teardown, `MetalTextureWrapper.destroyTexture()` only flushed the Metal
+// texture cache and never released that +1 retain (nor the CVMetalTexture),
+// so each session leaked one screen-sized surface (~22 MB on an iPad Pro
+// 12.9). The Dart side also never removed destroyed descriptors from
+// `_descriptors` because nothing ever appended to `_destroyed`.
+//
+// This test mounts and unmounts a ThermionWidget several times and asserts
+// that `phys_footprint` (the kernel's accounting of the bytes the process
+// truly owes) does not grow by a full surface per session. A small,
+// bounded drift is tolerated — Filament's own per-engine caches, the Dart
+// heap, and texture caches all settle asynchronously — but a leak of one
+// surface per session is far above that floor.
+//
+// Status (see the fix branch for issue #178): bug 1 — balancing the
+// unbalanced passRetained(+1) in MetalTextureWrapper + the render-target
+// orphan — is landed and proven safe. It does NOT by itself stop this leak:
+// the destroyed descriptor is still ARC-pinned in `_descriptors`, so its
+// MetalTextureWrapper (and the imported MTLTexture's IOSurface) outlives the
+// session. Fully freeing the surface (bug 2) requires releasing the wrapper
+// only after Filament drops the import (view/RT destruction); doing it
+// earlier over-releases the CVMetalTexture-backed MTLTexture and traps (see
+// the reverted bug 2 commit). Until bug 2 lands safely, this test is
+// expected to FAIL — it is the regression target for the complete fix.
+//
+// Run on a real target:
+//
+//   flutter test integration_test/darwin_texture_leak_test.dart -d macos
+//   flutter test integration_test/darwin_texture_leak_test.dart -d <ios-device>
+//
+// Skipped on non-darwin platforms: the leak is specific to the Metal
+// texture wrapper in darwin/Classes/MetalTextureWrapper.swift.
+import 'dart:io';
+
+import 'package:flutter/material.dart' hide View;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:thermion_flutter/thermion_flutter.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final bool isDarwin = Platform.isMacOS || Platform.isIOS;
+
+  testWidgets(
+    'repeated ThermionWidget mount/unmount does not leak IOSurfaces',
+    (tester) async {
+      // Surface size chosen so a single leaked BGRA IOSurface is large
+      // relative to cache noise: 768x576x4 ≈ 1.69 MB. A few sessions of
+      // that dwarf the asynchronous cache drift a correct fix leaves
+      // behind, while still running in seconds.
+      const surfaceWidth = 768;
+      const surfaceHeight = 576;
+      const surfaceBytes = surfaceWidth * surfaceHeight * 4;
+
+      // One long-lived viewer reused across every session — the common
+      // pattern (navigate into/out of a 3D screen without rebuilding the
+      // viewer). It is also the pattern the fix targets: each remount
+      // replaces the view's render target, which is when Filament releases
+      // the previous session's imported MTLTexture and the plugin can
+      // release the parked descriptor.
+      final viewer = await ThermionFlutterPlugin.createViewer();
+
+      // Warm up: the first session pays one-time costs (Filament engine,
+      // shader compile, texture caches) that should NOT be charged against
+      // steady-state. We measure drift from the second session onward.
+      await _pumpOneSessionAndUnmount(tester, viewer, surfaceWidth, surfaceHeight);
+      await _drain(tester);
+      final baseline = isDarwin ? _DarwinMemory.physFootprintBytes() : 0;
+      debugPrint(
+        '[leak-test] baseline phys_footprint='
+        '${(baseline / 1024 / 1024).toStringAsFixed(2)} MB',
+      );
+
+      // Each iteration mounts a fresh ThermionWidget, lets it render a few
+      // frames, then unmounts it. With the leak, each iteration pins one
+      // screen-sized IOSurface. We sample after every session so a steady
+      // per-session leak is visible even if the absolute floor drifts.
+      const sessions = 5;
+      var prev = baseline;
+      for (var i = 0; i < sessions; i++) {
+        await _pumpOneSessionAndUnmount(
+          tester,
+          viewer,
+          surfaceWidth,
+          surfaceHeight,
+        );
+        await _drain(tester);
+        final now = isDarwin ? _DarwinMemory.physFootprintBytes() : 0;
+        debugPrint(
+          '[leak-test] session ${i + 1}/$sessions phys_footprint='
+          '${(now / 1024 / 1024).toStringAsFixed(2)} MB '
+          '(delta=${((now - prev) / 1024 / 1024).toStringAsFixed(2)} MB)',
+        );
+        prev = now;
+      }
+      final after = prev;
+
+      // Tear down the reused viewer now that all sessions are measured.
+      await viewer.dispose();
+
+      if (!isDarwin) {
+        // Sanity: the test compiles and runs on non-darwin, but asserts
+        // nothing — the leak is darwin-only.
+        return;
+      }
+
+      final drift = after - baseline;
+      // Tolerance: half of one leaked surface's worth of total drift across
+      // ALL sessions. A correct fix leaves behind only asynchronous cache
+      // settling (well under one surface); a leak pins one surface per
+      // session, so `sessions` surfaces vs. half-a-surface is a wide gap.
+      const toleranceBytes = surfaceBytes ~/ 2;
+      expect(
+        drift,
+        lessThan(toleranceBytes),
+        reason:
+            'phys_footprint grew by ${(drift / 1024 / 1024).toStringAsFixed(2)} '
+            'MB across $sessions mount/unmount sessions (tolerance '
+            '${(toleranceBytes / 1024 / 1024).toStringAsFixed(2)} MB); expected '
+            'the darwin texture wrapper to release its +1 retain on destroy. '
+            '(baseline=${(baseline / 1024 / 1024).toStringAsFixed(2)} MB, '
+            'after=${(after / 1024 / 1024).toStringAsFixed(2)} MB)',
+      );
+    },
+    // darwin-only leak: the unbalanced passRetained lives in
+    // darwin/Classes/MetalTextureWrapper.swift.
+    skip: !isDarwin,
+  );
+}
+
+/// Mounts a ThermionWidget backed by [viewer], pumps a few frames so the
+/// surface is actually allocated and rendered into, then unmounts it. The
+/// viewer (and its view) are reused across sessions — this is the common
+/// pattern (one long-lived viewer, navigate into/out of the 3D screen), and
+/// it is the pattern the fix targets: each remount replaces the view's render
+/// target, which is the point Filament releases the previous session's
+/// imported MTLTexture and the plugin can release the parked descriptor.
+Future<void> _pumpOneSessionAndUnmount(
+  WidgetTester tester,
+  ThermionViewer viewer,
+  int width,
+  int height,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: width.toDouble(),
+          height: height.toDouble(),
+          child: ThermionWidget(viewer: viewer),
+        ),
+      ),
+    ),
+  );
+  // Let the descriptor allocate, bind, and render a handful of frames.
+  await tester.pumpAndSettle(const Duration(seconds: 2));
+  for (var i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 16));
+  }
+  // Unmount the widget (destroyTextureForView owns the complete
+  // render-target and descriptor teardown).
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pumpAndSettle(const Duration(seconds: 1));
+}
+
+/// Give the engine, the Dart GC, and Metal's deferred-release queue time to
+/// settle before sampling phys_footprint.
+Future<void> _drain(WidgetTester tester) async {
+  // Pump a few frames so the Dart GC and Metal's autorelease pool can run,
+  // then wait in REAL time: the native passRetained(+1) is parked at dispose
+  // and only drained at the next allocate, age-gated to >= 2 s of wall clock
+  // (CFAbsoluteTimeGetCurrent, which pumps do not advance). Waiting past 2 s
+  // here ensures the next session's allocate drains the previous park, and
+  // its RT replacement releases the parked descriptor — so the previous
+  // session's surface has actually freed before we sample.
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 16));
+  }
+  await Future<void>.delayed(const Duration(milliseconds: 2500));
+}
+
+/// Thin FFI wrapper around the mach `task_info` call.
+///
+/// We bind this directly rather than going through a plugin channel so the
+/// measurement itself can't perturb the heap in a way that masks the leak.
+class _DarwinMemory {
+  static final DynamicLibrary _lib = DynamicLibrary.process();
+
+  // kern_return_t task_info(task_name_t target, task_flavor_t flavor,
+  //                         task_info_t task_info_out,
+  //                         mach_msg_type_number_t *task_info_count);
+  //
+  // task_name_t / task_flavor_t / mach_msg_type_number_t are all natural_t
+  // (uint32) on 64-bit darwin, and mach_port_t is uint32. We bind the
+  // integer args as Uint32 so the values aren't misread.
+  static final int Function(int, int, Pointer<Uint8>, Pointer<Uint32>)
+      _taskInfo = _lib.lookupFunction<
+          Int32 Function(
+            Uint32,
+            Uint32,
+            Pointer<Uint8>,
+            Pointer<Uint32>,
+          ),
+          int Function(
+            int,
+            int,
+            Pointer<Uint8>,
+            Pointer<Uint32>,
+          )>('task_info');
+
+  // mach_port_t mach_task_self(void);  (mach_port_t == uint32)
+  static final int Function() _machTaskSelf = _lib.lookupFunction<
+      Uint32 Function(),
+      int Function()>('mach_task_self');
+
+  // TASK_VM_INFO flavor. phys_footprint lives in this struct.
+  static const _taskVmInfoFlavor = 22;
+  // Buffer capacity in natural_t (uint32) units. task_info writes at most
+  // the full task_vm_info_data_t (rev7, ~400 bytes); 256 uint32 = 1 KB is
+  // comfortably past that. We pass this as the in count so the kernel
+  // doesn't reject the call with KERN_INVALID_ARGUMENT.
+  static const _bufferNaturalCount = 256;
+
+  /// Returns the process's phys_footprint in bytes, or -1 on failure.
+  ///
+  /// phys_footprint is the memory the kernel considers "owned" by the
+  /// process — it drops when IOSurfaces and MTLTextures are actually
+  /// released, even if the underlying allocation came from a shared GPU
+  /// pool. That makes it the right signal for this leak: a retained
+  /// MTLTexture keeps its IOSurface alive and phys_footprint stays high.
+  static int physFootprintBytes() {
+    if (!Platform.isMacOS && !Platform.isIOS) return -1;
+
+    final buffer = calloc<Uint8>(_bufferNaturalCount * 4);
+    final outCount = calloc<Uint32>();
+    try {
+      // count is in/out: set to the buffer capacity (in natural_t units)
+      // before the call; the kernel returns the count it actually filled.
+      outCount.value = _bufferNaturalCount;
+      final kr = _taskInfo(
+        _machTaskSelf(),
+        _taskVmInfoFlavor,
+        buffer,
+        outCount,
+      );
+      if (kr != 0) return -1;
+
+      // task_vm_info layout (see mach/mach/task_info.h):
+      //   u64 virtual_size          // offset 0
+      //   i32 region_count          // offset 8
+      //   i32 page_size             // offset 12
+      //   u64 resident_size         // offset 16
+      //   u64 resident_size_peak    // offset 24
+      //   u64 device                // offset 32
+      //   u64 device_peak           // offset 40
+      //   u64 internal              // offset 48
+      //   u64 internal_peak         // offset 56
+      //   u64 external              // offset 64
+      //   u64 external_peak         // offset 72
+      //   u64 reusable              // offset 80
+      //   u64 reusable_peak         // offset 88
+      //   u64 purgeable_volatile_pmap       // offset 96
+      //   u64 purgeable_volatile_resident   // offset 104
+      //   u64 purgeable_volatile_virtual    // offset 112
+      //   u64 compressed            // offset 120
+      //   u64 compressed_peak       // offset 128
+      //   u64 compressed_lifetime   // offset 136
+      //   u64 phys_footprint        // offset 144
+      final u64 = buffer.cast<Uint64>();
+      return u64[18]; // 18 * 8 = 144 bytes
+    } finally {
+      calloc.free(buffer);
+      calloc.free(outCount);
+    }
+  }
+}

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
@@ -19,6 +19,32 @@ bool shouldDeferNativeTextureBinding({
   return !managesFilamentSurface && hardwareId == 0 && supportsDeferredBinding;
 }
 
+/// Destroys a render target before the textures it references.
+///
+/// Exposed for regression tests because reversing this order can free imported
+/// platform memory while Filament still retains it through the render target.
+@visibleForTesting
+Future<void> destroyRenderTargetResourcesInOrder({
+  required Future<void> Function()? destroyRenderTarget,
+  required Future<void> Function()? destroyColorTexture,
+  required Future<void> Function()? destroyDepthTexture,
+}) async {
+  await destroyRenderTarget?.call();
+  await destroyColorTexture?.call();
+  await destroyDepthTexture?.call();
+}
+
+class _FilamentResourceRollbackFailure implements Exception {
+  const _FilamentResourceRollbackFailure(this.cause);
+
+  final Object cause;
+
+  @override
+  String toString() =>
+      'Could not safely roll back partially-created Filament resources: '
+      '$cause';
+}
+
 /// Owns native platform texture descriptors and their Filament resources.
 ///
 /// Allocation, view binding, resize, deferred cleanup, and destruction stay in
@@ -99,25 +125,43 @@ class NativeTextureSurfaceManager {
     int width,
     int height,
   ) {
-    return registry.serialized(() => _createAndBind(view, width, height));
+    return registry.serialized(
+      () => _lifecycle.duringTextureMutation(
+        () => _createAndBind(view, width, height),
+      ),
+    );
   }
 
   Future<PlatformTextureDescriptor> _createAndBind(
     View view,
     int width,
-    int height,
-  ) async {
+    int height, {
+    PlatformTextureDescriptor? destroyAfterDeferredBinding,
+  }) async {
     if (width == 0 || height == 0) {
       throw ArgumentError(
         'Invalid dimensions for texture descriptor: ${width}x$height',
       );
     }
 
+    final previousBindings = registry.descriptors
+        .where((descriptor) => descriptor.boundView == view)
+        .toList();
     final descriptor = await registry.create(width, height);
     try {
+      // Complete the only fallible view mutation shared by descriptor-managed
+      // surfaces before replacing their existing binding.
+      await view.setViewport(width, height);
+
+      final mayRequireDeferredBinding =
+          descriptor.hardwareId == 0 && descriptor.deferred;
       final managesFilamentSurface = await registry.bindToView(
         descriptor,
         view,
+        // Keep the previous descriptor associated with this view until the
+        // deferred replacement has a Filament target. Teardown can then find
+        // and destroy both descriptors if the widget unmounts while waiting.
+        releaseExistingBindings: !mayRequireDeferredBinding,
       );
 
       // Prefer a hardware handle returned by native allocation. In particular,
@@ -132,7 +176,15 @@ class NativeTextureSurfaceManager {
       )) {
         // Some Linux EGL/OpenGL paths can only publish the hardware texture
         // from Flutter's populate callback, after the Texture widget exists.
-        unawaited(_completeDeferredBinding(descriptor, view, width, height));
+        unawaited(
+          _completeDeferredBinding(
+            descriptor,
+            view,
+            width,
+            height,
+            destroyAfterBinding: destroyAfterDeferredBinding,
+          ),
+        );
       } else if (!managesFilamentSurface) {
         throw StateError(
           'Platform texture did not provide a hardware handle and does not '
@@ -140,10 +192,18 @@ class NativeTextureSurfaceManager {
         );
       }
 
-      await view.setViewport(width, height);
       return descriptor;
     } catch (error, stackTrace) {
-      await _destroyAfterBindingFailure(descriptor);
+      if (error is _FilamentResourceRollbackFailure) {
+        // The descriptor's platform memory must outlive the Filament objects
+        // that could not be destroyed. Detach it from the view but deliberately
+        // keep both the descriptor and its native allocation alive.
+        await descriptor.releaseBinding();
+        _logger.severe(error);
+      } else {
+        await _destroyAfterBindingFailure(descriptor);
+      }
+      await _restoreBindingsAfterFailure(previousBindings, view);
       Error.throwWithStackTrace(error, stackTrace);
     }
   }
@@ -152,25 +212,42 @@ class NativeTextureSurfaceManager {
     PlatformTextureDescriptor descriptor,
     View view,
     int width,
-    int height,
-  ) async {
+    int height, {
+    PlatformTextureDescriptor? destroyAfterBinding,
+  }) async {
     try {
       final hardwareId = await descriptor.awaitTextureReady();
       await registry.serialized(() async {
         if (!registry.contains(descriptor) || descriptor.destroyed) return;
-        descriptor.hardwareId = hardwareId;
-        _logger.info(
-          'Deferred texture ready: flutter=${descriptor.flutterTextureId} '
-          'hardware=$hardwareId',
-        );
-        await _createFilamentResources(descriptor, view, width, height);
+        await _lifecycle.duringTextureMutation(() async {
+          if (!registry.contains(descriptor) || descriptor.destroyed) return;
+          descriptor.hardwareId = hardwareId;
+          _logger.info(
+            'Deferred texture ready: flutter=${descriptor.flutterTextureId} '
+            'hardware=$hardwareId',
+          );
+          await _createFilamentResources(descriptor, view, width, height);
+          if (destroyAfterBinding != null &&
+              registry.contains(destroyAfterBinding)) {
+            await registry.destroy(destroyAfterBinding);
+          }
+        });
       });
     } catch (error, stackTrace) {
       _logger.warning('Deferred texture binding failed', error, stackTrace);
+      if (error is _FilamentResourceRollbackFailure) {
+        // Keep the platform allocation alive for any Filament object whose
+        // rollback failed. It remains registry-owned until engine shutdown.
+        await registry.serialized(descriptor.releaseBinding);
+        _logger.severe(error);
+        return;
+      }
       try {
         await registry.serialized(() async {
           if (registry.contains(descriptor)) {
-            await registry.destroy(descriptor);
+            await _lifecycle.duringTextureMutation(
+              () => registry.destroy(descriptor),
+            );
           }
         });
       } catch (cleanupError, cleanupStackTrace) {
@@ -197,6 +274,24 @@ class NativeTextureSurfaceManager {
     }
   }
 
+  Future<void> _restoreBindingsAfterFailure(
+    List<PlatformTextureDescriptor> descriptors,
+    View view,
+  ) async {
+    for (final descriptor in descriptors) {
+      if (!registry.contains(descriptor) || descriptor.destroyed) continue;
+      try {
+        await registry.bindToView(descriptor, view);
+      } catch (error, stackTrace) {
+        _logger.warning(
+          'Failed to restore the previous texture binding',
+          error,
+          stackTrace,
+        );
+      }
+    }
+  }
+
   Future<void> _createFilamentResources(
     PlatformTextureDescriptor descriptor,
     View view,
@@ -211,53 +306,72 @@ class NativeTextureSurfaceManager {
       throw StateError('Cannot bind a texture after Filament shutdown');
     }
 
-    final color = await app.createTexture(
-      width,
-      height,
-      importedTextureHandle: useExternalImage ? -1 : descriptor.hardwareId,
-      flags: {
-        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-        TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
-        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
-      },
-      textureFormat: options.renderTargetColorTextureFormat,
-      textureSamplerType: TextureSamplerType.SAMPLER_2D,
-    );
-
-    if (useExternalImage) {
-      await app.setExternalImage(color, descriptor.hardwareId);
-    }
-
-    final depth = await app.createTexture(
-      width,
-      height,
-      flags: {
-        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-        TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT,
-        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
-        TextureUsage.TEXTURE_USAGE_STENCIL_ATTACHMENT,
-      },
-      textureFormat: options.renderTargetDepthTextureFormat,
-      textureSamplerType: TextureSamplerType.SAMPLER_2D,
-    );
-
     final existingRenderTarget = _viewRenderTargets[view];
-    final renderTarget = await app.createRenderTarget(
-      width,
-      height,
-      color: color,
-      depth: depth,
-    );
+    Texture? color;
+    Texture? depth;
+    RenderTarget? renderTarget;
+    try {
+      color = await app.createTexture(
+        width,
+        height,
+        importedTextureHandle: useExternalImage ? -1 : descriptor.hardwareId,
+        flags: {
+          TextureUsage.TEXTURE_USAGE_BLIT_SRC,
+          TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
+          TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+        },
+        textureFormat: options.renderTargetColorTextureFormat,
+        textureSamplerType: TextureSamplerType.SAMPLER_2D,
+      );
 
-    await view.setRenderTarget(renderTarget);
-    _viewRenderTargets[view] = renderTarget;
+      if (useExternalImage) {
+        await app.setExternalImage(color, descriptor.hardwareId);
+      }
 
-    if (existingRenderTarget != null) {
-      await _destroyRenderTarget(existingRenderTarget);
+      depth = await app.createTexture(
+        width,
+        height,
+        flags: {
+          TextureUsage.TEXTURE_USAGE_BLIT_SRC,
+          TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT,
+          TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+          TextureUsage.TEXTURE_USAGE_STENCIL_ATTACHMENT,
+        },
+        textureFormat: options.renderTargetDepthTextureFormat,
+        textureSamplerType: TextureSamplerType.SAMPLER_2D,
+      );
+
+      renderTarget = await app.createRenderTarget(
+        width,
+        height,
+        color: color,
+        depth: depth,
+      );
+
+      // Do every operation that can reject the replacement before publishing
+      // it in _viewRenderTargets or destroying the previous target.
+      final swapChains = await app.getSwapChains();
+      await app.renderManager.attach(view, swapChains.first);
+      await view.setRenderTarget(renderTarget);
+    } catch (error, stackTrace) {
+      final rolledBack = await _destroyCreatedRenderTarget(
+        renderTarget: renderTarget,
+        color: color,
+        depth: depth,
+      );
+      if (!rolledBack) {
+        throw _FilamentResourceRollbackFailure(error);
+      }
+      Error.throwWithStackTrace(error, stackTrace);
     }
 
-    final swapChains = await app.getSwapChains();
-    await app.renderManager.attach(view, swapChains.first);
+    _viewRenderTargets[view] = renderTarget;
+    if (existingRenderTarget != null) {
+      await _destroyRenderTargetBestEffort(
+        existingRenderTarget,
+        'replacing a texture render target',
+      );
+    }
   }
 
   Future<PlatformTextureDescriptor> resize(
@@ -283,8 +397,19 @@ class NativeTextureSurfaceManager {
       return _resizeWindows(texture, view, width, height);
     }
 
-    final newTexture = await _createAndBind(view, width, height);
-    await registry.destroy(texture);
+    final newTexture = await _createAndBind(
+      view,
+      width,
+      height,
+      destroyAfterDeferredBinding: texture,
+    );
+    if (!shouldDeferNativeTextureBinding(
+      managesFilamentSurface: false,
+      hardwareId: newTexture.hardwareId,
+      supportsDeferredBinding: newTexture.deferred,
+    )) {
+      await registry.destroy(texture);
+    }
     return newTexture;
   }
 
@@ -299,57 +424,77 @@ class NativeTextureSurfaceManager {
       width,
       height,
     );
-    final app = FilamentApp.instance;
-    if (app == null) {
-      throw StateError('Cannot resize a texture after Filament shutdown');
-    }
-    final options = _options();
-
-    final color = await app.createTexture(
-      width,
-      height,
-      importedTextureHandle: -1,
-      flags: {
-        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-        TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
-        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
-      },
-      textureFormat: options.renderTargetColorTextureFormat,
-      textureSamplerType: TextureSamplerType.SAMPLER_2D,
-    );
-    await app.setExternalImage(color, externalImage);
-
-    final depth = await app.createTexture(
-      width,
-      height,
-      flags: {
-        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-        TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT,
-        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
-        TextureUsage.TEXTURE_USAGE_STENCIL_ATTACHMENT,
-      },
-      textureFormat: options.renderTargetDepthTextureFormat,
-      textureSamplerType: TextureSamplerType.SAMPLER_2D,
-    );
-
     final existingRenderTarget = _viewRenderTargets[view];
-    final renderTarget = await app.createRenderTarget(
-      width,
-      height,
-      color: color,
-      depth: depth,
-    );
+    Texture? color;
+    Texture? depth;
+    RenderTarget? renderTarget;
+    try {
+      final app = FilamentApp.instance;
+      if (app == null) {
+        throw StateError('Cannot resize a texture after Filament shutdown');
+      }
+      final options = _options();
 
-    await view.setRenderTarget(renderTarget);
+      color = await app.createTexture(
+        width,
+        height,
+        importedTextureHandle: -1,
+        flags: {
+          TextureUsage.TEXTURE_USAGE_BLIT_SRC,
+          TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
+          TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+        },
+        textureFormat: options.renderTargetColorTextureFormat,
+        textureSamplerType: TextureSamplerType.SAMPLER_2D,
+      );
+      await app.setExternalImage(color, externalImage);
+
+      depth = await app.createTexture(
+        width,
+        height,
+        flags: {
+          TextureUsage.TEXTURE_USAGE_BLIT_SRC,
+          TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT,
+          TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+          TextureUsage.TEXTURE_USAGE_STENCIL_ATTACHMENT,
+        },
+        textureFormat: options.renderTargetDepthTextureFormat,
+        textureSamplerType: TextureSamplerType.SAMPLER_2D,
+      );
+
+      renderTarget = await app.createRenderTarget(
+        width,
+        height,
+        color: color,
+        depth: depth,
+      );
+
+      final swapChains = await app.getSwapChains();
+      await app.renderManager.attach(view, swapChains.first);
+      await view.setViewport(width, height);
+      await view.setRenderTarget(renderTarget);
+    } catch (error, stackTrace) {
+      await _destroyCreatedRenderTarget(
+        renderTarget: renderTarget,
+        color: color,
+        depth: depth,
+      );
+      try {
+        await registry.cancelWindowsTextureResize(texture);
+      } catch (cleanupError, cleanupStackTrace) {
+        _logger.severe(
+          'Failed to cancel native Windows texture resize',
+          cleanupError,
+          cleanupStackTrace,
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+
     _viewRenderTargets[view] = renderTarget;
-
     if (existingRenderTarget != null) {
       _deferredRenderTargets.add((existingRenderTarget, 5));
     }
-
-    final swapChains = await app.getSwapChains();
-    await app.renderManager.attach(view, swapChains.first);
-    await view.setViewport(width, height);
 
     texture.hardwareId = externalImage;
     texture.width = width;
@@ -357,22 +502,25 @@ class NativeTextureSurfaceManager {
     return texture;
   }
 
-  Future<void> releaseView(View view) {
+  Future<void> destroyForView(View view) {
     return registry.serialized(
       () => _lifecycle.duringTextureMutation(() async {
-        await registry.releaseBindingsForView(view);
-        await _destroyRenderTargetForView(view);
+        await registry.destroyBindingsForView(
+          view,
+          beforeDescriptorDestroy: () => _destroyRenderTargetForView(view),
+        );
       }),
     );
   }
 
   Future<void> _destroyRenderTargetForView(View view) async {
-    final renderTarget = _viewRenderTargets.remove(view);
+    final renderTarget = _viewRenderTargets[view];
     if (renderTarget == null) return;
 
     final app = FilamentApp.instance;
     if (app == null) {
       // The engine owns resources that survived until shutdown.
+      _viewRenderTargets.remove(view);
       return;
     }
 
@@ -383,13 +531,58 @@ class NativeTextureSurfaceManager {
       await overlay.overlayView.setRenderTarget(null);
     }
     await _destroyRenderTarget(renderTarget);
+    if (identical(_viewRenderTargets[view], renderTarget)) {
+      _viewRenderTargets.remove(view);
+    }
   }
 
   Future<void> _destroyRenderTarget(RenderTarget renderTarget) async {
     final color = await renderTarget.getColorTexture();
     final depth = await renderTarget.getDepthTexture();
-    await renderTarget.destroy();
-    await color.destroy();
-    await depth.destroy();
+    await destroyRenderTargetResourcesInOrder(
+      destroyRenderTarget: renderTarget.destroy,
+      destroyColorTexture: color.destroy,
+      destroyDepthTexture: depth.destroy,
+    );
+  }
+
+  Future<bool> _destroyCreatedRenderTarget({
+    required RenderTarget? renderTarget,
+    required Texture? color,
+    required Texture? depth,
+  }) async {
+    try {
+      await destroyRenderTargetResourcesInOrder(
+        destroyRenderTarget: renderTarget?.destroy,
+        destroyColorTexture: color?.destroy,
+        destroyDepthTexture: depth?.destroy,
+      );
+      return true;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Failed to roll back partially-created Filament resources',
+        error,
+        stackTrace,
+      );
+      return false;
+    }
+  }
+
+  Future<void> _destroyRenderTargetBestEffort(
+    RenderTarget renderTarget,
+    String operation,
+  ) async {
+    try {
+      await _destroyRenderTarget(renderTarget);
+    } catch (error, stackTrace) {
+      // The replacement is already committed. Do not tear it back down because
+      // cleanup of the superseded target failed; retain the old resources and
+      // keep the new surface usable.
+      _logger.warning(
+        'Failed while $operation; retaining superseded resources',
+        error,
+        stackTrace,
+      );
+    }
   }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
@@ -45,6 +45,11 @@ abstract class PlatformTextureDescriptor {
   void markTextureFrameAvailable();
 
   /// Schedules this texture for destruction.
+  ///
+  /// Package code should normally call
+  /// `ThermionFlutterPlugin.destroyTextureForView` so any Filament
+  /// resource that imports this descriptor's platform memory is destroyed
+  /// first. This low-level method exists for descriptor owners and rollback.
   /// Idempotent; it is safe to call this method multiple times on the same
   /// [PlatformTextureDescriptor].
   Future<void> destroy();

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry.dart
@@ -46,16 +46,19 @@ class PlatformTextureDescriptorRegistry {
   /// target backed by [PlatformTextureDescriptor.hardwareId].
   Future<bool> bindToView(
     PlatformTextureDescriptor descriptor,
-    View view,
-  ) async {
+    View view, {
+    bool releaseExistingBindings = true,
+  }) async {
     if (!contains(descriptor)) {
       throw StateError('Cannot bind an unregistered texture descriptor');
     }
 
     final managesFilamentSurface = await descriptor.bindToView(view);
-    for (final other in List<PlatformTextureDescriptor>.of(_descriptors)) {
-      if (!identical(other, descriptor) && other.boundView == view) {
-        await other.releaseBinding();
+    if (releaseExistingBindings) {
+      for (final other in List<PlatformTextureDescriptor>.of(_descriptors)) {
+        if (!identical(other, descriptor) && other.boundView == view) {
+          await other.releaseBinding();
+        }
       }
     }
     return managesFilamentSurface;
@@ -84,6 +87,62 @@ class PlatformTextureDescriptorRegistry {
       _remove(descriptor);
     }
     return released;
+  }
+
+  /// Releases every descriptor bound to [view], runs
+  /// [beforeDescriptorDestroy], then destroys the released descriptors.
+  ///
+  /// The callback is where a native owner tears down Filament render targets.
+  /// Keeping descriptor destruction here makes the required dependency order
+  /// explicit:
+  ///
+  /// 1. detach descriptor-managed surfaces such as Android swapchains;
+  /// 2. destroy Filament objects that reference platform memory;
+  /// 3. release the underlying platform textures.
+  Future<void> destroyBindingsForView(
+    View view, {
+    FutureOr<void> Function()? beforeDescriptorDestroy,
+  }) async {
+    final released = _descriptors
+        .where((descriptor) => descriptor.boundView == view)
+        .toList();
+    for (final descriptor in released) {
+      await descriptor.releaseBinding();
+    }
+
+    try {
+      await beforeDescriptorDestroy?.call();
+    } catch (error, stackTrace) {
+      // Keep the descriptors owned and recover their view association so a
+      // caller can retry teardown. Android also recreates its swapchain here;
+      // the platform surface is deliberately still alive.
+      for (final descriptor in released) {
+        if (!descriptor.destroyed) {
+          try {
+            await descriptor.bindToView(view);
+          } catch (_) {
+            // Preserve the teardown error. The descriptor remains tracked even
+            // if restoring a platform binding is itself unsuccessful.
+          }
+        }
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+
+    Object? firstError;
+    StackTrace? firstStackTrace;
+    for (final descriptor in released) {
+      try {
+        await descriptor.destroy();
+        _remove(descriptor);
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
+    }
   }
 
   void markFrameAvailable() {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry_native.dart
@@ -133,6 +133,15 @@ class NativePlatformTextureDescriptorRegistry
     return result.first as int;
   }
 
+  Future<void> cancelWindowsTextureResize(
+    PlatformTextureDescriptor descriptor,
+  ) {
+    return channel.invokeMethod<void>(
+      'cancelResizeTexture',
+      descriptor.flutterTextureId,
+    );
+  }
+
   PlatformTextureDescriptor? _descriptorForTextureId(int textureId) {
     for (final descriptor in descriptors) {
       if (descriptor.flutterTextureId == textureId) {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -149,7 +149,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   }
 
   @override
-  Future<void> releaseTextureBindingForView(View view) {
-    return _textureSurfaces.releaseView(view);
+  Future<void> destroyTextureForView(View view) {
+    return _textureSurfaces.destroyForView(view);
   }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
@@ -248,9 +248,9 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
   }
 
   @override
-  Future<void> releaseTextureBindingForView(View view) {
+  Future<void> destroyTextureForView(View view) {
     return _textureDescriptorRegistry.serialized(() async {
-      await _textureDescriptorRegistry.releaseBindingsForView(view);
+      await _textureDescriptorRegistry.destroyBindingsForView(view);
     });
   }
 

--- a/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
@@ -56,17 +56,17 @@ abstract class ThermionFlutterPlugin {
     int height,
   );
 
-  /// Release plugin-side resources bound to this view (e.g. the per-view
-  /// `SwapChain` the Android plugin tracks). Call this BEFORE destroying
-  /// the underlying texture / surface descriptor — otherwise on Android
-  /// the SurfaceTexture is released first, the swap chain's native
-  /// window becomes invalid, and Filament's next `eglSwapBuffers` call
-  /// for that swap chain returns `EGL_BAD_SURFACE` until the widget
-  /// finishes unmounting.
+  /// Releases every texture resource bound to [view].
   ///
-  /// Safe to call on platforms that don't track per-view bindings (e.g.
-  /// the web plugin) — it's a no-op there.
-  Future<void> releaseTextureBindingForView(View view);
+  /// Implementations must detach descriptor-managed surfaces, destroy
+  /// Filament render targets, and only then destroy the underlying platform
+  /// texture. Descriptors previously bound to [view] are invalid after this
+  /// future completes.
+  Future<void> destroyTextureForView(View view);
+
+  @Deprecated('Use destroyTextureForView')
+  Future<void> releaseTextureBindingForView(View view) =>
+      destroyTextureForView(view);
 
   static Future<ThermionViewer> createViewer({
     bool destroySwapchain = true,

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -86,13 +86,12 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
     _debounceTimer?.cancel();
     final view = widget.view;
     _enqueueTextureOperation(() async {
-      // Release a per-view surface binding before destroying its platform
-      // texture. Serializing this after allocation/resize also guarantees the
-      // final descriptor is destroyed exactly once.
-      await ThermionFlutterPlugin.instance.releaseTextureBindingForView(view);
-      final texture = _texture;
+      // The plugin owns the complete dependency-ordered teardown: detach any
+      // descriptor-managed surface, destroy Filament render targets, then
+      // release the platform texture. Serializing this after allocation/resize
+      // also guarantees the final descriptor is destroyed exactly once.
+      await ThermionFlutterPlugin.instance.destroyTextureForView(view);
       _texture = null;
-      await texture?.destroy();
     }, 'disposing a Thermion widget texture');
     super.dispose();
   }

--- a/thermion_flutter/thermion_flutter/test/native_texture_surface_manager_test.dart
+++ b/thermion_flutter/thermion_flutter/test/native_texture_surface_manager_test.dart
@@ -36,4 +36,39 @@ void main() {
       );
     });
   });
+
+  group('destroyRenderTargetResourcesInOrder', () {
+    test('destroys the target before its attachment textures', () async {
+      final events = <String>[];
+
+      await destroyRenderTargetResourcesInOrder(
+        destroyRenderTarget: () async => events.add('render-target'),
+        destroyColorTexture: () async => events.add('color'),
+        destroyDepthTexture: () async => events.add('depth'),
+      );
+
+      expect(events, ['render-target', 'color', 'depth']);
+    });
+
+    test(
+      'keeps attachment textures alive when target destruction fails',
+      () async {
+        final events = <String>[];
+
+        await expectLater(
+          destroyRenderTargetResourcesInOrder(
+            destroyRenderTarget: () async {
+              events.add('render-target');
+              throw StateError('expected');
+            },
+            destroyColorTexture: () async => events.add('color'),
+            destroyDepthTexture: () async => events.add('depth'),
+          ),
+          throwsStateError,
+        );
+
+        expect(events, ['render-target']);
+      },
+    );
+  });
 }

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_registry_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_registry_test.dart
@@ -118,6 +118,117 @@ void main() {
       expect(registry.descriptors.single, same(first));
     });
 
+    test('can retain an old binding during deferred replacement', () async {
+      var nextTextureId = 1;
+      final registry = PlatformTextureDescriptorRegistry(
+        allocator: (width, height) => _TestDescriptor(
+          width: width,
+          height: height,
+          flutterTextureId: nextTextureId++,
+        ),
+      );
+      final view = _TestView();
+      final first = await registry.create(1, 1) as _TestDescriptor;
+      final second = await registry.create(1, 1) as _TestDescriptor;
+      await registry.bindToView(first, view);
+
+      await registry.bindToView(second, view, releaseExistingBindings: false);
+
+      expect(first.boundView, same(view));
+      expect(second.boundView, same(view));
+
+      await registry.destroyBindingsForView(view);
+      expect(first.destroyCount, 1);
+      expect(second.destroyCount, 1);
+    });
+
+    test('destroys platform descriptors after view-owned resources', () async {
+      final events = <String>[];
+      final descriptor = _TestDescriptor(
+        width: 1,
+        height: 1,
+        lifecycleEvents: events,
+      );
+      final registry = PlatformTextureDescriptorRegistry(
+        allocator: (_, __) => descriptor,
+      );
+      final view = _TestView();
+      await registry.create(1, 1);
+      await registry.bindToView(descriptor, view);
+
+      await registry.destroyBindingsForView(
+        view,
+        beforeDescriptorDestroy: () async {
+          events.add('destroy-view-resources');
+        },
+      );
+
+      expect(events, [
+        'release-binding',
+        'destroy-view-resources',
+        'destroy-platform-texture',
+      ]);
+      expect(registry.contains(descriptor), isFalse);
+    });
+
+    test(
+      'keeps the platform texture alive when view-resource cleanup fails',
+      () async {
+        final descriptor = _TestDescriptor(width: 1, height: 1);
+        final registry = PlatformTextureDescriptorRegistry(
+          allocator: (_, __) => descriptor,
+        );
+        final view = _TestView();
+        await registry.create(1, 1);
+        await registry.bindToView(descriptor, view);
+
+        await expectLater(
+          registry.destroyBindingsForView(
+            view,
+            beforeDescriptorDestroy: () => throw StateError('expected'),
+          ),
+          throwsStateError,
+        );
+
+        expect(descriptor.releaseBindingCount, 1);
+        expect(descriptor.destroyCount, 0);
+        expect(descriptor.boundView, same(view));
+        expect(registry.contains(descriptor), isTrue);
+      },
+    );
+
+    test(
+      'attempts every platform texture destroy after target cleanup',
+      () async {
+        var nextTextureId = 1;
+        final registry = PlatformTextureDescriptorRegistry(
+          allocator: (width, height) {
+            return _TestDescriptor(
+              width: width,
+              height: height,
+              flutterTextureId: nextTextureId++,
+            );
+          },
+        );
+        final view = _TestView();
+        final first = await registry.create(1, 1) as _TestDescriptor;
+        final second = await registry.create(1, 1) as _TestDescriptor;
+        await registry.bindToView(first, view);
+        await registry.bindToView(second, view, releaseExistingBindings: false);
+        first.throwOnDestroy = true;
+
+        await expectLater(
+          registry.destroyBindingsForView(view),
+          throwsStateError,
+        );
+
+        expect(first.destroyCount, 1);
+        expect(second.destroyCount, 1);
+        expect(registry.contains(first), isTrue);
+        expect(registry.contains(second), isFalse);
+      },
+    );
+
     test('serializes operations and continues after failures', () async {
       final registry = PlatformTextureDescriptorRegistry(
         allocator: (width, height) =>
@@ -157,13 +268,16 @@ class _TestDescriptor extends PlatformTextureDescriptor {
     required super.width,
     required super.height,
     int flutterTextureId = 1,
+    this.lifecycleEvents,
   }) : super(flutterTextureId: flutterTextureId, hardwareId: 2);
 
+  final List<String>? lifecycleEvents;
   int markFrameAvailableCount = 0;
   int releaseBindingCount = 0;
   int destroyCount = 0;
   bool _destroyed = false;
   bool _surfaceAvailable = true;
+  bool throwOnDestroy = false;
 
   @override
   bool get destroyed => _destroyed;
@@ -184,14 +298,19 @@ class _TestDescriptor extends PlatformTextureDescriptor {
   @override
   Future<void> releaseBinding() async {
     releaseBindingCount++;
+    lifecycleEvents?.add('release-binding');
     await super.releaseBinding();
   }
 
   @override
   Future<void> destroy() async {
     if (_destroyed) return;
-    _destroyed = true;
     destroyCount++;
+    lifecycleEvents?.add('destroy-platform-texture');
+    if (throwOnDestroy) {
+      throw StateError('expected');
+    }
+    _destroyed = true;
   }
 }
 

--- a/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
+++ b/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
@@ -418,6 +418,25 @@ namespace thermion::tflutter::windows
     {
       ResizeTexture(methodCall, std::move(result));
     }
+    else if (methodCall.method_name() == "cancelResizeTexture")
+    {
+      const auto *flutterTextureId =
+          std::get_if<int64_t>(methodCall.arguments());
+      if (!flutterTextureId) {
+        result->Error("BAD_ARGUMENT", "Missing Flutter texture ID");
+        return;
+      }
+
+      std::lock_guard<std::mutex> contextLock(_contextMutex);
+      auto pendingIt = _pendingSwaps.find(*flutterTextureId);
+      if (pendingIt != _pendingSwaps.end()) {
+        if (_context) {
+          _context->DestroyRenderingSurface(pendingIt->second.newD3DHandle);
+        }
+        _pendingSwaps.erase(pendingIt);
+      }
+      result->Success(flutter::EncodableValue((int64_t) nullptr));
+    }
     else if (methodCall.method_name() == "markTextureFrameAvailable")
     {
       std::lock_guard<std::mutex> contextLock(_contextMutex);


### PR DESCRIPTION
PR 4 of 4 in the platform texture lifecycle stack.
- makes texture replacement transactional and safely rolls back partial allocation failures
- serializes resize/dispose work and preserves platform-specific destruction ordering
- defers descriptor destruction until native surfaces are detached
- hardens Windows backing-texture retirement
- adds lifecycle/rollback coverage and a Darwin repeated create-dispose leak regression test