### PR TITLE
Harden render lifecycle transitions

### DIFF
--- a/thermion_dart/ffigen/native.yaml
+++ b/thermion_dart/ffigen/native.yaml
@@ -13,6 +13,11 @@ functions:
   leaf:
     include:
       - '.*'
+    exclude:
+      # FrameScheduler_stop joins the scheduler thread and waits for the final
+      # render task to drain. Blocking functions must not be Dart FFI leaf
+      # calls. This excludes it only from isLeaf:true, not from the bindings.
+      - 'FrameScheduler_stop'
 enums:
   as-int:
     include:

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -6755,7 +6755,7 @@ external void RenderManager_setPaused(
 @ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
 external void FrameScheduler_start(FrameCallback callback, int targetFps);
 
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
+@ffi.Native<ffi.Void Function()>()
 external void FrameScheduler_stop();
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -86,6 +86,11 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     this.transformManager = FFITransformManager(transformManagerPtr, this);
     this.animationManager = FFIAnimationManager(animationManagerPointer, this);
     this.renderManager = FFIRenderManager(renderManager);
+
+    // A new engine starts uncapped. Scheduler stop/start within this engine
+    // preserves later user changes, but a cap from an older hot-restarted
+    // engine must not leak into this one.
+    bindings.FrameScheduler_setTargetFps(0);
   }
 
   //
@@ -385,6 +390,12 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
   //
   @override
   Future destroy() async {
+    for (final callback in _onBeforeDestroy) {
+      await callback.call();
+    }
+    _onBeforeDestroy.clear();
+    await drainRequestFrameHooks();
+
     for (final swapChain in _swapChains.toList()) {
       await renderManager.detachAll(swapChain);
       await destroySwapChain(swapChain);
@@ -876,6 +887,13 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
   }
 
   bool _processingRenderHooks = false;
+
+  /// Waits for any request-frame hook that is already running.
+  Future<void> drainRequestFrameHooks() async {
+    while (_processingRenderHooks) {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+  }
 
   //
   @override
@@ -1752,9 +1770,17 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     }
   }
 
+  final _onBeforeDestroy = <Future Function()>[];
   final _onDestroy = <Future Function()>[];
 
   //
+  @override
+  void onBeforeDestroy(Future Function() callback) {
+    _onBeforeDestroy.add(callback);
+  }
+
+  //
+  @override
   void onDestroy(Future Function() callback) {
     _onDestroy.add(callback);
   }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
@@ -5,6 +5,68 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_swapchain.dart
 import 'package:thermion_dart/src/filament/src/interface/render_manager.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 
+/// Tracks view-to-swapchain associations separately from whether a view should
+/// currently be submitted for rendering.
+///
+/// A view can be paused before its platform surface exists. Keeping that state
+/// independent of the attachment lets a later Android surface callback attach
+/// the correct swapchain without accidentally enabling the view.
+class RenderAttachmentState {
+  final _attachments = <Pointer<TSwapChain>, List<(int, View)>>{};
+  final _renderable = <View, bool>{};
+
+  void attach(View view, Pointer<TSwapChain> swapChain, {int renderOrder = 0}) {
+    final views = _attachments.putIfAbsent(swapChain, () => []);
+    views.removeWhere((entry) => entry.$2 == view);
+    views.add((renderOrder, view));
+    views.sort((a, b) => a.$1.compareTo(b.$1));
+  }
+
+  void setRenderable(View view, bool renderable) {
+    _renderable[view] = renderable;
+  }
+
+  void detach(View view, {Pointer<TSwapChain>? swapChain}) {
+    if (swapChain == null) {
+      for (final views in _attachments.values) {
+        views.removeWhere((entry) => entry.$2 == view);
+      }
+      _renderable.remove(view);
+      return;
+    }
+    _attachments[swapChain]?.removeWhere((entry) => entry.$2 == view);
+  }
+
+  void detachAll(Pointer<TSwapChain> swapChain) {
+    _attachments.remove(swapChain);
+  }
+
+  Map<Pointer<TSwapChain>, List<(int, View)>> activeSnapshot() {
+    return {
+      for (final entry in _attachments.entries)
+        entry.key: entry.value
+            .where((attachment) => _renderable[attachment.$2] ?? true)
+            .toList(),
+    };
+  }
+
+  Iterable<View> getAttachedViews(Pointer<TSwapChain> swapChain) =>
+      _attachments[swapChain]?.map((entry) => entry.$2) ?? [];
+
+  Iterable<Pointer<TSwapChain>> getAttachedSwapChains(View view) sync* {
+    for (final entry in _attachments.entries) {
+      if (entry.value.any((attachment) => attachment.$2 == view)) {
+        yield entry.key;
+      }
+    }
+  }
+
+  void clear() {
+    _attachments.clear();
+    _renderable.clear();
+  }
+}
+
 class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
   final Pointer<TRenderManager> pointer;
 
