### PR TITLE
Extract native platform texture lifecycle management

### DIFF
--- a/thermion_dart/native/src/vulkan/windows/WindowsVulkanContext.cpp
+++ b/thermion_dart/native/src/vulkan/windows/WindowsVulkanContext.cpp
@@ -196,6 +196,7 @@ class WindowsVulkanContext::Impl {
 
         void DestroyRenderingSurface(HANDLE handle) {
             std::cerr << "Destroying rendering surface " << handle << std::endl;
+            _pendingFirstBlit.erase(handle);
 
             // Find index of the D3D texture with this handle and remove from all three vectors
             for (size_t i = 0; i < _d3dTextures.size(); i++) {

--- a/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
+++ b/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
@@ -55,6 +55,32 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
   private lateinit var activity:Activity
 
+  private fun notifyDartBeforeReleasingSurface(
+      method: String,
+      arguments: Any,
+      surface: Surface?
+  ) {
+      channel.invokeMethod(method, arguments, object : MethodChannel.Result {
+          override fun success(result: Any?) {
+              surface?.release()
+          }
+
+          override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+              Log.e(
+                  TAG,
+                  "$method failed before releasing the Android surface: " +
+                      "$errorCode ${errorMessage ?: ""}"
+              )
+              surface?.release()
+          }
+
+          override fun notImplemented() {
+              Log.e(TAG, "$method was not handled before releasing the Android surface")
+              surface?.release()
+          }
+      })
+  }
+
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     this.flutterPluginBinding = flutterPluginBinding
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, CHANNEL_NAME)
@@ -120,9 +146,13 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 producer.setCallback(object : TextureRegistry.SurfaceProducer.Callback {
                     override fun onSurfaceCleanup() {
                         val entry = textures[flutterTextureId] ?: return
-                        entry.surface?.release()
+                        val surfaceToRelease = entry.surface
                         entry.surface = null
-                        channel.invokeMethod("onSurfaceCleanup", flutterTextureId)
+                        notifyDartBeforeReleasingSurface(
+                            "onSurfaceCleanup",
+                            flutterTextureId,
+                            surfaceToRelease
+                        )
                     }
 
                     override fun onSurfaceAvailable() {
@@ -151,11 +181,12 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                             return
                         }
 
-                        entry.surface?.release()
+                        val surfaceToRelease = entry.surface
                         entry.surface = newSurface
-                        channel.invokeMethod(
+                        notifyDartBeforeReleasingSurface(
                             "onSurfaceAvailable",
-                            listOf(flutterTextureId, newNativeWindowPtr)
+                            listOf(flutterTextureId, newNativeWindowPtr),
+                            surfaceToRelease
                         )
                     }
                 })

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
@@ -1,0 +1,199 @@
+import 'dart:async';
+import 'dart:ffi' as ffi;
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:logging/logging.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+// ignore: implementation_imports
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+import 'frame_scheduler.dart';
+
+enum _RenderingPauseReason { explicit, lifecycle, textureMutation }
+
+/// Coordinates Flutter lifecycle events with Thermion's frame scheduler.
+///
+/// Texture ownership remains outside this class. Callers provide the
+/// registry-derived surface availability check and the work that should run
+/// after each rendered frame.
+class NativeRenderingLifecycleController with WidgetsBindingObserver {
+  NativeRenderingLifecycleController({
+    required bool Function() hasUnavailableSurfaces,
+    required Future<void> Function() onFrameRendered,
+  }) : _hasUnavailableSurfaces = hasUnavailableSurfaces,
+       _onFrameRendered = onFrameRendered;
+
+  static final _logger = Logger('NativeRenderingLifecycleController');
+
+  final bool Function() _hasUnavailableSurfaces;
+  final Future<void> Function() _onFrameRendered;
+  final _pauseReasons = <_RenderingPauseReason>{};
+
+  bool get _shouldPauseRendering =>
+      _pauseReasons.isNotEmpty || _hasUnavailableSurfaces();
+
+  /// Stops callbacks left by a previous initialization and removes this
+  /// observer before the engine is initialized again.
+  void prepareForInitialization() {
+    FrameScheduler.instance.stop();
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  /// Starts the appropriate frame scheduling mode for the current platform.
+  Future<void> start() async {
+    FrameScheduler.instance.setOnFrame(_renderFrame);
+
+    if (Platform.isLinux) {
+      await _startFlutterSynced();
+    } else {
+      await FrameScheduler.instance.start();
+    }
+
+    WidgetsBinding.instance.addObserver(this);
+    _syncLifecycleState();
+    if (_shouldPauseRendering) {
+      FrameScheduler.instance.pause();
+    }
+  }
+
+  void stop() {
+    FrameScheduler.instance.stop();
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  void pauseExplicitly() {
+    _pauseReasons.add(_RenderingPauseReason.explicit);
+    FrameScheduler.instance.pause();
+  }
+
+  void resumeExplicitly() {
+    _pauseReasons.remove(_RenderingPauseReason.explicit);
+    resumeRenderingIfReady();
+  }
+
+  /// Pauses rendering for registry-owned surface availability callbacks.
+  ///
+  /// Surface availability is intentionally not copied into [_pauseReasons]:
+  /// multiple descriptors can be unavailable independently, so the registry
+  /// remains the source of truth.
+  void pauseRendering() {
+    FrameScheduler.instance.pause();
+  }
+
+  void resumeRenderingIfReady() {
+    if (!_shouldPauseRendering) {
+      FrameScheduler.instance.resume();
+    }
+  }
+
+  /// Drains the current frame and Filament render thread before [operation].
+  ///
+  /// The texture mutation reason composes with explicit and lifecycle pauses,
+  /// so completing the operation never resumes rendering prematurely.
+  Future<T> duringTextureMutation<T>(Future<T> Function() operation) async {
+    _pauseReasons.add(_RenderingPauseReason.textureMutation);
+    FrameScheduler.instance.pause();
+    try {
+      while (FrameScheduler.instance.isRendering) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+      await FilamentApp.instance?.flush();
+      return await operation();
+    } finally {
+      _pauseReasons.remove(_RenderingPauseReason.textureMutation);
+      resumeRenderingIfReady();
+    }
+  }
+
+  Future<void> _startFlutterSynced() async {
+    final dylib = ffi.DynamicLibrary.process();
+    final getHandleFn = dylib
+        .lookupFunction<
+          ffi.Pointer<ffi.Void> Function(),
+          ffi.Pointer<ffi.Void> Function()
+        >('thermion_flutter_get_plugin_handle');
+    final pluginHandle = getHandleFn();
+    final markTexturesFnPtr = dylib
+        .lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'thermion_flutter_mark_textures',
+        );
+
+    final app = FilamentApp.instance as FFIFilamentApp;
+    await FrameScheduler.instance.startFlutterSynced(
+      renderThreadHandle: app.renderThreadHandle,
+      renderManagerHandle: app.renderManager.getNativeHandle(),
+      postRenderCallback: markTexturesFnPtr,
+      postRenderUserData: pluginHandle,
+    );
+  }
+
+  Future<void> _renderFrame() async {
+    final app = FilamentApp.instance;
+    if (app == null) return;
+
+    await app.render();
+    await _onFrameRendered();
+  }
+
+  bool _suspendForLifecycle() {
+    if (!_pauseReasons.add(_RenderingPauseReason.lifecycle)) return false;
+
+    if (Platform.isLinux) {
+      // Linux registers one persistent Flutter frame callback. Keep it
+      // registered, but stop it from re-arming while the app is hidden.
+      FrameScheduler.instance.pause();
+    } else {
+      FrameScheduler.instance.stop();
+    }
+    return true;
+  }
+
+  Future<void> _resumeFromLifecycle() async {
+    if (!_pauseReasons.remove(_RenderingPauseReason.lifecycle)) return;
+    if (FilamentApp.instance == null) return;
+
+    if (Platform.isLinux) {
+      resumeRenderingIfReady();
+    } else {
+      await FrameScheduler.instance.start();
+      if (_shouldPauseRendering) {
+        FrameScheduler.instance.pause();
+      } else {
+        FrameScheduler.instance.resume();
+      }
+    }
+    _logger.info('App foregrounded, frame scheduler resumed');
+  }
+
+  void _syncLifecycleState() {
+    final state = WidgetsBinding.instance.lifecycleState;
+    if (state != null) {
+      didChangeAppLifecycleState(state);
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.detached:
+        if (_suspendForLifecycle()) {
+          _logger.info('App hidden, frame scheduler suspended');
+        }
+        break;
+      case AppLifecycleState.resumed:
+        unawaited(
+          _resumeFromLifecycle().catchError((Object error) {
+            _logger.severe('Failed to resume frame scheduler: $error');
+          }),
+        );
+        break;
+      case AppLifecycleState.inactive:
+        // The app can remain visible while inactive (split screen, system UI,
+        // or an unfocused desktop window), so rendering remains enabled.
+        break;
+    }
+  }
+}

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
@@ -1,0 +1,395 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_flutter/src/options.dart';
+
+import 'native_rendering_lifecycle_controller.dart';
+import 'platform_texture_descriptor.dart';
+import 'platform_texture_descriptor_registry_native.dart';
+
+@visibleForTesting
+bool shouldDeferNativeTextureBinding({
+  required bool managesFilamentSurface,
+  required int hardwareId,
+  required bool supportsDeferredBinding,
+}) {
+  return !managesFilamentSurface && hardwareId == 0 && supportsDeferredBinding;
+}
+
+/// Owns native platform texture descriptors and their Filament resources.
+///
+/// Allocation, view binding, resize, deferred cleanup, and destruction stay in
+/// one place so imported platform memory always outlives the Filament render
+/// target that refers to it.
+class NativeTextureSurfaceManager {
+  NativeTextureSurfaceManager({
+    required NativeRenderingLifecycleController lifecycle,
+    required NativeOptions Function() options,
+  }) : _lifecycle = lifecycle,
+       _options = options,
+       registry = NativePlatformTextureDescriptorRegistry(
+         pauseRendering: lifecycle.pauseRendering,
+         resumeRenderingIfReady: lifecycle.resumeRenderingIfReady,
+         runTextureMutation: lifecycle.duringTextureMutation,
+       );
+
+  static final _logger = Logger('NativeTextureSurfaceManager');
+
+  final NativeRenderingLifecycleController _lifecycle;
+  final NativeOptions Function() _options;
+  final NativePlatformTextureDescriptorRegistry registry;
+
+  // The view can be redirected to an internal target in composite highlight
+  // mode, so track the Flutter-facing render target independently.
+  final _viewRenderTargets = <View, RenderTarget>{};
+
+  // Windows keeps old render targets alive briefly while the native side
+  // blits into a pending replacement image.
+  final _deferredRenderTargets = <(RenderTarget, int)>[];
+
+  bool get hasUnavailableSurfaces => registry.hasUnavailableSurfaces;
+
+  Future<FilamentRenderingContext> getFilamentRenderingContext(
+    Backend backend,
+  ) {
+    return registry.getFilamentRenderingContext(backend);
+  }
+
+  Future<void> destroyFilamentRenderingContext() {
+    return registry.destroyFilamentRenderingContext();
+  }
+
+  /// Releases references whose native resources are owned by a dying engine.
+  void onEngineDestroyed() {
+    registry.clear();
+    _viewRenderTargets.clear();
+    _deferredRenderTargets.clear();
+  }
+
+  /// Notifies live descriptors and reaps render targets deferred by Windows
+  /// resize operations.
+  Future<void> onFrameRendered() async {
+    registry.markFrameAvailable();
+
+    if (_deferredRenderTargets.isEmpty) return;
+
+    final ready = <RenderTarget>[];
+    final remaining = <(RenderTarget, int)>[];
+    for (final (renderTarget, frames) in _deferredRenderTargets) {
+      if (frames <= 0) {
+        ready.add(renderTarget);
+      } else {
+        remaining.add((renderTarget, frames - 1));
+      }
+    }
+    _deferredRenderTargets
+      ..clear()
+      ..addAll(remaining);
+
+    for (final renderTarget in ready) {
+      await _destroyRenderTarget(renderTarget);
+    }
+  }
+
+  Future<PlatformTextureDescriptor> createAndBind(
+    View view,
+    int width,
+    int height,
+  ) {
+    return registry.serialized(() => _createAndBind(view, width, height));
+  }
+
+  Future<PlatformTextureDescriptor> _createAndBind(
+    View view,
+    int width,
+    int height,
+  ) async {
+    if (width == 0 || height == 0) {
+      throw ArgumentError(
+        'Invalid dimensions for texture descriptor: ${width}x$height',
+      );
+    }
+
+    final descriptor = await registry.create(width, height);
+    try {
+      final managesFilamentSurface = await registry.bindToView(
+        descriptor,
+        view,
+      );
+
+      // Prefer a hardware handle returned by native allocation. In particular,
+      // Linux Vulkan returns an ExternalVulkanImage pointer here; replacing it
+      // with awaitTextureReady's Flutter-side GL texture ID is invalid.
+      if (!managesFilamentSurface && descriptor.hardwareId != 0) {
+        await _createFilamentResources(descriptor, view, width, height);
+      } else if (shouldDeferNativeTextureBinding(
+        managesFilamentSurface: managesFilamentSurface,
+        hardwareId: descriptor.hardwareId,
+        supportsDeferredBinding: descriptor.deferred,
+      )) {
+        // Some Linux EGL/OpenGL paths can only publish the hardware texture
+        // from Flutter's populate callback, after the Texture widget exists.
+        unawaited(_completeDeferredBinding(descriptor, view, width, height));
+      } else if (!managesFilamentSurface) {
+        throw StateError(
+          'Platform texture did not provide a hardware handle and does not '
+          'support deferred binding',
+        );
+      }
+
+      await view.setViewport(width, height);
+      return descriptor;
+    } catch (error, stackTrace) {
+      await _destroyAfterBindingFailure(descriptor);
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  Future<void> _completeDeferredBinding(
+    PlatformTextureDescriptor descriptor,
+    View view,
+    int width,
+    int height,
+  ) async {
+    try {
+      final hardwareId = await descriptor.awaitTextureReady();
+      await registry.serialized(() async {
+        if (!registry.contains(descriptor) || descriptor.destroyed) return;
+        descriptor.hardwareId = hardwareId;
+        _logger.info(
+          'Deferred texture ready: flutter=${descriptor.flutterTextureId} '
+          'hardware=$hardwareId',
+        );
+        await _createFilamentResources(descriptor, view, width, height);
+      });
+    } catch (error, stackTrace) {
+      _logger.warning('Deferred texture binding failed', error, stackTrace);
+      try {
+        await registry.serialized(() async {
+          if (registry.contains(descriptor)) {
+            await registry.destroy(descriptor);
+          }
+        });
+      } catch (cleanupError, cleanupStackTrace) {
+        _logger.warning(
+          'Failed to clean up deferred texture descriptor',
+          cleanupError,
+          cleanupStackTrace,
+        );
+      }
+    }
+  }
+
+  Future<void> _destroyAfterBindingFailure(
+    PlatformTextureDescriptor descriptor,
+  ) async {
+    try {
+      await registry.destroy(descriptor);
+    } catch (cleanupError, cleanupStackTrace) {
+      _logger.warning(
+        'Failed to clean up texture descriptor after binding failure',
+        cleanupError,
+        cleanupStackTrace,
+      );
+    }
+  }
+
+  Future<void> _createFilamentResources(
+    PlatformTextureDescriptor descriptor,
+    View view,
+    int width,
+    int height,
+  ) async {
+    final options = _options();
+    final useExternalImage =
+        Platform.isWindows || options.backend == Backend.VULKAN;
+    final app = FilamentApp.instance;
+    if (app == null) {
+      throw StateError('Cannot bind a texture after Filament shutdown');
+    }
+
+    final color = await app.createTexture(
+      width,
+      height,
+      importedTextureHandle: useExternalImage ? -1 : descriptor.hardwareId,
+      flags: {
+        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
+        TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
+        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+      },
+      textureFormat: options.renderTargetColorTextureFormat,
+      textureSamplerType: TextureSamplerType.SAMPLER_2D,
+    );
+
+    if (useExternalImage) {
+      await app.setExternalImage(color, descriptor.hardwareId);
+    }
+
+    final depth = await app.createTexture(
+      width,
+      height,
+      flags: {
+        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
+        TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT,
+        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+        TextureUsage.TEXTURE_USAGE_STENCIL_ATTACHMENT,
+      },
+      textureFormat: options.renderTargetDepthTextureFormat,
+      textureSamplerType: TextureSamplerType.SAMPLER_2D,
+    );
+
+    final existingRenderTarget = _viewRenderTargets[view];
+    final renderTarget = await app.createRenderTarget(
+      width,
+      height,
+      color: color,
+      depth: depth,
+    );
+
+    await view.setRenderTarget(renderTarget);
+    _viewRenderTargets[view] = renderTarget;
+
+    if (existingRenderTarget != null) {
+      await _destroyRenderTarget(existingRenderTarget);
+    }
+
+    final swapChains = await app.getSwapChains();
+    await app.renderManager.attach(view, swapChains.first);
+  }
+
+  Future<PlatformTextureDescriptor> resize(
+    PlatformTextureDescriptor texture,
+    View view,
+    int width,
+    int height,
+  ) {
+    return registry.serialized(
+      () => _lifecycle.duringTextureMutation(
+        () => _resize(texture, view, width, height),
+      ),
+    );
+  }
+
+  Future<PlatformTextureDescriptor> _resize(
+    PlatformTextureDescriptor texture,
+    View view,
+    int width,
+    int height,
+  ) async {
+    if (Platform.isWindows) {
+      return _resizeWindows(texture, view, width, height);
+    }
+
+    final newTexture = await _createAndBind(view, width, height);
+    await registry.destroy(texture);
+    return newTexture;
+  }
+
+  Future<PlatformTextureDescriptor> _resizeWindows(
+    PlatformTextureDescriptor texture,
+    View view,
+    int width,
+    int height,
+  ) async {
+    final externalImage = await registry.resizeWindowsTexture(
+      texture,
+      width,
+      height,
+    );
+    final app = FilamentApp.instance;
+    if (app == null) {
+      throw StateError('Cannot resize a texture after Filament shutdown');
+    }
+    final options = _options();
+
+    final color = await app.createTexture(
+      width,
+      height,
+      importedTextureHandle: -1,
+      flags: {
+        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
+        TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
+        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+      },
+      textureFormat: options.renderTargetColorTextureFormat,
+      textureSamplerType: TextureSamplerType.SAMPLER_2D,
+    );
+    await app.setExternalImage(color, externalImage);
+
+    final depth = await app.createTexture(
+      width,
+      height,
+      flags: {
+        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
+        TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT,
+        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
+        TextureUsage.TEXTURE_USAGE_STENCIL_ATTACHMENT,
+      },
+      textureFormat: options.renderTargetDepthTextureFormat,
+      textureSamplerType: TextureSamplerType.SAMPLER_2D,
+    );
+
+    final existingRenderTarget = _viewRenderTargets[view];
+    final renderTarget = await app.createRenderTarget(
+      width,
+      height,
+      color: color,
+      depth: depth,
+    );
+
+    await view.setRenderTarget(renderTarget);
+    _viewRenderTargets[view] = renderTarget;
+
+    if (existingRenderTarget != null) {
+      _deferredRenderTargets.add((existingRenderTarget, 5));
+    }
+
+    final swapChains = await app.getSwapChains();
+    await app.renderManager.attach(view, swapChains.first);
+    await view.setViewport(width, height);
+
+    texture.hardwareId = externalImage;
+    texture.width = width;
+    texture.height = height;
+    return texture;
+  }
+
+  Future<void> releaseView(View view) {
+    return registry.serialized(
+      () => _lifecycle.duringTextureMutation(() async {
+        await registry.releaseBindingsForView(view);
+        await _destroyRenderTargetForView(view);
+      }),
+    );
+  }
+
+  Future<void> _destroyRenderTargetForView(View view) async {
+    final renderTarget = _viewRenderTargets.remove(view);
+    if (renderTarget == null) return;
+
+    final app = FilamentApp.instance;
+    if (app == null) {
+      // The engine owns resources that survived until shutdown.
+      return;
+    }
+
+    final overlay = view.getHighlightOverlay();
+    if (overlay == null) {
+      await view.setRenderTarget(null);
+    } else {
+      await overlay.overlayView.setRenderTarget(null);
+    }
+    await _destroyRenderTarget(renderTarget);
+  }
+
+  Future<void> _destroyRenderTarget(RenderTarget renderTarget) async {
+    final color = await renderTarget.getColorTexture();
+    final depth = await renderTarget.getDepthTexture();
+    await renderTarget.destroy();
+    await color.destroy();
+    await depth.destroy();
+  }
+}

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry_native.dart
@@ -10,6 +10,9 @@ import 'method_channel_platform_texture_descriptor.dart';
 import 'platform_texture_descriptor.dart';
 import 'platform_texture_descriptor_registry.dart';
 
+typedef TextureMutationRunner =
+    Future<T> Function<T>(Future<T> Function() operation);
+
 class FilamentRenderingContext {
   const FilamentRenderingContext({
     required this.driverPlatform,
@@ -32,8 +35,10 @@ class NativePlatformTextureDescriptorRegistry
   NativePlatformTextureDescriptorRegistry({
     required void Function() pauseRendering,
     required void Function() resumeRenderingIfReady,
+    required TextureMutationRunner runTextureMutation,
   }) : _pauseRendering = pauseRendering,
        _resumeRenderingIfReady = resumeRenderingIfReady,
+       _runTextureMutation = runTextureMutation,
        super(allocator: _allocate) {
     if (Platform.isAndroid) {
       channel.setMethodCallHandler(_handlePlatformMethodCall);
@@ -44,6 +49,7 @@ class NativePlatformTextureDescriptorRegistry
 
   final void Function() _pauseRendering;
   final void Function() _resumeRenderingIfReady;
+  final TextureMutationRunner _runTextureMutation;
   final Logger _logger = Logger('NativePlatformTextureDescriptorRegistry');
 
   static Future<PlatformTextureDescriptor> _allocate(int width, int height) {
@@ -143,27 +149,29 @@ class NativePlatformTextureDescriptorRegistry
         if (descriptor == null) return null;
         descriptor.markSurfaceUnavailable();
         _pauseRendering();
-        await serialized(() async {
-          if (contains(descriptor)) {
-            await descriptor.cleanupSurface();
-          }
-        });
+        try {
+          await serialized(() async {
+            if (contains(descriptor)) {
+              await _runTextureMutation(descriptor.cleanupSurface);
+            }
+          });
+        } finally {
+          _resumeRenderingIfReady();
+        }
         return null;
       case 'onSurfaceAvailable':
         final arguments = call.arguments as List<Object?>;
         final textureId = arguments[0] as int;
         final descriptor = _descriptorForTextureId(textureId);
         if (descriptor == null) return null;
-        final wasAvailable = descriptor.isSurfaceAvailable;
         descriptor.markSurfaceUnavailable();
-        if (wasAvailable) {
-          _pauseRendering();
-        }
+        _pauseRendering();
         try {
           await serialized(() async {
             if (!contains(descriptor)) return;
-            await descriptor.restoreSurface(arguments[1] as int);
-            _resumeRenderingIfReady();
+            await _runTextureMutation(
+              () => descriptor.restoreSurface(arguments[1] as int),
+            );
           });
         } catch (error, stackTrace) {
           _logger.severe(
@@ -172,6 +180,8 @@ class NativePlatformTextureDescriptorRegistry
             stackTrace,
           );
           rethrow;
+        } finally {
+          _resumeRenderingIfReady();
         }
         return null;
       case 'onSurfaceError':

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -1,192 +1,52 @@
-import 'dart:async';
-import 'dart:ffi' as ffi;
 import 'dart:io';
+
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart' hide View;
-import 'package:logging/logging.dart';
-import 'package:thermion_flutter/src/platform/src/frame_scheduler.dart';
-import '../../../thermion_flutter.dart';
-import 'platform_texture_descriptor.dart';
-import 'platform_texture_descriptor_registry_native.dart';
 // ignore: implementation_imports
 import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 
-/// Handles platform-specific initialization to create a backing rendering
-/// surface in a Flutter application and lifecycle listeners to pause rendering
-/// when the app is inactive or in the background.
-///
-/// Frame scheduling is delegated to [FrameScheduler]; this class owns the
-/// descriptor / render-target lifecycle and the [WidgetsBindingObserver]
-/// hookup.
-class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
-    with WidgetsBindingObserver {
+import 'native_rendering_lifecycle_controller.dart';
+import 'native_texture_surface_manager.dart';
+import 'platform_texture_descriptor.dart';
+import '../../../thermion_flutter.dart';
+
+/// Initializes the native Filament application and delegates frame lifecycle
+/// and texture-surface ownership to focused collaborators.
+class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   ThermionFlutterPluginImpl() {
-    _textureDescriptorRegistry = NativePlatformTextureDescriptorRegistry(
-      pauseRendering: FrameScheduler.instance.pause,
-      resumeRenderingIfReady: _resumeTextureRenderingIfReady,
+    _lifecycle = NativeRenderingLifecycleController(
+      hasUnavailableSurfaces: () => _textureSurfaces.hasUnavailableSurfaces,
+      onFrameRendered: () => _textureSurfaces.onFrameRendered(),
+    );
+    _textureSurfaces = NativeTextureSurfaceManager(
+      lifecycle: _lifecycle,
+      options: () => options.nativeOptions,
     );
   }
 
-  static final _logger = Logger("ThermionFlutterPluginImpl");
-
-  static ThermionFlutterPluginImpl get instance =>
-      ThermionFlutterPlugin.instance as ThermionFlutterPluginImpl;
+  late final NativeRenderingLifecycleController _lifecycle;
+  late final NativeTextureSurfaceManager _textureSurfaces;
 
   static Future<Uint8List> loadAsset(String path) async {
-    if (path.startsWith("file://")) {
-      return File(path.replaceAll("file://", "")).readAsBytesSync();
+    if (path.startsWith('file://')) {
+      return File(path.replaceAll('file://', '')).readAsBytesSync();
     }
-    if (path.startsWith("asset://")) {
-      path = path.replaceAll("asset://", "");
+    if (path.startsWith('asset://')) {
+      path = path.replaceAll('asset://', '');
     }
-    var asset = await rootBundle.load(path);
+    final asset = await rootBundle.load(path);
     return asset.buffer.asUint8List(asset.offsetInBytes);
-  }
-
-  late final NativePlatformTextureDescriptorRegistry _textureDescriptorRegistry;
-
-  // Track render targets created by Flutter for each view.
-  // This allows us to destroy the correct RT on resize, even when the view
-  // has been redirected to an internal RT (e.g. in composite highlight mode).
-  static final _viewRenderTargets = <View, RenderTarget>{};
-
-  // Deferred Filament render target cleanup for Windows resize.
-  // Old RT stays alive so native can Blit from it during the swap window.
-  static final _deferredRenderTargets = <(RenderTarget, int)>[];
-
-  bool _explicitlyPaused = false;
-  bool _lifecycleSuspended = false;
-  bool _resizing = false;
-
-  bool get _pauseRequested =>
-      _explicitlyPaused ||
-      _lifecycleSuspended ||
-      _resizing ||
-      _textureDescriptorRegistry.hasUnavailableSurfaces;
-
-  void _resumeTextureRenderingIfReady() {
-    if (!_pauseRequested) {
-      FrameScheduler.instance.resume();
-    }
-  }
-
-  bool _suspendForLifecycle() {
-    if (_lifecycleSuspended) return false;
-    _lifecycleSuspended = true;
-
-    if (Platform.isLinux) {
-      // Linux registers one persistent Flutter frame callback. Keep it
-      // registered, but stop it from re-arming while the app is hidden.
-      FrameScheduler.instance.pause();
-    } else {
-      FrameScheduler.instance.stop();
-    }
-    return true;
-  }
-
-  Future<void> _resumeFromLifecycle() async {
-    if (!_lifecycleSuspended) return;
-    _lifecycleSuspended = false;
-
-    if (FilamentApp.instance == null) return;
-
-    if (Platform.isLinux) {
-      if (!_pauseRequested) {
-        FrameScheduler.instance.resume();
-      }
-    } else {
-      await FrameScheduler.instance.start();
-      if (_pauseRequested) {
-        FrameScheduler.instance.pause();
-      } else {
-        FrameScheduler.instance.resume();
-      }
-    }
-    _logger.info('App foregrounded, frame scheduler resumed');
-  }
-
-  void _syncLifecycleState() {
-    final state = WidgetsBinding.instance.lifecycleState;
-    if (state != null) {
-      didChangeAppLifecycleState(state);
-    }
-  }
-
-  Future<void> _renderFrame() async {
-    if (FilamentApp.instance == null) return;
-
-    await FilamentApp.instance?.render();
-
-    _textureDescriptorRegistry.markFrameAvailable();
-
-    // Process deferred render target cleanup (Windows resize path).
-    // Old RTs stay alive for a few frames so native can Blit from them.
-    if (_deferredRenderTargets.isNotEmpty) {
-      final ready = <(RenderTarget, int)>[];
-      final remaining = <(RenderTarget, int)>[];
-      for (final (rt, frames) in _deferredRenderTargets) {
-        if (frames <= 0) {
-          ready.add((rt, frames));
-        } else {
-          remaining.add((rt, frames - 1));
-        }
-      }
-      _deferredRenderTargets
-        ..clear()
-        ..addAll(remaining);
-      for (final (rt, _) in ready) {
-        final color = await rt.getColorTexture();
-        final depth = await rt.getDepthTexture();
-        await color.destroy();
-        await depth.destroy();
-        await rt.destroy();
-      }
-    }
   }
 
   @override
   Future<SwapChain?> initialize({bool destroySwapchain = true}) async {
-    // After a hot restart in debug mode, any previous Dart isolate no longer
-    // exists, but the native scheduler may have retained a dangling callback
-    // pointer to the old isolate. We call stop() here (which is idempotent)
-    // to ensure this is disposed cleanly before instantiating a new FrameScheduler.instance.
-    FrameScheduler.instance.stop();
-    WidgetsBinding.instance.removeObserver(this);
+    // A hot restart can leave the native scheduler holding a callback into the
+    // previous isolate. stop() is idempotent and clears that callback first.
+    _lifecycle.prepareForInitialization();
 
-    late Backend backend;
-    if (options.nativeOptions.backend != null) {
-      switch (options.nativeOptions.backend) {
-        case Backend.VULKAN:
-          if (!Platform.isWindows && !Platform.isLinux) {
-            throw Exception("Vulkan only supported on Windows and Linux");
-          }
-        case Backend.METAL:
-          if (!Platform.isIOS || !Platform.isMacOS) {
-            throw Exception("Metal only supported on iOS/macOS");
-          }
-        case Backend.OPENGL:
-          if (!Platform.isAndroid && !Platform.isLinux) {
-            throw Exception("OpenGL only supported on Android and Linux");
-          }
-        default:
-          throw Exception("Unsupported backend");
-      }
-      backend = options.nativeOptions.backend!;
-    } else {
-      if (Platform.isWindows) {
-        backend = Backend.VULKAN;
-      } else if (Platform.isMacOS || Platform.isIOS) {
-        backend = Backend.METAL;
-      } else if (Platform.isAndroid || Platform.isLinux) {
-        backend = Backend.OPENGL;
-      } else {
-        throw Exception("Unsupported platform");
-      }
-    }
-
-    final renderingContext = await _textureDescriptorRegistry
-        .getFilamentRenderingContext(backend);
-
+    final backend = _resolveBackend();
+    final renderingContext = await _textureSurfaces.getFilamentRenderingContext(
+      backend,
+    );
     final config = FFIFilamentConfig(
       backend: backend,
       loadResource: loadAsset,
@@ -198,223 +58,75 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     if (FilamentApp.instance == null) {
       await FFIFilamentApp.create(config: config);
       FilamentApp.instance!.onDestroy(() async {
-        // Stop the frame scheduler BEFORE destroying the engine
-        // to prevent crashes from dangling callback pointers
-        FrameScheduler.instance.stop();
-        WidgetsBinding.instance.removeObserver(this);
-
-        await _textureDescriptorRegistry.destroyFilamentRenderingContext();
+        // Stop callbacks before the engine releases their native targets.
+        _lifecycle.stop();
+        _textureSurfaces.onEngineDestroyed();
+        await _textureSurfaces.destroyFilamentRenderingContext();
       });
     }
 
-    // on MacOS/iOS, even though we render directly into a render target,
-    // for some reason we still need to create a headless swapchain (though the
-    // dimensions don't seem to matter).
-    // TODO - see if we can use `renderStandaloneView` in FilamentViewer to
-    // avoid this
-    SwapChain? swapChain;
-    if (Platform.isMacOS ||
-        Platform.isIOS ||
-        Platform.isWindows ||
-        Platform.isLinux) {
-      swapChain ??= await FilamentApp.instance!.createHeadlessSwapChain(
-        1,
-        1,
-        hasStencilBuffer: true,
-      );
-    }
-
-    FrameScheduler.instance.setOnFrame(_renderFrame);
-
-    if (Platform.isLinux) {
-      // Native render loop: vsync → render → mark textures all in native.
-      // Bypasses Dart event loop entirely for minimal frame latency.
-      final dylib = ffi.DynamicLibrary.process();
-      final getHandleFn = dylib
-          .lookupFunction<
-            ffi.Pointer<ffi.Void> Function(),
-            ffi.Pointer<ffi.Void> Function()
-          >('thermion_flutter_get_plugin_handle');
-      final pluginHandle = getHandleFn();
-      final markTexturesFnPtr = dylib
-          .lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-            'thermion_flutter_mark_textures',
-          );
-
-      final app = FilamentApp.instance as FFIFilamentApp;
-      await FrameScheduler.instance.startFlutterSynced(
-        renderThreadHandle: app.renderThreadHandle,
-        renderManagerHandle: app.renderManager.getNativeHandle(),
-        postRenderCallback: markTexturesFnPtr,
-        postRenderUserData: pluginHandle,
-      );
-    } else {
-      await FrameScheduler.instance.start();
-    }
-
-    // Register only after the scheduler has started, then immediately apply
-    // the current state. This covers initialization while already hidden
-    // without allowing the subsequent start call to undo the suspension.
-    WidgetsBinding.instance.addObserver(this);
-    _syncLifecycleState();
-    if (_pauseRequested) {
-      FrameScheduler.instance.pause();
-    }
-
+    final swapChain = await _createDefaultSwapChain();
+    await _lifecycle.start();
     return swapChain;
+  }
+
+  Backend _resolveBackend() {
+    final configured = options.nativeOptions.backend;
+    if (configured != null) {
+      switch (configured) {
+        case Backend.VULKAN:
+          if (!Platform.isWindows && !Platform.isLinux) {
+            throw UnsupportedError(
+              'Vulkan is only supported on Windows and Linux',
+            );
+          }
+        case Backend.METAL:
+          if (!Platform.isIOS && !Platform.isMacOS) {
+            throw UnsupportedError('Metal is only supported on iOS and macOS');
+          }
+        case Backend.OPENGL:
+          if (!Platform.isAndroid && !Platform.isLinux) {
+            throw UnsupportedError(
+              'OpenGL is only supported on Android and Linux',
+            );
+          }
+        default:
+          throw UnsupportedError('Unsupported backend: $configured');
+      }
+      return configured;
+    }
+
+    if (Platform.isWindows) return Backend.VULKAN;
+    if (Platform.isMacOS || Platform.isIOS) return Backend.METAL;
+    if (Platform.isAndroid || Platform.isLinux) return Backend.OPENGL;
+    throw UnsupportedError('Unsupported platform: $Platform');
+  }
+
+  Future<SwapChain?> _createDefaultSwapChain() async {
+    if (!Platform.isMacOS &&
+        !Platform.isIOS &&
+        !Platform.isWindows &&
+        !Platform.isLinux) {
+      return null;
+    }
+
+    // Direct render targets on desktop and Darwin still require a headless
+    // swapchain for RenderManager scheduling.
+    return FilamentApp.instance!.createHeadlessSwapChain(
+      1,
+      1,
+      hasStencilBuffer: true,
+    );
   }
 
   @override
   void pauseFrameScheduler() {
-    _explicitlyPaused = true;
-    FrameScheduler.instance.pause();
+    _lifecycle.pauseExplicitly();
   }
 
   @override
   void resumeFrameScheduler() {
-    _explicitlyPaused = false;
-    if (!_pauseRequested) {
-      FrameScheduler.instance.resume();
-    }
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    switch (state) {
-      case AppLifecycleState.hidden:
-      case AppLifecycleState.paused:
-      case AppLifecycleState.detached:
-        if (_suspendForLifecycle()) {
-          _logger.info('App hidden, frame scheduler suspended');
-        }
-        break;
-      case AppLifecycleState.resumed:
-        unawaited(
-          _resumeFromLifecycle().catchError((Object error) {
-            _logger.severe('Failed to resume frame scheduler: $error');
-          }),
-        );
-        break;
-      case AppLifecycleState.inactive:
-        // The app can remain visible while inactive (split screen, system UI,
-        // or an unfocused desktop window), so rendering remains enabled.
-        break;
-    }
-  }
-
-  /// Creates Filament textures + render target and binds them to [view].
-  /// Extracted so it can be called immediately or deferred.
-  static Future<void> _createFilamentResources(
-    PlatformTextureDescriptor descriptor,
-    View view,
-    int width,
-    int height,
-  ) async {
-    // Determine if we need the Vulkan external image path or direct GL/Metal import.
-    // Vulkan path: builder.external() + setExternalImage (Windows, or Linux with Vulkan)
-    // Direct import path: builder.import(textureId) (macOS/iOS Metal, Linux with OpenGL)
-    final useExternalImage =
-        Platform.isWindows ||
-        ThermionFlutterPlugin.instance.options.nativeOptions.backend ==
-            Backend.VULKAN;
-
-    final color = await FilamentApp.instance!.createTexture(
-      width,
-      height,
-      importedTextureHandle: useExternalImage ? -1 : descriptor.hardwareId,
-      flags: {
-        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-        TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
-        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
-      },
-      textureFormat:
-          instance.options.nativeOptions.renderTargetColorTextureFormat,
-      textureSamplerType: TextureSamplerType.SAMPLER_2D,
-    );
-
-    if (useExternalImage) {
-      await FilamentApp.instance!.setExternalImage(
-        color,
-        descriptor.hardwareId,
-      );
-    }
-
-    final depth = await FilamentApp.instance!.createTexture(
-      width,
-      height,
-      flags: {
-        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-        TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT,
-        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
-        TextureUsage.TEXTURE_USAGE_STENCIL_ATTACHMENT,
-      },
-      textureFormat:
-          instance.options.nativeOptions.renderTargetDepthTextureFormat,
-      textureSamplerType: TextureSamplerType.SAMPLER_2D,
-    );
-
-    // Use tracked RT for destruction (not view.getRenderTarget()) because
-    // in composite mode the view's RT may be an internal RT, not the Flutter RT
-    final existingRenderTarget = _viewRenderTargets[view];
-
-    var renderTarget = await FilamentApp.instance!.createRenderTarget(
-      width,
-      height,
-      color: color,
-      depth: depth,
-    );
-
-    await view.setRenderTarget(renderTarget);
-    _viewRenderTargets[view] = renderTarget; // Track the new RT
-
-    if (existingRenderTarget != null) {
-      final color = await existingRenderTarget.getColorTexture();
-      final depth = await existingRenderTarget.getDepthTexture();
-      await color.destroy();
-      await depth.destroy();
-      await existingRenderTarget.destroy();
-    }
-    final swapChains = await FilamentApp.instance!.getSwapChains();
-    await FilamentApp.instance!.renderManager.attach(view, swapChains.first);
-  }
-
-  /// Waits for Flutter's populate callback to create the GL texture and then
-  /// creates the Filament resources. This future is deliberately not awaited
-  /// by createTextureAndBindToView: Flutter must first build its Texture widget
-  /// before populate can run.
-  static Future<void> _completeDeferredBinding(
-    PlatformTextureDescriptor descriptor,
-    View view,
-    int width,
-    int height,
-  ) async {
-    final registry = instance._textureDescriptorRegistry;
-    try {
-      final hardwareId = await descriptor.awaitTextureReady();
-      await registry.serialized(() async {
-        if (!registry.contains(descriptor) || descriptor.destroyed) return;
-        descriptor.hardwareId = hardwareId;
-        _logger.info(
-          'Deferred texture ready: flutter=${descriptor.flutterTextureId} hardware=$hardwareId',
-        );
-        await _createFilamentResources(descriptor, view, width, height);
-      });
-    } catch (error, stackTrace) {
-      _logger.warning('Deferred texture binding failed', error, stackTrace);
-      try {
-        await registry.serialized(() async {
-          if (registry.contains(descriptor)) {
-            await registry.destroy(descriptor);
-          }
-        });
-      } catch (cleanupError, cleanupStackTrace) {
-        _logger.warning(
-          'Failed to clean up deferred texture descriptor',
-          cleanupError,
-          cleanupStackTrace,
-        );
-      }
-    }
+    _lifecycle.resumeExplicitly();
   }
 
   @override
@@ -423,51 +135,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     int width,
     int height,
   ) {
-    return _textureDescriptorRegistry.serialized(
-      () => _createTextureAndBindToView(view, width, height),
-    );
-  }
-
-  Future<PlatformTextureDescriptor?> _createTextureAndBindToView(
-    View view,
-    int width,
-    int height,
-  ) async {
-    if (width == 0 || height == 0) {
-      throw Exception(
-        "Invalid dimensions for texture descriptor : ${width}x$height",
-      );
-    }
-
-    final descriptor = await _textureDescriptorRegistry.create(width, height);
-    try {
-      final managesFilamentSurface = await _textureDescriptorRegistry
-          .bindToView(descriptor, view);
-
-      // On Linux, when running via EGL/OpenGL backend (Wayland),
-      // we can only access the EGL context in the native populate() callback;
-      // in other words, the platform thread cannot return a hardware texture
-      // ID. Binding must finish after Flutter invokes populate().
-      if (descriptor.deferred) {
-        unawaited(_completeDeferredBinding(descriptor, view, width, height));
-      } else if (!managesFilamentSurface && descriptor.hardwareId != 0) {
-        await _createFilamentResources(descriptor, view, width, height);
-      }
-
-      await view.setViewport(width, height);
-      return descriptor;
-    } catch (error, stackTrace) {
-      try {
-        await _textureDescriptorRegistry.destroy(descriptor);
-      } catch (cleanupError, cleanupStackTrace) {
-        _logger.warning(
-          'Failed to clean up texture descriptor after binding failure',
-          cleanupError,
-          cleanupStackTrace,
-        );
-      }
-      Error.throwWithStackTrace(error, stackTrace);
-    }
+    return _textureSurfaces.createAndBind(view, width, height);
   }
 
   @override
@@ -477,178 +145,11 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     int width,
     int height,
   ) {
-    return _textureDescriptorRegistry.serialized(
-      () => _resizeTexture(texture, view, width, height),
-    );
-  }
-
-  Future<PlatformTextureDescriptor> _resizeTexture(
-    PlatformTextureDescriptor texture,
-    View view,
-    int width,
-    int height,
-  ) async {
-    // Block new frames while we swap textures, then wait for any in-flight
-    // frame to finish before we touch render targets.
-    _resizing = true;
-    FrameScheduler.instance.pause();
-    while (FrameScheduler.instance.isRendering) {
-      await Future<void>.delayed(const Duration(milliseconds: 1));
-    }
-
-    // Flush Filament's render thread so all queued GPU commands complete.
-    await FilamentApp.instance!.flush();
-
-    try {
-      if (Platform.isWindows) {
-        return await _resizeTextureWindows(texture, view, width, height);
-      }
-
-      // Non-Windows: full destroy + recreate (existing path).
-      // TODO: alternatively, allocate a larger swapchain up front and just
-      // change the viewport on resize, avoiding the destroy/recreate.
-      var newTexture = await _createTextureAndBindToView(view, width, height);
-      if (newTexture == null) {
-        throw Exception('Failed to create texture during resize');
-      }
-
-      await _textureDescriptorRegistry.destroy(texture);
-
-      return newTexture;
-    } finally {
-      _resizing = false;
-      if (!_pauseRequested) {
-        FrameScheduler.instance.resume();
-      }
-    }
-  }
-
-  /// Windows-specific resize: reuses the Flutter texture ID.
-  ///
-  /// The native side creates new D3D + Vulkan textures and stores a
-  /// pending swap.  The swap fires after the first successful Blit into
-  /// the new render target, so Flutter keeps compositing the last valid
-  /// frame until the new one is ready.  No black frame.
-  Future<PlatformTextureDescriptor> _resizeTextureWindows(
-    PlatformTextureDescriptor texture,
-    View view,
-    int width,
-    int height,
-  ) async {
-    // Ask native to create new GPU resources (no new Flutter texture)
-    final externalImage = await _textureDescriptorRegistry.resizeWindowsTexture(
-      texture,
-      width,
-      height,
-    );
-
-    // Re-create Filament render target with the new external image
-    final color = await FilamentApp.instance!.createTexture(
-      width,
-      height,
-      importedTextureHandle: -1,
-      flags: {
-        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-        TextureUsage.TEXTURE_USAGE_COLOR_ATTACHMENT,
-        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
-      },
-      textureFormat: options.nativeOptions.renderTargetColorTextureFormat,
-      textureSamplerType: TextureSamplerType.SAMPLER_2D,
-    );
-    await FilamentApp.instance!.setExternalImage(color, externalImage);
-
-    final depth = await FilamentApp.instance!.createTexture(
-      width,
-      height,
-      flags: {
-        TextureUsage.TEXTURE_USAGE_BLIT_SRC,
-        TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT,
-        TextureUsage.TEXTURE_USAGE_SAMPLEABLE,
-        TextureUsage.TEXTURE_USAGE_STENCIL_ATTACHMENT,
-      },
-      textureFormat: options.nativeOptions.renderTargetDepthTextureFormat,
-      textureSamplerType: TextureSamplerType.SAMPLER_2D,
-    );
-
-    final existingRenderTarget = _viewRenderTargets[view];
-
-    var renderTarget = await FilamentApp.instance!.createRenderTarget(
-      width,
-      height,
-      color: color,
-      depth: depth,
-    );
-
-    await view.setRenderTarget(renderTarget);
-    _viewRenderTargets[view] = renderTarget;
-
-    if (existingRenderTarget != null) {
-      // Defer destruction: native still needs the old render target's
-      // VkImage for Blit during the swap window (1-2 frames).
-      // Clean up after 5 frames to be safe.
-      _deferredRenderTargets.add((existingRenderTarget, 5));
-    }
-
-    final swapChains = await FilamentApp.instance!.getSwapChains();
-    await FilamentApp.instance!.renderManager.attach(view, swapChains.first);
-
-    await view.setViewport(width, height);
-
-    // Update the existing descriptor in place — same Flutter texture ID
-    texture.hardwareId = externalImage;
-    texture.width = width;
-    texture.height = height;
-
-    return texture;
-  }
-
-  Future<void> _destroyRenderTargetForView(View view) async {
-    final renderTarget = _viewRenderTargets.remove(view);
-    if (renderTarget == null) return;
-
-    final app = FilamentApp.instance;
-    if (app == null) {
-      // The engine owns any resources that survived until shutdown. Drop the
-      // Dart reference without attempting to enqueue work on a dead engine.
-      return;
-    }
-
-    final overlay = view.getHighlightOverlay();
-    if (overlay == null) {
-      await view.setRenderTarget(null);
-    } else {
-      // Composite highlight mode redirects the Flutter render target to the
-      // overlay view rather than the caller's view.
-      await overlay.overlayView.setRenderTarget(null);
-    }
-
-    final color = await renderTarget.getColorTexture();
-    final depth = await renderTarget.getDepthTexture();
-    await color.destroy();
-    await depth.destroy();
-    await renderTarget.destroy();
+    return _textureSurfaces.resize(texture, view, width, height);
   }
 
   @override
   Future<void> releaseTextureBindingForView(View view) {
-    return _textureDescriptorRegistry.serialized(() async {
-      // The render target imports descriptor-owned platform memory on Darwin.
-      // Drain rendering and destroy that target before the widget destroys the
-      // descriptor and releases its Metal / CoreVideo objects.
-      _resizing = true;
-      FrameScheduler.instance.pause();
-      while (FrameScheduler.instance.isRendering) {
-        await Future<void>.delayed(const Duration(milliseconds: 1));
-      }
-      await FilamentApp.instance?.flush();
-
-      try {
-        await _textureDescriptorRegistry.releaseBindingsForView(view);
-        await _destroyRenderTargetForView(view);
-      } finally {
-        _resizing = false;
-        _resumeTextureRenderingIfReady();
-      }
-    });
+    return _textureSurfaces.releaseView(view);
   }
 }

--- a/thermion_flutter/thermion_flutter/test/native_texture_surface_manager_test.dart
+++ b/thermion_flutter/thermion_flutter/test/native_texture_surface_manager_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thermion_flutter/src/platform/src/native_texture_surface_manager.dart';
+
+void main() {
+  group('shouldDeferNativeTextureBinding', () {
+    test('prefers an immediately available Linux hardware handle', () {
+      expect(
+        shouldDeferNativeTextureBinding(
+          managesFilamentSurface: false,
+          hardwareId: 0x1234,
+          supportsDeferredBinding: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('defers only when no hardware handle is available', () {
+      expect(
+        shouldDeferNativeTextureBinding(
+          managesFilamentSurface: false,
+          hardwareId: 0,
+          supportsDeferredBinding: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not defer descriptor-managed surfaces', () {
+      expect(
+        shouldDeferNativeTextureBinding(
+          managesFilamentSurface: true,
+          hardwareId: 0,
+          supportsDeferredBinding: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
+++ b/thermion_flutter/thermion_flutter/windows/thermion_flutter_plugin.cpp
@@ -31,6 +31,7 @@
 #include <condition_variable>
 #include <queue>
 #include <atomic>
+#include <set>
 
 #include "flutter_d3d_texture.h"
 
@@ -107,8 +108,12 @@ namespace thermion::tflutter::windows
   static constexpr size_t kMaxBlitQueueDepth = 16;
 
   static std::mutex _blitMutex;
+  // WindowsVulkanContext owns one command buffer/queue and parallel vectors of
+  // surface resources. Serialize worker blits with create/resize/destroy.
+  static std::mutex _contextMutex;
   static std::condition_variable _blitCv;
   static std::queue<BlitJob> _blitQueue;
+  static std::set<int64_t> _retiringTextureIds;
   static std::thread _blitWorker;
   static std::atomic<bool> _blitWorkerStarted{false};
   static std::atomic<bool> _blitWorkerShouldStop{false};
@@ -127,11 +132,24 @@ namespace thermion::tflutter::windows
         job = _blitQueue.front();
         _blitQueue.pop();
       }
-      if (job.context) {
-        job.context->Blit(job.handle);
+      // A texture can begin retiring after its job is popped. Recheck while
+      // holding the same context lock used by surface destruction: either this
+      // blit completes before destruction, or it is skipped after retirement.
+      std::lock_guard<std::mutex> contextLock(_contextMutex);
+      bool retiring = false;
+      {
+        std::lock_guard<std::mutex> blitLock(_blitMutex);
+        retiring =
+            _retiringTextureIds.find(job.flutterTextureId) !=
+            _retiringTextureIds.end();
       }
-      if (job.registrar) {
-        job.registrar->MarkTextureFrameAvailable(job.flutterTextureId);
+      if (!retiring) {
+        if (job.context) {
+          job.context->Blit(job.handle);
+        }
+        if (job.registrar) {
+          job.registrar->MarkTextureFrameAvailable(job.flutterTextureId);
+        }
       }
     }
   }
@@ -147,6 +165,10 @@ namespace thermion::tflutter::windows
     EnsureBlitWorkerStarted();
     {
       std::lock_guard<std::mutex> lock(_blitMutex);
+      if (_retiringTextureIds.find(job.flutterTextureId) !=
+          _retiringTextureIds.end()) {
+        return;
+      }
       // Bounded queue — drop oldest under sustained GPU pressure
       // rather than growing without limit. Visual effect under
       // overload: one stale frame, no hang, no crash.
@@ -156,6 +178,21 @@ namespace thermion::tflutter::windows
       _blitQueue.push(std::move(job));
     }
     _blitCv.notify_one();
+  }
+
+  static void RetireBlitJobs(int64_t flutterTextureId) {
+    std::lock_guard<std::mutex> lock(_blitMutex);
+    _retiringTextureIds.insert(flutterTextureId);
+
+    std::queue<BlitJob> retained;
+    while (!_blitQueue.empty()) {
+      auto job = std::move(_blitQueue.front());
+      _blitQueue.pop();
+      if (job.flutterTextureId != flutterTextureId) {
+        retained.push(std::move(job));
+      }
+    }
+    _blitQueue.swap(retained);
   }
 
   ThermionFlutterPlugin::~ThermionFlutterPlugin() {
@@ -179,6 +216,7 @@ namespace thermion::tflutter::windows
       const flutter::MethodCall<flutter::EncodableValue> &methodCall,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
   {
+    std::lock_guard<std::mutex> contextLock(_contextMutex);
     if (!_context)
     {
       _context = new thermion::vulkan::windows::WindowsVulkanContext();
@@ -226,6 +264,7 @@ namespace thermion::tflutter::windows
       const flutter::MethodCall<flutter::EncodableValue> &methodCall,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
   {
+    std::lock_guard<std::mutex> contextLock(_contextMutex);
     if (!_context)
     {
       result->Error("NO_CONTEXT", "No rendering context");
@@ -250,6 +289,16 @@ namespace thermion::tflutter::windows
     }
 
     HANDLE oldD3DHandle = (*it)->GetD3DTextureHandle();
+
+    // A second resize can arrive before the two-frame descriptor swap. The
+    // abandoned replacement is no longer a Flutter surface, but its Filament
+    // target is retained by Dart's deferred cleanup. Transfer image ownership
+    // to Filament and retire the native interop resources before replacing it.
+    auto pendingIt = _pendingSwaps.find(flutterTextureId);
+    if (pendingIt != _pendingSwaps.end()) {
+      _context->DestroyRenderingSurface(pendingIt->second.newD3DHandle);
+      _pendingSwaps.erase(pendingIt);
+    }
 
     // Create new D3D + Vulkan textures
     auto newD3DHandle = _context->CreateRenderingSurface(width, height, 0, 0);
@@ -276,6 +325,7 @@ namespace thermion::tflutter::windows
   {
     std::cerr << "ThermionFlutterPlugin::OnTextureUnregistered" << std::endl;
 
+    std::lock_guard<std::mutex> contextLock(_contextMutex);
     if (!_context) {
       std::cerr << "No rendering context is active, cannot destroy Flutter texture ID" << flutterTextureId << std::endl;
       return false;    
@@ -293,7 +343,21 @@ namespace thermion::tflutter::windows
     HANDLE d3dTextureHandle = flutterTexture->GetD3DTextureHandle();
     _flutterTextures.erase(it);
     std::cerr << "Erased flutter texture" << std::endl;
-    _context->DestroyRenderingSurface(d3dTextureHandle);
+
+    // If unregister races the two-frame resize handshake, Flutter still owns
+    // the old descriptor while Filament is rendering into the new surface.
+    // Retire both native surfaces and remove the stale handshake.
+    std::vector<HANDLE> handles{d3dTextureHandle};
+    auto pendingIt = _pendingSwaps.find(flutterTextureId);
+    if (pendingIt != _pendingSwaps.end()) {
+      handles.push_back(pendingIt->second.oldD3DHandle);
+      handles.push_back(pendingIt->second.newD3DHandle);
+      _pendingSwaps.erase(pendingIt);
+    }
+    std::set<HANDLE> uniqueHandles(handles.begin(), handles.end());
+    for (auto handle : uniqueHandles) {
+      _context->DestroyRenderingSurface(handle);
+    }
 
     return true;
     
@@ -308,6 +372,10 @@ namespace thermion::tflutter::windows
     auto shared_result = std::shared_ptr<flutter::MethodResult<flutter::EncodableValue>>(result.release());
 
     std::cerr << "Unregistering Flutter texture ID " << flutterTextureId << std::endl;
+
+    // Prevent queued or subsequently delivered frame notifications from
+    // touching the surface after TextureRegistrar begins unregistration.
+    RetireBlitJobs(flutterTextureId);
 
     _textureRegistrar->UnregisterTexture(
       flutterTextureId,
@@ -352,6 +420,7 @@ namespace thermion::tflutter::windows
     }
     else if (methodCall.method_name() == "markTextureFrameAvailable")
     {
+      std::lock_guard<std::mutex> contextLock(_contextMutex);
       if (_context)
       {
         const auto *flutterTextureId = std::get_if<int64_t>(methodCall.arguments());
@@ -422,6 +491,7 @@ namespace thermion::tflutter::windows
       result->Success(flutter::EncodableValue((int64_t) nullptr));
     }
     else if (methodCall.method_name() == "destroyContext") {
+      std::lock_guard<std::mutex> contextLock(_contextMutex);
       _context = std::nullptr_t();
       std::cerr << "Destroyed context" << std::endl;
       result->Success(flutter::EncodableValue((int64_t)nullptr));


### PR DESCRIPTION
PR 3 of 4 for platform texture lifecycle improvements.
- extracts render scheduling/pause state into a native lifecycle controller
- extracts surface creation, resizing, replacement, and destruction into a native surface manager
- preserves the Android, Windows, and Linux/Vulkan platform-specific texture paths
- adds focused native surface manager tests