### PR TITLE
feat: (web) engine-per-viewer multi-viewer support

### DIFF
--- a/examples/flutter/quickstart/README.md
+++ b/examples/flutter/quickstart/README.md
@@ -8,7 +8,8 @@ many viewers to mount at a time; tapping the button body mounts that many
 cells in a single frame (each cell owns an independent `ThermionViewer`).
 Clicking it again removes that many, so the control doubles as a toggle for
 the concurrent mount/dispose stress path. Use the **×** on a cell to remove
-it individually.
+it individually. On web, each viewer runs its own engine and canvas, and the
+batch is capped by `WebOptions.maxViewers`.
 
 > Note: the grid is rebuilt from a fresh list on every add/remove (see
 > `_MyHomePageState`). Mutating the list in place will leave new cells latent

--- a/examples/flutter/quickstart/integration_test/texture_resize_test.dart
+++ b/examples/flutter/quickstart/integration_test/texture_resize_test.dart
@@ -40,7 +40,7 @@ void main() {
                   child: ThermionWidgetInternal(
                     key: const ValueKey('resizable-thermion-surface'),
                     view: viewer.view,
-                    surfaceWidgetBuilder: (descriptor) {
+                    surfaceWidgetBuilder: (descriptor, view) {
                       if (descriptor == null) {
                         return const SizedBox.expand();
                       }

--- a/examples/flutter/quickstart/lib/main.dart
+++ b/examples/flutter/quickstart/lib/main.dart
@@ -99,14 +99,17 @@ class _MyHomePageState extends State<MyHomePage> {
 
   late DirectLight _sun;
 
+  /// Web runs one engine per viewer (browser WebGL context limit), so the
+  /// batch is capped by the plugin's web option; native is unlimited-ish.
+  late final int _maxBatch;
+
   @override
   void initState() {
     super.initState();
     _sun = DirectLight.sun(direction: Vector3(0.7, -1, -0.8).normalized());
-    if (kIsWeb) {
-      ThermionFlutterPlugin.instance.setOptions(const ThermionFlutterOptions(
-          webOptions: WebOptions(importCanvasAsWidget: false)));
-    }
+    _maxBatch = kIsWeb
+        ? ThermionFlutterPlugin.instance.options.webOptions.maxViewers
+        : 64;
   }
 
   /// Applies the batch: mounts `_batch` viewers at once when the grid is
@@ -176,7 +179,8 @@ class _MyHomePageState extends State<MyHomePage> {
               onApplyBatch: _applyBatch,
               onFramerateChanged: (v) {
                 setState(() => _framerate = v);
-                FilamentApp.instance!.setTargetFramerate(v);
+                // Applies to every engine (web runs one engine per viewer).
+                ThermionFlutterPlugin.instance.setTargetFramerate(v);
               },
             ),
           ],

--- a/examples/flutter/quickstart/lib/main.dart
+++ b/examples/flutter/quickstart/lib/main.dart
@@ -175,6 +175,7 @@ class _MyHomePageState extends State<MyHomePage> {
               framerate: _framerate,
               viewerCount: _tiles.length,
               batch: _batch,
+              maxBatch: _maxBatch,
               onBatchChanged: (v) => setState(() => _batch = v),
               onApplyBatch: _applyBatch,
               onFramerateChanged: (v) {
@@ -373,6 +374,7 @@ class _Footer extends StatelessWidget {
     required this.framerate,
     required this.viewerCount,
     required this.batch,
+    required this.maxBatch,
     required this.onBatchChanged,
     required this.onApplyBatch,
     required this.onFramerateChanged,
@@ -381,6 +383,7 @@ class _Footer extends StatelessWidget {
   final int framerate;
   final int viewerCount;
   final int batch;
+  final int maxBatch;
   final ValueChanged<int> onBatchChanged;
   final VoidCallback onApplyBatch;
   final ValueChanged<int> onFramerateChanged;
@@ -413,7 +416,7 @@ class _Footer extends StatelessWidget {
                 _EmbeddedStepper(
                   value: batch,
                   min: 1,
-                  max: 64,
+                  max: maxBatch,
                   onChanged: onBatchChanged,
                 ),
                 const SizedBox(width: 10),

--- a/examples/flutter/quickstart/pubspec.yaml
+++ b/examples/flutter/quickstart/pubspec.yaml
@@ -22,6 +22,14 @@ dependency_overrides:
     path: ../../../thermion_dart
   thermion_flutter:
     path: ../../../thermion_flutter/thermion_flutter
+
+# Iterating on thermion_dart's native C++ against web: copy the locally
+# built emscripten artifacts (native/web/build/build/out) instead of
+# downloading the R2 release build. Remove before shipping.
+hooks:
+  user_defines:
+    thermion_dart:
+      web_local: true
   
 dev_dependencies:
   flutter_test:

--- a/thermion_dart/CHANGELOG.md
+++ b/thermion_dart/CHANGELOG.md
@@ -1,6 +1,12 @@
 > Shared changelog for `thermion_dart` and `thermion_flutter` (released in lockstep).
 
 ## 0.5.0-pre
+New features:
+ - add web multi-viewer support with one engine, render thread, WebGL context,
+   and canvas per viewer.
+ - add `WebOptions.maxViewers`, per-viewer canvas IDs and lifecycle hooks, and
+   host web canvases inside each viewer widget by default.
+
 Fixes:
  - route loadKtx2 through the render thread on web.
  - pick readPixels type per-view from render-target format.
@@ -10,11 +16,18 @@ Fixes:
  - add releaseSourceData() to ThermionAsset so the CPU-side glTF source copy
    can be freed after all instances have been created.
  - update the thermion_flutter dependency on thermion_dart to 0.5.0-pre.
+ - scope render attachment state per engine so one web viewer never submits
+   another engine's views or swapchains.
 
 ### Breaking changes:
  - remove the releaseSourceData parameter from createGeometry — source-data
    release only applies to glTF assets, so call releaseSourceData() on the
    returned asset instead.
+ - engine-scoped FFI objects now retain their owning `FFIFilamentApp`;
+   `ThermionViewerFFI` and tone-mapper factories require it explicitly.
+ - `ThermionFlutterPlugin.initialize()` now returns `InitializeResult`, and
+   `ThermionWidgetInternal.surfaceWidgetBuilder` receives the owning `View`.
+ - `WebOptions.importCanvasAsWidget` now defaults to `true`.
 
 ## 0.4.1
 - re-publish without Melos

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -2667,6 +2667,11 @@ external void TransformManager_commitLocalTransformTransaction(
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
 external ffi.Pointer<ffi.Void> RenderThread_create();
 
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(
+  ffi.Pointer<ffi.Char> canvasSelector,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
 external void RenderThread_destroy(ffi.Pointer<ffi.Void> renderThread);
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -26,7 +26,7 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int height,
   );
   external void _Thermion_destroyCanvas();
-  external int _Thermion_createGLContext();
+  external int _Thermion_createGLContext(Pointer<Char> canvasSelector);
   external int _Thermion_getGLContext();
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_TRANSPARENT;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
@@ -1237,6 +1237,9 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TTransformManager> tTransformManager,
   );
   external Pointer<Void> _RenderThread_create();
+  external Pointer<Void> _RenderThread_createForCanvas(
+    Pointer<Char> canvasSelector,
+  );
   external void _RenderThread_destroy(Pointer<Void> renderThread);
   external void _RenderThread_addTask(
     Pointer<NativeFunction<void Function()>> task,
@@ -3134,8 +3137,10 @@ void Thermion_destroyCanvas() {
   return result;
 }
 
-int Thermion_createGLContext() {
-  final result = GeneratedBindings.instance._Thermion_createGLContext();
+int Thermion_createGLContext(Pointer<Char> canvasSelector) {
+  final result = GeneratedBindings.instance._Thermion_createGLContext(
+    canvasSelector,
+  );
   return result;
 }
 
@@ -6453,6 +6458,13 @@ void TransformManager_commitLocalTransformTransaction(
 
 Pointer<Void> RenderThread_create() {
   final result = GeneratedBindings.instance._RenderThread_create();
+  return Pointer<Void>(result);
+}
+
+Pointer<Void> RenderThread_createForCanvas(Pointer<Char> canvasSelector) {
+  final result = GeneratedBindings.instance._RenderThread_createForCanvas(
+    canvasSelector,
+  );
   return Pointer<Void>(result);
 }
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -25,7 +25,7 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int width,
     int height,
   );
-  external void _Thermion_destroyCanvas();
+  external void _Thermion_destroyCanvas(Pointer<Char> canvasSelector);
   external int _Thermion_createGLContext(Pointer<Char> canvasSelector);
   external int _Thermion_getGLContext();
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_TRANSPARENT;
@@ -3132,8 +3132,10 @@ void Thermion_setCanvasElementSize(Pointer<Char> name, int width, int height) {
   return result;
 }
 
-void Thermion_destroyCanvas() {
-  final result = GeneratedBindings.instance._Thermion_destroyCanvas();
+void Thermion_destroyCanvas(Pointer<Char> canvasSelector) {
+  final result = GeneratedBindings.instance._Thermion_destroyCanvas(
+    canvasSelector,
+  );
   return result;
 }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -114,6 +114,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
   static Future create({
     FFIFilamentConfig? config,
+    String? canvasSelector,
     bool destroyExisting = true,
   }) async {
     config ??= FFIFilamentConfig();
@@ -126,8 +127,19 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       await FilamentApp.instance!.destroy();
     }
 
+    // Web multi-viewer: each engine gets its own RenderThread, which
+    // transfers its own canvas element to the worker. The selector is the
+    // CSS id of that viewer's canvas; native passes null and gets the
+    // default thread.
     RenderThread_destroy(nullptr);
-    final renderThreadHandle = RenderThread_create();
+    late final Pointer<Void> renderThreadHandle;
+    if (canvasSelector != null) {
+      final selectorPtr = canvasSelector.toNativeUtf8().cast<Char>();
+      renderThreadHandle = RenderThread_createForCanvas(selectorPtr);
+      free(selectorPtr);
+    } else {
+      renderThreadHandle = RenderThread_create();
+    }
 
     if (renderThreadHandle == nullptr) {
       throw Exception("Failed to create render thread");

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -20,6 +20,9 @@ namespace thermion
         typedef void (*FilamentRenderCallback)(void *const owner);
 
         EMSCRIPTEN_KEEPALIVE void* RenderThread_create();
+        // Creates a RenderThread that transfers the given canvas element
+        // (CSS selector) to its worker — one thread per viewer on web.
+        EMSCRIPTEN_KEEPALIVE void* RenderThread_createForCanvas(const char *canvasSelector);
         EMSCRIPTEN_KEEPALIVE void RenderThread_destroy(void *renderThread);
         
         EMSCRIPTEN_KEEPALIVE void RenderThread_addTask(void (*task)());

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -51,6 +51,13 @@ public:
     const char *canvasSelector() const { return _canvasSelector.c_str(); }
 
     /**
+     * @brief True when the worker pthread failed to start (web). The C API
+     *        returns a null handle in that case so Dart can fail loudly
+     *        instead of hanging on tasks that will never run.
+     */
+    bool creationFailed() const { return _creationFailed; }
+
+    /**
      * @brief Adds a task to the render thread's task queue.
      * 
      * @param pt The packaged task to be executed
@@ -133,6 +140,7 @@ private:
     // RenderThread_createForCanvas returns, and Engine_create reads the
     // selector later (during the same serialized engine creation).
     std::string _canvasSelector = "#thermion_canvas";
+    bool _creationFailed = false;
 
     
 #ifdef __EMSCRIPTEN__

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <future>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <utility>
 
@@ -30,13 +31,24 @@ class RenderThread {
 public:
     /**
      * @brief Constructs a new RenderThread and starts the render thread.
+     *
+     * @param canvasSelector Web-only: the CSS selector of the canvas element
+     *        transferred to this thread's worker (default "#thermion_canvas").
+     *        Each engine-per-viewer thread owns its own canvas.
      */
-    explicit RenderThread();
+    explicit RenderThread(const char *canvasSelector = "#thermion_canvas");
 
     /**
      * @brief Destroys the RenderThread and stops the render thread.
      */
     ~RenderThread();
+
+    /**
+     * @brief The CSS selector of the canvas transferred to this thread's
+     *        worker (web only). Used by Engine_create to create the WebGL
+     *        context on the right canvas.
+     */
+    const char *canvasSelector() const { return _canvasSelector.c_str(); }
 
     /**
      * @brief Adds a task to the render thread's task queue.
@@ -117,8 +129,12 @@ private:
     int _frameCount = 0;
     float _accumulatedTime = 0.0f;
     float _fps = 0.0f;
+    // Owned copy: the Dart side frees its UTF8 buffer right after
+    // RenderThread_createForCanvas returns, and Engine_create reads the
+    // selector later (during the same serialized engine creation).
+    std::string _canvasSelector = "#thermion_canvas";
 
-
+    
 #ifdef __EMSCRIPTEN__
     pthread_t t;
 #else

--- a/thermion_dart/native/src/c_api/TEngine.cpp
+++ b/thermion_dart/native/src/c_api/TEngine.cpp
@@ -46,8 +46,10 @@ namespace thermion
         using namespace filament;
 
         // Defined in ThermionDartRenderThreadApi.cpp. Direct-API getters use
-        // this to record which render thread owns an engine-scoped object.
+        // these to record which render thread owns an engine-scoped object
+        // (and which canvas the active thread's engine renders to).
         void RenderThread_registerOwnerFromOwner(void *owner, void *knownOwner);
+        const char *RenderThread_getActiveCanvasSelector();
 #endif
 
         EMSCRIPTEN_KEEPALIVE uint64_t TSWAP_CHAIN_CONFIG_TRANSPARENT = filament::backend::SWAP_CHAIN_CONFIG_TRANSPARENT;
@@ -63,7 +65,10 @@ namespace thermion
             bool disableHandleUseAfterFreeCheck)
         {
             #ifdef __EMSCRIPTEN__
-            auto handle = Thermion_createGLContext();
+            // Engine_create runs inside the engine's RenderThread task, so the
+            // active thread IS this engine's thread — create the WebGL context
+            // on the canvas that was transferred to it.
+            auto handle = Thermion_createGLContext(RenderThread_getActiveCanvasSelector());
             tSharedContext = (void*)handle;
             tPlatform = (backend::Platform *)new filament::backend::PlatformWebGL();
             #endif

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -189,9 +189,17 @@ extern "C"
     {
       Log("WARNING - you are attempting to create a RenderThread when the previous one has not been disposed.");
     }
-    _renderThread = std::make_unique<RenderThread>();
-    // The assignment above destroyed the previous RenderThread (and joined its
-    // worker). Sweep stale owner registrations AFTER the join — the dying
+    auto thread = std::make_unique<RenderThread>();
+    if (thread->creationFailed())
+    {
+      // pthread_create failed on web (e.g. worker pool exhausted); a null
+      // handle lets Dart fail loudly instead of hanging on never-run tasks.
+      Log("RenderThread worker failed to start; returning null handle");
+      return nullptr;
+    }
+    _renderThread = std::move(thread);
+    // The move-assignment above destroyed the previous RenderThread (and joined
+    // its worker). Sweep stale owner registrations AFTER the join — the dying
     // worker's last creation task can't then re-add an entry pointing at freed
     // memory, and a recycled handle address can't resolve to it via RT().
     if (stale != nullptr)
@@ -207,6 +215,11 @@ extern "C"
   {
     TRACE("RenderThread_createForCanvas %s", canvasSelector);
     auto thread = std::make_unique<RenderThread>(canvasSelector);
+    if (thread->creationFailed())
+    {
+      Log("RenderThread worker failed to start for canvas %s; returning null handle", canvasSelector);
+      return nullptr;
+    }
     auto *raw = thread.get();
     g_activeThread = raw;
     _renderThreads[raw] = std::move(thread);

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -172,6 +172,15 @@ extern "C"
     setOwner(owner, rt);
   }
 
+  // Web-only: the CSS selector of the canvas owned by the most recently
+  // created RenderThread, used by Engine_create to create the WebGL context
+  // on the right canvas.
+  EMSCRIPTEN_KEEPALIVE const char *RenderThread_getActiveCanvasSelector()
+  {
+    RenderThread *rt = g_activeThread != nullptr ? g_activeThread : _renderThread.get();
+    return rt != nullptr ? rt->canvasSelector() : "#thermion_canvas";
+  }
+
   EMSCRIPTEN_KEEPALIVE void* RenderThread_create()
   {
     TRACE("RenderThread_create");
@@ -192,6 +201,17 @@ extern "C"
     g_activeThread = _renderThread.get();
     TRACE("RenderThread created");
     return _renderThread.get();
+  }
+
+  EMSCRIPTEN_KEEPALIVE void* RenderThread_createForCanvas(const char *canvasSelector)
+  {
+    TRACE("RenderThread_createForCanvas %s", canvasSelector);
+    auto thread = std::make_unique<RenderThread>(canvasSelector);
+    auto *raw = thread.get();
+    g_activeThread = raw;
+    _renderThreads[raw] = std::move(thread);
+    TRACE("RenderThread created for canvas %s", canvasSelector);
+    return raw;
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderThread_destroy(void *renderThread)

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -73,7 +73,8 @@ static void *startHelper(void * parm) {
 
 #endif
 
-RenderThread::RenderThread()
+RenderThread::RenderThread(const char *canvasSelector)
+    : _canvasSelector(canvasSelector != nullptr ? canvasSelector : "#thermion_canvas")
 {
     srand(time(NULL));
     _lastFrameTime = std::chrono::high_resolution_clock::now();
@@ -82,7 +83,7 @@ RenderThread::RenderThread()
     outer = pthread_self();
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    emscripten_pthread_attr_settransferredcanvases(&attr, "#thermion_canvas");
+    emscripten_pthread_attr_settransferredcanvases(&attr, canvasSelector);
     auto *workerArg = new WorkerArg{this, _stop};
     pthread_create(&t, &attr, startHelper, workerArg);
     #else

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -85,7 +85,17 @@ RenderThread::RenderThread(const char *canvasSelector)
     pthread_attr_init(&attr);
     emscripten_pthread_attr_settransferredcanvases(&attr, canvasSelector);
     auto *workerArg = new WorkerArg{this, _stop};
-    pthread_create(&t, &attr, startHelper, workerArg);
+    int rc = pthread_create(&t, &attr, startHelper, workerArg);
+    if (rc != 0) {
+      // The worker never started, so tasks queued for this thread will never
+      // run — every caller would hang forever. Surface it: the C API returns
+      // a null handle and Dart throws "Failed to create render thread".
+      Log("SEVERE - pthread_create failed with code %d; worker did not start "
+          "(canvas selector %s, pool exhausted?)",
+          rc, canvasSelector);
+      _creationFailed = true;
+      delete workerArg;
+    }
     #else
     t = new std::thread([this]() { runNativeLoop(); });
     #endif

--- a/thermion_dart/native/web/CMakeLists.txt
+++ b/thermion_dart/native/web/CMakeLists.txt
@@ -20,7 +20,13 @@ set(EMCC_CFLAGS ${EMCC_CFLAGS} -sERROR_ON_UNDEFINED_SYMBOLS=0 )
 set(EMCC_CFLAGS ${EMCC_CFLAGS} -sEXPORTED_RUNTIME_METHODS=wasmExports,wasmTable,addFunction,removeFunction,ccall,cwrap,intArrayFromString,intArrayToString,getValue,setValue,UTF8ToString,stringToUTF8,writeArrayToMemory,lengthBytesUTF8,HEAPU8,HEAPU32,HEAPF32)
 set(EMCC_CFLAGS ${EMCC_CFLAGS} -sEXPORTED_FUNCTIONS=_malloc,stackAlloc,_free,stackSave,stackRestore)
 set(EMCC_CFLAGS ${EMCC_CFLAGS} -sFULL_ES3)
-set(EMCC_CFLAGS ${EMCC_CFLAGS} -sPTHREAD_POOL_SIZE=1)
+# Pre-spawn one worker per engine/viewer (matches WebOptions.maxViewers
+# default). With a pool smaller than the viewer count, the Nth pthread_create
+# takes emscripten's lazy-spawn path (spawn + wasm load mid-flight), which is
+# fragile and can hang; the pool workers are loaded and awaited at module
+# startup instead. Each worker receives its own canvas at thread start
+# (emscripten_pthread_attr_settransferredcanvases).
+set(EMCC_CFLAGS ${EMCC_CFLAGS} -sPTHREAD_POOL_SIZE=8)
 set(EMCC_CFLAGS ${EMCC_CFLAGS} -sALLOW_BLOCKING_ON_MAIN_THREAD=1)
 set(EMCC_CFLAGS ${EMCC_CFLAGS} -sMALLOC=mimalloc)
 set(EMCC_CFLAGS ${EMCC_CFLAGS} -sOFFSCREENCANVAS_SUPPORT=1)

--- a/thermion_dart/native/web/include/ThermionWebApi.h
+++ b/thermion_dart/native/web/include/ThermionWebApi.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 void Thermion_setCanvasElementSize(const char *name, int width, int height);
-void Thermion_destroyCanvas();
+void Thermion_destroyCanvas(const char *canvasSelector);
 // Creates a WebGL2 context on the given canvas element (e.g.
 // "#thermion_canvas_0"). Called from Engine_create on the engine's render
 // thread; the canvas must have been transferred to that thread.

--- a/thermion_dart/native/web/include/ThermionWebApi.h
+++ b/thermion_dart/native/web/include/ThermionWebApi.h
@@ -8,7 +8,10 @@ extern "C" {
 
 void Thermion_setCanvasElementSize(const char *name, int width, int height);
 void Thermion_destroyCanvas();
-EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_createGLContext();
+// Creates a WebGL2 context on the given canvas element (e.g.
+// "#thermion_canvas_0"). Called from Engine_create on the engine's render
+// thread; the canvas must have been transferred to that thread.
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_createGLContext(const char *canvasSelector);
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_getGLContext();
 
 

--- a/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
+++ b/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
@@ -50,9 +50,9 @@ extern "C"
     return _context;
   }
 
-  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE EMSCRIPTEN_KEEPALIVE Thermion_createGLContext() {
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE EMSCRIPTEN_KEEPALIVE Thermion_createGLContext(const char *canvasSelector) {
 
-    std::cout << "Creating WebGL context." << std::endl;
+    std::cout << "Creating WebGL context for " << canvasSelector << std::endl;
 
     EmscriptenWebGLContextAttributes attr;
 
@@ -68,7 +68,7 @@ extern "C"
     attr.renderViaOffscreenBackBuffer = EM_FALSE;
     attr.majorVersion = 2;
 
-    _context = emscripten_webgl_create_context("#thermion_canvas", &attr);
+    _context = emscripten_webgl_create_context(canvasSelector, &attr);
 
     if(!_context) {
       std::cout << "Failed to create WebGL context" << std::endl;  

--- a/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
+++ b/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
@@ -33,14 +33,14 @@ extern "C"
     
   }
 
-  EMSCRIPTEN_KEEPALIVE void Thermion_destroyCanvas() {
+  EMSCRIPTEN_KEEPALIVE void Thermion_destroyCanvas(const char *canvasSelector) {
     val document = val::global("document");
-    val canvas = document.call<val>("querySelector", val("#thermion_canvas"));
+    val canvas = document.call<val>("querySelector", val(std::string(canvasSelector)));
     if (!canvas.isNull() && !canvas.isUndefined()) {
       canvas.call<void>("remove");
-      std::cout << "Removed #thermion_canvas element" << std::endl;
+      std::cout << "Removed " << canvasSelector << " element" << std::endl;
     } else {
-      std::cout << "#thermion_canvas element not found" << std::endl;
+      std::cout << canvasSelector << " element not found" << std::endl;
     }
   }
 

--- a/thermion_flutter/thermion_flutter/lib/src/options.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/options.dart
@@ -62,11 +62,17 @@ class NativeOptions {
 class WebOptions {
   final bool createCanvas;
   final bool importCanvasAsWidget;
+
+  /// Hard cap on concurrent viewers. Web runs one engine + WebGL context per
+  /// viewer; browsers allow ~16 contexts per tab, so this guards runaway
+  /// mounting. 0 disables the cap.
+  final int maxViewers;
   final String jsPath;
 
   const WebOptions({
-    this.importCanvasAsWidget = false,
+    this.importCanvasAsWidget = true,
     this.createCanvas = true,
+    this.maxViewers = 8,
     this.jsPath = "./thermion_dart.js",
   });
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -55,7 +55,11 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   static Future<InitializeResult>? _initialization;
 
   @override
-  Future<InitializeResult> initialize({bool destroySwapchain = true}) {
+  Future<InitializeResult> initialize({
+    bool destroySwapchain = true,
+    String? canvasId,
+  }) {
+    // canvasId is web-only; native renders into its own surfaces.
     return _initialization ??= _initialize().whenComplete(
       () => _initialization = null,
     );

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -52,16 +52,16 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   ///
   /// All callers now share one in-flight initialization (and therefore one
   /// engine); the rest of the mount proceeds concurrently as before.
-  static Future<SwapChain?>? _initialization;
+  static Future<InitializeResult>? _initialization;
 
   @override
-  Future<SwapChain?> initialize({bool destroySwapchain = true}) {
+  Future<InitializeResult> initialize({bool destroySwapchain = true}) {
     return _initialization ??= _initialize().whenComplete(
       () => _initialization = null,
     );
   }
 
-  Future<SwapChain?> _initialize() async {
+  Future<InitializeResult> _initialize() async {
     // A hot restart can leave the native scheduler holding a callback into the
     // previous isolate. stop() is idempotent and clears that callback first.
     _lifecycle.prepareForInitialization();
@@ -93,7 +93,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
 
     final swapChain = await _createDefaultSwapChain();
     await _lifecycle.start();
-    return swapChain;
+    return InitializeResult(app: FilamentApp.instance!, swapChain: swapChain);
   }
 
   Backend _resolveBackend() {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
@@ -71,13 +71,16 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
   static Future<void> _initChain = Future.value();
 
   @override
-  Future<InitializeResult> initialize({bool destroySwapchain = true}) {
+  Future<InitializeResult> initialize({
+    bool destroySwapchain = true,
+    String? canvasId,
+  }) {
     final completer = Completer<InitializeResult>();
     final prev = _initChain;
     _initChain = completer.future.then((_) {}, onError: (_) {});
     return prev.then((_) async {
       try {
-        final result = await _initialize();
+        final result = await _initialize(canvasId);
         completer.complete(result);
         return result;
       } catch (error, stackTrace) {
@@ -87,7 +90,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     });
   }
 
-  Future<InitializeResult> _initialize() async {
+  Future<InitializeResult> _initialize(String? canvasId) async {
     final maxViewers = options.webOptions.maxViewers;
     if (maxViewers > 0 && _appsBySwapChain.length >= maxViewers) {
       throw StateError(
@@ -131,11 +134,31 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
 
     // Each viewer gets its own canvas, transferred to its own worker by
     // RenderThread_createForCanvas (called inside FFIFilamentApp.create via
-    // the canvasSelector).
-    final canvasId = 'thermion_canvas_${_canvasSeq++}';
-    final canvas = document.createElement('canvas') as HTMLCanvasElement;
-    canvas.id = canvasId;
-    document.body!.appendChild(canvas);
+    // the canvasSelector). A caller-provided id adopts an existing element
+    // (or creates one with that id); otherwise a default id is generated.
+    final String resolvedCanvasId;
+    final HTMLCanvasElement canvas;
+    if (canvasId != null) {
+      if (_appsBySwapChain.values.any((b) => b.canvasId == canvasId)) {
+        throw StateError(
+          'Canvas "$canvasId" is already in use by another viewer.',
+        );
+      }
+      resolvedCanvasId = canvasId;
+      final existing = document.getElementById(canvasId);
+      if (existing is HTMLCanvasElement) {
+        canvas = existing;
+      } else {
+        canvas = document.createElement('canvas') as HTMLCanvasElement;
+        canvas.id = canvasId;
+        document.body!.appendChild(canvas);
+      }
+    } else {
+      resolvedCanvasId = 'thermion_canvas_${_canvasSeq++}';
+      canvas = document.createElement('canvas') as HTMLCanvasElement;
+      canvas.id = resolvedCanvasId;
+      document.body!.appendChild(canvas);
+    }
 
     if (!options.webOptions.importCanvasAsWidget) {
       // Legacy single-canvas layout: the canvas floats behind the app.
@@ -144,7 +167,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     } else {
       // Host the canvas inside the viewer's widget via a platform view.
       ui_web.platformViewRegistry.registerViewFactory(
-        'imported-canvas-$canvasId',
+        'imported-canvas-$resolvedCanvasId',
         (int viewId, {Object? params}) => canvas as Object,
       );
     }
@@ -156,16 +179,16 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
       sharedContext: null,
       uberArchivePath: options.uberarchivePath,
     );
-    await FFIFilamentApp.create(config: config, canvasSelector: '#$canvasId');
+    await FFIFilamentApp.create(config: config, canvasSelector: '#$resolvedCanvasId');
     final app = FilamentApp.instance as FFIFilamentApp;
 
     // Use a headless swapchain as the scheduling token; the view renders
     // into this engine's canvas framebuffer 0.
     final swapChain = await app.createHeadlessSwapChain(1, 1);
-    _logger.info('Created swapchain for canvas #$canvasId');
+    _logger.info('Created swapchain for canvas #$resolvedCanvasId');
 
     final bundle = _WebViewerApp(
-      canvasId: canvasId,
+      canvasId: resolvedCanvasId,
       app: app,
       swapChain: swapChain,
     );

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:ui_web' as ui_web;
 import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
@@ -92,6 +93,40 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
       throw StateError(
         'Maximum of $maxViewers concurrent viewers reached on web.',
       );
+    }
+
+    // Load the WASM module bindings. If the app didn't include
+    // thermion_dart.js in index.html, append it manually and wait for the
+    // module to construct before initializing the interop.
+    try {
+      NativeLibrary.initBindings("thermion_dart");
+    } catch (err) {
+      _logger.info(
+        "Failed to find thermion_dart in window context, appending manually",
+      );
+      var scriptElement = document.createElement("script") as HTMLScriptElement;
+      scriptElement.src = options.webOptions.jsPath;
+      document.head!.appendChild(scriptElement);
+      final completer = Completer<JSObject?>();
+      scriptElement.addEventListener(
+        "load",
+        () {
+          final constructor =
+              globalContext.getProperty("thermion_dart".toJS) as JSFunction?;
+          if (constructor == null) {
+            _logger.severe("Failed to find JS library constructor");
+            completer.complete(null);
+          } else {
+            final lib = constructor.callAsFunction() as JSPromise;
+            lib.toDart.then((resolved) {
+              completer.complete(resolved as JSObject);
+            });
+          }
+        }.toJS,
+      );
+      final lib = await completer.future;
+      globalContext.setProperty("thermion_dart".toJS, lib);
+      NativeLibrary.initBindings("thermion_dart");
     }
 
     // Each viewer gets its own canvas, transferred to its own worker by

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
+import 'dart:ui_web' as ui_web;
 import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart' hide View;
@@ -20,6 +20,23 @@ import 'package:thermion_dart/src/bindings/src/thermion_dart_js_interop.g.dart';
 import 'package:thermion_dart/src/bindings/src/thermion_dart_js_interop.g.dart'
     as js;
 
+/// One engine per viewer on web: each viewer owns a canvas element, a
+/// RenderThread (worker), a WebGL context and a headless swapchain. All
+/// per-viewer state lives in this bundle; the plugin-wide statics are shared
+/// across engines (rAF loop, FPS pacing, pause state).
+class _WebViewerApp {
+  _WebViewerApp({
+    required this.canvasId,
+    required this.app,
+    required this.swapChain,
+  });
+
+  /// DOM element id of this viewer's canvas (no '#' prefix).
+  final String canvasId;
+  final FFIFilamentApp app;
+  final SwapChain swapChain;
+}
+
 class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     with WidgetsBindingObserver {
   static js.Pointer<js.Void>? _stackPtr;
@@ -30,6 +47,7 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
   static double? _nextRenderDeadlineMs;
   static bool _explicitlyPaused = false;
   static bool _lifecycleSuspended = false;
+  static int _canvasSeq = 0;
 
   static bool get _renderPaused => _explicitlyPaused || _lifecycleSuspended;
 
@@ -38,11 +56,111 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
         WebPlatformTextureDescriptor(width: width, height: height),
   );
 
+  // Identity-keyed: the same View/SwapChain wrapper instances flow through
+  // createViewer → createTextureAndBindToView → teardown, and each engine has
+  // exactly one view, so there is no cross-engine handle collision.
+  static final Map<View, _WebViewerApp> _appsByView = {};
+  static final Map<SwapChain, _WebViewerApp> _appsBySwapChain = {};
+
+  /// Serialises engine creation. Each createViewer builds its own engine
+  /// (per-viewer), but `FFIFilamentApp.create` destroys whatever engine is
+  /// current — racing calls would tear each other down (the-wne3). The chain
+  /// runs one initialization at a time; the rest of the mount proceeds
+  /// concurrently.
+  static Future<void> _initChain = Future.value();
+
+  @override
+  Future<InitializeResult> initialize({bool destroySwapchain = true}) {
+    final completer = Completer<InitializeResult>();
+    final prev = _initChain;
+    _initChain = completer.future.then((_) {}, onError: (_) {});
+    return prev.then((_) async {
+      try {
+        final result = await _initialize();
+        completer.complete(result);
+        return result;
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+        rethrow;
+      }
+    });
+  }
+
+  Future<InitializeResult> _initialize() async {
+    final maxViewers = options.webOptions.maxViewers;
+    if (maxViewers > 0 && _appsBySwapChain.length >= maxViewers) {
+      throw StateError(
+        'Maximum of $maxViewers concurrent viewers reached on web.',
+      );
+    }
+
+    // Each viewer gets its own canvas, transferred to its own worker by
+    // RenderThread_createForCanvas (called inside FFIFilamentApp.create via
+    // the canvasSelector).
+    final canvasId = 'thermion_canvas_${_canvasSeq++}';
+    final canvas = document.createElement('canvas') as HTMLCanvasElement;
+    canvas.id = canvasId;
+    document.body!.appendChild(canvas);
+
+    if (!options.webOptions.importCanvasAsWidget) {
+      // Legacy single-canvas layout: the canvas floats behind the app.
+      (canvas as HTMLElement).style.position = 'fixed';
+      (canvas as HTMLElement).style.zIndex = '-1';
+    } else {
+      // Host the canvas inside the viewer's widget via a platform view.
+      ui_web.platformViewRegistry.registerViewFactory(
+        'imported-canvas-$canvasId',
+        (int viewId, {Object? params}) => canvas as Object,
+      );
+    }
+
+    final config = FFIFilamentConfig(
+      backend: Backend.OPENGL,
+      loadResource: loadAsset,
+      platform: nullptr,
+      sharedContext: null,
+      uberArchivePath: options.uberarchivePath,
+    );
+    await FFIFilamentApp.create(config: config, canvasSelector: '#$canvasId');
+    final app = FilamentApp.instance as FFIFilamentApp;
+
+    // Use a headless swapchain as the scheduling token; the view renders
+    // into this engine's canvas framebuffer 0.
+    final swapChain = await app.createHeadlessSwapChain(1, 1);
+    _logger.info('Created swapchain for canvas #$canvasId');
+
+    final bundle = _WebViewerApp(
+      canvasId: canvasId,
+      app: app,
+      swapChain: swapChain,
+    );
+    _appsBySwapChain[swapChain] = bundle;
+
+    // Per-viewer teardown: when this engine is destroyed (viewer disposed),
+    // remove its canvas and bundle entries; only when the last engine goes
+    // away do we stop the shared rAF loop and unregister the observer.
+    app.onDestroy(() async {
+      _appsByView.removeWhere((_, b) => b.app == app);
+      _appsBySwapChain.removeWhere((_, b) => b.app == app);
+      canvas.remove();
+      if (_appsBySwapChain.isEmpty) {
+        WidgetsBinding.instance.removeObserver(this);
+        _resetWebState();
+      }
+    });
+
+    _ensureFrameLoopRunning();
+    WidgetsBinding.instance.addObserver(this);
+    _syncLifecycleState();
+    _applyRenderPause();
+
+    return InitializeResult(app: app, swapChain: swapChain);
+  }
+
   static void _applyRenderPause() {
-    final app = FilamentApp.instance as FFIFilamentApp?;
-    if (app != null) {
+    for (final bundle in _appsBySwapChain.values) {
       RenderManager_setPaused(
-        app.renderManager.getNativeHandle(),
+        bundle.app.renderManager.getNativeHandle(),
         _renderPaused,
       );
     }
@@ -66,11 +184,14 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
 
     _stackPtr = js.NativeLibrary.instance.stackSave();
 
-    final app = FilamentApp.instance;
-    final targetFps = app is FFIFilamentApp ? app.targetFramerate : 0;
+    final apps = _appsBySwapChain.values.map((b) => b.app).toList();
+    final targetFps = apps.isEmpty ? 0 : apps.first.targetFramerate;
     final rendered = _shouldRender(timestamp.toDartDouble, targetFps);
     if (rendered) {
-      app?.render();
+      // One rAF loop drives every engine.
+      for (final app in apps) {
+        app.render();
+      }
 
       // RenderManager still executes its backend task queue while paused, but
       // it does not produce a new frame, so do not notify Flutter of one.
@@ -124,126 +245,39 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
     _nextRenderDeadlineMs = null;
     _explicitlyPaused = false;
     _lifecycleSuspended = false;
-
     _stackPtr = null;
-    swapChain = null;
-    _textureDescriptorRegistry.clear();
   }
-
-  static SwapChain? swapChain;
-
-  /// Serialises concurrent [initialize] calls — same race as the native
-  /// plugin: batch-mounting viewers run `createViewer` concurrently, each
-  /// `FFIFilamentApp.create` destroys whatever engine is current, so racing
-  /// initializers tear the engine down from under each other's swapchains.
-  /// Callers share one in-flight initialization.
-  static Future<SwapChain>? _initialization;
 
   @override
-  Future<SwapChain> initialize({bool destroySwapchain = true}) {
-    return _initialization ??= _initialize().whenComplete(
-      () => _initialization = null,
-    );
+  void onViewerCreated(View view, SwapChain? swapChain) {
+    if (swapChain == null) {
+      return;
+    }
+    final bundle = _appsBySwapChain[swapChain];
+    if (bundle != null) {
+      _appsByView[view] = bundle;
+    }
   }
 
-  Future<SwapChain> _initialize() async {
-    WidgetsBinding.instance.removeObserver(this);
-
-    if (FilamentApp.instance != null && swapChain != null) {
-      // Hot reload re-enters initialize without disposing the existing web
-      // engine. Reuse the live app instead of spawning another em-pthread.
-      _ensureFrameLoopRunning();
-      WidgetsBinding.instance.addObserver(this);
-      _syncLifecycleState();
-      _applyRenderPause();
-      return swapChain!;
+  @override
+  Future<void> onViewerDisposed(View view) async {
+    final bundle = _appsByView.remove(view);
+    if (bundle == null) {
+      return;
     }
+    _appsBySwapChain.remove(bundle.swapChain);
+    // The canvas element is removed by the app's onDestroy hook.
+    await bundle.app.destroy();
+  }
 
-    HTMLCanvasElement? canvas;
-    // first, try and initialize bindings to see if the user has included thermion_dart.js manually in index.html
-    try {
-      NativeLibrary.initBindings("thermion_dart");
-    } catch (err) {
-      _logger.info(
-        "Failed to find thermion_dart in window context, appending manually",
-      );
-      // if not, manually add the script to the DOM
-      var scriptElement = document.createElement("script") as HTMLScriptElement;
-      scriptElement.src = options.webOptions.jsPath;
-      document.head!.appendChild(scriptElement);
-      final completer = Completer<JSObject?>();
-      scriptElement.addEventListener(
-        "load",
-        () {
-          final constructor =
-              globalContext.getProperty("thermion_dart".toJS) as JSFunction?;
-          if (constructor == null) {
-            _logger.severe("Failed to find JS library constructor");
-            completer.complete(null);
-          } else {
-            final lib = constructor.callAsFunction() as JSPromise;
-            lib.toDart.then((resolved) {
-              completer.complete(resolved as JSObject);
-            });
-          }
-        }.toJS,
-      );
-      final lib = await completer.future;
-      globalContext.setProperty("thermion_dart".toJS, lib);
-      NativeLibrary.initBindings("thermion_dart");
+  @override
+  String? canvasIdForView(View view) => _appsByView[view]?.canvasId;
+
+  @override
+  void setTargetFramerate(int fps) {
+    for (final bundle in _appsBySwapChain.values) {
+      bundle.app.setTargetFramerate(fps);
     }
-
-    canvas = document.getElementById("thermion_canvas") as HTMLCanvasElement?;
-
-    if (options.webOptions.createCanvas) {
-      // Remove and re-create the canvas if createCanvas is true and the canvas
-      // already exists. This fixes the hot-reload problem (where the canvas
-      // has already been created by the previous iteration and transferred to
-      // the pthread. This is still an issue if createCanvas is false.
-      // if(canvas.context)
-      canvas?.remove();
-      canvas = document.createElement("canvas") as HTMLCanvasElement?;
-    }
-
-    if (canvas == null) {
-      throw Exception("Could not locate or create canvas");
-    }
-    canvas.id = "thermion_canvas";
-    // canvas.style.display = "none";
-    document.body!.appendChild(canvas);
-
-    if (options.webOptions.createCanvas) {
-      (canvas as HTMLElement).style.position = "fixed";
-      (canvas as HTMLElement).style.zIndex = "-1";
-    }
-
-    final config = FFIFilamentConfig(
-      backend: Backend.OPENGL,
-      loadResource: loadAsset,
-      platform: nullptr,
-      sharedContext: null,
-      uberArchivePath: options.uberarchivePath,
-    );
-    await FFIFilamentApp.create(config: config);
-    // resetting the web state when the app is destroyed
-    (FilamentApp.instance as FFIFilamentApp).onDestroy(() async {
-      WidgetsBinding.instance.removeObserver(this);
-      _resetWebState();
-    });
-
-    // Use createSwapChain with nullptr to render to the canvas's default
-    // framebuffer (framebuffer 0). createHeadlessSwapChain creates an offscreen
-    // buffer that never gets displayed.
-    swapChain = await FilamentApp.instance!.createHeadlessSwapChain(1, 1);
-
-    _logger.info("Created 1x1 headless swapchain");
-
-    _ensureFrameLoopRunning();
-    WidgetsBinding.instance.addObserver(this);
-    _syncLifecycleState();
-    _applyRenderPause();
-
-    return swapChain!;
   }
 
   @override
@@ -291,29 +325,35 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
 
     // On web, we don't use hardware textures but we return a descriptor
     // with dimensions so the callback can update viewport/camera
+    final bundle = _appsByView[view];
+    if (bundle == null) {
+      throw StateError(
+        'No web app registered for view (onViewerCreated not called?)',
+      );
+    }
+
     final descriptor = await _textureDescriptorRegistry.create(width, height);
     try {
       await _textureDescriptorRegistry.bindToView(descriptor, view);
       final dpr = window.devicePixelRatio;
       _logger.info(
-        "Creating descriptor for HTML canvas ${descriptor.width}x${descriptor.height} at dpr $dpr",
+        "Creating descriptor for canvas #${bundle.canvasId} "
+        "${descriptor.width}x${descriptor.height} at dpr $dpr",
       );
 
       var overlay = view.getHighlightOverlay();
-      await overlay?.setSwapChain(swapChain!);
+      await overlay?.setSwapChain(bundle.swapChain);
 
       Thermion_setCanvasElementSize(
-        js.StringUtils("#thermion_canvas").toNativeUtf8(),
+        js.StringUtils('#${bundle.canvasId}').toNativeUtf8(),
         descriptor.width,
         descriptor.height,
       );
 
       // [width] and [height] have already been scaled by [devicePixelRatio]
       // so we need to undo this when setting the CSS dimensions
-
       final canvas =
-          document.getElementById("thermion_canvas") as HTMLCanvasElement;
-
+          document.getElementById(bundle.canvasId) as HTMLCanvasElement;
       canvas.style.width = "${width / dpr}px";
       canvas.style.height = "${height / dpr}px";
 

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_web.dart
@@ -179,7 +179,15 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin
       sharedContext: null,
       uberArchivePath: options.uberarchivePath,
     );
-    await FFIFilamentApp.create(config: config, canvasSelector: '#$resolvedCanvasId');
+    // destroyExisting: false — this is a NEW engine for a NEW viewer;
+    // FFIFilamentApp.create would otherwise destroy the previous viewer's
+    // engine (and its worker) underneath its render loop, deadlocking when
+    // the destructor drains pending render tasks on the main thread.
+    await FFIFilamentApp.create(
+      config: config,
+      canvasSelector: '#$resolvedCanvasId',
+      destroyExisting: false,
+    );
     final app = FilamentApp.instance as FFIFilamentApp;
 
     // Use a headless swapchain as the scheduling token; the view renders

--- a/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
@@ -9,6 +9,22 @@ import 'package:logging/logging.dart';
 
 export 'platform/platform.dart' hide ThermionFlutterPluginImpl;
 
+/// Result of [ThermionFlutterPlugin.initialize].
+///
+/// Callers must use [app] (never `FilamentApp.instance`): on web each
+/// `createViewer` builds its own engine, and the static may have moved on
+/// to a newer engine by the time the caller resumes.
+class InitializeResult {
+  const InitializeResult({required this.app, this.swapChain});
+
+  /// The engine app created (or reused) by this initialization.
+  final FilamentApp app;
+
+  /// The default swapchain to attach new views to, or null on platforms
+  /// that provide their own surfaces.
+  final SwapChain? swapChain;
+}
+
 /// An implementation of [ThermionFlutterPlatform] that uses
 /// a Flutter platform channel to create a native rendering context, resource
 /// loader and rendering surfaces.
@@ -34,7 +50,27 @@ abstract class ThermionFlutterPlugin {
   void resumeFrameScheduler();
 
   /// Initialize the plugin and create the default swapchain.
-  Future<SwapChain?> initialize({bool destroySwapchain = true});
+  Future<InitializeResult> initialize({bool destroySwapchain = true});
+
+  /// Hook invoked by [createViewer] once [view] exists and is attached to
+  /// [swapChain]. Web uses it to route the view to the engine/canvas that
+  /// this initialization created. Defaults to a no-op.
+  void onViewerCreated(View view, SwapChain? swapChain) {}
+
+  /// Hook invoked after a viewer's resources (its View etc.) have been
+  /// disposed. Web destroys the viewer's engine here (one engine per viewer).
+  /// Defaults to a no-op.
+  Future<void> onViewerDisposed(View view) async {}
+
+  /// Web-only: the DOM canvas id hosting [view]'s engine, or null when the
+  /// canvas is not hosted as a widget. Used by the web surface builder.
+  String? canvasIdForView(View view) => null;
+
+  /// Applies the target frame rate to every engine (web runs one engine per
+  /// viewer).
+  void setTargetFramerate(int fps) {
+    FilamentApp.instance?.setTargetFramerate(fps);
+  }
 
   /// Creates a rendering surface and binds to the given [View].
   /// This is an internal method, don't call this yourself unless you are a
@@ -74,23 +110,26 @@ abstract class ThermionFlutterPlugin {
     bool destroySwapchain = true,
   }) async {
     _logger.finest("Creating viewer");
-    final swapChain = await instance.initialize(
+    final result = await instance.initialize(
       destroySwapchain: destroySwapchain,
     );
     _logger.finest("Plugin initialized");
     final viewer = ThermionViewerFFI(
       createOverlay: instance.options.nativeOptions.createOverlay,
-      // The foundation still has the native single-app initialize contract.
-      // The web feature layer replaces this with its per-initialization app.
-      app: FilamentApp.instance as FFIFilamentApp,
+      app: result.app as FFIFilamentApp,
     );
     await viewer.initialized;
     _logger.finest("Viewer initialized");
+    final swapChain = result.swapChain;
     if (swapChain != null) {
       _logger.finest("Registering swapchain");
-      await FilamentApp.instance!.renderManager.attach(viewer.view, swapChain);
+      // Use the app from THIS initialization — on web each createViewer
+      // builds its own engine, so FilamentApp.instance may already point at
+      // a newer one by the time we resume.
+      await result.app.renderManager.attach(viewer.view, swapChain);
       _logger.finest("Swapchain registered");
     }
+    instance.onViewerCreated(viewer.view, swapChain);
 
     return viewer;
   }

--- a/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
@@ -50,7 +50,15 @@ abstract class ThermionFlutterPlugin {
   void resumeFrameScheduler();
 
   /// Initialize the plugin and create the default swapchain.
-  Future<InitializeResult> initialize({bool destroySwapchain = true});
+  ///
+  /// [canvasId] is web-only: the DOM id of the canvas this viewer's engine
+  /// should render into. An existing element with that id is adopted
+  /// (transfer happens immediately, so it must exist before the call);
+  /// otherwise one is created. Null generates a default id.
+  Future<InitializeResult> initialize({
+    bool destroySwapchain = true,
+    String? canvasId,
+  });
 
   /// Hook invoked by [createViewer] once [view] exists and is attached to
   /// [swapChain]. Web uses it to route the view to the engine/canvas that
@@ -108,10 +116,12 @@ abstract class ThermionFlutterPlugin {
 
   static Future<ThermionViewer> createViewer({
     bool destroySwapchain = true,
+    String? canvasId,
   }) async {
     _logger.finest("Creating viewer");
     final result = await instance.initialize(
       destroySwapchain: destroySwapchain,
+      canvasId: canvasId,
     );
     _logger.finest("Plugin initialized");
     final viewer = ThermionViewerFFI(

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -51,7 +51,7 @@ class _ThermionWidgetState extends State<ThermionWidget> {
 class ThermionWidgetInternal extends StatefulWidget {
   final View view;
   final void Function(PlatformTextureDescriptor? descriptor)? onTextureUpdated;
-  final Widget Function(PlatformTextureDescriptor?) surfaceWidgetBuilder;
+  final Widget Function(PlatformTextureDescriptor?, View) surfaceWidgetBuilder;
 
   const ThermionWidgetInternal({
     super.key,
@@ -115,14 +115,14 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
             // Initial case - no texture yet
             _scheduleTextureAllocation(width, height);
           }
-          return widget.surfaceWidgetBuilder(_texture);
+          return widget.surfaceWidgetBuilder(_texture, widget.view);
         }
 
         // Size changed - schedule a debounced allocation
         _scheduleTextureAllocation(width, height);
 
         // Keep showing the old texture during debounce
-        return widget.surfaceWidgetBuilder(_texture);
+        return widget.surfaceWidgetBuilder(_texture, widget.view);
       },
     );
   }

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/canvas_widget_builder.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/canvas_widget_builder.dart
@@ -1,7 +1,24 @@
 import 'package:flutter/material.dart' hide View;
+import 'package:thermion_dart/thermion_dart.dart' show View;
+import 'package:thermion_flutter/thermion_flutter.dart';
 
 import '../../../platform/src/platform_texture_descriptor.dart';
 
-Widget surfaceWidgetBuilder(PlatformTextureDescriptor? descriptor) {
-  return Container(color: Colors.transparent);
+/// Web surface builder. With `importCanvasAsWidget` (the default) each
+/// viewer's engine renders into its own DOM canvas, which is hosted inside
+/// this widget via an `HtmlElementView` — the widget slot positions the
+/// canvas element, and the engine paints it directly. With the legacy flag
+/// off, the canvas floats behind the app and the widget is a transparent
+/// placeholder.
+Widget surfaceWidgetBuilder(PlatformTextureDescriptor? descriptor, View view) {
+  final plugin = ThermionFlutterPlugin.instance;
+  if (!plugin.options.webOptions.importCanvasAsWidget) {
+    return Container(color: Colors.transparent);
+  }
+  final canvasId = plugin.canvasIdForView(view);
+  if (canvasId == null) {
+    // Viewer not registered yet (still initializing) — keep the slot warm.
+    return Container(color: Colors.transparent);
+  }
+  return HtmlElementView(viewType: 'imported-canvas-$canvasId');
 }

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/canvas_widget_builder.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/canvas_widget_builder.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart' hide View;
-import 'package:thermion_dart/thermion_dart.dart' show View;
 import 'package:thermion_flutter/thermion_flutter.dart';
 
 import '../../../platform/src/platform_texture_descriptor.dart';

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/texture_widget_builder.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/texture_widget_builder.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart' hide View;
+import 'package:thermion_dart/thermion_dart.dart' show View;
 import '../../../platform/src/platform_texture_descriptor.dart';
 
-Widget surfaceWidgetBuilder(PlatformTextureDescriptor? descriptor) {
+Widget surfaceWidgetBuilder(PlatformTextureDescriptor? descriptor, View view) {
   if (descriptor == null) {
     return const SizedBox.shrink();
   }

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/viewer_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/viewer_widget.dart
@@ -386,6 +386,12 @@ class _ViewerWidgetState extends State<ViewerWidget> {
           await currentViewer.dispose();
         }
       });
+      // Platform hook (web: destroy this viewer's engine + canvas).
+      await runCleanup(() async {
+        await ThermionFlutterPlugin.instance.onViewerDisposed(
+          currentViewer.view,
+        );
+      });
     }
 
     if (widget.destroyEngineOnUnload && FilamentApp.instance != null) {


### PR DESCRIPTION
Implement multi-viewer support for web by giving every viewer its own Filament engine, render thread, canvas, and render manager.
Old design:
- capped at one viewer
- A single global `#thermion_canvas` transferred to one worker, with one WebGL2 context created at `Engine_create` and permanently bound to that canvas — N views meant "last one wins".
- All web plugin state was static singleton (swapchain, rAF id, stack ptr, descriptor registry, init guard), and the Flutter web widget was a transparent placeholder.
- Hard constraint: a WebGL context is permanently bound to its canvas and cannot be retargeted under a live driver → engine-per-viewer was the smallest viable delta.