@@ -16,9 +78,9 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
 
   FFIRenderManager(this.pointer);
 
-  static final _attachments = <Pointer<TSwapChain>, List<(int, View)>>{};
+  static final _attachmentState = RenderAttachmentState();
 
-  /// Serialises every operation that mutates `_attachments` and runs
+  /// Serialises every operation that mutates attachment state and runs
   /// `_syncViews` (attach / detach / detachAll). Concurrent calls from
   /// sibling viewers in multi-viewer apps were running in parallel,
   /// each taking its own `_syncViews` snapshot at a different moment.
@@ -53,14 +115,19 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
   @override
   Future attach(View view, SwapChain swapChain, {int renderOrder = 0}) {
     return _serialize(() async {
-      final handle = swapChain.getNativeHandle();
-      if (!_attachments.containsKey(handle)) {
-        _attachments[handle] = [];
-      }
+      _attachmentState.attach(
+        view,
+        swapChain.getNativeHandle(),
+        renderOrder: renderOrder,
+      );
+      await _syncViews();
+    });
+  }
 
-      _attachments[handle]!.removeWhere((v) => v.$2 == view);
-      _attachments[handle]!.add((renderOrder, view));
-      _attachments[handle]!.sort((a, b) => a.$1.compareTo(b.$1));
+  @override
+  Future setRenderable(View view, bool renderable) {
+    return _serialize(() async {
+      _attachmentState.setRenderable(view, renderable);
       await _syncViews();
     });
   }
@@ -68,19 +135,7 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
   @override
   Future detach(View view, {SwapChain? swapChain}) {
     return _serialize(() async {
-      if (swapChain == null) {
-        for (final swapChainHandle in _attachments.keys) {
-          _attachments[swapChainHandle]!.removeWhere((v) => v.$2 == view);
-        }
-      } else {
-        if (!_attachments.containsKey(swapChain.getNativeHandle())) {
-          _attachments[swapChain.getNativeHandle()] = [];
-        }
-
-        _attachments[swapChain.getNativeHandle()]!.removeWhere(
-          (v) => v.$2 == view,
-        );
-      }
+      _attachmentState.detach(view, swapChain: swapChain?.getNativeHandle());
       await _syncViews();
     });
   }
@@ -102,10 +157,7 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
     // Snapshotting also tolerates removal: if an entry was deleted
     // by the time we get back to it, the views list will be null
     // and we skip it.
-    final snapshot = <Pointer<TSwapChain>, List<(int, View)>>{};
-    for (final entry in _attachments.entries) {
-      snapshot[entry.key] = List.of(entry.value);
-    }
+    final snapshot = _attachmentState.activeSnapshot();
 
     for (final swapChainHandle in snapshot.keys) {
       final views = snapshot[swapChainHandle];
@@ -143,11 +195,12 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
           cb,
         ),
       );
-      _attachments.remove(swapChain.getNativeHandle());
+      _attachmentState.detachAll(swapChain.getNativeHandle());
     });
   }
 
   void destroy() {
+    _attachmentState.clear();
     RenderManager_destroy(pointer);
   }
 
@@ -175,17 +228,13 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
 
   @override
   Iterable<View> getAttachedViews(SwapChain swapChain) {
-    return _attachments[swapChain.getNativeHandle()]?.map((v) => v.$2) ?? [];
+    return _attachmentState.getAttachedViews(swapChain.getNativeHandle());
   }
 
   @override
   Iterable<SwapChain> getAttachedSwapChains(View view) sync* {
-    for (final entry in _attachments.entries) {
-      for (final views in entry.value) {
-        if (views.$2 == view) {
-          yield FFISwapChain(entry.key);
-        }
-      }
+    for (final handle in _attachmentState.getAttachedSwapChains(view)) {
+      yield FFISwapChain(handle);
     }
   }
 }

