### PR TITLE
fix: (ios) accept 0 as valid flutter texture ID on iOS

### DIFF
--- a/.github/workflows/run-flutter-builds.yml
+++ b/.github/workflows/run-flutter-builds.yml
@@ -49,6 +49,13 @@ jobs:
           channel: ${{ matrix.flutter-channel }}
           architecture: ${{ matrix.flutter-arch }}
 
+      - name: Run thermion_flutter unit tests (macOS)
+        if: matrix.name == 'macOS'
+        working-directory: thermion_flutter/thermion_flutter
+        run: |
+          flutter pub get
+          flutter test
+
       # macOS: build native macOS + Android + web
       - name: Set up JDK 17
         if: matrix.name == 'macOS'

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/darwin_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/darwin_platform_texture_descriptor.dart
@@ -1,6 +1,19 @@
+import 'dart:io';
+
 import 'package:thermion_flutter/src/swift/swift_bindings.g.dart';
 
 import 'platform_texture_descriptor.dart';
+
+/// Whether Flutter's Darwin texture registry reported a failed registration.
+///
+/// macOS returns zero when registration fails. iOS also uses zero, but as the
+/// first valid texture ID because its registry returns `nextTextureId++`.
+bool didDarwinTextureRegistrationFail({
+  required bool isIOS,
+  required int textureId,
+}) {
+  return !isIOS && textureId == 0;
+}
 
 /// [DarwinPlatformTextureDescriptorImpl] now handles the Metal platform texture
 /// allocation/lifecycle that was previously handled by
@@ -94,8 +107,10 @@ class DarwinPlatformTextureDescriptorImpl extends PlatformTextureDescriptor {
       metalTexture,
     );
     final flutterTextureId = _textureRegistry.registerTexture_(adapter);
-    // FlutterTextureRegistry.registerTexture returns 0 on failure.
-    if (flutterTextureId == 0) {
+    if (didDarwinTextureRegistrationFail(
+      isIOS: Platform.isIOS,
+      textureId: flutterTextureId,
+    )) {
       throw Exception('Failed to register Flutter texture');
     }
 

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thermion_flutter/src/platform/src/android_platform_texture_descriptor.dart';
+import 'package:thermion_flutter/src/platform/src/darwin_platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/options.dart';
 
@@ -9,6 +10,33 @@ import 'package:thermion_dart/src/filament/src/interface/native_handle.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Darwin texture registration', () {
+    test('accepts zero as the first valid iOS texture ID', () {
+      expect(
+        didDarwinTextureRegistrationFail(isIOS: true, textureId: 0),
+        isFalse,
+      );
+    });
+
+    test('treats zero as a macOS registration failure', () {
+      expect(
+        didDarwinTextureRegistrationFail(isIOS: false, textureId: 0),
+        isTrue,
+      );
+    });
+
+    test('accepts non-zero texture IDs on both platforms', () {
+      expect(
+        didDarwinTextureRegistrationFail(isIOS: true, textureId: 1),
+        isFalse,
+      );
+      expect(
+        didDarwinTextureRegistrationFail(isIOS: false, textureId: 1),
+        isFalse,
+      );
+    });
+  });
 
   group('PlatformTextureDescriptor equality', () {
     test(


### PR DESCRIPTION
Fixes a regression on iOS where textures are initially assigned to zero by `FlutterEngine.nextTextureId` and registerTexture returns nextTextureId++. The shared Darwin implementation treated zero as a failed registration, so the first successful iOS texture allocation was rejected while later allocations succeeded.