### PR TITLE
fix: correctly assign dummy UVs in Geometry

### DIFF
--- a/thermion_dart/lib/src/filament/src/interface/geometry.dart
+++ b/thermion_dart/lib/src/filament/src/interface/geometry.dart
@@ -42,7 +42,6 @@ class Geometry {
     bool createDummyUvs1 = true,
   }) {
     this.attribute0 = attribute0 ?? Float32List(0);
-    this.uvs = uvs ?? Float32List(0);
     this.normals = normals ?? Float32List(0);
 
     if (colors == null) {
@@ -70,6 +69,7 @@ class Geometry {
         uvs = makeFloat32List(0);
       }
     }
+    this.uvs = uvs;
 
     final numVertices = vertices.length ~/ 3;
     final expectedUvs = numVertices * 2;

--- a/thermion_dart/test/geometry_ctor_tests.dart
+++ b/thermion_dart/test/geometry_ctor_tests.dart
@@ -13,19 +13,26 @@ void main() {
   final indices = [0, 1, 2];
 
   group('Geometry constructor dummy attributes', () {
-    test('createDummyUvs=true supplies zero UVs for UV-less geometry',
-        () async {
-      final geometry = Geometry(vertices, indices);
-      expect(geometry.hasUVs, true,
-          reason: 'dummy UVs should be created and assigned');
-      expect(geometry.uvs.length, 3 * 2, reason: 'one UV pair per vertex');
-      expect(geometry.uvs.every((v) => v == 0.0), true,
-          reason: 'dummy UVs are zero-filled');
-    });
+    test(
+      'createDummyUvs=true supplies zero UVs for UV-less geometry',
+      () async {
+        final geometry = Geometry(vertices, indices);
+        expect(
+          geometry.hasUVs,
+          true,
+          reason: 'dummy UVs should be created and assigned',
+        );
+        expect(geometry.uvs.length, 3 * 2, reason: 'one UV pair per vertex');
+        expect(
+          geometry.uvs.every((v) => v == 0.0),
+          true,
+          reason: 'dummy UVs are zero-filled',
+        );
+      },
+    );
 
     test('createDummyUvs=false leaves UVs empty', () async {
-      final geometry =
-          Geometry(vertices, indices, createDummyUvs: false);
+      final geometry = Geometry(vertices, indices, createDummyUvs: false);
       expect(geometry.hasUVs, false);
       expect(geometry.uvs.length, 0);
     });
@@ -37,19 +44,23 @@ void main() {
       expect(geometry.uvs, uvs);
     });
 
-    test('createDummyColors=true supplies opaque white RGBA colors',
-        () async {
+    test('createDummyColors=true supplies opaque white RGBA colors', () async {
       final geometry = Geometry(vertices, indices);
-      expect(geometry.hasColors, true,
-          reason: 'dummy colors should be created and assigned');
+      expect(
+        geometry.hasColors,
+        true,
+        reason: 'dummy colors should be created and assigned',
+      );
       expect(geometry.colors.length, 3 * 4, reason: 'RGBA per vertex');
-      expect(geometry.colors.every((c) => c == 1.0), true,
-          reason: 'dummy colors are opaque white');
+      expect(
+        geometry.colors.every((c) => c == 1.0),
+        true,
+        reason: 'dummy colors are opaque white',
+      );
     });
 
     test('createDummyColors=false leaves colors empty', () async {
-      final geometry =
-          Geometry(vertices, indices, createDummyColors: false);
+      final geometry = Geometry(vertices, indices, createDummyColors: false);
       expect(geometry.hasColors, false);
       expect(geometry.colors.length, 0);
     });
@@ -61,8 +72,11 @@ void main() {
       expect(withUvs.uvs1, uvs);
 
       final withoutUvs = Geometry(vertices, indices);
-      expect(withoutUvs.hasUVs1, true,
-          reason: 'ubershader requires two UV sets');
+      expect(
+        withoutUvs.hasUVs1,
+        true,
+        reason: 'ubershader requires two UV sets',
+      );
       expect(withoutUvs.uvs1.length, 3 * 2);
       expect(withoutUvs.uvs1.every((v) => v == 0.0), true);
     });

--- a/thermion_dart/test/geometry_ctor_tests.dart
+++ b/thermion_dart/test/geometry_ctor_tests.dart
@@ -1,0 +1,70 @@
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:thermion_dart/src/filament/src/interface/geometry.dart';
+
+// Unit tests for the Geometry constructor's dummy-attribute behavior.
+// Regression coverage for the dummy-UV assignment bug: dummy UVs were
+// created locally but never assigned to this.uvs, so hasUVs stayed false
+// for geometry constructed without UVs.
+void main() {
+  // A single triangle.
+  final vertices = Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  final indices = [0, 1, 2];
+
+  group('Geometry constructor dummy attributes', () {
+    test('createDummyUvs=true supplies zero UVs for UV-less geometry',
+        () async {
+      final geometry = Geometry(vertices, indices);
+      expect(geometry.hasUVs, true,
+          reason: 'dummy UVs should be created and assigned');
+      expect(geometry.uvs.length, 3 * 2, reason: 'one UV pair per vertex');
+      expect(geometry.uvs.every((v) => v == 0.0), true,
+          reason: 'dummy UVs are zero-filled');
+    });
+
+    test('createDummyUvs=false leaves UVs empty', () async {
+      final geometry =
+          Geometry(vertices, indices, createDummyUvs: false);
+      expect(geometry.hasUVs, false);
+      expect(geometry.uvs.length, 0);
+    });
+
+    test('provided UVs are preserved (not overwritten by dummies)', () async {
+      final uvs = Float32List.fromList([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+      final geometry = Geometry(vertices, indices, uvs: uvs);
+      expect(geometry.hasUVs, true);
+      expect(geometry.uvs, uvs);
+    });
+
+    test('createDummyColors=true supplies opaque white RGBA colors',
+        () async {
+      final geometry = Geometry(vertices, indices);
+      expect(geometry.hasColors, true,
+          reason: 'dummy colors should be created and assigned');
+      expect(geometry.colors.length, 3 * 4, reason: 'RGBA per vertex');
+      expect(geometry.colors.every((c) => c == 1.0), true,
+          reason: 'dummy colors are opaque white');
+    });
+
+    test('createDummyColors=false leaves colors empty', () async {
+      final geometry =
+          Geometry(vertices, indices, createDummyColors: false);
+      expect(geometry.hasColors, false);
+      expect(geometry.colors.length, 0);
+    });
+
+    test('dummy UV1 mirrors UV0 when UV0 exists, else zeros', () async {
+      final uvs = Float32List.fromList([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+      final withUvs = Geometry(vertices, indices, uvs: uvs);
+      expect(withUvs.hasUVs1, true);
+      expect(withUvs.uvs1, uvs);
+
+      final withoutUvs = Geometry(vertices, indices);
+      expect(withoutUvs.hasUVs1, true,
+          reason: 'ubershader requires two UV sets');
+      expect(withoutUvs.uvs1.length, 3 * 2);
+      expect(withoutUvs.uvs1.every((v) => v == 0.0), true);
+    });
+  });
+}


### PR DESCRIPTION
Fix a bug in `Geometry` constructor where `this.uvs` is assigned before the `createDummyUvs` block, so the dummy UVs it built were discarded and `hasUVs` stayed `false` for geometry created without UVs. The `colors` path assigns `this.colors` **after** creating dummies — `uvs` was simply missed.