--- a/thermion_dart/lib/src/filament/src/interface/filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/interface/filament_app.dart
@@ -395,6 +395,10 @@ abstract class FilamentApp<T> {
   //
   Future flush();
 
+  /// Registers work that must finish before engine-owned render resources are
+  /// torn down.
+  void onBeforeDestroy(Future Function() callback);
+
   //
   void onDestroy(Future Function() callback);
 

--- a/thermion_dart/lib/src/filament/src/interface/render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/render_manager.dart
@@ -3,6 +3,14 @@ import 'package:thermion_dart/thermion_dart.dart';
 
 abstract class RenderManager<T> extends NativeHandle<T> {
   Future attach(View view, SwapChain swapChain, {int renderOrder = 0});
+
+  /// Includes or excludes [view] from rendering while preserving its
+  /// swapchain association.
+  ///
+  /// The requested state is retained when the view has not been attached yet,
+  /// so platform surfaces can be created asynchronously.
+  Future setRenderable(View view, bool renderable);
+
   Future detach(View view, {SwapChain? swapChain});
   Future detachAll(SwapChain swapChain);
   Iterable<View> getAttachedViews(SwapChain swapChain);

--- a/thermion_dart/lib/src/input/src/implementations/free_flight_camera_delegate_v2.dart
+++ b/thermion_dart/lib/src/input/src/implementations/free_flight_camera_delegate_v2.dart
@@ -162,7 +162,7 @@ class FreeFlightInputHandlerDelegateV2 extends InputHandlerDelegate {
 
   @override
   Future dispose() async {
-    FilamentApp.instance!.unregisterRequestFrameHook(_onFrame);
+    await FilamentApp.instance!.unregisterRequestFrameHook(_onFrame);
     _heldKeys.clear();
   }
 }

--- a/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
+++ b/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
@@ -98,16 +98,8 @@ class ThermionViewerFFI extends ThermionViewer {
   //
   @override
   Future setRendering(bool render) async {
+    await FilamentApp.instance!.renderManager.setRenderable(view, render);
     _rendering = render;
-    final rm = FilamentApp.instance!.renderManager;
-
-    final swapChains = await FilamentApp.instance!.getSwapChains();
-
-    if (render) {
-      await rm.attach(view, swapChains.first);
-    } else {
-      await rm.detach(view);
-    }
   }
 
   //

--- a/thermion_dart/native/src/c_api/FrameSchedulerApi.cpp
+++ b/thermion_dart/native/src/c_api/FrameSchedulerApi.cpp
@@ -26,6 +26,8 @@ extern "C"
   static TRenderManager* _nativeRenderManager = nullptr;
   static RenderThread* _renderThread = nullptr;  // non-owning; owned by ThermionDartRenderThreadApi
   static std::atomic<bool> _nativeRenderInProgress{false};
+  static PostRenderCallback _postRenderCallback = nullptr;
+  static void* _postRenderUserData = nullptr;
 
   // Process-wide desired cap. It survives scheduler stop/start so lifecycle
   // transitions do not silently discard the user's setting. 0 = unlimited.
@@ -61,11 +63,16 @@ extern "C"
       delete _frameScheduler;
       _frameScheduler = nullptr;
     }
-    _nativeRenderManager = nullptr;
-    // Wait for any in-progress native render to finish
-    while (_nativeRenderInProgress.load()) {
+
+    // No scheduler callback can be admitted after stop() returns. Wait for
+    // the final accepted render before invalidating any pointer it captured.
+    while (_nativeRenderInProgress.load(std::memory_order_acquire)) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
+    _nativeRenderManager = nullptr;
+    _renderThread = nullptr;
+    _postRenderCallback = nullptr;
+    _postRenderUserData = nullptr;
 #endif
   }
 
@@ -131,9 +138,6 @@ extern "C"
     _nativeRenderManager = rm;
   }
 
-  static PostRenderCallback _postRenderCallback = nullptr;
-  static void* _postRenderUserData = nullptr;
-
   EMSCRIPTEN_KEEPALIVE void FrameScheduler_setPostRenderCallback(PostRenderCallback callback, void* userData) {
     _postRenderCallback = callback;
     _postRenderUserData = userData;
@@ -141,19 +145,28 @@ extern "C"
 
   // Frame callback for native render loop — runs on scheduler thread
   static bool _nativeFrameCallback(uint64_t frameTimeNanos) {
-    if (!_nativeRenderManager || !_renderThread) return false;
-    if (_nativeRenderInProgress.exchange(true)) {
+    auto* renderManager = _nativeRenderManager;
+    auto* renderThread = _renderThread;
+    auto postRenderCallback = _postRenderCallback;
+    auto* postRenderUserData = _postRenderUserData;
+    if (!renderManager || !renderThread) return false;
+    if (_nativeRenderInProgress.exchange(true, std::memory_order_acq_rel)) {
       return false; // skip if still rendering
     }
 
-    _renderThread->addDetachedTask([frameTimeNanos]() {
-      RenderManager_render(_nativeRenderManager, frameTimeNanos);
+    renderThread->addDetachedTask([
+      renderManager,
+      frameTimeNanos,
+      postRenderCallback,
+      postRenderUserData
+    ]() {
+      RenderManager_render(renderManager, frameTimeNanos);
 
-      if (_postRenderCallback) {
-        _postRenderCallback(_postRenderUserData);
+      if (postRenderCallback) {
+        postRenderCallback(postRenderUserData);
       }
 
-      _nativeRenderInProgress.store(false);
+      _nativeRenderInProgress.store(false, std::memory_order_release);
     });
     return true;
   }
@@ -212,6 +225,7 @@ extern "C"
       delete _frameScheduler;
       _frameScheduler = nullptr;
     }
+
     _frameScheduler = new thermion::TimerFrameScheduler(
         targetFps > 0 ? targetFps : 60);
     applyTargetFps(_frameScheduler);

--- a/thermion_dart/test/render_attachment_state_test.dart
+++ b/thermion_dart/test/render_attachment_state_test.dart
@@ -1,0 +1,89 @@
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_render_manager.dart';
+
+class _TestView implements View<Pointer<TView>> {
+  _TestView(int address) : _handle = Pointer<TView>.fromAddress(address);
+
+  final Pointer<TView> _handle;
+
+  @override
+  Pointer<TView> getNativeHandle() => _handle;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Pointer<TSwapChain> _swapChain(int address) =>
+    Pointer<TSwapChain>.fromAddress(address);
+
+void main() {
+  group('RenderAttachmentState', () {
+    test('accepts an enabled view before its first attachment', () {
+      final state = RenderAttachmentState();
+      final view = _TestView(1);
+      final swapChain = _swapChain(1);
+
+      state.setRenderable(view, true);
+
+      expect(state.getAttachedSwapChains(view), isEmpty);
+      expect(state.activeSnapshot(), isEmpty);
+
+      state.attach(view, swapChain);
+      expect(state.activeSnapshot()[swapChain], [(0, view)]);
+    });
+
+    test('remembers a paused view before its first attachment', () {
+      final state = RenderAttachmentState();
+      final view = _TestView(1);
+      final swapChain = _swapChain(1);
+
+      state.setRenderable(view, false);
+      state.attach(view, swapChain);
+
+      expect(state.getAttachedSwapChains(view), [swapChain]);
+      expect(state.activeSnapshot()[swapChain], isEmpty);
+    });
+
+    test('resumes the view on its existing swapchain', () {
+      final state = RenderAttachmentState();
+      final view = _TestView(1);
+      final swapChain = _swapChain(1);
+
+      state.attach(view, swapChain);
+      state.setRenderable(view, false);
+      state.setRenderable(view, true);
+
+      expect(state.activeSnapshot()[swapChain], [(0, view)]);
+    });
+
+    test('preserves pause state while replacing a swapchain', () {
+      final state = RenderAttachmentState();
+      final view = _TestView(1);
+      final oldSwapChain = _swapChain(1);
+      final replacementSwapChain = _swapChain(2);
+
+      state.attach(view, oldSwapChain);
+      state.setRenderable(view, false);
+      state.attach(view, replacementSwapChain);
+      state.detachAll(oldSwapChain);
+
+      expect(state.getAttachedSwapChains(view), [replacementSwapChain]);
+      expect(state.activeSnapshot()[replacementSwapChain], isEmpty);
+    });
+
+    test('a fully detached view defaults to rendering when reused', () {
+      final state = RenderAttachmentState();
+      final view = _TestView(1);
+      final oldSwapChain = _swapChain(1);
+      final newSwapChain = _swapChain(2);
+
+      state.setRenderable(view, false);
+      state.attach(view, oldSwapChain);
+      state.detach(view);
+      state.attach(view, newSwapChain);
+
+      expect(state.activeSnapshot()[newSwapChain], [(0, view)]);
+    });
+  });
+}

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/frame_scheduler.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/frame_scheduler.dart
@@ -90,7 +90,7 @@ class FrameScheduler {
   int get scheduledFrameCount => _scheduledFrameCount;
 
   /// Start the native scheduler. Picks port mode in debug builds on
-  /// macOS/iOS/Android/Windows, direct callback otherwise.
+  /// macOS/iOS/Android/Windows and a direct native callback otherwise.
   ///
   /// Idempotent: a no-op if already active. Guards against a rapid
   /// pause→resume (or an in-flight [start]) double-registering the
@@ -151,6 +151,8 @@ class FrameScheduler {
     _active = false;
     _flutterSynced = false;
 
+    // Always stop native state even when Dart has just hot-restarted and no
+    // longer remembers that the previous isolate started a scheduler.
     FrameScheduler_stop();
 
     _frameCallable?.close();
@@ -158,6 +160,14 @@ class FrameScheduler {
 
     _framePort?.close();
     _framePort = null;
+  }
+
+  /// Stops all scheduler state and forgets pointers owned by the old engine.
+  void reset() {
+    stop();
+    _paused = false;
+    _rendering = false;
+    _onFrameCallback = null;
   }
 
   void pause() => _paused = true;

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
@@ -36,7 +36,7 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
   /// Stops callbacks left by a previous initialization and removes this
   /// observer before the engine is initialized again.
   void prepareForInitialization() {
-    FrameScheduler.instance.stop();
+    FrameScheduler.instance.reset();
     WidgetsBinding.instance.removeObserver(this);
   }
 
@@ -44,6 +44,10 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
   Future<void> start() async {
     FrameScheduler.instance.setOnFrame(_renderFrame);
 
+    // Android must keep render admission on the Dart callback/port path.
+    // SurfaceProducer consumes ImageReader frames from Android's main looper;
+    // a producer loop decoupled from Flutter can fill that pipeline and block
+    // acquireLatestImage() on the main thread for seconds.
     if (Platform.isLinux) {
       await _startFlutterSynced();
     } else {
@@ -98,7 +102,11 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
       while (FrameScheduler.instance.isRendering) {
         await Future<void>.delayed(const Duration(milliseconds: 1));
       }
-      await FilamentApp.instance?.flush();
+      final app = FilamentApp.instance;
+      if (app is FFIFilamentApp) {
+        await app.drainRequestFrameHooks();
+      }
+      await app?.flush();
       return await operation();
     } finally {
       _pauseReasons.remove(_RenderingPauseReason.textureMutation);

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -57,9 +57,12 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
 
     if (FilamentApp.instance == null) {
       await FFIFilamentApp.create(config: config);
-      FilamentApp.instance!.onDestroy(() async {
-        // Stop callbacks before the engine releases their native targets.
+      FilamentApp.instance!.onBeforeDestroy(() async {
+        // Stop and drain the native scheduler while its RenderManager and
+        // RenderThread pointers are still valid.
         _lifecycle.stop();
+      });
+      FilamentApp.instance!.onDestroy(() async {
         _textureSurfaces.onEngineDestroyed();
         await _textureSurfaces.destroyFilamentRenderingContext();
       });


### PR DESCRIPTION
This PR makes the following engine lifecycle events more robust:
- ensures the frame scheduler is stopped before engine-owned render resources are destroyed
- preserve each view's requested rendering state before its first or replacement swapchain attachment
- drains in-flight frame hooks and hardens native scheduler pointer lifetime during shutdown
