### PR TITLE
fix: (hook) handle web builds without code assets

### DIFF
--- a/thermion_dart/hook/link.dart
+++ b/thermion_dart/hook/link.dart
@@ -12,6 +12,22 @@ void main(List<String> args) async {
     var pkgRootFilePath = packageRoot.toFilePath(windows: Platform.isWindows);
     final logger = createBuildLogger(pkgRootFilePath, "link.log");
 
+    // Web builds register no code assets (the wasm is copied into the
+    // consuming app's web/ directory by the build hook), and the tool only
+    // populates `config.code` when buildCodeAssets is true — pass any code
+    // assets through unchanged and skip linking. (Accessing
+    // `input.config.code` unconditionally throws on web.)
+    if (!input.config.buildCodeAssets) {
+      for (final asset in input.assets.code) {
+        output.assets.code.add(asset);
+      }
+      logger.info(
+        "No code assets to build (web build); passed through "
+        "${input.assets.code.length} code asset(s).",
+      );
+      return;
+    }
+
     // The CLinker.library(... LinkerOptions.manual(...)) call below
     // delegates to native_toolchain_c.runCl on Windows, which builds a
     // cl.exe command line from the constructor's `sources` list. Our


### PR DESCRIPTION
Web builds have `buildCodeAssets == false`, leaving `input.config.code` unset. Guard the code-configuration lookup and pass assets through unchanged so `flutter build web` does not fail in the link hook.
