### PR TITLE
fix: (example) dispose quickstart viewer resources

### DIFF
--- a/examples/flutter/quickstart/integration_test/lifecycle_test.dart
+++ b/examples/flutter/quickstart/integration_test/lifecycle_test.dart
@@ -25,6 +25,7 @@
 //   flutter test integration_test/lifecycle_test.dart -d <device-id>
 //
 // Requires the example assets (assets/cube.glb, default_env_*.ktx).
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -213,5 +214,49 @@ void main() {
 
     ThermionFlutterPlugin.instance.resumeFrameScheduler();
     expect(FrameScheduler.instance.isPaused, isFalse);
+  }, skip: Platform.isWindows); // TODO: needs a Windows host to run
+
+  testWidgets('repeated full viewer creation and removal tears down resources',
+      (tester) async {
+    for (var iteration = 0; iteration < 3; iteration++) {
+      final available = Completer<void>();
+      final disposalStarted = Completer<void>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ViewerWidget(
+              assetPath: 'assets/cube.glb',
+              skyboxPath: 'assets/default_env_skybox.ktx',
+              iblPath: 'assets/default_env_ibl.ktx',
+              directLight: DirectLight.sun(
+                direction: Vector3(0.7, -1, -0.8).normalized(),
+              ),
+              onViewerAvailable: (viewer) async {
+                viewer.onDispose(() async {
+                  if (!disposalStarted.isCompleted) {
+                    disposalStarted.complete();
+                  }
+                });
+                if (!available.isCompleted) {
+                  available.complete();
+                }
+              },
+            ),
+          ),
+        ),
+      );
+
+      await available.future.timeout(const Duration(seconds: 30));
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await disposalStarted.future.timeout(const Duration(seconds: 30));
+
+      // Viewer disposal continues with scene/view/camera destruction after
+      // onDispose callbacks. Give that render-thread work time to drain before
+      // creating the next viewer.
+      await tester.pump(const Duration(milliseconds: 500));
+    }
   }, skip: Platform.isWindows); // TODO: needs a Windows host to run
 }

