### PR TITLE
fix: (linux) ExternalImage deletion on Vulkan texture destroy

### DIFF
--- a/thermion_dart/native/include/vulkan/ExternalVulkanImage.h
+++ b/thermion_dart/native/include/vulkan/ExternalVulkanImage.h
@@ -22,6 +22,9 @@ struct ExternalVulkanImage : public filament::backend::Platform::ExternalImage {
     // Filament-level metadata
     filament::backend::TextureFormat filamentFormat = filament::backend::TextureFormat::RGBA8;
     filament::backend::TextureUsage filamentUsage = filament::backend::TextureUsage::COLOR_ATTACHMENT;
+
+protected:
+    ~ExternalVulkanImage() override = default;
 };
 
 }

--- a/thermion_flutter/thermion_flutter/linux/thermion_flutter_plugin.cc
+++ b/thermion_flutter/thermion_flutter/linux/thermion_flutter_plugin.cc
@@ -568,7 +568,9 @@ static FlMethodResponse *handle_destroy_texture(ThermionFlutterPlugin *self, FlM
         auto extIt = self->external_images->find(surfaceId);
         if (extIt != self->external_images->end())
         {
-          delete extIt->second;
+          // Filament holds a reference to this ExternalImage and releases it when the
+          // texture is destroyed; ExternalImage's destructor is protected to forbid manual deletion.
+          // Only drop the raw pointer.
           self->external_images->erase(extIt);
         }
         if (self->vulkan_context)

--- a/thermion_flutter/thermion_flutter/linux/thermion_flutter_plugin.cc
+++ b/thermion_flutter/thermion_flutter/linux/thermion_flutter_plugin.cc
@@ -348,7 +348,9 @@ static FlMethodResponse *handle_create_texture_vulkan(ThermionFlutterPlugin *sel
   FlTexture *flTexture = FL_TEXTURE(textureGL);
   if (!fl_texture_registrar_register_texture(self->texture_registrar, flTexture))
   {
-    delete extImg;
+    // Nothing has referenced extImg yet (Texture_setExternalImage never ran), so its
+    // refcount is still zero. Let it expire and Filament performs the delete.
+    filament::backend::Platform::ExternalImageHandle reclaim(extImg);
     self->external_images->erase(surfaceId);
     self->vulkan_context->DestroyRenderingSurface(surfaceId);
     return FL_METHOD_RESPONSE(fl_method_error_response_new(
@@ -738,10 +740,6 @@ static void thermion_flutter_plugin_dispose(GObject *object)
   }
   if (self->external_images)
   {
-    for (auto &pair : *self->external_images)
-    {
-      delete pair.second;
-    }
     delete self->external_images;
     self->external_images = nullptr;
   }


### PR DESCRIPTION
### Summary

Disposing or resizing a `ThermionWidget` on Linux with `Backend.VULKAN` causes an app crash

### Cause

`handle_destroy_texture` deletes the `ExternalVulkanImage`:

```cpp
auto extIt = self->external_images->find(surfaceId);
if (extIt != self->external_images->end())
{
  delete extIt->second;
  self->external_images->erase(extIt);
}
```

`ExternalVulkanImage` derives from `filament::backend::Platform::ExternalImage`, which is
reference-counted and managed through `ExternalImageHandle`. Its destructor is `protected`

```cpp
class ExternalImage {
    friend class ExternalImageHandle;
    std::atomic_uint32_t mRefCount{0};
protected:
    virtual ~ExternalImage() noexcept;
};
```

Filament takes a reference when the image is passed to `Texture::setExternalImage()` and releases it
when the texture is destroyed. By the time `destroyTexture` reaches the plugin, Filament has already
destroyed the render target's colour texture and dropped its reference, so the plugin's `delete` is a
second free

### Reproduction

- disposing the widget: `thermion_widget.dart` calls `texture?.destroy()` in `dispose()`
- resizing the widget or window: the resize path calls `texture.destroy()` after rebinding

Both crash:

```
Thread 1 received signal SIGSEGV, Segmentation fault.
#0  handle_destroy_texture (…) at thermion_flutter_plugin.cc:571
571	          delete extIt->second;
#1  thermion_flutter_plugin_handle_method_call (…) at thermion_flutter_plugin.cc:708
#2  method_call_cb (…) at thermion_flutter_plugin.cc:774
```

### Proposed change

Drop the raw pointer and let Filament free the image:

```cpp
auto extIt = self->external_images->find(surfaceId);
if (extIt != self->external_images->end())
{
  self->external_images->erase(extIt);
}
```

The refcount reaches zero when the texture is destroyed and Filament invokes the
destructor itself

### Verification

Verified in a Flutter application rendering a .glb asset with `Backend.VULKAN` on Linux:

- pushing a route containing the viewer, then popping it
- resizing the window while the viewer is visible

Tested on Ubuntu 24.04, AMD Radeon 860M (RADV, Mesa 25.2.8), Flutter 3.41.3.

### Notes

The Windows plugin shares this Vulkan branch and may be affected by the same double free. It hasn't been tested