### PR TITLE
fix: (android) restore SurfaceTexture rendering performance

### DIFF
--- a/examples/flutter/quickstart/integration_test/framerate_test.dart
+++ b/examples/flutter/quickstart/integration_test/framerate_test.dart
@@ -68,6 +68,22 @@ void main() {
     expect(viewer, isNotNull, reason: 'viewer should be available after init');
     expect(FrameScheduler.instance.isActive, isTrue);
 
+    // onViewerAvailable can run before the debounced ThermionWidget texture
+    // allocation has attached its Android swapchain. This test concerns frame
+    // pacing rather than pre-attachment rendering state, so wait for the
+    // surface instead of depending on that separate behavior.
+    final attachmentDeadline = DateTime.now().add(const Duration(seconds: 5));
+    var swapChains = await FilamentApp.instance!.getSwapChains();
+    while (swapChains.isEmpty && DateTime.now().isBefore(attachmentDeadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      swapChains = await FilamentApp.instance!.getSwapChains();
+    }
+    expect(
+      swapChains,
+      isNotEmpty,
+      reason: 'Android rendering surface should be attached before sampling',
+    );
+
     // Ensure continuous rendering is on (a static scene may otherwise render
     // only on demand).
     await viewer!.setRendering(true);
@@ -79,6 +95,9 @@ void main() {
     // Let the loop settle, then measure the 60 FPS rate.
     await Future<void>.delayed(const Duration(seconds: 1));
     final defaultFps = await measureScheduledFps(const Duration(seconds: 2));
+    debugPrint(
+      'Thermion scheduled FPS: default=${defaultFps.toStringAsFixed(1)}',
+    );
 
     // Sanity: the loop is rendering continuously (not stalled). The absolute
     // rate is bounded by render() cost (debug builds) and the display refresh,
@@ -92,6 +111,7 @@ void main() {
     // Give the new interval a moment to take effect.
     await Future<void>.delayed(const Duration(milliseconds: 500));
     final lowFps = await measureScheduledFps(const Duration(seconds: 2));
+    debugPrint('Thermion scheduled FPS: limited=${lowFps.toStringAsFixed(1)}');
 
     expect(lowFps, lessThan(defaultFps / 2),
         reason: '5 FPS cap should schedule far fewer frames than the default '
@@ -107,6 +127,10 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 500));
       final afterRestartFps =
           await measureScheduledFps(const Duration(seconds: 2));
+      debugPrint(
+        'Thermion scheduled FPS: after restart='
+        '${afterRestartFps.toStringAsFixed(1)}',
+      );
       expect(afterRestartFps, closeTo(5, 3),
           reason: '5 FPS cap should survive scheduler restart; '
               'got $afterRestartFps');
@@ -116,6 +140,9 @@ void main() {
     FilamentApp.instance!.setTargetFramerate(60);
     await Future<void>.delayed(const Duration(milliseconds: 500));
     final restoredFps = await measureScheduledFps(const Duration(seconds: 2));
+    debugPrint(
+      'Thermion scheduled FPS: restored=${restoredFps.toStringAsFixed(1)}',
+    );
     expect(restoredFps, greaterThan(lowFps * 2),
         reason: 'restoring 60 FPS should raise the rate well above the 5 FPS '
             'cap (low=$lowFps, restored=$restoredFps)');

--- a/examples/flutter/quickstart/integration_test/lifecycle_test.dart
+++ b/examples/flutter/quickstart/integration_test/lifecycle_test.dart
@@ -38,8 +38,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   Future<void> pumpViewer(WidgetTester tester) async {
-    final sun =
-        DirectLight.sun(direction: Vector3(0.7, -1, -0.8).normalized());
+    final sun = DirectLight.sun(direction: Vector3(0.7, -1, -0.8).normalized());
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -130,6 +129,23 @@ void main() {
 
   testWidgets('lifecycle hidden/paused resumes the scheduler cleanly',
       (tester) async {
+    // Exercise SurfaceProducer's callback-capable path on Android as well as
+    // the default SurfaceTexture path covered by the tests above.
+    if (Platform.isAndroid) {
+      ThermionFlutterPlugin.instance.setOptions(
+        const ThermionFlutterOptions(
+          nativeOptions: NativeOptions(
+            androidTextureSource: AndroidTextureSource.surfaceProducer,
+          ),
+        ),
+      );
+      addTearDown(() {
+        ThermionFlutterPlugin.instance.setOptions(
+          const ThermionFlutterOptions(),
+        );
+      });
+    }
+
     await pumpViewer(tester);
     expect(FrameScheduler.instance.isActive, isTrue);
 

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -58,6 +58,13 @@ The `FrameScheduler` dispatches its callback to Dart in one of two ways:
 - **Release**: a raw C function pointer (`ffi.NativeCallable`) — minimum latency.
 - **Debug** (hot-restart safe): `Dart_PostCObject_DL` onto a `ReceivePort`. `Dart_PostCObject` silently drops messages to dead ports, so stale native schedulers created in a previous isolate can't crash the new one.
 
+Android intentionally keeps render admission on these Dart callback paths.
+Flutter's `ImageReaderSurfaceProducer` receives images through a listener on
+Android's main looper. A fully native producer loop can continue submitting
+buffers while that consumer is delayed, filling the ImageReader pipeline and
+blocking `acquireLatestImage()` on the main thread. The Dart in-flight guard
+provides the required backpressure.
+
 ### Framerate limiting
 
 By default the viewer renders on **every vsync** — i.e. at the display's native refresh rate (60 fps on a 60 Hz panel, 120 on a 120 Hz panel, etc.). Nothing pins it to 60.

--- a/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
+++ b/thermion_flutter/thermion_flutter/android/src/main/kotlin/dev/thermion/android/ThermionFlutterPlugin.kt
@@ -42,13 +42,19 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
   private var lifecycle: Lifecycle? = null
 
-  // The legacy SurfaceTexture external-texture path composites transparent
-  // Filament output with incorrect premultiplied alpha under Impeller. The
-  // SurfaceProducer path composites premultiplied alpha correctly.
   private data class TextureEntry(
-      val surfaceProducer: TextureRegistry.SurfaceProducer,
+      val surfaceProducer: TextureRegistry.SurfaceProducer?,
+      val surfaceTextureEntry: TextureRegistry.SurfaceTextureEntry?,
       var surface: Surface?
-  )
+  ) {
+      fun release() {
+          surfaceProducer?.setCallback(null)
+          surface?.release()
+          surface = null
+          surfaceProducer?.release()
+          surfaceTextureEntry?.release()
+      }
+  }
 
   var _surface: Surface? = null
   private val textures: MutableMap<Long, TextureEntry> = mutableMapOf()
@@ -103,25 +109,48 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 val args = call.arguments as List<*>
                 val width = args[0] as Int
                 val height = args[1] as Int
+                val useSurfaceProducer = args.getOrNull(4) as? Boolean ?: false
                 if (width < 1 || height < 1) {
                     result.error("DIMENSION_MISMATCH", "Both dimensions must be greater than zero (you provided $width x $height)", null)
                     return
                 }
-                Log.d("thermion_flutter", "Creating SurfaceProducer ${width}x${height}")
+                val producer: TextureRegistry.SurfaceProducer?
+                val surfaceTextureEntry: TextureRegistry.SurfaceTextureEntry?
+                val surface: Surface
+                val flutterTextureId: Long
 
-                // Allow Flutter to release the ImageReader-backed surface
-                // while the app is backgrounded. The callback below notifies
-                // Dart to destroy and recreate the Filament swapchain around
-                // the replacement surface.
-                val producer = flutterPluginBinding.textureRegistry.createSurfaceProducer(
-                    TextureRegistry.SurfaceLifecycle.resetInBackground
-                )
-                producer.setSize(width, height)
-                val surface = producer.getSurface()
+                if (useSurfaceProducer) {
+                    Log.d("thermion_flutter", "Creating SurfaceProducer ${width}x${height}")
+
+                    // SurfaceProducer fixes premultiplied-alpha compositing
+                    // under Impeller, but Flutter's implementation is backed
+                    // by an ImageReader on API 29+.
+                    producer = flutterPluginBinding.textureRegistry.createSurfaceProducer(
+                        TextureRegistry.SurfaceLifecycle.resetInBackground
+                    )
+                    producer.setSize(width, height)
+                    surfaceTextureEntry = null
+                    surface = producer.getSurface()
+                    flutterTextureId = producer.id()
+                } else {
+                    Log.d("thermion_flutter", "Creating SurfaceTexture ${width}x${height}")
+
+                    // SurfaceTexture avoids ImageReader acquisition on the
+                    // Android main thread and is substantially faster on some
+                    // devices. It is the default for opaque Thermion views.
+                    producer = null
+                    surfaceTextureEntry =
+                        flutterPluginBinding.textureRegistry.createSurfaceTexture()
+                    val surfaceTexture = surfaceTextureEntry.surfaceTexture()
+                    surfaceTexture.setDefaultBufferSize(width, height)
+                    surface = Surface(surfaceTexture)
+                    flutterTextureId = surfaceTextureEntry.id()
+                }
 
                 if (!surface.isValid) {
                     surface.release()
-                    producer.release()
+                    producer?.release()
+                    surfaceTextureEntry?.release()
                     result.error("SURFACE_INVALID", "Failed to create valid surface", null)
                     return
                 }
@@ -131,7 +160,8 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 val nativeWindowPtr = NativeWindowHelper.getNativeWindowFromSurface(surface)
                 if (nativeWindowPtr == 0L) {
                     surface.release()
-                    producer.release()
+                    producer?.release()
+                    surfaceTextureEntry?.release()
                     result.error(
                         "NATIVE_WINDOW_UNAVAILABLE",
                         "Failed to acquire a native window from the surface",
@@ -140,66 +170,74 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                     return
                 }
 
-                val flutterTextureId = producer.id()
-                val textureEntry = TextureEntry(producer, surface)
+                val textureEntry = TextureEntry(
+                    producer,
+                    surfaceTextureEntry,
+                    surface
+                )
                 textures[flutterTextureId] = textureEntry
-                producer.setCallback(object : TextureRegistry.SurfaceProducer.Callback {
-                    override fun onSurfaceCleanup() {
-                        val entry = textures[flutterTextureId] ?: return
-                        val surfaceToRelease = entry.surface
-                        entry.surface = null
-                        notifyDartBeforeReleasingSurface(
-                            "onSurfaceCleanup",
-                            flutterTextureId,
-                            surfaceToRelease
-                        )
-                    }
-
-                    override fun onSurfaceAvailable() {
-                        val entry = textures[flutterTextureId] ?: return
-                        val newSurface = producer.getSurface()
-                        if (!newSurface.isValid) {
-                            newSurface.release()
-                            channel.invokeMethod(
-                                "onSurfaceError",
-                                listOf(flutterTextureId, "Replacement surface is invalid")
+                producer?.setCallback(
+                    object : TextureRegistry.SurfaceProducer.Callback {
+                        override fun onSurfaceCleanup() {
+                            val entry = textures[flutterTextureId] ?: return
+                            val surfaceToRelease = entry.surface
+                            entry.surface = null
+                            notifyDartBeforeReleasingSurface(
+                                "onSurfaceCleanup",
+                                flutterTextureId,
+                                surfaceToRelease
                             )
-                            return
                         }
 
-                        val newNativeWindowPtr =
-                            NativeWindowHelper.getNativeWindowFromSurface(newSurface)
-                        if (newNativeWindowPtr == 0L) {
-                            newSurface.release()
-                            channel.invokeMethod(
-                                "onSurfaceError",
+                        override fun onSurfaceAvailable() {
+                            val entry = textures[flutterTextureId] ?: return
+                            val newSurface = producer.getSurface()
+                            if (!newSurface.isValid) {
+                                newSurface.release()
+                                channel.invokeMethod(
+                                    "onSurfaceError",
+                                    listOf(
+                                        flutterTextureId,
+                                        "Replacement surface is invalid"
+                                    )
+                                )
+                                return
+                            }
+
+                            val newNativeWindowPtr =
+                                NativeWindowHelper.getNativeWindowFromSurface(newSurface)
+                            if (newNativeWindowPtr == 0L) {
+                                newSurface.release()
+                                channel.invokeMethod(
+                                    "onSurfaceError",
+                                    listOf(
+                                        flutterTextureId,
+                                        "Failed to acquire replacement native window"
+                                    )
+                                )
+                                return
+                            }
+
+                            val surfaceToRelease = entry.surface
+                            entry.surface = newSurface
+                            notifyDartBeforeReleasingSurface(
+                                "onSurfaceAvailable",
                                 listOf(
                                     flutterTextureId,
-                                    "Failed to acquire replacement native window"
-                                )
+                                    newNativeWindowPtr
+                                ),
+                                surfaceToRelease
                             )
-                            return
                         }
-
-                        val surfaceToRelease = entry.surface
-                        entry.surface = newSurface
-                        notifyDartBeforeReleasingSurface(
-                            "onSurfaceAvailable",
-                            listOf(flutterTextureId, newNativeWindowPtr),
-                            surfaceToRelease
-                        )
                     }
-                })
+                )
                 result.success(listOf(flutterTextureId, flutterTextureId, nativeWindowPtr))
             }
             "destroyTexture" -> {
                 val textureId = (call.arguments as Int).toLong()
                 val textureEntry = textures.remove(textureId)
                 if (textureEntry != null) {
-                    textureEntry.surfaceProducer.setCallback(null)
-                    textureEntry.surface?.release()
-                    textureEntry.surface = null
-                    textureEntry.surfaceProducer.release()
+                    textureEntry.release()
                     result.success(true)
                 } else {
                     result.error("TEXTURE_NOT_FOUND", "Texture with id $textureId not found", null)
@@ -230,10 +268,7 @@ class ThermionFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       channel.setMethodCallHandler(null)
         // Release all textures
         for ((_, textureEntry) in textures) {
-            textureEntry.surfaceProducer.setCallback(null)
-            textureEntry.surface?.release()
-            textureEntry.surface = null
-            textureEntry.surfaceProducer.release()
+            textureEntry.release()
         }
         textures.clear()
   }

--- a/thermion_flutter/thermion_flutter/lib/src/options.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/options.dart
@@ -1,5 +1,21 @@
 import 'package:thermion_dart/thermion_dart.dart';
 
+/// The Android texture-registry surface used to present Filament frames.
+enum AndroidTextureSource {
+  /// Uses Flutter's `SurfaceTexture` external-texture path.
+  ///
+  /// This avoids the main-thread `ImageReader` work performed by
+  /// [surfaceProducer] and is the preferred path for opaque views.
+  surfaceTexture,
+
+  /// Uses Flutter's `SurfaceProducer` path.
+  ///
+  /// This preserves premultiplied alpha when compositing a transparent
+  /// Filament view with Impeller, but its ImageReader-backed implementation
+  /// can be substantially more expensive on some Android devices.
+  surfaceProducer,
+}
+
 class ThermionFlutterOptions {
   final String? uberarchivePath;
 
@@ -16,6 +32,12 @@ class ThermionFlutterOptions {
 class NativeOptions {
   final Backend? backend;
 
+  /// The texture-registry surface used on Android.
+  ///
+  /// Prefer [AndroidTextureSource.surfaceTexture] unless the Filament output
+  /// must be composited transparently over Flutter content.
+  final AndroidTextureSource androidTextureSource;
+
   /// The format to use for the default render target color attachment.
   /// Currently only applicable on iOS/macOS.
   final TextureFormat renderTargetColorTextureFormat;
@@ -30,6 +52,7 @@ class NativeOptions {
 
   const NativeOptions({
     this.backend,
+    this.androidTextureSource = AndroidTextureSource.surfaceTexture,
     this.renderTargetColorTextureFormat = TextureFormat.RGBA8,
     this.renderTargetDepthTextureFormat = TextureFormat.DEPTH24_STENCIL8,
     this.createOverlay = false,

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_flutter/src/options.dart';
 
 import 'method_channel_platform_texture_descriptor.dart';
 import 'platform_texture_descriptor.dart';
 
-/// Describes an Android SurfaceProducer texture and its native window.
+/// Describes an Android texture-registry surface and its native window.
 class AndroidPlatformTextureDescriptor
     extends MethodChannelPlatformTextureDescriptor
     with ReplaceablePlatformTextureDescriptorMixin {
@@ -28,15 +29,26 @@ class AndroidPlatformTextureDescriptor
   @override
   bool get deferred => false;
 
+  /// Android's texture-registry surfaces publish queued buffers without an
+  /// explicit method-channel notification. The old call only acknowledged the
+  /// texture ID, adding one platform message per frame without changing
+  /// presentation state.
+  @override
+  void markTextureFrameAvailable() {}
+
   static Future<AndroidPlatformTextureDescriptor> allocate(
     MethodChannel channel,
     int width,
     int height,
+    AndroidTextureSource textureSource,
   ) async {
     final allocation = await allocateMethodChannelTexture(
       channel,
       width,
       height,
+      additionalArguments: [
+        textureSource == AndroidTextureSource.surfaceProducer,
+      ],
     );
     final windowHandle = allocation.windowHandle;
     if (windowHandle == null || windowHandle == 0) {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
@@ -85,13 +85,15 @@ typedef MethodChannelTextureAllocation = ({
 Future<MethodChannelTextureAllocation> allocateMethodChannelTexture(
   MethodChannel channel,
   int width,
-  int height,
-) async {
+  int height, {
+  List<Object?> additionalArguments = const [],
+}) async {
   final result = await channel.invokeMethod("createTexture", [
     width,
     height,
     0,
     0,
+    ...additionalArguments,
   ]);
   if (result == null || (result[0] == -1)) {
     throw Exception("Failed to create texture");

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
@@ -60,6 +60,7 @@ class NativeTextureSurfaceManager {
          pauseRendering: lifecycle.pauseRendering,
          resumeRenderingIfReady: lifecycle.resumeRenderingIfReady,
          runTextureMutation: lifecycle.duringTextureMutation,
+         androidTextureSource: () => options().androidTextureSource,
        );
 
   static final _logger = Logger('NativeTextureSurfaceManager');

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry_native.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_flutter/src/options.dart';
 
 import 'android_platform_texture_descriptor.dart';
 import 'darwin_platform_texture_descriptor.dart';
@@ -36,10 +37,14 @@ class NativePlatformTextureDescriptorRegistry
     required void Function() pauseRendering,
     required void Function() resumeRenderingIfReady,
     required TextureMutationRunner runTextureMutation,
+    required AndroidTextureSource Function() androidTextureSource,
   }) : _pauseRendering = pauseRendering,
        _resumeRenderingIfReady = resumeRenderingIfReady,
        _runTextureMutation = runTextureMutation,
-       super(allocator: _allocate) {
+       super(
+         allocator: (width, height) =>
+             _allocate(width, height, androidTextureSource()),
+       ) {
     if (Platform.isAndroid) {
       channel.setMethodCallHandler(_handlePlatformMethodCall);
     }
@@ -52,14 +57,23 @@ class NativePlatformTextureDescriptorRegistry
   final TextureMutationRunner _runTextureMutation;
   final Logger _logger = Logger('NativePlatformTextureDescriptorRegistry');
 
-  static Future<PlatformTextureDescriptor> _allocate(int width, int height) {
+  static Future<PlatformTextureDescriptor> _allocate(
+    int width,
+    int height,
+    AndroidTextureSource androidTextureSource,
+  ) {
     if (Platform.isMacOS || Platform.isIOS) {
       return Future.value(
         DarwinPlatformTextureDescriptorImpl.allocate(width, height),
       );
     }
     if (Platform.isAndroid) {
-      return AndroidPlatformTextureDescriptor.allocate(channel, width, height);
+      return AndroidPlatformTextureDescriptor.allocate(
+        channel,
+        width,
+        height,
+        androidTextureSource,
+      );
     }
     if (Platform.isWindows) {
       return MethodChannelPlatformTextureDescriptor.allocate(

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/viewer_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/viewer_widget.dart
@@ -100,6 +100,8 @@ class _ViewerWidgetState extends State<ViewerWidget> {
           webOptions: currentOptions.webOptions,
           nativeOptions: NativeOptions(
             backend: currentOptions.nativeOptions.backend,
+            androidTextureSource:
+                currentOptions.nativeOptions.androidTextureSource,
             renderTargetColorTextureFormat:
                 currentOptions.nativeOptions.renderTargetColorTextureFormat,
             renderTargetDepthTextureFormat:

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
@@ -1,10 +1,15 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:thermion_flutter/src/platform/src/android_platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
+import 'package:thermion_flutter/src/options.dart';
 
 // ignore: implementation_imports
 import 'package:thermion_dart/src/filament/src/interface/native_handle.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('PlatformTextureDescriptor equality', () {
     test(
       'descriptors with the same flutterTextureId match (== and hashCode)',
@@ -44,6 +49,70 @@ void main() {
       expect(_TestNativeHandle(42) == _TestNativeHandle(43), isFalse);
     });
   });
+  test('Android frame publication does not send a platform message', () async {
+    const channel = MethodChannel('thermion.test.texture');
+    var methodCallCount = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          methodCallCount++;
+          return null;
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    final descriptor = AndroidPlatformTextureDescriptor(
+      channel,
+      flutterTextureId: 1,
+      hardwareId: 2,
+      windowHandle: 3,
+      width: 4,
+      height: 5,
+    );
+
+    descriptor.markTextureFrameAvailable();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(methodCallCount, 0);
+  });
+
+  for (final (textureSource, expectedSurfaceProducer) in [
+    (AndroidTextureSource.surfaceTexture, false),
+    (AndroidTextureSource.surfaceProducer, true),
+  ]) {
+    test('Android allocation requests ${textureSource.name}', () async {
+      const channel = MethodChannel('thermion.test.texture.allocation');
+      MethodCall? receivedCall;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            receivedCall = call;
+            return <int>[11, 11, 22];
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final descriptor = await AndroidPlatformTextureDescriptor.allocate(
+        channel,
+        640,
+        480,
+        textureSource,
+      );
+
+      expect(receivedCall?.method, 'createTexture');
+      expect(receivedCall?.arguments, <Object?>[
+        640,
+        480,
+        0,
+        0,
+        expectedSurfaceProducer,
+      ]);
+      expect(descriptor.flutterTextureId, 11);
+      expect(descriptor.windowHandle, 22);
+    });
+  }
 }
 
 class _TestDescriptor extends PlatformTextureDescriptor {


### PR DESCRIPTION
This PR reinstates Flutter's SurfaceTexture path as the Android default, while preserving the new SurfaceProducer implementation. The latter must be uses for correct transparent composition on Impeller, but performs ImageReader work on the main looper which degrades performance on certain devices.