--- a/examples/flutter/quickstart/lib/main.dart
+++ b/examples/flutter/quickstart/lib/main.dart
@@ -40,6 +40,8 @@ class _MyHomePageState extends State<MyHomePage> {
   ThermionViewer? _viewer;
   ManipulatorType _manipulatorType = ManipulatorType.ORBIT;
   int _framerate = 60;
+  Timer? _assetAnimationTimer;
+  Timer? _skyboxRemovalTimer;
 
   late DirectLight _sun;
 
@@ -54,6 +56,19 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   bool _showViewer = false;
+
+  void _cancelViewerCallbacks() {
+    _assetAnimationTimer?.cancel();
+    _assetAnimationTimer = null;
+    _skyboxRemovalTimer?.cancel();
+    _skyboxRemovalTimer = null;
+  }
+
+  @override
+  void dispose() {
+    _cancelViewerCallbacks();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -72,21 +87,45 @@ class _MyHomePageState extends State<MyHomePage> {
               background: Colors.blue,
               manipulatorType: _manipulatorType,
               onAssetLoaded: (viewer, asset) async {
-                var last = DateTime.now();
-                Timer.periodic(Duration(milliseconds: 16), (timer) async {
-                  var now = DateTime.now();
-                  await asset.setTransform(Matrix4.rotationY(
-                      (now.millisecondsSinceEpoch.toDouble() -
-                              last.millisecondsSinceEpoch) /
-                          1000));
-                });
+                _assetAnimationTimer?.cancel();
+                final startedAt = DateTime.now();
+                _assetAnimationTimer = Timer.periodic(
+                  const Duration(milliseconds: 16),
+                  (timer) async {
+                    if (!mounted ||
+                        !_showViewer ||
+                        !identical(_viewer, viewer)) {
+                      timer.cancel();
+                      return;
+                    }
+                    final now = DateTime.now();
+                    final elapsed = (now.millisecondsSinceEpoch -
+                            startedAt.millisecondsSinceEpoch) /
+                        1000;
+                    await asset.setTransform(Matrix4.rotationY(elapsed));
+                  },
+                );
               },
               onViewerAvailable: (viewer) async {
+                if (!mounted || !_showViewer) {
+                  return;
+                }
                 setState(() {
                   _viewer = viewer;
                 });
-                await Future.delayed(const Duration(seconds: 5));
-                await viewer.removeSkybox();
+
+                _skyboxRemovalTimer?.cancel();
+                _skyboxRemovalTimer = Timer(const Duration(seconds: 5), () {
+                  if (!mounted || !_showViewer || !identical(_viewer, viewer)) {
+                    return;
+                  }
+                  viewer
+                      .removeSkybox()
+                      .catchError((Object error, StackTrace stack) {
+                    debugPrint(
+                        'Failed to remove quickstart skybox: $error\n$stack');
+                  });
+                });
               },
               initial: Container(
                 color: Colors.red,
@@ -104,6 +143,7 @@ class _MyHomePageState extends State<MyHomePage> {
                             setState(() {
                               _showViewer = !_showViewer;
                               if (!_showViewer) {
+                                _cancelViewerCallbacks();
                                 _viewer = null;
                               }
                             });

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_indirect_light.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_indirect_light.dart
@@ -87,6 +87,12 @@ class FFIIndirectLight extends IndirectLight {
       ),
     );
 
+    if (_irradianceTexture != null || _reflectionsTexture != null) {
+      // The indirect light references these textures. Engine destruction is
+      // queued, so drain it before releasing the referenced textures.
+      await FilamentApp.instance!.flush();
+    }
+
     if (_irradianceTexture != null) {
       await withVoidCallback(
         (requestId, cb) => Engine_destroyTextureRenderThread(

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -294,11 +294,11 @@ class FFIView extends View<Pointer<TView>> {
     );
   }
 
-  Future setScene(Scene scene) async {
+  Future setScene(Scene? scene) async {
     await withVoidCallback(
       (requestId, cb) => View_setSceneRenderThread(
         view,
-        scene.getNativeHandle(),
+        scene?.getNativeHandle() ?? nullptr,
         requestId,
         cb,
       ),

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -309,8 +309,9 @@ abstract class View<T> extends NativeHandle<T> {
   /// Gets the scene currently associated with this View.
   Future<Scene> getScene();
 
-  /// Sets the scene currently associated with this View.
-  Future setScene(Scene scene);
+  /// Sets the scene currently associated with this View, or detaches the
+  /// current scene when [scene] is null.
+  Future setScene(Scene? scene);
 
   // Sets the (debug) name for this View.
   Future setName(String name);

--- a/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
+++ b/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
@@ -145,13 +145,45 @@ class ThermionViewerFFI extends ThermionViewer {
 
   final _onDispose = <Future Function()>[];
   bool _disposed = false;
+  Future<void>? _disposeFuture;
+  Future<void> _sceneResourceOperations = Future<void>.value();
+
+  Future<T> _serializeSceneResourceOperation<T>(
+    Future<T> Function() operation,
+  ) {
+    final previous = _sceneResourceOperations;
+    final current = () async {
+      await previous;
+      return operation();
+    }();
+    _sceneResourceOperations = current.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    return current;
+  }
+
+  void _throwIfDisposed() {
+    if (_disposed) {
+      throw ViewerDisposedException();
+    }
+  }
 
   //
   @override
-  Future dispose() async {
+  Future<void> dispose() {
+    return _disposeFuture ??= _dispose();
+  }
+
+  Future<void> _dispose() async {
     _disposed = true;
     await setRendering(false);
 
+    // Finish any load/remove operation that was accepted before dispose, then
+    // detach and destroy every scene-level resource while the scene is valid.
+    await _sceneResourceOperations;
+    await _removeSkybox();
+    await _removeIbl(destroy: true);
     await clearBackgroundImage(destroy: true);
 
     await destroyAssets();
@@ -160,7 +192,15 @@ class ThermionViewerFFI extends ThermionViewer {
     for (final callback in _onDispose) {
       await callback.call();
     }
-    View_setScene(view.getNativeHandle(), nullptr);
+
+    await view.setHighlightOverlayEnabled(false);
+    await view.setCamera(null);
+    for (final camera in _cameras.toList()) {
+      await camera.destroy();
+    }
+    _cameras.clear();
+
+    await view.setScene(null);
 
     await FilamentApp.instance!.destroyScene(scene);
     await FilamentApp.instance!.destroyView(view);
@@ -214,7 +254,13 @@ class ThermionViewerFFI extends ThermionViewer {
     bool isKtx = path.endsWith(".ktx");
     if (isKtx) {
       final bundle = await FFIKtx1Bundle.create(imageData);
-      await _backgroundImage!.setImageFromKtxBundle(bundle);
+      try {
+        await _backgroundImage!.setImageFromKtxBundle(bundle);
+        // Ktx1Reader borrows the bundle's blobs until the upload completes.
+        await FilamentApp.instance!.flush();
+      } finally {
+        await bundle.destroy();
+      }
     } else {
       await _backgroundImage!.setImage(imageData);
     }
@@ -223,11 +269,149 @@ class ThermionViewerFFI extends ThermionViewer {
 
   //
   @override
-  Future setBackgroundColor(double r, double g, double b, double a) async {
-    await removeSkybox();
-    _skybox = await FilamentApp.instance!.buildSkybox() as FFISkybox;
-    await scene.setSkybox(_skybox!);
-    await _skybox!.setColor(r, g, b, a);
+  Future setBackgroundColor(double r, double g, double b, double a) {
+    _throwIfDisposed();
+    return _serializeSceneResourceOperation(() async {
+      await _removeSkybox();
+      _skybox = await FilamentApp.instance!.buildSkybox() as FFISkybox;
+      await scene.setSkybox(_skybox!);
+      await _skybox!.setColor(r, g, b, a);
+    });
+  }
+
+  Future<void> _loadSkybox(String skyboxPath) async {
+    await _removeSkybox();
+
+    var data = await FilamentApp.instance!.loadResource(skyboxPath);
+
+    final completer = Completer<void>();
+    FFIKtx1Bundle? bundle;
+
+    final uploadFuture = withVoidCallback((
+      requestId,
+      onTextureUploadComplete,
+    ) async {
+      bundle = await FFIKtx1Bundle.create(data) as FFIKtx1Bundle;
+
+      _skyboxTexture =
+          await bundle!.createTexture(
+                onTextureUploadComplete: onTextureUploadComplete,
+                textureUploadCompleteRequestId: requestId,
+              )
+              as FFITexture;
+
+      _skybox =
+          await FilamentApp.instance!.buildSkybox(texture: _skyboxTexture)
+              as FFISkybox;
+
+      await scene.setSkybox(_skybox!);
+
+      completer.complete();
+    });
+
+    late final Future<void> trackedUploadFuture;
+    trackedUploadFuture = uploadFuture.whenComplete(() async {
+      await bundle?.destroy();
+      if (identical(_skyboxTextureUploadComplete, trackedUploadFuture)) {
+        _skyboxTextureUploadComplete = null;
+      }
+    });
+    _skyboxTextureUploadComplete = trackedUploadFuture;
+    await completer.future;
+  }
+
+  //
+  @override
+  Future loadSkybox(String skyboxPath) {
+    _throwIfDisposed();
+    return _serializeSceneResourceOperation(() => _loadSkybox(skyboxPath));
+  }
+
+  Future<void> _loadIbl(
+    String lightingPath, {
+    double intensity = 30000,
+    bool destroyExisting = true,
+  }) async {
+    await _removeIbl(destroy: destroyExisting);
+
+    final completer = Completer<void>();
+    FFIKtx1Bundle? bundle;
+    final uploadFuture = withVoidCallback((
+      requestId,
+      onTextureUploadComplete,
+    ) async {
+      var data = await FilamentApp.instance!.loadResource(lightingPath);
+
+      bundle = await FFIKtx1Bundle.create(data) as FFIKtx1Bundle;
+
+      final texture = await bundle!.createTexture(
+        onTextureUploadComplete: onTextureUploadComplete,
+        textureUploadCompleteRequestId: requestId,
+      );
+      final harmonics = bundle!.getSphericalHarmonics();
+
+      final ibl = await FFIIndirectLight.fromIrradianceHarmonics(
+        harmonics,
+        reflectionsTexture: texture,
+        intensity: intensity,
+      );
+
+      await scene.setIndirectLight(ibl);
+
+      if (FILAMENT_WASM) {
+        data.free();
+      }
+
+      completer.complete();
+      _logger.info("IBL texture ready");
+    });
+
+    late final Future<void> trackedUploadFuture;
+    trackedUploadFuture = uploadFuture.whenComplete(() async {
+      await bundle?.destroy();
+      if (identical(_iblTextureUploadComplete, trackedUploadFuture)) {
+        _iblTextureUploadComplete = null;
+      }
+      _logger.info("IBL texture upload complete");
+    });
+    _iblTextureUploadComplete = trackedUploadFuture;
+    await completer.future;
+  }
+
+  Future<void> _loadIblFromTexture(
+    Texture texture, {
+    Texture? reflectionsTexture,
+    double intensity = 30000,
+    bool destroyExisting = true,
+  }) async {
+    await _removeIbl(destroy: destroyExisting);
+
+    final ibl = await FFIIndirectLight.fromIrradianceTexture(
+      texture,
+      reflectionsTexture: reflectionsTexture,
+      intensity: intensity,
+    );
+
+    await scene.setIndirectLight(ibl);
+  }
+
+  Future<void> _removeSkybox() async {
+    final upload = _skyboxTextureUploadComplete;
+    if (upload != null) {
+      await FilamentApp.instance!.flush();
+      await upload;
+    }
+
+    await scene.setSkybox(null);
+    await _skybox?.destroy();
+    if (_skybox != null && _skyboxTexture != null) {
+      // Engine::destroy queues the skybox destruction. Ensure the skybox has
+      // released its environment texture before destroying that texture.
+      await FilamentApp.instance!.flush();
+    }
+    await _skyboxTexture?.destroy();
+    _skybox = null;
+    _skyboxTexture = null;
   }
 
   //
@@ -244,39 +428,6 @@ class ThermionViewerFFI extends ThermionViewer {
   FFITexture? _skyboxTexture;
   FFISkybox? _skybox;
 
-  //
-  @override
-  Future loadSkybox(String skyboxPath) async {
-    await removeSkybox();
-
-    var data = await FilamentApp.instance!.loadResource(skyboxPath);
-
-    final completer = Completer();
-
-    _skyboxTextureUploadComplete =
-        withVoidCallback((requestId, onTextureUploadComplete) async {
-          var bundle = await FFIKtx1Bundle.create(data);
-
-          _skyboxTexture =
-              await bundle.createTexture(
-                    onTextureUploadComplete: onTextureUploadComplete,
-                    textureUploadCompleteRequestId: requestId,
-                  )
-                  as FFITexture;
-
-          _skybox =
-              await FilamentApp.instance!.buildSkybox(texture: _skyboxTexture)
-                  as FFISkybox;
-
-          await scene.setSkybox(_skybox!);
-
-          completer.complete();
-        }).then((_) async {
-          _skyboxTextureUploadComplete = null;
-        });
-    await completer.future;
-  }
-
   Future? _iblTextureUploadComplete;
 
   //
@@ -285,70 +436,33 @@ class ThermionViewerFFI extends ThermionViewer {
     String lightingPath, {
     double intensity = 30000,
     bool destroyExisting = true,
-  }) async {
-    await removeIbl(destroy: destroyExisting);
-
-    final completer = Completer();
-    _iblTextureUploadComplete =
-        withVoidCallback((requestId, onTextureUploadComplete) async {
-              late Pointer stackPtr;
-              if (FILAMENT_WASM) {
-                //stackPtr = stackSave();
-              }
-
-              var data = await FilamentApp.instance!.loadResource(lightingPath);
-
-              final bundle = await FFIKtx1Bundle.create(data);
-
-              final texture = await bundle.createTexture(
-                onTextureUploadComplete: onTextureUploadComplete,
-                textureUploadCompleteRequestId: requestId,
-              );
-              final harmonics = bundle.getSphericalHarmonics();
-
-              final ibl = await FFIIndirectLight.fromIrradianceHarmonics(
-                harmonics,
-                reflectionsTexture: texture,
-                intensity: intensity,
-              );
-
-              await scene.setIndirectLight(ibl);
-
-              if (FILAMENT_WASM) {
-                //stackRestore(stackPtr);
-                data.free();
-              }
-              data.free();
-
-              completer.complete();
-              _logger.info("IBL texture upload complete");
-            })
-            .then((_) {
-              _logger.info("IBL texture upload complete");
-              _iblTextureUploadComplete = null;
-            })
-            .onError((err, st) {
-              _logger.severe(err.toString());
-            });
-    await completer.future;
+  }) {
+    _throwIfDisposed();
+    return _serializeSceneResourceOperation(
+      () => _loadIbl(
+        lightingPath,
+        intensity: intensity,
+        destroyExisting: destroyExisting,
+      ),
+    );
   }
 
   //
   Future loadIblFromTexture(
     Texture texture, {
-    Texture? reflectionsTexture = null,
+    Texture? reflectionsTexture,
     double intensity = 30000,
     bool destroyExisting = true,
-  }) async {
-    await removeIbl(destroy: destroyExisting);
-
-    final ibl = await FFIIndirectLight.fromIrradianceTexture(
-      texture,
-      reflectionsTexture: reflectionsTexture,
-      intensity: intensity,
+  }) {
+    _throwIfDisposed();
+    return _serializeSceneResourceOperation(
+      () => _loadIblFromTexture(
+        texture,
+        reflectionsTexture: reflectionsTexture,
+        intensity: intensity,
+        destroyExisting: destroyExisting,
+      ),
     );
-
-    await scene.setIndirectLight(ibl);
   }
 
   //
@@ -362,35 +476,30 @@ class ThermionViewerFFI extends ThermionViewer {
 
   //
   @override
-  Future removeSkybox() async {
-    if (_disposed) {
-      throw ViewerDisposedException();
-    }
-
-    if (_skyboxTextureUploadComplete != null) {
-      await FilamentApp.instance!.flush();
-      await _skyboxTextureUploadComplete;
-      _skyboxTextureUploadComplete = null;
-    }
-
-    await _skybox?.destroy();
-    _skybox = null;
-    _skyboxTexture = null;
+  Future removeSkybox() {
+    _throwIfDisposed();
+    return _serializeSceneResourceOperation(_removeSkybox);
   }
 
-  //
-  @override
-  Future removeIbl({bool destroy = true}) async {
+  Future<void> _removeIbl({bool destroy = true}) async {
+    final upload = _iblTextureUploadComplete;
+    if (upload != null) {
+      await FilamentApp.instance!.flush();
+      await upload;
+    }
+
     var ibl = await scene.getIndirectLight();
     await scene.setIndirectLight(null);
     if (ibl != null && destroy) {
       await ibl.destroy();
     }
-    if (_iblTextureUploadComplete != null) {
-      await FilamentApp.instance!.flush();
-      await _iblTextureUploadComplete!;
-      _iblTextureUploadComplete = null;
-    }
+  }
+
+  //
+  @override
+  Future removeIbl({bool destroy = true}) {
+    _throwIfDisposed();
+    return _serializeSceneResourceOperation(() => _removeIbl(destroy: destroy));
   }
 
   final _lights = <ThermionEntity>{};

--- a/thermion_dart/native/src/c_api/TEngine.cpp
+++ b/thermion_dart/native/src/c_api/TEngine.cpp
@@ -289,6 +289,14 @@ namespace thermion
         {
             auto *engine = reinterpret_cast<Engine *>(tEngine);
             auto *texture = reinterpret_cast<Texture *>(tTexture);
+            // Parent resources can release a texture as part of their queued
+            // destruction. Treat a later explicit release as idempotent;
+            // Engine::destroy on an invalid texture can raise inside the
+            // render-thread packaged_task and strand the Dart completion.
+            if (!engine->isValid(texture))
+            {
+                return;
+            }
             engine->destroy(texture);
         }
 

--- a/thermion_dart/test/viewer_lifecycle_test.dart
+++ b/thermion_dart/test/viewer_lifecycle_test.dart
@@ -1,5 +1,6 @@
 @Timeout(const Duration(seconds: 600))
 import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
 import 'helpers.dart';
 
 // Minimal isolation repro: does PURE viewer create/destroy (no loadGltf,
@@ -21,4 +22,34 @@ void main() async {
       print('[iter] $i done');
     }
   });
+
+  test(
+    'viewer disposal releases loaded scene resources and is idempotent',
+    () async {
+      await ViewerBuilder(testHelper)
+          .setRenderTargetEnabled(true)
+          .addDirectLight(
+            DirectLight.sun(direction: Vector3(0.7, -1, -0.8).normalized()),
+          )
+          .execute((result) async {
+            await result.viewer.loadGltf(
+              'file://${testHelper.assetsDir}/cube.glb',
+            );
+            await result.viewer.loadSkybox(
+              'file://${testHelper.assetsDir}/default_env_skybox.ktx',
+            );
+            await result.viewer.loadIbl(
+              'file://${testHelper.assetsDir}/default_env_ibl.ktx',
+            );
+            await result.viewer.createCamera();
+
+            expect(result.viewer.getCameraCount(), 2);
+
+            await result.viewer.dispose();
+            await result.viewer.dispose();
+
+            expect(result.viewer.getCameraCount(), 0);
+          });
+    },
+  );
 }

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/viewer_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/viewer_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:thermion_flutter/thermion_flutter.dart' hide Texture;
@@ -81,13 +83,22 @@ class ViewerWidget extends StatefulWidget {
 
 class _ViewerWidgetState extends State<ViewerWidget> {
   ThermionViewer? viewer;
+  Future<void>? _initialization;
+  Future<void>? _tearDownFuture;
+  Future<void>? _inputHandlerUpdate;
+  bool _disposing = false;
 
   late final _logger = Logger(runtimeType.toString());
 
   @override
   void initState() {
     super.initState();
-    _createViewer();
+    _initialization = _createViewer();
+    unawaited(
+      _initialization!.catchError((Object error, StackTrace stack) {
+        _reportAsyncError('initialization', error, stack);
+      }),
+    );
   }
 
   Future<void> _createViewer() async {
@@ -114,8 +125,11 @@ class _ViewerWidgetState extends State<ViewerWidget> {
 
     final viewer = await ThermionFlutterPlugin.createViewer();
     this.viewer = viewer;
+    if (_disposing) {
+      return;
+    }
     await _configure();
-    if (mounted) {
+    if (mounted && !_disposing) {
       setState(() {});
     }
   }
@@ -124,8 +138,22 @@ class _ViewerWidgetState extends State<ViewerWidget> {
   void didUpdateWidget(ViewerWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.manipulatorType != widget.manipulatorType) {
-      _setViewportWidget();
-      setState(() {});
+      _inputHandlerUpdate = _setViewportWidget();
+      unawaited(
+        _inputHandlerUpdate!
+            .then((_) {
+              if (mounted && !_disposing) {
+                setState(() {});
+              }
+            })
+            .catchError((Object error, StackTrace stack) {
+              _reportAsyncError('updating the input handler', error, stack);
+            }),
+      );
+    }
+
+    if (viewer == null || _disposing) {
+      return;
     }
 
     if (oldWidget.postProcessing != widget.postProcessing) {
@@ -177,7 +205,16 @@ class _ViewerWidgetState extends State<ViewerWidget> {
   final _focusNode = FocusNode();
   InputHandler? _inputHandler;
 
-  void _setViewportWidget() {
+  Future<void> _setViewportWidget() async {
+    final previousInputHandler = _inputHandler;
+    _inputHandler = null;
+    await previousInputHandler?.dispose();
+
+    if (_disposing || viewer == null || thermionWidget == null) {
+      viewport = thermionWidget;
+      return;
+    }
+
     switch (widget.manipulatorType) {
       case ManipulatorType.NONE:
         _inputHandler = null;
@@ -202,38 +239,49 @@ class _ViewerWidgetState extends State<ViewerWidget> {
         inputHandler: _inputHandler!,
         child: thermionWidget,
       );
-      _focusNode.requestFocus();
+      if (mounted && !_disposing) {
+        _focusNode.requestFocus();
+      }
     }
   }
 
   ThermionAsset? asset;
-  late final ThermionWidget? thermionWidget;
+  ThermionWidget? thermionWidget;
   Widget? viewport;
 
   Future _configure() async {
+    if (_disposing) return;
+
     if (widget.assetPath != null) {
       asset = await viewer!.loadGltf(widget.assetPath!);
+      if (_disposing) return;
       await asset!.setCastShadows(true);
+      if (_disposing) return;
       await viewer!.view.setShadowsEnabled(true);
     }
 
+    if (_disposing) return;
     if (widget.skyboxPath != null) {
       await viewer!.loadSkybox(widget.skyboxPath!);
     }
 
+    if (_disposing) return;
     if (widget.iblPath != null) {
       await viewer!.loadIbl(widget.iblPath!);
     }
 
+    if (_disposing) return;
     if (widget.postProcessing) {
       await viewer!.setPostProcessing(true);
       await viewer!.setAntiAliasing(false, true, false);
     }
 
+    if (_disposing) return;
     final camera = await viewer!.getActiveCamera();
 
     await camera.lookAt(widget.initialCameraPosition);
 
+    if (_disposing) return;
     if (widget.background != null) {
       if (widget.skyboxPath != null) {
         _logger.severe("Specify skyboxPath or background, not both");
@@ -247,37 +295,119 @@ class _ViewerWidgetState extends State<ViewerWidget> {
       }
     }
 
+    if (_disposing) return;
     if (widget.directLight != null) {
       await viewer!.addDirectLight(widget.directLight!);
     }
 
+    if (_disposing) return;
     thermionWidget = ThermionWidget(
       key: const Key("viewer_thermion_widget"),
       viewer: viewer!,
     );
 
-    _setViewportWidget();
+    await _setViewportWidget();
+    if (_disposing) return;
 
-    widget.onViewerAvailable?.call(viewer!);
-    if (asset != null) {
-      widget.onAssetLoaded?.call(viewer!, asset!);
+    final onViewerAvailable = widget.onViewerAvailable;
+    if (onViewerAvailable != null) {
+      _invokeCallback(
+        () => onViewerAvailable(viewer!),
+        'onViewerAvailable callback',
+      );
     }
-    setState(() {});
+    if (asset != null) {
+      final onAssetLoaded = widget.onAssetLoaded;
+      if (onAssetLoaded != null) {
+        _invokeCallback(
+          () => onAssetLoaded(viewer!, asset!),
+          'onAssetLoaded callback',
+        );
+      }
+    }
+  }
+
+  void _invokeCallback(Future Function() callback, String context) {
+    unawaited(
+      Future.sync(callback).catchError((Object error, StackTrace stack) {
+        _reportAsyncError(context, error, stack);
+      }),
+    );
+  }
+
+  void _reportAsyncError(String context, Object error, StackTrace stack) {
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stack,
+        library: 'thermion_flutter',
+        context: ErrorDescription('while $context in ViewerWidget'),
+      ),
+    );
+  }
+
+  Future<void> _performTearDown() async {
+    Object? firstError;
+    StackTrace? firstStack;
+
+    Future<void> runCleanup(Future<void> Function() cleanup) async {
+      try {
+        await cleanup();
+      } catch (error, stack) {
+        firstError ??= error;
+        firstStack ??= stack;
+      }
+    }
+
+    await runCleanup(() async {
+      await _initialization;
+    });
+    await runCleanup(() async {
+      await _inputHandlerUpdate;
+    });
+
+    final inputHandler = _inputHandler;
+    _inputHandler = null;
+    await runCleanup(() async {
+      await inputHandler?.dispose();
+    });
+
+    final currentViewer = viewer;
+    viewer = null;
+    if (currentViewer != null) {
+      await runCleanup(() async {
+        try {
+          // The texture owns render targets and swapchains that refer to the
+          // view. Release those before the viewer destroys its view.
+          await ThermionFlutterPlugin.instance.destroyTextureForView(
+            currentViewer.view,
+          );
+        } finally {
+          await currentViewer.dispose();
+        }
+      });
+    }
+
+    if (widget.destroyEngineOnUnload && FilamentApp.instance != null) {
+      await runCleanup(() => FilamentApp.instance!.destroy());
+    }
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStack!);
+    }
   }
 
   @override
   void dispose() {
+    _disposing = true;
+    _focusNode.dispose();
+    _tearDownFuture ??= _performTearDown();
+    unawaited(
+      _tearDownFuture!.catchError((Object error, StackTrace stack) {
+        _reportAsyncError('teardown', error, stack);
+      }),
+    );
     super.dispose();
-    if (viewer != null) {
-      _tearDown();
-    }
-  }
-
-  Future _tearDown() async {
-    await viewer!.dispose();
-    if (widget.destroyEngineOnUnload) {
-      await FilamentApp.instance!.destroy();
-    }
   }
 
   @override


### PR DESCRIPTION
1. cancel animation and delayed skybox timers when the quickstart viewer is removed
2. guard delayed callbacks against stale viewer instances
3. extend the quickstart lifecycle integration test to exercise repeated viewer creation and removal

