### PR TITLE
refactor: make Filament engine ownership explicit

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -19,1276 +19,16 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 @ffi.Native<ffi.Uint64>()
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)
->(isLeaf: true)
-external void Camera_setExposure(
-  ffi.Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-  isLeaf: true,
-)
-external void Camera_getFrustum(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> out,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Pointer<ffi.Double>,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
-  isLeaf: true,
-)
-external void Camera_lookAt(
-  ffi.Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(
-  ffi.Pointer<TCamera> camera,
-  double focusDistance,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)
->(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-  isLeaf: true,
-)
-external void Camera_setModelMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> tModelMatrix,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.UnsignedInt,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.UnsignedInt,
-    Aabb3,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tVertexBuffer,
-  ffi.Pointer<TIndexBuffer> tIndexBuffer,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
-);
-
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void SceneAsset_addToScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void SceneAsset_removeFromScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
-  isLeaf: true,
-)
-external void SceneAsset_getChildEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int index,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
-  ffi.Pointer<TSceneAsset> asset,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
-
-@ffi.Native<
-  ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int SceneAsset_getPrimitiveOffsetForEntity(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)
->(isLeaf: true)
-external void SceneAsset_getBones(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-);
-
-@ffi.Native<
-  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)
->(isLeaf: true)
-external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-);
-
-@ffi.Native<
-  ffi.Pointer<TGltfAssetLoader> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Pointer<TNameComponentManager>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external void GltfAssetLoader_destroy(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-);
-
-@ffi.Native<
-  ffi.Pointer<TFilamentAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int numInstances,
-);
-
-@ffi.Native<
-  ffi.Pointer<TMaterialInstance> Function(
-    ffi.Pointer<TRenderableManager>,
-    ffi.Pointer<TFilamentAsset>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  ffi.Pointer<TFilamentAsset> tAsset,
-);
-
-@ffi.Native<
-  ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)
->(isLeaf: true)
-external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getResourceUriCount(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<
-  ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)
->(isLeaf: true)
-external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external void NameComponentManager_destroy(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
-
-@ffi.Native<
-  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)
->(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientationBuilder>
-SurfaceOrientationBuilder_create();
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
->(isLeaf: true)
-external void SurfaceOrientationBuilder_vertexCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_normals(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> normals,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_tangents(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> tangents,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_uvs(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> uvs,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_positions(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> positions,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangleCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Uint32>,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_uint(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint32> triangles,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Uint16>,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_ushort(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint16> triangles,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSurfaceOrientation> Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
-  isLeaf: true,
-)
-external void SurfaceOrientationBuilder_destroy(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external int SurfaceOrientation_getVertexCount(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientation_getQuats_float4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Float> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Int16>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientation_getQuats_short4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Int16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Uint16>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientation_getQuats_half4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Uint16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external void SurfaceOrientation_destroy(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)
->(isLeaf: true)
-external void FilamentAsset_getEntities(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TViewport View_getViewport(ffi.Pointer<TView> view);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createLinear(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createACES(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGX(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(
-  ffi.Pointer<TEngine> tEngine,
-  int look,
-);
-
-@ffi.Native<
-  ffi.Pointer<TToneMapper> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
-  ffi.Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
-
-@ffi.Native<
-  ffi.Pointer<TColorGrading> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TToneMapper>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TColorGrading> ColorGrading_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TToneMapper> toneMapper,
-);
-
-@ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
-
-@ffi.Native<
-  ffi.Pointer<TColorGrading> Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Pointer<TEngine>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
-external void ColorGradingBuilder_destroy(
-  ffi.Pointer<TColorGradingBuilder> builder,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)
->(isLeaf: true)
-external void ColorGrading_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TColorGrading> colorGrading,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)
->(isLeaf: true)
-external void ColorGradingBuilder_quality(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int level,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)
->(isLeaf: true)
-external void ColorGradingBuilder_format(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int format,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_dimensions(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int dim,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)
->(isLeaf: true)
-external void ColorGradingBuilder_toneMapper(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  ffi.Pointer<TToneMapper> toneMapper,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_exposure(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double exposure,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_nightAdaptation(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double adaptation,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)
->(isLeaf: true)
-external void ColorGradingBuilder_whiteBalance(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double temperature,
-  double tint,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_contrast(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double contrast,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_vibrance(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double vibrance,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_saturation(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double saturation,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_channelMixer(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double outRedR,
-  double outRedG,
-  double outRedB,
-  double outGreenR,
-  double outGreenG,
-  double outGreenB,
-  double outBlueR,
-  double outBlueG,
-  double outBlueB,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_shadowsMidtonesHighlights(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double shadowsR,
-  double shadowsG,
-  double shadowsB,
-  double shadowsW,
-  double midtonesR,
-  double midtonesG,
-  double midtonesB,
-  double midtonesW,
-  double highlightsR,
-  double highlightsG,
-  double highlightsB,
-  double highlightsW,
-  double rangesX,
-  double rangesY,
-  double rangesZ,
-  double rangesW,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_slopeOffsetPower(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double slopeR,
-  double slopeG,
-  double slopeB,
-  double offsetR,
-  double offsetG,
-  double offsetB,
-  double powerR,
-  double powerG,
-  double powerB,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_curves(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double shadowGammaR,
-  double shadowGammaG,
-  double shadowGammaB,
-  double midPointR,
-  double midPointG,
-  double midPointB,
-  double highlightScaleR,
-  double highlightScaleG,
-  double highlightScaleB,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_luminanceScaling(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_gamutMapping(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(
-  isLeaf: true,
-)
-external void View_setColorGrading(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TColorGrading> tColorGrading,
-);
-
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TColorGrading> View_getColorGrading(
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(
-  isLeaf: true,
-)
-external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(
-  isLeaf: true,
-)
-external void View_setRenderTarget(
-  ffi.Pointer<TView> view,
-  ffi.Pointer<TRenderTarget> renderTarget,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrustumCullingEnabled(
-  ffi.Pointer<TView> view,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TRenderTarget> View_getRenderTarget(
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
-external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getShadowType(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(
-  isLeaf: true,
-)
-external void View_setSoftShadowOptions(
-  ffi.Pointer<TView> tView,
-  TSoftShadowOptions options,
-);
-
-@ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(
-  isLeaf: true,
-)
-external void View_setVsmShadowOptions(
-  ffi.Pointer<TView> tView,
-  TVsmShadowOptions options,
-);
-
-@ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(
-  isLeaf: true,
-)
-external void View_setBloom(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  double strength,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)
->(isLeaf: true)
-external void View_setAntiAliasing(
-  ffi.Pointer<TView> tView,
-  bool msaa,
-  bool fxaa,
-  bool taa,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(
-  isLeaf: true,
-)
-external void View_setLayerEnabled(
-  ffi.Pointer<TView> tView,
-  int layer,
-  bool visible,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(
-  isLeaf: true,
-)
-external void View_setCamera(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TCamera> tCamera,
-);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setStencilBufferEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void View_setScene(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrontFaceWindingInverted(
-  ffi.Pointer<TView> tView,
-  bool inverted,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(
-  isLeaf: true,
-)
-external void View_setAmbientOcclusionOptions(
-  ffi.Pointer<TView> tView,
-  TAmbientOcclusionOptions options,
-);
-
-@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
-external void View_setFogOptions(
-  ffi.Pointer<TView> tView,
-  TFogOptions tFogOptions,
-);
-
-@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setTransparentPickingEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    PickCallback,
-  )
->(isLeaf: true)
-external void View_pick(
-  ffi.Pointer<TView> tView,
-  int requestId,
-  int x,
-  int y,
-  PickCallback callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(
-  isLeaf: true,
-)
-external void View_setName(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<ffi.Char> name,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSkybox>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Skybox_setColor(
-  ffi.Pointer<TSkybox> tSkybox,
-  double r,
-  double g,
-  double b,
-  double a,
-);
-
-@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
-  isLeaf: true,
-)
-external void IndexBufferBuilder_indexCount(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)
->(isLeaf: true)
-external void IndexBufferBuilder_bufferType(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndexBuffer> Function(
-    ffi.Pointer<TIndexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
-external void IndexBufferBuilder_destroy(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external void IndexBuffer_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
-  isLeaf: true,
-)
-external void IndexBuffer_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-);
-
 @ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external ffi.Pointer<TMaterialInstance> Material_createInstance(
   ffi.Pointer<TMaterial> tMaterial,
 );
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
+external int Material_getFeatureLevel(
+  ffi.Pointer<TMaterial> tMaterial,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TMaterial> Material_createImageMaterial(
@@ -1331,8 +71,7 @@ external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool Material_hasParameter(
   ffi.Pointer<TMaterial> tMaterial,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1344,52 +83,43 @@ external bool MaterialInstance_isStencilWriteEnabled(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setStencilWrite(
   ffi.Pointer<TMaterialInstance> materialInstance,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setCullingMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int culling,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setDoubleSided(
   ffi.Pointer<TMaterialInstance> materialInstance,
   bool doubleSided,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setDepthWrite(
   ffi.Pointer<TMaterialInstance> materialInstance,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setDepthCulling(
   ffi.Pointer<TMaterialInstance> materialInstance,
   bool enabled,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1397,13 +127,8 @@ external void MaterialInstance_setParameterFloat(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Double, ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat2(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1412,14 +137,8 @@ external void MaterialInstance_setParameterFloat2(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat3(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1429,13 +148,8 @@ external void MaterialInstance_setParameterFloat3(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Double>,
-    ffi.Uint32,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Double>, ffi.Uint32)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat3Array(
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1444,15 +158,8 @@ external void MaterialInstance_setParameterFloat3Array(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat4(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1463,12 +170,8 @@ external void MaterialInstance_setParameterFloat4(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Double>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Double>)>(isLeaf: true)
 external void MaterialInstance_setParameterMat3(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1476,12 +179,8 @@ external void MaterialInstance_setParameterMat3(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Double>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Double>)>(isLeaf: true)
 external void MaterialInstance_setParameterMat4(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1489,12 +188,8 @@ external void MaterialInstance_setParameterMat4(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Int)>(isLeaf: true)
 external void MaterialInstance_setParameterInt(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1502,12 +197,8 @@ external void MaterialInstance_setParameterInt(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Bool)>(isLeaf: true)
 external void MaterialInstance_setParameterBool(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1515,13 +206,8 @@ external void MaterialInstance_setParameterBool(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTextureSampler>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTextureSampler>)>(isLeaf: true)
 external void MaterialInstance_setParameterTexture(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -1530,20 +216,15 @@ external void MaterialInstance_setParameterTexture(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setDepthFunc(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int depthFunc,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilOpStencilFail(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
@@ -1551,12 +232,8 @@ external void MaterialInstance_setStencilOpStencilFail(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilOpDepthFail(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
@@ -1564,12 +241,8 @@ external void MaterialInstance_setStencilOpDepthFail(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilOpDepthStencilPass(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
@@ -1577,12 +250,8 @@ external void MaterialInstance_setStencilOpDepthStencilPass(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilCompareFunction(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int func,
@@ -1590,8 +259,8 @@ external void MaterialInstance_setStencilCompareFunction(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8, ffi.UnsignedInt)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilReferenceValue(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int value,
@@ -1599,52 +268,1139 @@ external void MaterialInstance_setStencilReferenceValue(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setStencilReadMask(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int mask,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setStencilWriteMask(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int mask,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MaterialInstance_setTransparencyMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int transparencyMode,
 );
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external int MaterialInstance_getTransparencyMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
 );
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
+external int Material_getBlendingMode(
+  ffi.Pointer<TMaterial> material,
+);
 
 @ffi.Native<
-  ffi.Pointer<TTexture> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint8,
-    ffi.Uint16,
-    ffi.IntPtr,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
+    ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>,
+        ffi.UnsignedInt)>(isLeaf: true)
+external int LightManager_createLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external void LightManager_destroyLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_hasComponent(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external int LightManager_getType(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isDirectional(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isPointLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isSpotLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityCandela(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double falloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSpotLightOuterCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSpotLightInnerCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloSize,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloFalloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
+    isLeaf: true)
+external void LightManager_setShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external TShadowOptions LightManager_getShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt,
+        ffi.Bool)>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool LightManager_getLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float,
+        ffi.Float)>(isLeaf: true)
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
+    isLeaf: true)
+external double LightManager_rgbToColorTemperature(
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void FilamentAsset_getEntities(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TGltfAssetLoader> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external void GltfAssetLoader_destroy(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+);
+
+@ffi.Native<
+    ffi.Pointer<TFilamentAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32)>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>,
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  ffi.Pointer<TFilamentAsset> tAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialProvider> Function(
+        ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getResourceUriCount(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<ffi.Pointer<ffi.Char>> Function(
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TViewport View_getViewport(
+  ffi.Pointer<TView> view,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createLinear(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACES(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGX(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(
+  ffi.Pointer<TEngine> tEngine,
+  int look,
+);
+
+@ffi.Native<
+    ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float,
+        ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
+  ffi.Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
+external void ToneMapper_destroy(
+  ffi.Pointer<TToneMapper> toneMapper,
+);
+
+@ffi.Native<
+    ffi.Pointer<TColorGrading> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
+external ffi.Pointer<TColorGrading> ColorGrading_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TToneMapper> toneMapper,
+);
+
+@ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
+
+@ffi.Native<
+    ffi.Pointer<TColorGrading> Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
+external void ColorGradingBuilder_destroy(
+  ffi.Pointer<TColorGradingBuilder> builder,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void ColorGrading_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TColorGrading> colorGrading,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_quality(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int level,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_format(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int format,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(
+    isLeaf: true)
+external void ColorGradingBuilder_dimensions(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int dim,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TColorGradingBuilder>,
+        ffi.Pointer<TToneMapper>)>(isLeaf: true)
+external void ColorGradingBuilder_toneMapper(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  ffi.Pointer<TToneMapper> toneMapper,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_exposure(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double exposure,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_nightAdaptation(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double adaptation,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_whiteBalance(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double temperature,
+  double tint,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_contrast(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double contrast,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_vibrance(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double vibrance,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_saturation(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double saturation,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_channelMixer(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double outRedR,
+  double outRedG,
+  double outRedB,
+  double outGreenR,
+  double outGreenG,
+  double outGreenB,
+  double outBlueR,
+  double outBlueG,
+  double outBlueB,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_shadowsMidtonesHighlights(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double shadowsR,
+  double shadowsG,
+  double shadowsB,
+  double shadowsW,
+  double midtonesR,
+  double midtonesG,
+  double midtonesB,
+  double midtonesW,
+  double highlightsR,
+  double highlightsG,
+  double highlightsB,
+  double highlightsW,
+  double rangesX,
+  double rangesY,
+  double rangesZ,
+  double rangesW,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_slopeOffsetPower(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double slopeR,
+  double slopeG,
+  double slopeB,
+  double offsetR,
+  double offsetG,
+  double offsetB,
+  double powerR,
+  double powerG,
+  double powerB,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_curves(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double shadowGammaR,
+  double shadowGammaG,
+  double shadowGammaB,
+  double midPointR,
+  double midPointG,
+  double midPointB,
+  double highlightScaleR,
+  double highlightScaleG,
+  double highlightScaleB,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void ColorGradingBuilder_luminanceScaling(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void ColorGradingBuilder_gamutMapping(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(
+    isLeaf: true)
+external void View_setColorGrading(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TColorGrading> tColorGrading,
+);
+
+@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(
+    isLeaf: true)
+external ffi.Pointer<TColorGrading> View_getColorGrading(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void View_setBlendMode(
+  ffi.Pointer<TView> view,
+  int blendMode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(
+    isLeaf: true)
+external void View_setViewport(
+  ffi.Pointer<TView> view,
+  int width,
+  int height,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(
+    isLeaf: true)
+external void View_setRenderTarget(
+  ffi.Pointer<TView> view,
+  ffi.Pointer<TRenderTarget> renderTarget,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrustumCullingEnabled(
+  ffi.Pointer<TView> view,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(
+    isLeaf: true)
+external ffi.Pointer<TRenderTarget> View_getRenderTarget(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setPostProcessing(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setShadowsEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
+external void View_setShadowType(
+  ffi.Pointer<TView> tView,
+  int shadowType,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
+external int View_getShadowType(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(
+    isLeaf: true)
+external void View_setSoftShadowOptions(
+  ffi.Pointer<TView> tView,
+  TSoftShadowOptions options,
+);
+
+@ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TSoftShadowOptions View_getSoftShadowOptions(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(
+    isLeaf: true)
+external void View_setVsmShadowOptions(
+  ffi.Pointer<TView> tView,
+  TVsmShadowOptions options,
+);
+
+@ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TVsmShadowOptions View_getVsmShadowOptions(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(
+    isLeaf: true)
+external void View_setBloom(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  double strength,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void View_setRenderQuality(
+  ffi.Pointer<TView> tView,
+  int qualityLevel,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void View_setAntiAliasing(
+  ffi.Pointer<TView> tView,
+  bool msaa,
+  bool fxaa,
+  bool taa,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(
+    isLeaf: true)
+external void View_setLayerEnabled(
+  ffi.Pointer<TView> tView,
+  int layer,
+  bool visible,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(
+    isLeaf: true)
+external void View_setCamera(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TCamera> tCamera,
+);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TScene> View_getScene(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TCamera> View_getCamera(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setStencilBufferEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isStencilBufferEnabled(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setDitheringEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isDitheringEnabled(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void View_setScene(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrontFaceWindingInverted(
+  ffi.Pointer<TView> tView,
+  bool inverted,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(
+    isLeaf: true)
+external void View_setAmbientOcclusionOptions(
+  ffi.Pointer<TView> tView,
+  TAmbientOcclusionOptions options,
+);
+
+@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
+external void View_setFogOptions(
+  ffi.Pointer<TView> tView,
+  TFogOptions tFogOptions,
+);
+
+@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TFogOptions View_getFogOptions(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setTransparentPickingEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isTransparentPickingEnabled(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
+        PickCallback)>(isLeaf: true)
+external void View_pick(
+  ffi.Pointer<TView> tView,
+  int requestId,
+  int x,
+  int y,
+  PickCallback callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(
+    isLeaf: true)
+external void View_setName(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<ffi.Char> name,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> View_getName(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external void NameComponentManager_destroy(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<
+    ffi.Pointer<ffi.Char> Function(
+        ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientationBuilder>
+    SurfaceOrientationBuilder_create();
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_vertexCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_normals(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> normals,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_tangents(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> tangents,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_uvs(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> uvs,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_positions(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> positions,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangleCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_uint(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint32> triangles,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_ushort(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint16> triangles,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSurfaceOrientation> Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
+    isLeaf: true)
+external void SurfaceOrientationBuilder_destroy(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external int SurfaceOrientation_getVertexCount(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_float4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Float> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_short4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Int16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_half4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Uint16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external void SurfaceOrientation_destroy(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void IndirectLight_setRotation(
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+  ffi.Pointer<ffi.Double> rotation,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint8,
+        ffi.Uint16,
+        ffi.IntPtr,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external ffi.Pointer<TTexture> Texture_build(
   ffi.Pointer<TEngine> engine,
   int width,
@@ -1658,12 +1414,8 @@ external ffi.Pointer<TTexture> Texture_build(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<ffi.Void>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
+        ffi.Pointer<ffi.Void>)>(isLeaf: true)
 external void Texture_setExternalImage(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -1671,18 +1423,18 @@ external void Texture_setExternalImage(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getLevels(ffi.Pointer<TTexture> tTexture);
+external int Texture_getLevels(
+  ffi.Pointer<TTexture> tTexture,
+);
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TLinearImage>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TLinearImage>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Int)>(isLeaf: true)
 external bool Texture_loadImage(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -1693,22 +1445,20 @@ external bool Texture_loadImage(
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Uint32,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-  )
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Uint32,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32)>(isLeaf: true)
 external bool Texture_setImage(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -1726,66 +1476,74 @@ external bool Texture_setImage(
 );
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-  isLeaf: true,
-)
-external int Texture_getWidth(ffi.Pointer<TTexture> tTexture, int level);
+    isLeaf: true)
+external int Texture_getWidth(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-  isLeaf: true,
-)
-external int Texture_getHeight(ffi.Pointer<TTexture> tTexture, int level);
+    isLeaf: true)
+external int Texture_getHeight(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-  isLeaf: true,
-)
-external int Texture_getDepth(ffi.Pointer<TTexture> tTexture, int level);
+    isLeaf: true)
+external int Texture_getDepth(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getFormat(ffi.Pointer<TTexture> tTexture);
+external int Texture_getFormat(
+  ffi.Pointer<TTexture> tTexture,
+);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-  isLeaf: true,
-)
-external int Texture_getUsage(ffi.Pointer<TTexture> tTexture, int level);
+    isLeaf: true)
+external int Texture_getUsage(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void Texture_generateMipMaps(
   ffi.Pointer<TTexture> tTexture,
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<
-  ffi.Pointer<TKtx1Bundle> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)
->(isLeaf: true)
+    ffi.Pointer<TKtx1Bundle> Function(
+        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
 external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(
   ffi.Pointer<ffi.Uint8> ktxData,
   int length,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
 external void Ktx1Bundle_getSphericalHarmonics(
   ffi.Pointer<TKtx1Bundle> tBundle,
   ffi.Pointer<ffi.Float> harmonics,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external bool Ktx1Bundle_isCubemap(ffi.Pointer<TKtx1Bundle> tBundle);
+external bool Ktx1Bundle_isCubemap(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external void Ktx1Bundle_destroy(ffi.Pointer<TKtx1Bundle> tBundle);
+external void Ktx1Bundle_destroy(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+);
 
 @ffi.Native<
-  ffi.Pointer<TTexture> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TKtx1Bundle>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TKtx1Bundle> tBundle,
@@ -1794,12 +1552,8 @@ external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
 );
 
 @ffi.Native<
-  ffi.Pointer<TTexture> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-  )
->(isLeaf: true)
+    ffi.Pointer<TTexture> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
 external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> data,
@@ -1807,8 +1561,8 @@ external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
 );
 
 @ffi.Native<
-  ffi.Pointer<TLinearImage> Function(ffi.Uint32, ffi.Uint32, ffi.Uint32)
->(isLeaf: true)
+    ffi.Pointer<TLinearImage> Function(
+        ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
 external ffi.Pointer<TLinearImage> Image_createEmpty(
   int width,
   int height,
@@ -1816,13 +1570,8 @@ external ffi.Pointer<TLinearImage> Image_createEmpty(
 );
 
 @ffi.Native<
-  ffi.Pointer<TLinearImage> Function(
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.Char>,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
+        ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
 external ffi.Pointer<TLinearImage> Image_decode(
   ffi.Pointer<ffi.Uint8> data,
   int length,
@@ -1831,34 +1580,39 @@ external ffi.Pointer<TLinearImage> Image_decode(
 );
 
 @ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external ffi.Pointer<ffi.Float> Image_getBytes(
   ffi.Pointer<TLinearImage> tLinearImage,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external void Image_destroy(ffi.Pointer<TLinearImage> tLinearImage);
+external void Image_destroy(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getWidth(ffi.Pointer<TLinearImage> tLinearImage);
+external int Image_getWidth(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getHeight(ffi.Pointer<TLinearImage> tLinearImage);
+external int Image_getHeight(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getChannels(ffi.Pointer<TLinearImage> tLinearImage);
+external int Image_getChannels(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
 
 @ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external ffi.Pointer<TTexture> RenderTarget_getColorTexture(
   ffi.Pointer<TRenderTarget> tRenderTarget,
 );
 
 @ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
   ffi.Pointer<TRenderTarget> tRenderTarget,
 );
@@ -1867,14 +1621,8 @@ external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
 external ffi.Pointer<TTextureSampler> TextureSampler_create();
 
 @ffi.Native<
-  ffi.Pointer<TTextureSampler> Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
+    ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt,
+        ffi.UnsignedInt, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
 external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
   int minFilter,
   int magFilter,
@@ -1884,68 +1632,58 @@ external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
 );
 
 @ffi.Native<
-  ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt)
->(isLeaf: true)
+    ffi.Pointer<TTextureSampler> Function(
+        ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
 external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(
   int compareMode,
   int compareFunc,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TextureSampler_setMinFilter(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TextureSampler_setMagFilter(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TextureSampler_setWrapModeS(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TextureSampler_setWrapModeT(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TextureSampler_setWrapModeR(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TextureSampler_setAnisotropy(
   ffi.Pointer<TTextureSampler> sampler,
   double anisotropy,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTextureSampler>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void TextureSampler_setCompareMode(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -1953,446 +1691,228 @@ external void TextureSampler_setCompareMode(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
-external void TextureSampler_destroy(ffi.Pointer<TTextureSampler> sampler);
+external void TextureSampler_destroy(
+  ffi.Pointer<TTextureSampler> sampler,
+);
 
 @ffi.Native<
-  ffi.Pointer<TEngine> Function(
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint8,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external ffi.Pointer<TEngine> Engine_create(
-  int backend,
-  ffi.Pointer<ffi.Void> platform,
-  ffi.Pointer<ffi.Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getSupportedFeatureLevel(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_destroy(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TRenderer> Engine_createRenderer(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(
-  isLeaf: true,
-)
-external void Engine_destroyRenderer(
+    ffi.Pointer<TRenderManager> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderer> tRenderer,
 );
 
-@ffi.Native<
-  ffi.Pointer<TSwapChain> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint64,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Void> window,
-  int flags,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(
+  ffi.Pointer<TRenderManager> tRenderer,
 );
 
 @ffi.Native<
-  ffi.Pointer<TSwapChain> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint64,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  int flags,
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
-  isLeaf: true,
-)
-external void Engine_destroySwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSwapChain> tSwapChain,
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external void Engine_destroyView(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
+    isLeaf: true)
+external void RenderManager_render(
+  ffi.Pointer<TRenderManager> tRenderer,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
+        ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)>(isLeaf: true)
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void RenderManager_removeSwapChain(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_detachFromRenderThread(
+  ffi.Pointer<TRenderManager> tRenderManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderManager_setPaused(
+  ffi.Pointer<TRenderManager> tRenderer,
+  bool paused,
+);
+
+@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_start(
+  FrameCallback callback,
+  int targetFps,
+);
+
+@ffi.Native<ffi.Void Function()>()
+external void FrameScheduler_stop();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void FrameScheduler_setRenderThread(
+  ffi.Pointer<ffi.Void> renderThread,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void FrameScheduler_setRenderManager(
+  ffi.Pointer<TRenderManager> rm,
+);
+
+@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
+    isLeaf: true)
+external void FrameScheduler_setPostRenderCallback(
+  PostRenderCallback callback,
+  ffi.Pointer<ffi.Void> userData,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Uint64)>(isLeaf: true)
+external bool FrameScheduler_requestRender(
+  int frameTimeNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startNativeRenderLoop(
+  int targetFps,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(
+  ffi.Pointer<ffi.Void> data,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(
+  int port,
+  int targetFps,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_setTargetFps(
+  int fps,
+);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
+
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(
+  int t,
+);
+
+@ffi.Native<
+    ffi.Pointer<TGizmo> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<TView>,
+        ffi.Pointer<TMaterial>,
+        ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TGizmo> Gizmo_create(
   ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> assetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
   ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void Engine_destroyScene(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)
->(isLeaf: true)
-external void Engine_destroyColorGrading(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TColorGrading> tColorGrading,
-);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TCamera> Engine_createCamera(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
-  isLeaf: true,
-)
-external void Engine_destroyCamera(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TCamera> tCamera,
-);
-
-@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TView> Engine_createView(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TCamera> Engine_getCameraComponent(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-);
-
-@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TTransformManager> Engine_getTransformManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TLightManager> Engine_getLightManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TEntityManager> Engine_getEntityManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
-external void Engine_setAutomaticInstancingEnabled(
-  ffi.Pointer<TEngine> tEngine,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getMaxAutomaticInstances(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
-  isLeaf: true,
-)
-external void Engine_destroyTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TFence> Engine_createFence(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
-  isLeaf: true,
-)
-external void Engine_destroyFence(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TFence> tFence,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_flushAndWait(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_execute(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<
-  ffi.Pointer<TMaterial> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external ffi.Pointer<TMaterial> Engine_buildMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> materialData,
-  int length,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
-  isLeaf: true,
-)
-external void Engine_destroyMaterial(
-  ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)
->(isLeaf: true)
-external void Engine_destroyMaterialInstance(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+    ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32,
+        GizmoPickCallback)>(isLeaf: true)
+external void Gizmo_pick(
+  ffi.Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  GizmoPickCallback callback,
 );
 
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TScene> Engine_createScene(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<
-  ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)
->(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void Gizmo_highlight(
+  ffi.Pointer<TGizmo> tGizmo,
+  int axis,
 );
 
-@ffi.Native<
-  ffi.Pointer<TSkybox> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
+external void Gizmo_unhighlight(
+  ffi.Pointer<TGizmo> tGizmo,
 );
 
 @ffi.Native<
-  ffi.Pointer<TIndirectLight> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-    ffi.Float,
-  )
->(isLeaf: true)
-external ffi.Pointer<TIndirectLight>
-Engine_buildIndirectLightFromIrradianceTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndirectLight> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Float,
-  )
->(isLeaf: true)
-external ffi.Pointer<TIndirectLight>
-Engine_buildIndirectLightFromIrradianceHarmonics(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<ffi.Float> irradianceHarmonics,
-  double intensity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
-  isLeaf: true,
-)
-external void Engine_destroySkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSkybox> tSkybox,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)
->(isLeaf: true)
-external void Engine_destroyIndirectLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
-external int EntityManager_createEntity(
-  ffi.Pointer<TEntityManager> tEntityManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
-  isLeaf: true,
-)
-external void EntityManager_destroyEntity(
-  ffi.Pointer<TEntityManager> tEntityManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
-external void Fence_waitAndDestroy(ffi.Pointer<TFence> tFence);
-
-@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)
->(isLeaf: true)
-external bool DebugRegistry_hasProperty(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TDebugRegistry>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external bool DebugRegistry_setProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  bool value,
-);
-
-@ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Int)
->(isLeaf: true)
-external bool DebugRegistry_setProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  int value,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TDebugRegistry>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Float,
-  )
->(isLeaf: true)
-external bool DebugRegistry_setProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  double value,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TDebugRegistry>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Bool>,
-  )
->(isLeaf: true)
-external bool DebugRegistry_getProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Bool> outValue,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TDebugRegistry>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Int>,
-  )
->(isLeaf: true)
-external bool DebugRegistry_getProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Int> outValue,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TDebugRegistry>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Float>,
-  )
->(isLeaf: true)
-external bool DebugRegistry_getProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Float> outValue,
-);
-
-@ffi.Native<
-  ffi.Pointer<TMaterialInstance> Function(
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Pointer<TMaterialInstance> Function(
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Int,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool)>(isLeaf: true)
 external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   ffi.Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -2435,35 +1955,80 @@ external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   bool hasVolume,
 );
 
+@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
+    isLeaf: true)
+external void IndexBufferBuilder_indexCount(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void IndexBufferBuilder_bufferType(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndexBuffer> Function(
+        ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
+external void IndexBufferBuilder_destroy(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external int IndexBuffer_getIndexCount(
+  ffi.Pointer<TIndexBuffer> buffer,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+external void IndexBuffer_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
+    isLeaf: true)
+external void IndexBuffer_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+);
+
 @ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void VertexBufferBuilder_bufferCount(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int count,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void VertexBufferBuilder_vertexCount(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int count,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.UnsignedInt,
-    ffi.Uint8,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    ffi.Uint8,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt,
+        ffi.Uint8, ffi.UnsignedInt, ffi.Uint32, ffi.Uint8)>(isLeaf: true)
 external void VertexBufferBuilder_attribute(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int attribute,
@@ -2474,12 +2039,8 @@ external void VertexBufferBuilder_attribute(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.UnsignedInt,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt,
+        ffi.Bool)>(isLeaf: true)
 external void VertexBufferBuilder_normalized(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int attribute,
@@ -2487,11 +2048,8 @@ external void VertexBufferBuilder_normalized(
 );
 
 @ffi.Native<
-  ffi.Pointer<TVertexBuffer> Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-  )
->(isLeaf: true)
+    ffi.Pointer<TVertexBuffer> Function(
+        ffi.Pointer<TVertexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TVertexBuffer> VertexBufferBuilder_build(
   ffi.Pointer<TVertexBufferBuilder> builder,
   ffi.Pointer<TEngine> engine,
@@ -2503,18 +2061,13 @@ external void VertexBufferBuilder_destroy(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external int VertexBuffer_getVertexCount(ffi.Pointer<TVertexBuffer> buffer);
+external int VertexBuffer_getVertexCount(
+  ffi.Pointer<TVertexBuffer> buffer,
+);
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
+        ffi.Uint8, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
 external void VertexBuffer_setBufferAt(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
@@ -2525,32 +2078,251 @@ external void VertexBuffer_setBufferAt(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
 external void VertexBuffer_destroy(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
 );
 
+@ffi.Native<
+    ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external ffi.Pointer<TRenderTarget> RenderTarget_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> color,
+  ffi.Pointer<TTexture> depth,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void RenderTarget_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
+    isLeaf: true)
+external void Scene_setSkybox(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TSkybox> skybox,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Scene_setIndirectLight(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external void Scene_addFilamentAsset(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TFilamentAsset> asset,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void Camera_setExposure(
+  ffi.Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+    isLeaf: true)
+external void Camera_getFrustum(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> out,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double, ffi.Bool)>(isLeaf: true)
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
+    isLeaf: true)
+external void Camera_lookAt(
+  ffi.Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(
+  ffi.Pointer<TCamera> camera,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(
+  ffi.Pointer<TCamera> camera,
+  double focusDistance,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+    isLeaf: true)
+external void Camera_setModelMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> tModelMatrix,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>,
+        ffi.UnsignedInt,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+);
+
 @ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external double4x4 TransformManager_getLocalTransform(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
 );
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external double4x4 TransformManager_getWorldTransform(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TTransformManager>, EntityId, double4x4)>(isLeaf: true)
 external void TransformManager_setTransform(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -2558,8 +2330,7 @@ external void TransformManager_setTransform(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool TransformManager_transformToUnitCube(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -2567,13 +2338,8 @@ external bool TransformManager_transformToUnitCube(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTransformManager>,
-    EntityId,
-    EntityId,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId,
+        ffi.Bool)>(isLeaf: true)
 external void TransformManager_setParent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
@@ -2582,40 +2348,35 @@ external void TransformManager_setParent(
 );
 
 @ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external int TransformManager_getParent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
 );
 
 @ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external int TransformManager_getAncestor(
   ffi.Pointer<TTransformManager> tTransformManager,
   int childEntityId,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TransformManager_createComponent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entity,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TransformManager_removeComponent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entity,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool TransformManager_hasComponent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -2632,21 +2393,15 @@ external int TransformManager_getComponentCount(
 );
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external int TransformManager_getChildCount(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTransformManager>,
-    EntityId,
-    ffi.Pointer<EntityId>,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId,
+        ffi.Pointer<EntityId>, ffi.Int)>(isLeaf: true)
 external void TransformManager_getChildren(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -2664,29 +2419,453 @@ external void TransformManager_commitLocalTransformTransaction(
   ffi.Pointer<TTransformManager> tTransformManager,
 );
 
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Double, ffi.Double,
+        ffi.Double, ffi.Double, ffi.Uint8, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void Renderer_setClearOptions(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>,
+        ffi.Uint64)>(isLeaf: true)
+external bool Renderer_beginFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Renderer_endFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Renderer_render(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Renderer_renderStandaloneView(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Pointer<TRenderTarget>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size)>(isLeaf: true)
+external void Renderer_readPixels(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8,
+        ffi.Uint8)>(isLeaf: true)
+external void Renderer_setFrameInterval(
+  ffi.Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+);
+
+@ffi.Native<
+    ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>,
+        ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TEngine> Engine_create(
+  int backend,
+  ffi.Pointer<ffi.Void> platform,
+  ffi.Pointer<ffi.Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getSupportedFeatureLevel(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_destroy(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TRenderer> Engine_createRenderer(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(
+    isLeaf: true)
+external void Engine_destroyRenderer(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSwapChain> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Void> window,
+  int flags,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSwapChain> Function(
+        ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  int flags,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
+    isLeaf: true)
+external void Engine_destroySwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSwapChain> tSwapChain,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Engine_destroyView(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void Engine_destroyScene(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void Engine_destroyColorGrading(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TColorGrading> tColorGrading,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
+    isLeaf: true)
+external ffi.Pointer<TCamera> Engine_createCamera(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
+    isLeaf: true)
+external void Engine_destroyCamera(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TCamera> tCamera,
+);
+
+@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TView> Engine_createView(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
+    isLeaf: true)
+external ffi.Pointer<TCamera> Engine_getCameraComponent(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+);
+
+@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TTransformManager> Engine_getTransformManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TLightManager> Engine_getLightManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TEntityManager> Engine_getEntityManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
+external void Engine_setAutomaticInstancingEnabled(
+  ffi.Pointer<TEngine> tEngine,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getMaxAutomaticInstances(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
+    isLeaf: true)
+external void Engine_destroyTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TFence> Engine_createFence(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
+    isLeaf: true)
+external void Engine_destroyFence(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TFence> tFence,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_flushAndWait(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_execute(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterial> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Engine_buildMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> materialData,
+  int length,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
+    isLeaf: true)
+external void Engine_destroyMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterial> tMaterial,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void Engine_destroyMaterialInstance(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TScene> Engine_createScene(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSkybox> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float,
+        ffi.Float, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TIndirectLight>
+    Engine_buildIndirectLightFromIrradianceTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TIndirectLight>
+    Engine_buildIndirectLightFromIrradianceHarmonics(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<ffi.Float> irradianceHarmonics,
+  double intensity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
+    isLeaf: true)
+external void Engine_destroySkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSkybox> tSkybox,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Engine_destroyIndirectLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
+external int EntityManager_createEntity(
+  ffi.Pointer<TEntityManager> tEntityManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
+    isLeaf: true)
+external void EntityManager_destroyEntity(
+  ffi.Pointer<TEntityManager> tEntityManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
+external void Fence_waitAndDestroy(
+  ffi.Pointer<TFence> tFence,
+);
+
+@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external bool DebugRegistry_hasProperty(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Bool)>(isLeaf: true)
+external bool DebugRegistry_setProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  bool value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Int)>(isLeaf: true)
+external bool DebugRegistry_setProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  int value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Float)>(isLeaf: true)
+external bool DebugRegistry_setProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  double value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Bool>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Bool> outValue,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Int>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Int> outValue,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Float> outValue,
+);
+
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
 external ffi.Pointer<ffi.Void> RenderThread_create();
 
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
-external void RenderThread_destroy();
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(
+  ffi.Pointer<ffi.Char> canvasSelector,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void RenderThread_destroy(
+  ffi.Pointer<ffi.Void> renderThread,
+);
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)>(isLeaf: true)
 external void RenderThread_addTask(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> task,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Pointer<ffi.Pointer<TView>>,
-    ffi.Uint8,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TSwapChain>,
+        ffi.Pointer<ffi.Pointer<TView>>,
+        ffi.Uint8,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderManager_setRenderableRenderThread(
   ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -2697,13 +2876,8 @@ external void RenderManager_setRenderableRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Uint64,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderManager_renderRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   int frameTimeInNanos,
@@ -2712,13 +2886,8 @@ external void RenderManager_renderRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TAnimationManager>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderManager_addAnimationManagerRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TAnimationManager> tAnimationManager,
@@ -2727,13 +2896,8 @@ external void RenderManager_addAnimationManagerRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TAnimationManager>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderManager_removeAnimationManagerRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TAnimationManager> tAnimationManager,
@@ -2742,13 +2906,8 @@ external void RenderManager_removeAnimationManagerRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderManager_removeSwapChainRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -2757,24 +2916,22 @@ external void RenderManager_removeSwapChainRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TAnimationManager>)>>)>(isLeaf: true)
 external void AnimationManager_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>
-  >
-  onComplete,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void AnimationManager_destroyRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int requestId,
@@ -2782,15 +2939,15 @@ external void AnimationManager_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.UnsignedInt,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Uint8,
+            ffi.Bool,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>)>(
+    isLeaf: true)
 external void Engine_createRenderThread(
   int backend,
   ffi.Pointer<ffi.Void> platform,
@@ -2798,29 +2955,25 @@ external void Engine_createRenderThread(
   int stereoscopicEyeCount,
   bool disableHandleUseAfterFreeCheck,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>)>(
+    isLeaf: true)
 external void Engine_createRendererRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TRenderer>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyRendererRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderer> tRenderer,
@@ -2829,61 +2982,58 @@ external void Engine_destroyRendererRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Uint64,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>)>(
+    isLeaf: true)
 external void Engine_createSwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Void> window,
   int flags,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint64,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>)>(
+    isLeaf: true)
 external void Engine_createHeadlessSwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int width,
   int height,
   int flags,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    EntityId,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            EntityId,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>)>(
+    isLeaf: true)
 external void Engine_createCameraRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int entityId,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TCamera>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyCameraRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TCamera> tCamera,
@@ -2892,36 +3042,36 @@ external void Engine_destroyCameraRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>)>(
+    isLeaf: true)
 external void Engine_createViewRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<ffi.Uint8>,
+            ffi.Size,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Engine_buildMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> materialData,
   int length,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void Engine_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int requestId,
@@ -2929,13 +3079,8 @@ external void Engine_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroySwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -2944,13 +3089,8 @@ external void Engine_destroySwapChainRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TView>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyViewRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TView> tView,
@@ -2959,13 +3099,8 @@ external void Engine_destroyViewRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TScene>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroySceneRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TScene> tScene,
@@ -2974,13 +3109,8 @@ external void Engine_destroySceneRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TColorGrading>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyColorGradingRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TColorGrading> tColorGrading,
@@ -2989,13 +3119,8 @@ external void Engine_destroyColorGradingRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterial>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterial> tMaterial,
@@ -3004,13 +3129,8 @@ external void Engine_destroyMaterialRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyMaterialInstanceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
@@ -3019,13 +3139,8 @@ external void Engine_destroyMaterialInstanceRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TSkybox>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroySkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSkybox> tSkybox,
@@ -3034,13 +3149,8 @@ external void Engine_destroySkyboxRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TIndirectLight>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyIndirectLightRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -3049,19 +3159,19 @@ external void Engine_destroyIndirectLightRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint8,
-    ffi.Uint16,
-    ffi.IntPtr,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint8,
+            ffi.Uint16,
+            ffi.IntPtr,
+            ffi.UnsignedInt,
+            ffi.UnsignedInt,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
+    isLeaf: true)
 external void Texture_buildRenderThread(
   ffi.Pointer<TEngine> engine,
   int width,
@@ -3073,18 +3183,12 @@ external void Texture_buildRenderThread(
   int sampler,
   int format,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
+        ffi.Pointer<ffi.Void>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Texture_setExternalImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -3094,13 +3198,8 @@ external void Texture_setExternalImageRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Texture_generateMipMapsRenderThread(
   ffi.Pointer<TTexture> tTexture,
   ffi.Pointer<TEngine> tEngine,
@@ -3109,47 +3208,42 @@ external void Texture_generateMipMapsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TKtx1Bundle>,
-    ffi.Uint32,
-    VoidCallback,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TKtx1Bundle>,
+            ffi.Uint32,
+            VoidCallback,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
+    isLeaf: true)
 external void Ktx1Reader_createTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TKtx1Bundle> tBundle,
   int requestId,
   VoidCallback onTextureUploadComplete,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<ffi.Uint8>,
+            ffi.Size,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
+    isLeaf: true)
 external void Ktx2Reader_createTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> data,
   int size,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyTextureRenderThread(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TTexture> tTexture,
@@ -3158,20 +3252,19 @@ external void Engine_destroyTextureRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>)>(
+    isLeaf: true)
 external void Engine_createFenceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void Fence_waitAndDestroyRenderThread(
   ffi.Pointer<TFence> tFence,
   int requestId,
@@ -3179,13 +3272,8 @@ external void Fence_waitAndDestroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TFence>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyFenceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TFence> tFence,
@@ -3194,8 +3282,7 @@ external void Engine_destroyFenceRenderThread(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void Engine_flushAndWaitRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int requestId,
@@ -3203,8 +3290,7 @@ external void Engine_flushAndWaitRenderThread(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void Engine_executeRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int requestId,
@@ -3212,29 +3298,29 @@ external void Engine_executeRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TTexture>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>)>(
+    isLeaf: true)
 external void Engine_buildSkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Float,
+            ffi.Float,
+            ffi.Float,
+            ffi.Float,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>)>(
+    isLeaf: true)
 external void Engine_buildColoredSkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   double r,
@@ -3242,67 +3328,59 @@ external void Engine_buildColoredSkyboxRenderThread(
   double b,
   double a,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-    ffi.Float,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TTexture>,
+        ffi.Float,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TIndirectLight>)>>)>(isLeaf: true)
 external void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<TTexture> tIrradianceTexture,
   double intensity,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>
-  >
-  onComplete,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Float,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<ffi.Float>,
+        ffi.Float,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TIndirectLight>)>>)>(isLeaf: true)
 external void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<ffi.Float> harmonics,
   double intensity,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>
-  >
-  onComplete,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Renderer_setClearOptionsRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   double clearR,
@@ -3317,13 +3395,12 @@ external void Renderer_setClearOptionsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TRenderer>,
+            ffi.Pointer<TSwapChain>,
+            ffi.Uint64,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void Renderer_beginFrameRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -3332,8 +3409,8 @@ external void Renderer_beginFrameRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Renderer_endFrameRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   int requestId,
@@ -3341,13 +3418,8 @@ external void Renderer_endFrameRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Pointer<TView>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Renderer_renderRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
@@ -3356,13 +3428,8 @@ external void Renderer_renderRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Pointer<TView>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Renderer_renderStandaloneViewRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
@@ -3371,21 +3438,19 @@ external void Renderer_renderStandaloneViewRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<TRenderTarget>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Pointer<TRenderTarget>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Renderer_readPixelsRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   int width,
@@ -3402,31 +3467,27 @@ external void Renderer_readPixelsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterial>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TMaterial>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TMaterialInstance>)>>)>(isLeaf: true)
 external void Material_createInstanceRenderThread(
   ffi.Pointer<TMaterial> tMaterial,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>
-  >
-  onComplete,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTextureSampler>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TMaterialInstance>,
+        ffi.Pointer<ffi.Char>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TTextureSampler>,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void MaterialInstance_setParameterTextureRenderThread(
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -3437,138 +3498,140 @@ external void MaterialInstance_setParameterTextureRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createImageMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createGizmoMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createBoneOverlayMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createSilhouetteMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createEdgeOutlineMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createWireframeMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createTranslationAxisMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TToneMapper>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TToneMapper>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TColorGrading>)>>)>(isLeaf: true)
 external void ColorGrading_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TToneMapper> toneMapper,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>
-  callback,
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TColorGradingBuilder>)>>)>(isLeaf: true)
 external void ColorGradingBuilder_createRenderThread(
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>
-  >
-  onComplete,
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TColorGrading>)>>)>(isLeaf: true)
 external void ColorGradingBuilder_buildRenderThread(
   ffi.Pointer<TColorGradingBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void ColorGradingBuilder_destroyRenderThread(
   ffi.Pointer<TColorGradingBuilder> tBuilder,
   int requestId,
@@ -3576,117 +3639,109 @@ external void ColorGradingBuilder_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createLinearRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createACESRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createACESLegacyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createFilmicRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createPBRNeutralRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createAGXRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Int,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Int,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createAGXWithLookRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int look,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Float,
+            ffi.Float,
+            ffi.Float,
+            ffi.Float,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createGenericRenderThread(
   ffi.Pointer<TEngine> tEngine,
   double contrast,
@@ -3694,26 +3749,25 @@ external void ToneMapper_createGenericRenderThread(
   double midGrayOut,
   double hdrMax,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createDisplayRangeRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void ToneMapper_destroyRenderThread(
   ffi.Pointer<TToneMapper> tToneMapper,
   int requestId,
@@ -3721,14 +3775,8 @@ external void ToneMapper_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    PickCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
+        PickCallback)>(isLeaf: true)
 external void View_pickRenderThread(
   ffi.Pointer<TView> tView,
   int requestId,
@@ -3738,13 +3786,8 @@ external void View_pickRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Pointer<TColorGrading>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setColorGradingRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TColorGrading> tColorGrading,
@@ -3753,14 +3796,8 @@ external void View_setColorGradingRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Bool,
-    ffi.Double,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Double, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setBloomRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3770,13 +3807,8 @@ external void View_setBloomRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Pointer<TCamera>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setCameraRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TCamera> tCamera,
@@ -3785,25 +3817,20 @@ external void View_setCameraRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TView>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>)>(
+    isLeaf: true)
 external void View_getNameRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setNameRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<ffi.Char> name,
@@ -3812,14 +3839,8 @@ external void View_setNameRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setViewportRenderThread(
   ffi.Pointer<TView> tView,
   int width,
@@ -3829,13 +3850,8 @@ external void View_setViewportRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Pointer<TRenderTarget>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setRenderTargetRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TRenderTarget> tRenderTarget,
@@ -3844,15 +3860,8 @@ external void View_setRenderTargetRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setAntiAliasingRenderThread(
   ffi.Pointer<TView> tView,
   bool msaa,
@@ -3863,8 +3872,8 @@ external void View_setAntiAliasingRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setPostProcessingRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3873,8 +3882,8 @@ external void View_setPostProcessingRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setFrustumCullingEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3883,8 +3892,8 @@ external void View_setFrustumCullingEnabledRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setStencilBufferEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3893,8 +3902,8 @@ external void View_setStencilBufferEnabledRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setDitheringEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3903,8 +3912,8 @@ external void View_setDitheringEnabledRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setRenderQualityRenderThread(
   ffi.Pointer<TView> tView,
   int qualityLevel,
@@ -3913,13 +3922,8 @@ external void View_setRenderQualityRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Pointer<TScene>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setSceneRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TScene> tScene,
@@ -3928,14 +3932,8 @@ external void View_setSceneRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setLayerEnabledRenderThread(
   ffi.Pointer<TView> tView,
   int layer,
@@ -3945,8 +3943,8 @@ external void View_setLayerEnabledRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setBlendModeRenderThread(
   ffi.Pointer<TView> tView,
   int blendMode,
@@ -3955,8 +3953,8 @@ external void View_setBlendModeRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setFogOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TFogOptions tFogOptions,
@@ -3965,13 +3963,8 @@ external void View_setFogOptionsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    TAmbientOcclusionOptions,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setAmbientOcclusionOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TAmbientOcclusionOptions options,
@@ -3980,8 +3973,8 @@ external void View_setAmbientOcclusionOptionsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setFrontFaceWindingInvertedRenderThread(
   ffi.Pointer<TView> tView,
   bool inverted,
@@ -3990,8 +3983,8 @@ external void View_setFrontFaceWindingInvertedRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setShadowsEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -4000,8 +3993,8 @@ external void View_setShadowsEnabledRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setShadowTypeRenderThread(
   ffi.Pointer<TView> tView,
   int shadowType,
@@ -4010,13 +4003,8 @@ external void View_setShadowTypeRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    TSoftShadowOptions,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setSoftShadowOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TSoftShadowOptions options,
@@ -4025,13 +4013,8 @@ external void View_setSoftShadowOptionsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TView>,
-    TVsmShadowOptions,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setVsmShadowOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TVsmShadowOptions options,
@@ -4040,8 +4023,8 @@ external void View_setVsmShadowOptionsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setTransparentPickingEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -4050,8 +4033,8 @@ external void View_setTransparentPickingEnabledRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_destroyRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int requestId,
@@ -4059,17 +4042,16 @@ external void SceneAsset_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Bool,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TGltfAssetLoader>,
+            ffi.Pointer<TNameComponentManager>,
+            ffi.Pointer<TFilamentAsset>,
+            ffi.Bool,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
+    isLeaf: true)
 external void SceneAsset_createFromFilamentAssetRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -4077,23 +4059,22 @@ external void SceneAsset_createFromFilamentAssetRenderThread(
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
   bool rebuildVertices,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.UnsignedInt,
-    Aabb3,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TVertexBuffer>,
+            ffi.Pointer<TIndexBuffer>,
+            ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+            ffi.Int,
+            ffi.UnsignedInt,
+            Aabb3,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
+    isLeaf: true)
 external void SceneAsset_createFromBuffersRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tVertexBuffer,
@@ -4103,30 +4084,29 @@ external void SceneAsset_createFromBuffersRenderThread(
   int tPrimitiveType,
   Aabb3 boundingBox,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-  callback,
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>
-    >,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TSceneAsset>,
+            ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+            ffi.Int,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
+    isLeaf: true)
 external void SceneAsset_createInstanceRenderThread(
   ffi.Pointer<TSceneAsset> asset,
   ffi.Pointer<ffi.Pointer<TMaterialInstance>> tMaterialInstances,
   int materialInstanceCount,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-  callback,
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_releaseSourceDataRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int requestId,
@@ -4134,13 +4114,8 @@ external void SceneAsset_releaseSourceDataRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Bool,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void SceneAsset_setFlatShadingRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   bool flatShading,
@@ -4149,51 +4124,50 @@ external void SceneAsset_setFlatShadingRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Int,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TMaterialInstance>)>>)>(isLeaf: true)
 external void MaterialProvider_createMaterialInstanceRenderThread(
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
   bool doubleSided,
@@ -4235,19 +4209,13 @@ external void MaterialProvider_createMaterialInstanceRenderThread(
   bool hasIOR,
   bool hasVolume,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>
-  >
-  callback,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Uint64,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void AnimationManager_updateRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int frameTimeInNanos,
@@ -4256,12 +4224,11 @@ external void AnimationManager_updateRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TAnimationManager>,
+            ffi.Pointer<TSceneAsset>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void AnimationManager_updateBoneMatricesRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -4269,14 +4236,13 @@ external void AnimationManager_updateBoneMatricesRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TAnimationManager>,
+            EntityId,
+            ffi.Pointer<ffi.Float>,
+            ffi.Int,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void AnimationManager_setMorphTargetWeightsRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -4286,58 +4252,55 @@ external void AnimationManager_setMorphTargetWeightsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TLinearImage>)>>)>(isLeaf: true)
 external void Image_createEmptyRenderThread(
   int width,
   int height,
   int channel,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.Char>,
-    ffi.Bool,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Pointer<ffi.Char>,
+        ffi.Bool,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TLinearImage>)>>)>(isLeaf: true)
 external void Image_decodeRenderThread(
   ffi.Pointer<ffi.Uint8> data,
   int length,
   ffi.Pointer<ffi.Char> name,
   bool alpha,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLinearImage>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TLinearImage>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>)>(
+    isLeaf: true)
 external void Image_getBytesRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Image_destroyRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   int requestId,
@@ -4345,49 +4308,42 @@ external void Image_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLinearImage>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TLinearImage>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
+    isLeaf: true)
 external void Image_getWidthRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLinearImage>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TLinearImage>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
+    isLeaf: true)
 external void Image_getHeightRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLinearImage>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TLinearImage>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
+    isLeaf: true)
 external void Image_getChannelsRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TLinearImage>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TTexture>,
+            ffi.Pointer<TLinearImage>,
+            ffi.UnsignedInt,
+            ffi.UnsignedInt,
+            ffi.Int,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void Texture_loadImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -4399,23 +4355,22 @@ external void Texture_loadImageRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Uint32,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TTexture>,
+            ffi.Uint32,
+            ffi.Pointer<ffi.Uint8>,
+            ffi.Size,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void Texture_setImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -4434,43 +4389,36 @@ external void Texture_setImageRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderTarget>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TRenderTarget>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
+    isLeaf: true)
 external void RenderTarget_getColorTextureRenderThread(
   ffi.Pointer<TRenderTarget> tRenderTarget,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TRenderTarget>)>>)>(isLeaf: true)
 external void RenderTarget_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> color,
   ffi.Pointer<TTexture> depth,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TRenderTarget>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderTarget_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderTarget> tRenderTarget,
@@ -4479,31 +4427,28 @@ external void RenderTarget_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
 external void TextureSampler_createRenderThread(
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
-  >
-  onComplete,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
 external void TextureSampler_createWithFilteringRenderThread(
   int minFilter,
   int magFilter,
@@ -4511,37 +4456,29 @@ external void TextureSampler_createWithFilteringRenderThread(
   int wrapT,
   int wrapR,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
-  >
-  onComplete,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
 external void TextureSampler_createWithComparisonRenderThread(
   int compareMode,
   int compareFunc,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
-  >
-  onComplete,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTextureSampler>,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setMinFilterRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
@@ -4550,13 +4487,8 @@ external void TextureSampler_setMinFilterRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTextureSampler>,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setMagFilterRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
@@ -4565,13 +4497,8 @@ external void TextureSampler_setMagFilterRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTextureSampler>,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeSRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4580,13 +4507,8 @@ external void TextureSampler_setWrapModeSRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTextureSampler>,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeTRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4595,13 +4517,8 @@ external void TextureSampler_setWrapModeTRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTextureSampler>,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeRRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4610,13 +4527,8 @@ external void TextureSampler_setWrapModeRRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTextureSampler>,
-    ffi.Double,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setAnisotropyRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   double anisotropy,
@@ -4625,14 +4537,8 @@ external void TextureSampler_setAnisotropyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTextureSampler>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
+        ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_setCompareModeRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4642,8 +4548,8 @@ external void TextureSampler_setCompareModeRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_destroyRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int requestId,
@@ -4651,13 +4557,8 @@ external void TextureSampler_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void AnimationManager_resetToRestPoseRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -4666,28 +4567,26 @@ external void AnimationManager_resetToRestPoseRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TGltfAssetLoader>)>>)>(isLeaf: true)
 external void GltfAssetLoader_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>
-  >
-  callback,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>>
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void GltfAssetLoader_destroyRenderThread(
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   int requestId,
@@ -4695,29 +4594,23 @@ external void GltfAssetLoader_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TGltfResourceLoader>)>>)>(isLeaf: true)
 external void GltfResourceLoader_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>
-  >
-  callback,
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>>
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void GltfResourceLoader_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfResourceLoader> tResourceLoader,
@@ -4726,12 +4619,11 @@ external void GltfResourceLoader_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TGltfResourceLoader>,
+            ffi.Pointer<TFilamentAsset>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void GltfResourceLoader_loadResourcesRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -4739,15 +4631,13 @@ external void GltfResourceLoader_loadResourcesRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void GltfResourceLoader_addResourceDataRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.Char> uri,
@@ -4758,12 +4648,11 @@ external void GltfResourceLoader_addResourceDataRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TGltfResourceLoader>,
+            ffi.Pointer<TFilamentAsset>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void GltfResourceLoader_asyncBeginLoadRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -4776,28 +4665,24 @@ external void GltfResourceLoader_asyncUpdateLoadRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TGltfResourceLoader>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>)>(
+    isLeaf: true)
 external void GltfResourceLoader_asyncGetLoadProgressRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>> callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>)>(isLeaf: true)
 external void GltfAssetLoader_loadRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -4805,19 +4690,13 @@ external void GltfAssetLoader_loadRenderThread(
   int length,
   int numInstances,
   ffi.Pointer<
-    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>
-  >
-  callback,
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TScene>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_addFilamentAssetRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TFilamentAsset> tAsset,
@@ -4826,19 +4705,17 @@ external void Scene_addFilamentAssetRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TFilamentAsset>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)>(
+    isLeaf: true)
 external void FilamentAsset_getWireframeRenderThread(
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_addEntityRenderThread(
   ffi.Pointer<TScene> tScene,
   int entityId,
@@ -4847,8 +4724,8 @@ external void Scene_addEntityRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_removeEntityRenderThread(
   ffi.Pointer<TScene> tScene,
   int entityId,
@@ -4857,13 +4734,8 @@ external void Scene_removeEntityRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<TScene>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void SceneAsset_addToSceneRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
@@ -4872,13 +4744,8 @@ external void SceneAsset_addToSceneRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<TScene>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void SceneAsset_removeFromSceneRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
@@ -4887,13 +4754,8 @@ external void SceneAsset_removeFromSceneRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TScene>,
-    ffi.Pointer<TSkybox>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Scene_setSkyboxRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TSkybox> tSkybox,
@@ -4902,13 +4764,8 @@ external void Scene_setSkyboxRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TScene>,
-    ffi.Pointer<TIndirectLight>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_setIndirectLightRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -4917,17 +4774,17 @@ external void Scene_setIndirectLightRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TView>,
-    ffi.Pointer<TMaterial>,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TGltfAssetLoader>,
+            ffi.Pointer<TGltfResourceLoader>,
+            ffi.Pointer<TNameComponentManager>,
+            ffi.Pointer<TView>,
+            ffi.Pointer<TMaterial>,
+            ffi.UnsignedInt,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>)>(
+    isLeaf: true)
 external void Gizmo_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -4937,33 +4794,26 @@ external void Gizmo_createRenderThread(
   ffi.Pointer<TMaterial> tMaterial,
   int tGizmoType,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>
-  callback,
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TVertexBufferBuilder>,
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>)>(isLeaf: true)
 external void VertexBufferBuilder_buildRenderThread(
   ffi.Pointer<TVertexBufferBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void VertexBuffer_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -4972,17 +4822,15 @@ external void VertexBuffer_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Uint8,
+        ffi.Pointer<ffi.Void>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void VertexBuffer_setBufferAtRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -4995,29 +4843,22 @@ external void VertexBuffer_setBufferAtRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TIndexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<
-      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>
-    >,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TIndexBufferBuilder>,
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>)>(isLeaf: true)
 external void IndexBufferBuilder_buildRenderThread(
   ffi.Pointer<TIndexBufferBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>
-  onComplete,
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void IndexBuffer_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndexBuffer> tBuffer,
@@ -5026,16 +4867,14 @@ external void IndexBuffer_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Void>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void IndexBuffer_setBufferRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndexBuffer> tBuffer,
@@ -5047,13 +4886,12 @@ external void IndexBuffer_setBufferRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Pointer<TEngine>,
-    EntityId,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TRenderableBuilder>,
+            ffi.Pointer<TEngine>,
+            EntityId,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>)>(
+    isLeaf: true)
 external void RenderableBuilder_buildRenderThread(
   ffi.Pointer<TRenderableBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
@@ -5062,24 +4900,17 @@ external void RenderableBuilder_buildRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEntityManager>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TEntityManager>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)>(
+    isLeaf: true)
 external void EntityManager_createEntityRenderThread(
   ffi.Pointer<TEntityManager> tEntityManager,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEntityManager>,
-    EntityId,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void EntityManager_destroyEntityRenderThread(
   ffi.Pointer<TEntityManager> tEntityManager,
   int entityId,
@@ -5088,14 +4919,8 @@ external void EntityManager_destroyEntityRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTransformManager>,
-    EntityId,
-    double4x4,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TransformManager_setTransformRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -5105,15 +4930,8 @@ external void TransformManager_setTransformRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTransformManager>,
-    EntityId,
-    EntityId,
-    ffi.Bool,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId,
+        ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TransformManager_setParentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
@@ -5124,13 +4942,8 @@ external void TransformManager_setParentRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTransformManager>,
-    EntityId,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TransformManager_createComponentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -5139,13 +4952,8 @@ external void TransformManager_createComponentRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTransformManager>,
-    EntityId,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TransformManager_removeComponentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -5154,13 +4962,8 @@ external void TransformManager_removeComponentRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderableManager_destroyEntityRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5169,16 +4972,14 @@ external void RenderableManager_destroyEntityRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>,
+        EntityId,
+        ffi.Pointer<ffi.Float>,
+        ffi.Size,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderableManager_setBonesFromMat4RenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5190,16 +4991,14 @@ external void RenderableManager_setBonesFromMat4RenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>,
+        EntityId,
+        ffi.Pointer<ffi.Float>,
+        ffi.Size,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderableManager_setBonesFromBoneRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5210,17 +5009,75 @@ external void RenderableManager_setBonesFromBoneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
-external void dummy(TGltfMeshData dummy);
+@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<
-  ffi.Int Function(
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<TGltfMeshData>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_asyncBeginLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_asyncUpdateLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external double GltfResourceLoader_asyncGetLoadProgress(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external void GltfResourceLoader_addResourceData(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.Char> uri,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_loadResources(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Skybox_setColor(
+  ffi.Pointer<TSkybox> tSkybox,
+  double r,
+  double g,
+  double b,
+  double a,
+);
+
+@ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
+external void dummy(
+  TGltfMeshData dummy,
+);
+
+@ffi.Native<
+    ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
 external int GltfParser_parseBuffer(
   ffi.Pointer<ffi.Uint8> data,
   int length,
@@ -5229,434 +5086,19 @@ external int GltfParser_parseBuffer(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
-external void GltfParser_freeMeshData(ffi.Pointer<TGltfMeshData> meshData);
-
-@ffi.Native<
-  ffi.Int Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TLightManager>,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external int LightManager_createLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external void LightManager_destroyLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_hasComponent(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external int LightManager_getType(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isDirectional(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isPointLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isSpotLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setIntensityCandela(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double falloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSpotLightOuterCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSpotLightInnerCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloSize,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloFalloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
-  isLeaf: true,
-)
-external void LightManager_setShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)
->(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-);
-
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external TShadowOptions LightManager_getShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.UnsignedInt,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)
->(isLeaf: true)
-external bool LightManager_getLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)
->(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<ffi.Float>,
-    ffi.Uint8,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
-  isLeaf: true,
-)
-external double LightManager_rgbToColorTemperature(
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
-  isLeaf: true,
-)
-external void Scene_setSkybox(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TSkybox> skybox,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)
->(isLeaf: true)
-external void Scene_setIndirectLight(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)
->(isLeaf: true)
-external void Scene_addFilamentAsset(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TFilamentAsset> asset,
+external void GltfParser_freeMeshData(
+  ffi.Pointer<TGltfMeshData> meshData,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableManager_destroyEntity(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool RenderableManager_hasComponent(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5668,8 +5110,7 @@ external bool RenderableManager_empty(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool RenderableManager_isRenderable(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5681,13 +5122,8 @@ external int RenderableManager_getComponentCount(
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Int,
-    ffi.Pointer<TMaterialInstance>,
-  )
->(isLeaf: true)
+    ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int,
+        ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
 external bool RenderableManager_setMaterialInstanceAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5696,12 +5132,8 @@ external bool RenderableManager_setMaterialInstanceAt(
 );
 
 @ffi.Native<
-  ffi.Pointer<TMaterialInstance> Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Pointer<TMaterialInstance> Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
 external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5709,8 +5141,8 @@ external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
 external void RenderableManager_clearMaterialInstanceAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5718,24 +5150,22 @@ external void RenderableManager_clearMaterialInstanceAt(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external int RenderableManager_getPrimitiveCount(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external Aabb3 RenderableManager_getAxisAlignedBoundingBox(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, Aabb3)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, Aabb3)>(isLeaf: true)
 external void RenderableManager_setAxisAlignedBoundingBox(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5743,29 +5173,22 @@ external void RenderableManager_setAxisAlignedBoundingBox(
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external Aabb3 RenderableManager_getAabb(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external Aabb3 RenderableManager_getBoundingBox(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Uint8,
-    ffi.Uint8,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8,
+        ffi.Uint8)>(isLeaf: true)
 external void RenderableManager_setLayerMask(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5774,16 +5197,15 @@ external void RenderableManager_setLayerMask(
 );
 
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external int RenderableManager_getLayerMask(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
 external void RenderableManager_setVisibilityLayer(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5791,8 +5213,8 @@ external void RenderableManager_setVisibilityLayer(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
 external void RenderableManager_setPriority(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5800,16 +5222,15 @@ external void RenderableManager_setPriority(
 );
 
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external int RenderableManager_getPriority(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
 external void RenderableManager_setChannel(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5817,8 +5238,8 @@ external void RenderableManager_setChannel(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
 external void RenderableManager_setCulling(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5826,16 +5247,15 @@ external void RenderableManager_setCulling(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool RenderableManager_getCulling(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
 external void RenderableManager_setFogEnabled(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5843,21 +5263,15 @@ external void RenderableManager_setFogEnabled(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool RenderableManager_getFogEnabled(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.UnsignedInt,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
 external void RenderableManager_setLightChannel(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5866,8 +5280,8 @@ external void RenderableManager_setLightChannel(
 );
 
 @ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt)
->(isLeaf: true)
+    ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.UnsignedInt)>(isLeaf: true)
 external bool RenderableManager_getLightChannel(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5875,8 +5289,8 @@ external bool RenderableManager_getLightChannel(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
 external void RenderableManager_setCastShadows(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5884,16 +5298,15 @@ external void RenderableManager_setCastShadows(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool RenderableManager_isShadowCaster(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
 external void RenderableManager_setReceiveShadows(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5901,16 +5314,15 @@ external void RenderableManager_setReceiveShadows(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool RenderableManager_isShadowReceiver(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
 external void RenderableManager_setScreenSpaceContactShadows(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5918,13 +5330,8 @@ external void RenderableManager_setScreenSpaceContactShadows(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Size,
-    ffi.Uint16,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size,
+        ffi.Uint16)>(isLeaf: true)
 external void RenderableManager_setBlendOrderAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5933,13 +5340,8 @@ external void RenderableManager_setBlendOrderAt(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Size,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size,
+        ffi.Bool)>(isLeaf: true)
 external void RenderableManager_setGlobalBlendOrderEnabledAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5948,14 +5350,8 @@ external void RenderableManager_setGlobalBlendOrderEnabledAt(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
 external void RenderableManager_setMorphWeights(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5965,22 +5361,15 @@ external void RenderableManager_setMorphWeights(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external int RenderableManager_getMorphTargetCount(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
 external void RenderableManager_setBonesFromMat4(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5990,14 +5379,8 @@ external void RenderableManager_setBonesFromMat4(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
 external void RenderableManager_setBonesFromBone(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -6017,20 +5400,15 @@ external void RenderableBuilder_destroy(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, Aabb3)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_boundingBox(
   ffi.Pointer<TRenderableBuilder> builder,
   Aabb3 aabb,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Size,
-    ffi.Pointer<TMaterialInstance>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
+        ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
 external void RenderableBuilder_material(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -6038,16 +5416,14 @@ external void RenderableBuilder_material(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Size,
-    ffi.Uint8,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableBuilder>,
+        ffi.Size,
+        ffi.Uint8,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Pointer<TIndexBuffer>,
+        ffi.Size,
+        ffi.Size)>(isLeaf: true)
 external void RenderableBuilder_geometry(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -6059,56 +5435,50 @@ external void RenderableBuilder_geometry(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_priority(
   ffi.Pointer<TRenderableBuilder> builder,
   int priority,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_channel(
   ffi.Pointer<TRenderableBuilder> builder,
   int channel,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_culling(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_castShadows(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_receiveShadows(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_fog(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt, ffi.Bool)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt,
+        ffi.Bool)>(isLeaf: true)
 external void RenderableBuilder_lightChannel(
   ffi.Pointer<TRenderableBuilder> builder,
   int channel,
@@ -6116,8 +5486,8 @@ external void RenderableBuilder_lightChannel(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
 external void RenderableBuilder_layerMask(
   ffi.Pointer<TRenderableBuilder> builder,
   int select,
@@ -6125,16 +5495,15 @@ external void RenderableBuilder_layerMask(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_screenSpaceContactShadows(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
 external void RenderableBuilder_blendOrder(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -6142,8 +5511,8 @@ external void RenderableBuilder_blendOrder(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)>(isLeaf: true)
 external void RenderableBuilder_globalBlendOrderEnabled(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -6151,20 +5520,15 @@ external void RenderableBuilder_globalBlendOrderEnabled(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_instances(
   ffi.Pointer<TRenderableBuilder> builder,
   int instanceCount,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Size,
-    ffi.Pointer<ffi.Float>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
+        ffi.Pointer<ffi.Float>)>(isLeaf: true)
 external void RenderableBuilder_skinningFromMat4(
   ffi.Pointer<TRenderableBuilder> builder,
   int boneCount,
@@ -6172,12 +5536,8 @@ external void RenderableBuilder_skinningFromMat4(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Size,
-    ffi.Pointer<ffi.Float>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
+        ffi.Pointer<ffi.Float>)>(isLeaf: true)
 external void RenderableBuilder_skinningFromBone(
   ffi.Pointer<TRenderableBuilder> builder,
   int boneCount,
@@ -6185,22 +5545,15 @@ external void RenderableBuilder_skinningFromBone(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void RenderableBuilder_enableSkinningBuffers(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Size,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
+        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
 external void RenderableBuilder_boneIndicesAndWeights(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -6210,130 +5563,203 @@ external void RenderableBuilder_boneIndicesAndWeights(
 );
 
 @ffi.Native<
-  ffi.Int Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Pointer<TEngine>,
-    EntityId,
-  )
->(isLeaf: true)
+    ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>,
+        EntityId)>(isLeaf: true)
 external int RenderableBuilder_build(
   ffi.Pointer<TRenderableBuilder> builder,
   ffi.Pointer<TEngine> engine,
   int entity,
 );
 
-@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+        ffi.Int,
+        ffi.UnsignedInt,
+        Aabb3)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
   ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tVertexBuffer,
+  ffi.Pointer<TIndexBuffer> tIndexBuffer,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)
->(isLeaf: true)
-external void GltfResourceLoader_destroy(
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<TFilamentAsset>,
+        ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-  )
->(isLeaf: true)
-external bool GltfResourceLoader_asyncBeginLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external double GltfResourceLoader_asyncGetLoadProgress(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void GltfResourceLoader_addResourceData(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.Char> uri,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-  )
->(isLeaf: true)
-external bool GltfResourceLoader_loadResources(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(int t);
-
-@ffi.Native<
-  ffi.Pointer<TGizmo> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TView>,
-    ffi.Pointer<TMaterial>,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGizmo> Gizmo_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> assetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
+);
+
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getType(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_destroy(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void SceneAsset_addToScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void SceneAsset_removeFromScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getEntity(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getChildEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
+    isLeaf: true)
+external void SceneAsset_getChildEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getCameraEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getLightEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGizmo>,
-    ffi.Uint32,
-    ffi.Uint32,
-    GizmoPickCallback,
-  )
->(isLeaf: true)
-external void Gizmo_pick(
-  ffi.Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  GizmoPickCallback callback,
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int index,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>,
+        ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
+  ffi.Pointer<TSceneAsset> asset,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external Aabb3 SceneAsset_getBoundingBox(
+  ffi.Pointer<TSceneAsset> asset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TVertexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
+external int SceneAsset_getPrimitiveOffsetForEntity(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_releaseSourceData(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
+external void SceneAsset_setFlatShading(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size,
+        ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getBones(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
+external int SceneAsset_getBoneCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+);
+
+@ffi.Native<
+    ffi.Pointer<ffi.Char> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+);
 
 @ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external ffi.Pointer<TAnimationManager> AnimationManager_create(
   ffi.Pointer<TEngine> tEngine,
 );
@@ -6344,72 +5770,67 @@ external void AnimationManager_destroy(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void AnimationManager_update(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int frameTimeInNanos,
 );
 
 @ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_addGltfAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_removeGltfAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void AnimationManager_addMorphAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void AnimationManager_removeMorphAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_addBoneAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_removeBoneAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Pointer<ffi.Uint32>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>,
+        EntityId,
+        ffi.Pointer<ffi.Float>,
+        ffi.Pointer<ffi.Uint32>,
+        ffi.Int,
+        ffi.Int,
+        ffi.Float)>(isLeaf: true)
 external bool AnimationManager_setMorphAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -6421,36 +5842,33 @@ external bool AnimationManager_setMorphAnimation(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external bool AnimationManager_clearMorphAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external void AnimationManager_resetToRestPose(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>,
+        ffi.Pointer<TSceneAsset>,
+        ffi.Int,
+        ffi.Int,
+        ffi.Pointer<ffi.Float>,
+        ffi.Int,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Bool)>(isLeaf: true)
 external bool AnimationManager_addBoneAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -6466,14 +5884,8 @@ external bool AnimationManager_addBoneAnimation(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
 external void AnimationManager_getRestLocalTransforms(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6483,14 +5895,8 @@ external void AnimationManager_getRestLocalTransforms(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Pointer<ffi.Float>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)>(isLeaf: true)
 external void AnimationManager_getInverseBindMatrix(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6500,18 +5906,16 @@ external void AnimationManager_getInverseBindMatrix(
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>,
+        ffi.Pointer<TSceneAsset>,
+        ffi.Int,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
 external bool AnimationManager_playGltfAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -6525,12 +5929,8 @@ external bool AnimationManager_playGltfAnimation(
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int)>(isLeaf: true)
 external bool AnimationManager_stopGltfAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6538,12 +5938,8 @@ external bool AnimationManager_stopGltfAnimation(
 );
 
 @ffi.Native<
-  ffi.Float Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int)>(isLeaf: true)
 external double AnimationManager_getGltfAnimationDuration(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6551,21 +5947,16 @@ external double AnimationManager_getGltfAnimationDuration(
 );
 
 @ffi.Native<
-  ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
->(isLeaf: true)
+    ffi.Int Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external int AnimationManager_getGltfAnimationCount(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
 external void AnimationManager_getGltfAnimationName(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6574,12 +5965,8 @@ external void AnimationManager_getGltfAnimationName(
 );
 
 @ffi.Native<
-  ffi.Int Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    EntityId,
-  )
->(isLeaf: true)
+    ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        EntityId)>(isLeaf: true)
 external int AnimationManager_getMorphTargetNameCount(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6587,14 +5974,8 @@ external int AnimationManager_getMorphTargetNameCount(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    EntityId,
-    ffi.Pointer<ffi.Char>,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        EntityId, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
 external void AnimationManager_getMorphTargetName(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6604,21 +5985,16 @@ external void AnimationManager_getMorphTargetName(
 );
 
 @ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_updateBoneMatrices(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-  )
->(isLeaf: true)
+    ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId,
+        ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
 external bool AnimationManager_setMorphTargetWeights(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -6627,13 +6003,8 @@ external bool AnimationManager_setMorphTargetWeights(
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int, ffi.Float)>(isLeaf: true)
 external bool AnimationManager_setGltfAnimationTime(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -6641,266 +6012,15 @@ external bool AnimationManager_setGltfAnimationTime(
   double timeInSeconds,
 );
 
-@ffi.Native<
-  ffi.Pointer<TRenderTarget> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TRenderTarget> RenderTarget_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> color,
-  ffi.Pointer<TTexture> depth,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)
->(isLeaf: true)
-external void RenderTarget_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)
->(isLeaf: true)
-external void IndirectLight_setRotation(
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-  ffi.Pointer<ffi.Double> rotation,
-);
-
-@ffi.Native<
-  ffi.Pointer<TRenderManager> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TRenderer>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
->(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
->(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
-  isLeaf: true,
-)
-external void RenderManager_render(
-  ffi.Pointer<TRenderManager> tRenderer,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Pointer<ffi.Pointer<TView>>,
-    ffi.Uint8,
-  )
->(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)
->(isLeaf: true)
-external void RenderManager_removeSwapChain(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
-external void RenderManager_detachFromRenderThread();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void RenderManager_setPaused(
-  ffi.Pointer<TRenderManager> tRenderer,
-  bool paused,
-);
-
-@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_start(FrameCallback callback, int targetFps);
-
-@ffi.Native<ffi.Void Function()>()
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void FrameScheduler_setRenderThread(
-  ffi.Pointer<ffi.Void> renderThread,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void FrameScheduler_setRenderManager(ffi.Pointer<TRenderManager> rm);
-
-@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
-  isLeaf: true,
-)
-external void FrameScheduler_setPostRenderCallback(
-  PostRenderCallback callback,
-  ffi.Pointer<ffi.Void> userData,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Uint64)>(isLeaf: true)
-external bool FrameScheduler_requestRender(int frameTimeNanos);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startNativeRenderLoop(int targetFps);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(int port, int targetFps);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_setTargetFps(int fps);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void Renderer_setClearOptions(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-);
-
-@ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)
->(isLeaf: true)
-external bool Renderer_beginFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external void Renderer_render(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external void Renderer_renderStandaloneView(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<TRenderTarget>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void Renderer_readPixels(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Uint8,
-    ffi.Uint8,
-  )
->(isLeaf: true)
-external void Renderer_setFrameInterval(
-  ffi.Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-);
-
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void MovementIntentExecutor_destroy(
   ffi.Pointer<TMovementIntentExecutor> executor,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMovementIntentExecutor>,
-    ffi.Pointer<TMovementIntent>,
-    ffi.Uint64,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>,
+        ffi.Pointer<TMovementIntent>, ffi.Uint64)>(isLeaf: true)
 external void MovementIntentExecutor_process(
   ffi.Pointer<TMovementIntentExecutor> executor,
   ffi.Pointer<TMovementIntent> intent,
@@ -6908,25 +6028,19 @@ external void MovementIntentExecutor_process(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void Pipeline_registerMovementIntentExecutor(
   ffi.Pointer<TMovementIntentExecutor> executor,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void TransformPipeline_setEngine(ffi.Pointer<ffi.Void> enginePtr);
+external void TransformPipeline_setEngine(
+  ffi.Pointer<ffi.Void> enginePtr,
+);
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Int,
-    ffi.Int,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Int, ffi.Int, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double)>(isLeaf: true)
 external void TransformPipeline_onMouseEvent(
   int eventType,
   int button,
@@ -6952,11 +6066,12 @@ external void TransformPipeline_onScrollEvent(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_update(double deltaTime);
+external void TransformPipeline_update(
+  double deltaTime,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>(
-  isLeaf: true,
-)
+    isLeaf: true)
 external void TransformPipeline_registerPipelineStage(
   ffi.Pointer<ffi.Void> pipelineStageHandle,
   ffi.Pointer<ffi.Char> name,
@@ -6978,10 +6093,14 @@ external void TransformPipeline_addKeyBinding(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForKey(int logicalKey);
+external void TransformPipeline_removeKeyBindingsForKey(
+  int logicalKey,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForAction(int intentAction);
+external void TransformPipeline_removeKeyBindingsForAction(
+  int intentAction,
+);
 
 @ffi.Native<ffi.Void Function()>(isLeaf: true)
 external void TransformPipeline_clearKeyBindings();
@@ -6994,13 +6113,19 @@ external void TransformPipeline_addMouseButtonBinding(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeMouseButtonBindings(int mouseButton);
+external void TransformPipeline_removeMouseButtonBindings(
+  int mouseButton,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_setMouseSensitivity(double sensitivity);
+external void TransformPipeline_setMouseSensitivity(
+  double sensitivity,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_setInvertMouseY(int invert);
+external void TransformPipeline_setInvertMouseY(
+  int invert,
+);
 
 typedef VoidCallbackFunction = ffi.Void Function(ffi.Int32 requestId);
 typedef DartVoidCallbackFunction = void Function(int requestId);
@@ -7262,9 +6387,155 @@ sealed class TIndexType {
   static const TINDEX_TYPE_UINT = 1;
 }
 
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
+sealed class TSamplerCompareFunc {
+  /// !< Less or equal
+  static const LE = 0;
+
+  /// !< Greater or equal
+  static const GE = 1;
+
+  /// !< Strictly less than
+  static const L = 2;
+
+  /// !< Strictly greater than
+  static const G = 3;
+
+  /// !< Equal
+  static const E = 4;
+
+  /// !< Not equal
+  static const NE = 5;
+
+  /// !< Always. Depth / stencil testing is deactivated.
+  static const A = 6;
+
+  /// !< Never. The depth / stencil test always fails.
+  static const N = 7;
+}
+
+sealed class TStencilOperation {
+  static const KEEP = 0;
+  static const ZERO = 1;
+  static const REPLACE = 2;
+  static const INCR = 3;
+  static const INCR_WRAP = 4;
+  static const DECR = 5;
+  static const DECR_WRAP = 6;
+  static const INVERT = 7;
+}
+
+sealed class TStencilFace {
+  static const STENCIL_FACE_FRONT = 1;
+  static const STENCIL_FACE_BACK = 2;
+  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+}
+
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
+sealed class TTransparencyMode {
+  /// ! the transparent object is drawn honoring the raster state
+  static const DEFAULT = 0;
+
+  /// the transparent object is first drawn in the depth buffer,
+  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
+  static const TWO_PASSES_ONE_SIDE = 1;
+
+  /// the transparent object is drawn twice in the color buffer,
+  /// first with back faces only, then with front faces; the culling
+  /// mode is ignored. Can be combined with two-sided lighting
+  static const TWO_PASSES_TWO_SIDES = 2;
+}
+
+sealed class TBlendingMode {
+  static const BLENDING_MODE_OPAQUE = 0;
+  static const BLENDING_MODE_TRANSPARENT = 1;
+  static const BLENDING_MODE_ADD = 2;
+  static const BLENDING_MODE_MASKED = 3;
+  static const BLENDING_MODE_FADE = 4;
+  static const BLENDING_MODE_MULTIPLY = 5;
+  static const BLENDING_MODE_SCREEN = 6;
+  static const BLENDING_MODE_CUSTOM = 7;
+}
+
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+final class TShadowOptions extends ffi.Struct {
+  @ffi.Uint32()
+  external int mapSize;
+
+  @ffi.Uint8()
+  external int shadowCascades;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.Float> cascadeSplitPositions;
+
+  @ffi.Float()
+  external double constantBias;
+
+  @ffi.Float()
+  external double normalBias;
+
+  @ffi.Float()
+  external double shadowFar;
+
+  @ffi.Float()
+  external double shadowNearHint;
+
+  @ffi.Float()
+  external double shadowFarHint;
+
+  @ffi.Bool()
+  external bool stable;
+
+  @ffi.Bool()
+  external bool lispsm;
+
+  @ffi.Float()
+  external double polygonOffsetConstant;
+
+  @ffi.Float()
+  external double polygonOffsetSlope;
+
+  @ffi.Bool()
+  external bool screenSpaceContactShadows;
+
+  @ffi.Uint8()
+  external int stepCount;
+
+  @ffi.Float()
+  external double maxShadowDistance;
+
+  @ffi.Bool()
+  external bool vsmElvsm;
+
+  @ffi.Float()
+  external double vsmBlurWidth;
+
+  @ffi.Float()
+  external double shadowBulbRadius;
+
+  @ffi.Float()
+  external double transformX;
+
+  @ffi.Float()
+  external double transformY;
+
+  @ffi.Float()
+  external double transformZ;
+
+  @ffi.Float()
+  external double transformW;
 }
 
 final class TViewport extends ffi.Struct {
@@ -7481,100 +6752,21 @@ final class TAmbientOcclusionOptions extends ffi.Struct {
   external TSsct ssct;
 }
 
-typedef PickCallbackFunction =
-    ffi.Void Function(
-      ffi.Uint32 requestId,
-      EntityId entityId,
-      ffi.Float depth,
-      ffi.Float fragX,
-      ffi.Float fragY,
-      ffi.Float fragZ,
-    );
-typedef DartPickCallbackFunction =
-    void Function(
-      int requestId,
-      DartEntityId entityId,
-      double depth,
-      double fragX,
-      double fragY,
-      double fragZ,
-    );
+typedef PickCallbackFunction = ffi.Void Function(
+    ffi.Uint32 requestId,
+    EntityId entityId,
+    ffi.Float depth,
+    ffi.Float fragX,
+    ffi.Float fragY,
+    ffi.Float fragZ);
+typedef DartPickCallbackFunction = void Function(
+    int requestId,
+    DartEntityId entityId,
+    double depth,
+    double fragX,
+    double fragY,
+    double fragZ);
 typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
-
-sealed class TSamplerCompareFunc {
-  /// !< Less or equal
-  static const LE = 0;
-
-  /// !< Greater or equal
-  static const GE = 1;
-
-  /// !< Strictly less than
-  static const L = 2;
-
-  /// !< Strictly greater than
-  static const G = 3;
-
-  /// !< Equal
-  static const E = 4;
-
-  /// !< Not equal
-  static const NE = 5;
-
-  /// !< Always. Depth / stencil testing is deactivated.
-  static const A = 6;
-
-  /// !< Never. The depth / stencil test always fails.
-  static const N = 7;
-}
-
-sealed class TStencilOperation {
-  static const KEEP = 0;
-  static const ZERO = 1;
-  static const REPLACE = 2;
-  static const INCR = 3;
-  static const INCR_WRAP = 4;
-  static const DECR = 5;
-  static const DECR_WRAP = 6;
-  static const INVERT = 7;
-}
-
-sealed class TStencilFace {
-  static const STENCIL_FACE_FRONT = 1;
-  static const STENCIL_FACE_BACK = 2;
-  static const STENCIL_FACE_FRONT_AND_BACK = 3;
-}
-
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
-}
-
-sealed class TTransparencyMode {
-  /// ! the transparent object is drawn honoring the raster state
-  static const DEFAULT = 0;
-
-  /// the transparent object is first drawn in the depth buffer,
-  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
-  static const TWO_PASSES_ONE_SIDE = 1;
-
-  /// the transparent object is drawn twice in the color buffer,
-  /// first with back faces only, then with front faces; the culling
-  /// mode is ignored. Can be combined with two-sided lighting
-  static const TWO_PASSES_TWO_SIDES = 2;
-}
-
-sealed class TBlendingMode {
-  static const BLENDING_MODE_OPAQUE = 0;
-  static const BLENDING_MODE_TRANSPARENT = 1;
-  static const BLENDING_MODE_ADD = 2;
-  static const BLENDING_MODE_MASKED = 3;
-  static const BLENDING_MODE_FADE = 4;
-  static const BLENDING_MODE_MULTIPLY = 5;
-  static const BLENDING_MODE_SCREEN = 6;
-  static const BLENDING_MODE_CUSTOM = 7;
-}
 
 sealed class TTextureSamplerType {
   static const SAMPLER_2D = 0;
@@ -7832,6 +7024,42 @@ sealed class TSamplerCompareMode {
   static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
 }
 
+typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
+typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
+typedef PostRenderCallbackFunction = ffi.Void Function(
+    ffi.Pointer<ffi.Void> userData);
+typedef DartPostRenderCallbackFunction = void Function(
+    ffi.Pointer<ffi.Void> userData);
+typedef PostRenderCallback
+    = ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+typedef GizmoPickCallbackFunction = ffi.Void Function(
+    ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
+typedef DartGizmoPickCallbackFunction = void Function(
+    int resultType, double x, double y, double z);
+typedef GizmoPickCallback
+    = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
 sealed class TBackend {
   /// !< Automatically selects an appropriate driver for the platform.
   static const BACKEND_DEFAULT = 0;
@@ -7849,12 +7077,12 @@ sealed class TBackend {
   static const BACKEND_NOOP = 4;
 }
 
-typedef FilamentRenderCallbackFunction =
-    ffi.Void Function(ffi.Pointer<ffi.Void> owner);
-typedef DartFilamentRenderCallbackFunction =
-    void Function(ffi.Pointer<ffi.Void> owner);
-typedef FilamentRenderCallback =
-    ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+typedef FilamentRenderCallbackFunction = ffi.Void Function(
+    ffi.Pointer<ffi.Void> owner);
+typedef DartFilamentRenderCallbackFunction = void Function(
+    ffi.Pointer<ffi.Void> owner);
+typedef FilamentRenderCallback
+    = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
 
 final class TGltfMeshData extends ffi.Struct {
   external ffi.Pointer<ffi.Float> vertices;
@@ -7870,117 +7098,6 @@ final class TGltfMeshData extends ffi.Struct {
   @ffi.UnsignedInt()
   external int primitiveType;
 }
-
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-final class TShadowOptions extends ffi.Struct {
-  @ffi.Uint32()
-  external int mapSize;
-
-  @ffi.Uint8()
-  external int shadowCascades;
-
-  @ffi.Array.multi([3])
-  external ffi.Array<ffi.Float> cascadeSplitPositions;
-
-  @ffi.Float()
-  external double constantBias;
-
-  @ffi.Float()
-  external double normalBias;
-
-  @ffi.Float()
-  external double shadowFar;
-
-  @ffi.Float()
-  external double shadowNearHint;
-
-  @ffi.Float()
-  external double shadowFarHint;
-
-  @ffi.Bool()
-  external bool stable;
-
-  @ffi.Bool()
-  external bool lispsm;
-
-  @ffi.Float()
-  external double polygonOffsetConstant;
-
-  @ffi.Float()
-  external double polygonOffsetSlope;
-
-  @ffi.Bool()
-  external bool screenSpaceContactShadows;
-
-  @ffi.Uint8()
-  external int stepCount;
-
-  @ffi.Float()
-  external double maxShadowDistance;
-
-  @ffi.Bool()
-  external bool vsmElvsm;
-
-  @ffi.Float()
-  external double vsmBlurWidth;
-
-  @ffi.Float()
-  external double shadowBulbRadius;
-
-  @ffi.Float()
-  external double transformX;
-
-  @ffi.Float()
-  external double transformY;
-
-  @ffi.Float()
-  external double transformZ;
-
-  @ffi.Float()
-  external double transformW;
-}
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-typedef GizmoPickCallbackFunction =
-    ffi.Void Function(
-      ffi.UnsignedInt resultType,
-      ffi.Float x,
-      ffi.Float y,
-      ffi.Float z,
-    );
-typedef DartGizmoPickCallbackFunction =
-    void Function(int resultType, double x, double y, double z);
-typedef GizmoPickCallback =
-    ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
-typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
-typedef PostRenderCallbackFunction =
-    ffi.Void Function(ffi.Pointer<ffi.Void> userData);
-typedef DartPostRenderCallbackFunction =
-    void Function(ffi.Pointer<ffi.Void> userData);
-typedef PostRenderCallback =
-    ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
 
 final class TMovementIntentCalculator extends ffi.Opaque {}
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -20,15 +20,14 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
 @ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TMaterialInstance> Material_createInstance(
   ffi.Pointer<TMaterial> tMaterial,
 );
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getFeatureLevel(
-  ffi.Pointer<TMaterial> tMaterial,
-);
+external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TMaterial> Material_createImageMaterial(
@@ -71,7 +70,8 @@ external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool Material_hasParameter(
   ffi.Pointer<TMaterial> tMaterial,
   ffi.Pointer<ffi.Char> propertyName,
@@ -83,43 +83,52 @@ external bool MaterialInstance_isStencilWriteEnabled(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setStencilWrite(
   ffi.Pointer<TMaterialInstance> materialInstance,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setCullingMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int culling,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setDoubleSided(
   ffi.Pointer<TMaterialInstance> materialInstance,
   bool doubleSided,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setDepthWrite(
   ffi.Pointer<TMaterialInstance> materialInstance,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setDepthCulling(
   ffi.Pointer<TMaterialInstance> materialInstance,
   bool enabled,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterFloat(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -127,8 +136,13 @@ external void MaterialInstance_setParameterFloat(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterFloat2(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -137,8 +151,14 @@ external void MaterialInstance_setParameterFloat2(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterFloat3(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -148,8 +168,13 @@ external void MaterialInstance_setParameterFloat3(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Double>, ffi.Uint32)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Double>,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterFloat3Array(
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -158,8 +183,15 @@ external void MaterialInstance_setParameterFloat3Array(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterFloat4(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -170,8 +202,12 @@ external void MaterialInstance_setParameterFloat4(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Double>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Double>,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterMat3(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -179,8 +215,12 @@ external void MaterialInstance_setParameterMat3(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Double>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Double>,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterMat4(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -188,8 +228,12 @@ external void MaterialInstance_setParameterMat4(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Int)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterInt(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -197,8 +241,12 @@ external void MaterialInstance_setParameterInt(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterBool(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -206,8 +254,13 @@ external void MaterialInstance_setParameterBool(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTextureSampler>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTextureSampler>,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterTexture(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -216,15 +269,20 @@ external void MaterialInstance_setParameterTexture(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setDepthFunc(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int depthFunc,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setStencilOpStencilFail(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
@@ -232,8 +290,12 @@ external void MaterialInstance_setStencilOpStencilFail(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setStencilOpDepthFail(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
@@ -241,8 +303,12 @@ external void MaterialInstance_setStencilOpDepthFail(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setStencilOpDepthStencilPass(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
@@ -250,8 +316,12 @@ external void MaterialInstance_setStencilOpDepthStencilPass(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setStencilCompareFunction(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int func,
@@ -259,8 +329,8 @@ external void MaterialInstance_setStencilCompareFunction(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8, ffi.UnsignedInt)
+>(isLeaf: true)
 external void MaterialInstance_setStencilReferenceValue(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int value,
@@ -268,40 +338,46 @@ external void MaterialInstance_setStencilReferenceValue(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setStencilReadMask(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int mask,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setStencilWriteMask(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int mask,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MaterialInstance_setTransparencyMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int transparencyMode,
 );
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int MaterialInstance_getTransparencyMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
 );
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getBlendingMode(
-  ffi.Pointer<TMaterial> material,
-);
+external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
 
 @ffi.Native<
-    ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Int Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TLightManager>,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external int LightManager_createLight(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TLightManager> tLightManager,
@@ -309,50 +385,62 @@ external int LightManager_createLight(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void LightManager_destroyLight(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool LightManager_hasComponent(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int LightManager_getType(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool LightManager_isDirectional(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool LightManager_isPointLight(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool LightManager_isSpotLight(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void LightManager_setPosition(
   ffi.Pointer<TLightManager> tLightManager,
   int light,
@@ -362,15 +450,22 @@ external void LightManager_setPosition(
 );
 
 @ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double3 LightManager_getPosition(
   ffi.Pointer<TLightManager> tLightManager,
   int light,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void LightManager_setDirection(
   ffi.Pointer<TLightManager> tLightManager,
   int light,
@@ -380,15 +475,22 @@ external void LightManager_setDirection(
 );
 
 @ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double3 LightManager_getDirection(
   ffi.Pointer<TLightManager> tLightManager,
   int light,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void LightManager_setColor(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -398,8 +500,8 @@ external void LightManager_setColor(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
 external void LightManager_setColorTemperature(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -407,15 +509,16 @@ external void LightManager_setColorTemperature(
 );
 
 @ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double3 LightManager_getColor(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
 external void LightManager_setIntensity(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -423,8 +526,8 @@ external void LightManager_setIntensity(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
 external void LightManager_setIntensityCandela(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -432,8 +535,13 @@ external void LightManager_setIntensityCandela(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void LightManager_setIntensityWatts(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -442,15 +550,16 @@ external void LightManager_setIntensityWatts(
 );
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double LightManager_getIntensity(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
 external void LightManager_setFalloff(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -458,15 +567,21 @@ external void LightManager_setFalloff(
 );
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double LightManager_getFalloff(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void LightManager_setSpotLightCone(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -475,21 +590,24 @@ external void LightManager_setSpotLightCone(
 );
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double LightManager_getSpotLightOuterCone(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double LightManager_getSpotLightInnerCone(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void LightManager_setSunAngularRadius(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -497,14 +615,16 @@ external void LightManager_setSunAngularRadius(
 );
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double LightManager_getSunAngularRadius(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void LightManager_setSunHaloSize(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -512,14 +632,16 @@ external void LightManager_setSunHaloSize(
 );
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double LightManager_getSunHaloSize(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void LightManager_setSunHaloFalloff(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -527,14 +649,16 @@ external void LightManager_setSunHaloFalloff(
 );
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double LightManager_getSunHaloFalloff(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void LightManager_setShadowCaster(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -542,15 +666,16 @@ external void LightManager_setShadowCaster(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool LightManager_isShadowCaster(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)
+>(isLeaf: true)
 external void LightManager_setShadowOptions(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -558,15 +683,21 @@ external void LightManager_setShadowOptions(
 );
 
 @ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external TShadowOptions LightManager_getShadowOptions(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.UnsignedInt,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external void LightManager_setLightChannel(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -575,8 +706,8 @@ external void LightManager_setLightChannel(
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)
+>(isLeaf: true)
 external bool LightManager_getLightChannel(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
@@ -590,8 +721,8 @@ external void LightManager_computeUniformSplits(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)
+>(isLeaf: true)
 external void LightManager_computeLogSplits(
   ffi.Pointer<ffi.Float> splitPositions,
   int cascades,
@@ -600,8 +731,14 @@ external void LightManager_computeLogSplits(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<ffi.Float>,
+    ffi.Uint8,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void LightManager_computePracticalSplits(
   ffi.Pointer<ffi.Float> splitPositions,
   int cascades,
@@ -611,7 +748,8 @@ external void LightManager_computePracticalSplits(
 );
 
 @ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double LightManager_rgbToColorTemperature(
   double r,
   double g,
@@ -624,8 +762,8 @@ external int FilamentAsset_getEntityCount(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)
+>(isLeaf: true)
 external void FilamentAsset_getEntities(
   ffi.Pointer<TFilamentAsset> filamentAsset,
   ffi.Pointer<EntityId> out,
@@ -637,16 +775,19 @@ external int FilamentAsset_getWireframe(
 );
 
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
   ffi.Pointer<TFilamentAsset> filamentAsset,
 );
 
 @ffi.Native<
-    ffi.Pointer<TGltfAssetLoader> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+  ffi.Pointer<TGltfAssetLoader> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Pointer<TNameComponentManager>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
@@ -659,12 +800,14 @@ external void GltfAssetLoader_destroy(
 );
 
 @ffi.Native<
-    ffi.Pointer<TFilamentAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32)>(isLeaf: true)
+  ffi.Pointer<TFilamentAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -674,16 +817,19 @@ external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
 );
 
 @ffi.Native<
-    ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>,
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+  ffi.Pointer<TMaterialInstance> Function(
+    ffi.Pointer<TRenderableManager>,
+    ffi.Pointer<TFilamentAsset>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   ffi.Pointer<TFilamentAsset> tAsset,
 );
 
 @ffi.Native<
-    ffi.Pointer<TMaterialProvider> Function(
-        ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+  ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)
+>(isLeaf: true)
 external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
 );
@@ -694,63 +840,74 @@ external int FilamentAsset_getResourceUriCount(
 );
 
 @ffi.Native<
-    ffi.Pointer<ffi.Pointer<ffi.Char>> Function(
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+  ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)
+>(isLeaf: true)
 external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
 );
 
 @ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TViewport View_getViewport(
-  ffi.Pointer<TView> view,
-);
+external TViewport View_getViewport(ffi.Pointer<TView> view);
 
 @ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createLinear(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createACES(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createAGX(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(
   ffi.Pointer<TEngine> tEngine,
   int look,
 );
 
 @ffi.Native<
-    ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float,
-        ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+  ffi.Pointer<TToneMapper> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
   ffi.Pointer<TEngine> tEngine,
   double contrast,
@@ -760,19 +917,21 @@ external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
 );
 
 @ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ToneMapper_destroy(
-  ffi.Pointer<TToneMapper> toneMapper,
-);
+external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
 
 @ffi.Native<
-    ffi.Pointer<TColorGrading> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
+  ffi.Pointer<TColorGrading> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TToneMapper>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TColorGrading> ColorGrading_create(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TToneMapper> toneMapper,
@@ -782,8 +941,11 @@ external ffi.Pointer<TColorGrading> ColorGrading_create(
 external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
 
 @ffi.Native<
-    ffi.Pointer<TColorGrading> Function(
-        ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+  ffi.Pointer<TColorGrading> Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Pointer<TEngine>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
   ffi.Pointer<TColorGradingBuilder> builder,
   ffi.Pointer<TEngine> engine,
@@ -795,61 +957,64 @@ external void ColorGradingBuilder_destroy(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)
+>(isLeaf: true)
 external void ColorGrading_destroy(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TColorGrading> colorGrading,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)
+>(isLeaf: true)
 external void ColorGradingBuilder_quality(
   ffi.Pointer<TColorGradingBuilder> builder,
   int level,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)
+>(isLeaf: true)
 external void ColorGradingBuilder_format(
   ffi.Pointer<TColorGradingBuilder> builder,
   int format,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void ColorGradingBuilder_dimensions(
   ffi.Pointer<TColorGradingBuilder> builder,
   int dim,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TColorGradingBuilder>,
-        ffi.Pointer<TToneMapper>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)
+>(isLeaf: true)
 external void ColorGradingBuilder_toneMapper(
   ffi.Pointer<TColorGradingBuilder> builder,
   ffi.Pointer<TToneMapper> toneMapper,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void ColorGradingBuilder_exposure(
   ffi.Pointer<TColorGradingBuilder> builder,
   double exposure,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void ColorGradingBuilder_nightAdaptation(
   ffi.Pointer<TColorGradingBuilder> builder,
   double adaptation,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)
+>(isLeaf: true)
 external void ColorGradingBuilder_whiteBalance(
   ffi.Pointer<TColorGradingBuilder> builder,
   double temperature,
@@ -857,38 +1022,43 @@ external void ColorGradingBuilder_whiteBalance(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void ColorGradingBuilder_contrast(
   ffi.Pointer<TColorGradingBuilder> builder,
   double contrast,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void ColorGradingBuilder_vibrance(
   ffi.Pointer<TColorGradingBuilder> builder,
   double vibrance,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void ColorGradingBuilder_saturation(
   ffi.Pointer<TColorGradingBuilder> builder,
   double saturation,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_channelMixer(
   ffi.Pointer<TColorGradingBuilder> builder,
   double outRedR,
@@ -903,24 +1073,26 @@ external void ColorGradingBuilder_channelMixer(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_shadowsMidtonesHighlights(
   ffi.Pointer<TColorGradingBuilder> builder,
   double shadowsR,
@@ -942,17 +1114,19 @@ external void ColorGradingBuilder_shadowsMidtonesHighlights(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_slopeOffsetPower(
   ffi.Pointer<TColorGradingBuilder> builder,
   double slopeR,
@@ -967,17 +1141,19 @@ external void ColorGradingBuilder_slopeOffsetPower(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_curves(
   ffi.Pointer<TColorGradingBuilder> builder,
   double shadowGammaR,
@@ -992,49 +1168,49 @@ external void ColorGradingBuilder_curves(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void ColorGradingBuilder_luminanceScaling(
   ffi.Pointer<TColorGradingBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void ColorGradingBuilder_gamutMapping(
   ffi.Pointer<TColorGradingBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setColorGrading(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TColorGrading> tColorGrading,
 );
 
 @ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TColorGrading> View_getColorGrading(
   ffi.Pointer<TView> tView,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void View_setBlendMode(
-  ffi.Pointer<TView> view,
-  int blendMode,
-);
+  isLeaf: true,
+)
+external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(
-    isLeaf: true)
-external void View_setViewport(
-  ffi.Pointer<TView> view,
-  int width,
-  int height,
-);
+  isLeaf: true,
+)
+external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setRenderTarget(
   ffi.Pointer<TView> view,
   ffi.Pointer<TRenderTarget> renderTarget,
@@ -1047,60 +1223,49 @@ external void View_setFrustumCullingEnabled(
 );
 
 @ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TRenderTarget> View_getRenderTarget(
   ffi.Pointer<TView> tView,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setPostProcessing(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
+external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setShadowsEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
+external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
-external void View_setShadowType(
-  ffi.Pointer<TView> tView,
-  int shadowType,
-);
+external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getShadowType(
-  ffi.Pointer<TView> tView,
-);
+external int View_getShadowType(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setSoftShadowOptions(
   ffi.Pointer<TView> tView,
   TSoftShadowOptions options,
 );
 
 @ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TSoftShadowOptions View_getSoftShadowOptions(
-  ffi.Pointer<TView> tView,
-);
+external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setVsmShadowOptions(
   ffi.Pointer<TView> tView,
   TVsmShadowOptions options,
 );
 
 @ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TVsmShadowOptions View_getVsmShadowOptions(
-  ffi.Pointer<TView> tView,
-);
+external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setBloom(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -1108,15 +1273,13 @@ external void View_setBloom(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void View_setRenderQuality(
-  ffi.Pointer<TView> tView,
-  int qualityLevel,
-);
+  isLeaf: true,
+)
+external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)
+>(isLeaf: true)
 external void View_setAntiAliasing(
   ffi.Pointer<TView> tView,
   bool msaa,
@@ -1125,7 +1288,8 @@ external void View_setAntiAliasing(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setLayerEnabled(
   ffi.Pointer<TView> tView,
   int layer,
@@ -1133,21 +1297,18 @@ external void View_setLayerEnabled(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setCamera(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TCamera> tCamera,
 );
 
 @ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TScene> View_getScene(
-  ffi.Pointer<TView> tView,
-);
+external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TCamera> View_getCamera(
-  ffi.Pointer<TView> tView,
-);
+external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
 external void View_setStencilBufferEnabled(
@@ -1156,23 +1317,17 @@ external void View_setStencilBufferEnabled(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isStencilBufferEnabled(
-  ffi.Pointer<TView> tView,
-);
+external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setDitheringEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
+external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isDitheringEnabled(
-  ffi.Pointer<TView> tView,
-);
+external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setScene(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TScene> tScene,
@@ -1185,7 +1340,8 @@ external void View_setFrontFaceWindingInverted(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setAmbientOcclusionOptions(
   ffi.Pointer<TView> tView,
   TAmbientOcclusionOptions options,
@@ -1203,9 +1359,7 @@ external void View_setFogOptions(
 );
 
 @ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TFogOptions View_getFogOptions(
-  ffi.Pointer<TView> tView,
-);
+external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
 external void View_setTransparentPickingEnabled(
@@ -1214,13 +1368,17 @@ external void View_setTransparentPickingEnabled(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isTransparentPickingEnabled(
-  ffi.Pointer<TView> tView,
-);
+external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
-        PickCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    PickCallback,
+  )
+>(isLeaf: true)
 external void View_pick(
   ffi.Pointer<TView> tView,
   int requestId,
@@ -1230,16 +1388,15 @@ external void View_pick(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void View_setName(
   ffi.Pointer<TView> tView,
   ffi.Pointer<ffi.Char> name,
 );
 
 @ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> View_getName(
-  ffi.Pointer<TView> tView,
-);
+external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
 external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
@@ -1250,8 +1407,8 @@ external void NameComponentManager_destroy(
 );
 
 @ffi.Native<
-    ffi.Pointer<ffi.Char> Function(
-        ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
+  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)
+>(isLeaf: true)
 external ffi.Pointer<ffi.Char> NameComponentManager_getName(
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
   int entity,
@@ -1259,19 +1416,23 @@ external ffi.Pointer<ffi.Char> NameComponentManager_getName(
 
 @ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TSurfaceOrientationBuilder>
-    SurfaceOrientationBuilder_create();
+SurfaceOrientationBuilder_create();
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
+>(isLeaf: true)
 external void SurfaceOrientationBuilder_vertexCount(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   int count,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void SurfaceOrientationBuilder_normals(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   ffi.Pointer<ffi.Float> normals,
@@ -1279,8 +1440,12 @@ external void SurfaceOrientationBuilder_normals(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void SurfaceOrientationBuilder_tangents(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   ffi.Pointer<ffi.Float> tangents,
@@ -1288,8 +1453,12 @@ external void SurfaceOrientationBuilder_tangents(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void SurfaceOrientationBuilder_uvs(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   ffi.Pointer<ffi.Float> uvs,
@@ -1297,8 +1466,12 @@ external void SurfaceOrientationBuilder_uvs(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void SurfaceOrientationBuilder_positions(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   ffi.Pointer<ffi.Float> positions,
@@ -1306,38 +1479,47 @@ external void SurfaceOrientationBuilder_positions(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
+>(isLeaf: true)
 external void SurfaceOrientationBuilder_triangleCount(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   int count,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Uint32>,
+  )
+>(isLeaf: true)
 external void SurfaceOrientationBuilder_triangles_uint(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   ffi.Pointer<ffi.Uint32> triangles,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Uint16>,
+  )
+>(isLeaf: true)
 external void SurfaceOrientationBuilder_triangles_ushort(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   ffi.Pointer<ffi.Uint16> triangles,
 );
 
 @ffi.Native<
-    ffi.Pointer<TSurfaceOrientation> Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+  ffi.Pointer<TSurfaceOrientation> Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void SurfaceOrientationBuilder_destroy(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
 );
@@ -1348,8 +1530,13 @@ external int SurfaceOrientation_getVertexCount(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void SurfaceOrientation_getQuats_float4(
   ffi.Pointer<TSurfaceOrientation> orientation,
   ffi.Pointer<ffi.Float> out,
@@ -1358,8 +1545,13 @@ external void SurfaceOrientation_getQuats_float4(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Int16>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void SurfaceOrientation_getQuats_short4(
   ffi.Pointer<TSurfaceOrientation> orientation,
   ffi.Pointer<ffi.Int16> out,
@@ -1368,8 +1560,13 @@ external void SurfaceOrientation_getQuats_short4(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Uint16>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void SurfaceOrientation_getQuats_half4(
   ffi.Pointer<TSurfaceOrientation> orientation,
   ffi.Pointer<ffi.Uint16> out,
@@ -1383,24 +1580,26 @@ external void SurfaceOrientation_destroy(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)
+>(isLeaf: true)
 external void IndirectLight_setRotation(
   ffi.Pointer<TIndirectLight> tIndirectLight,
   ffi.Pointer<ffi.Double> rotation,
 );
 
 @ffi.Native<
-    ffi.Pointer<TTexture> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint8,
-        ffi.Uint16,
-        ffi.IntPtr,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Pointer<TTexture> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint8,
+    ffi.Uint16,
+    ffi.IntPtr,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TTexture> Texture_build(
   ffi.Pointer<TEngine> engine,
   int width,
@@ -1414,8 +1613,12 @@ external ffi.Pointer<TTexture> Texture_build(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
-        ffi.Pointer<ffi.Void>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<ffi.Void>,
+  )
+>(isLeaf: true)
 external void Texture_setExternalImage(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -1423,18 +1626,18 @@ external void Texture_setExternalImage(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getLevels(
-  ffi.Pointer<TTexture> tTexture,
-);
+external int Texture_getLevels(ffi.Pointer<TTexture> tTexture);
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TLinearImage>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Int)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TLinearImage>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external bool Texture_loadImage(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -1445,20 +1648,22 @@ external bool Texture_loadImage(
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Uint32,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Uint32,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
 external bool Texture_setImage(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -1476,74 +1681,66 @@ external bool Texture_setImage(
 );
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getWidth(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
+  isLeaf: true,
+)
+external int Texture_getWidth(ffi.Pointer<TTexture> tTexture, int level);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getHeight(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
+  isLeaf: true,
+)
+external int Texture_getHeight(ffi.Pointer<TTexture> tTexture, int level);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getDepth(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
+  isLeaf: true,
+)
+external int Texture_getDepth(ffi.Pointer<TTexture> tTexture, int level);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getFormat(
-  ffi.Pointer<TTexture> tTexture,
-);
+external int Texture_getFormat(ffi.Pointer<TTexture> tTexture);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getUsage(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
+  isLeaf: true,
+)
+external int Texture_getUsage(ffi.Pointer<TTexture> tTexture, int level);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Texture_generateMipMaps(
   ffi.Pointer<TTexture> tTexture,
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<
-    ffi.Pointer<TKtx1Bundle> Function(
-        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+  ffi.Pointer<TKtx1Bundle> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)
+>(isLeaf: true)
 external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(
   ffi.Pointer<ffi.Uint8> ktxData,
   int length,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)
+>(isLeaf: true)
 external void Ktx1Bundle_getSphericalHarmonics(
   ffi.Pointer<TKtx1Bundle> tBundle,
   ffi.Pointer<ffi.Float> harmonics,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external bool Ktx1Bundle_isCubemap(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-);
+external bool Ktx1Bundle_isCubemap(ffi.Pointer<TKtx1Bundle> tBundle);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external void Ktx1Bundle_destroy(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-);
+external void Ktx1Bundle_destroy(ffi.Pointer<TKtx1Bundle> tBundle);
 
 @ffi.Native<
-    ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Pointer<TTexture> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TKtx1Bundle>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TKtx1Bundle> tBundle,
@@ -1552,8 +1749,12 @@ external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
 );
 
 @ffi.Native<
-    ffi.Pointer<TTexture> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+  ffi.Pointer<TTexture> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> data,
@@ -1561,8 +1762,8 @@ external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
 );
 
 @ffi.Native<
-    ffi.Pointer<TLinearImage> Function(
-        ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+  ffi.Pointer<TLinearImage> Function(ffi.Uint32, ffi.Uint32, ffi.Uint32)
+>(isLeaf: true)
 external ffi.Pointer<TLinearImage> Image_createEmpty(
   int width,
   int height,
@@ -1570,8 +1771,13 @@ external ffi.Pointer<TLinearImage> Image_createEmpty(
 );
 
 @ffi.Native<
-    ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
-        ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
+  ffi.Pointer<TLinearImage> Function(
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.Char>,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TLinearImage> Image_decode(
   ffi.Pointer<ffi.Uint8> data,
   int length,
@@ -1580,39 +1786,34 @@ external ffi.Pointer<TLinearImage> Image_decode(
 );
 
 @ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<ffi.Float> Image_getBytes(
   ffi.Pointer<TLinearImage> tLinearImage,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external void Image_destroy(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
+external void Image_destroy(ffi.Pointer<TLinearImage> tLinearImage);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getWidth(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
+external int Image_getWidth(ffi.Pointer<TLinearImage> tLinearImage);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getHeight(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
+external int Image_getHeight(ffi.Pointer<TLinearImage> tLinearImage);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getChannels(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
+external int Image_getChannels(ffi.Pointer<TLinearImage> tLinearImage);
 
 @ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TTexture> RenderTarget_getColorTexture(
   ffi.Pointer<TRenderTarget> tRenderTarget,
 );
 
 @ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
   ffi.Pointer<TRenderTarget> tRenderTarget,
 );
@@ -1621,8 +1822,14 @@ external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
 external ffi.Pointer<TTextureSampler> TextureSampler_create();
 
 @ffi.Native<
-    ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt,
-        ffi.UnsignedInt, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Pointer<TTextureSampler> Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
   int minFilter,
   int magFilter,
@@ -1632,58 +1839,68 @@ external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
 );
 
 @ffi.Native<
-    ffi.Pointer<TTextureSampler> Function(
-        ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt)
+>(isLeaf: true)
 external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(
   int compareMode,
   int compareFunc,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TextureSampler_setMinFilter(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TextureSampler_setMagFilter(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TextureSampler_setWrapModeS(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TextureSampler_setWrapModeT(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TextureSampler_setWrapModeR(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TextureSampler_setAnisotropy(
   ffi.Pointer<TTextureSampler> sampler,
   double anisotropy,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTextureSampler>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external void TextureSampler_setCompareMode(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -1691,49 +1908,54 @@ external void TextureSampler_setCompareMode(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
-external void TextureSampler_destroy(
-  ffi.Pointer<TTextureSampler> sampler,
-);
+external void TextureSampler_destroy(ffi.Pointer<TTextureSampler> sampler);
 
 @ffi.Native<
-    ffi.Pointer<TRenderManager> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+  ffi.Pointer<TRenderManager> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TRenderer>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TRenderManager> RenderManager_create(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderer> tRenderer,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
+external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
+>(isLeaf: true)
 external void RenderManager_addAnimationManager(
   ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TAnimationManager> tAnimationManager,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
+>(isLeaf: true)
 external void RenderManager_removeAnimationManager(
   ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TAnimationManager> tAnimationManager,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderManager_render(
   ffi.Pointer<TRenderManager> tRenderer,
   int frameTimeInNanos,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
-        ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Pointer<ffi.Pointer<TView>>,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
 external void RenderManager_setRenderable(
   ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TSwapChain> swapChain,
@@ -1742,8 +1964,8 @@ external void RenderManager_setRenderable(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)
+>(isLeaf: true)
 external void RenderManager_removeSwapChain(
   ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TSwapChain> swapChain,
@@ -1765,17 +1987,15 @@ external void RenderManager_detachFromRenderThread(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderManager_setPaused(
   ffi.Pointer<TRenderManager> tRenderer,
   bool paused,
 );
 
 @ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_start(
-  FrameCallback callback,
-  int targetFps,
-);
+external void FrameScheduler_start(FrameCallback callback, int targetFps);
 
 @ffi.Native<ffi.Void Function()>()
 external void FrameScheduler_stop();
@@ -1786,60 +2006,48 @@ external void FrameScheduler_setRenderThread(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void FrameScheduler_setRenderManager(
-  ffi.Pointer<TRenderManager> rm,
-);
+external void FrameScheduler_setRenderManager(ffi.Pointer<TRenderManager> rm);
 
 @ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void FrameScheduler_setPostRenderCallback(
   PostRenderCallback callback,
   ffi.Pointer<ffi.Void> userData,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Uint64)>(isLeaf: true)
-external bool FrameScheduler_requestRender(
-  int frameTimeNanos,
-);
+external bool FrameScheduler_requestRender(int frameTimeNanos);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startNativeRenderLoop(
-  int targetFps,
-);
+external void FrameScheduler_startNativeRenderLoop(int targetFps);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(
-  ffi.Pointer<ffi.Void> data,
-);
+external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
 
 @ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(
-  int port,
-  int targetFps,
-);
+external void FrameScheduler_startWithPort(int port, int targetFps);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_setTargetFps(
-  int fps,
-);
+external void FrameScheduler_setTargetFps(int fps);
 
 @ffi.Native<ffi.Int64 Function()>(isLeaf: true)
 external int FrameScheduler_steadyClockUs();
 
 @ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(
-  int t,
-);
+external void Gizmo_dummy(int t);
 
 @ffi.Native<
-    ffi.Pointer<TGizmo> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<TView>,
-        ffi.Pointer<TMaterial>,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Pointer<TGizmo> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TView>,
+    ffi.Pointer<TMaterial>,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TGizmo> Gizmo_create(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> assetLoader,
@@ -1851,8 +2059,13 @@ external ffi.Pointer<TGizmo> Gizmo_create(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32,
-        GizmoPickCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGizmo>,
+    ffi.Uint32,
+    ffi.Uint32,
+    GizmoPickCallback,
+  )
+>(isLeaf: true)
 external void Gizmo_pick(
   ffi.Pointer<TGizmo> tGizmo,
   int x,
@@ -1861,58 +2074,56 @@ external void Gizmo_pick(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void Gizmo_highlight(
-  ffi.Pointer<TGizmo> tGizmo,
-  int axis,
-);
+  isLeaf: true,
+)
+external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(
-  ffi.Pointer<TGizmo> tGizmo,
-);
+external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
 
 @ffi.Native<
-    ffi.Pointer<TMaterialInstance> Function(
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Int,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Pointer<TMaterialInstance> Function(
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   ffi.Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -1959,23 +2170,27 @@ external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
 external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void IndexBufferBuilder_indexCount(
   ffi.Pointer<TIndexBufferBuilder> builder,
   int count,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)
+>(isLeaf: true)
 external void IndexBufferBuilder_bufferType(
   ffi.Pointer<TIndexBufferBuilder> builder,
   int indexType,
 );
 
 @ffi.Native<
-    ffi.Pointer<TIndexBuffer> Function(
-        ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+  ffi.Pointer<TIndexBuffer> Function(
+    ffi.Pointer<TIndexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
   ffi.Pointer<TIndexBufferBuilder> builder,
   ffi.Pointer<TEngine> engine,
@@ -1987,13 +2202,17 @@ external void IndexBufferBuilder_destroy(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(
-  ffi.Pointer<TIndexBuffer> buffer,
-);
+external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
 external void IndexBuffer_setBuffer(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TIndexBuffer> buffer,
@@ -2003,7 +2222,8 @@ external void IndexBuffer_setBuffer(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void IndexBuffer_destroy(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TIndexBuffer> buffer,
@@ -2013,22 +2233,31 @@ external void IndexBuffer_destroy(
 external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void VertexBufferBuilder_bufferCount(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int count,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void VertexBufferBuilder_vertexCount(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int count,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt,
-        ffi.Uint8, ffi.UnsignedInt, ffi.Uint32, ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.UnsignedInt,
+    ffi.Uint8,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
 external void VertexBufferBuilder_attribute(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int attribute,
@@ -2039,8 +2268,12 @@ external void VertexBufferBuilder_attribute(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.UnsignedInt,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external void VertexBufferBuilder_normalized(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int attribute,
@@ -2048,8 +2281,11 @@ external void VertexBufferBuilder_normalized(
 );
 
 @ffi.Native<
-    ffi.Pointer<TVertexBuffer> Function(
-        ffi.Pointer<TVertexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+  ffi.Pointer<TVertexBuffer> Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TVertexBuffer> VertexBufferBuilder_build(
   ffi.Pointer<TVertexBufferBuilder> builder,
   ffi.Pointer<TEngine> engine,
@@ -2061,13 +2297,18 @@ external void VertexBufferBuilder_destroy(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external int VertexBuffer_getVertexCount(
-  ffi.Pointer<TVertexBuffer> buffer,
-);
+external int VertexBuffer_getVertexCount(ffi.Pointer<TVertexBuffer> buffer);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
-        ffi.Uint8, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
 external void VertexBuffer_setBufferAt(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
@@ -2078,16 +2319,20 @@ external void VertexBuffer_setBufferAt(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)
+>(isLeaf: true)
 external void VertexBuffer_destroy(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
 );
 
 @ffi.Native<
-    ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(isLeaf: true)
+  ffi.Pointer<TRenderTarget> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TRenderTarget> RenderTarget_create(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> color,
@@ -2095,51 +2340,46 @@ external ffi.Pointer<TRenderTarget> RenderTarget_create(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)
+>(isLeaf: true)
 external void RenderTarget_destroy(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderTarget> tRenderTarget,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-);
+external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-);
+external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Scene_setSkybox(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TSkybox> skybox,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)
+>(isLeaf: true)
 external void Scene_setIndirectLight(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TIndirectLight> tIndirectLight,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)
+>(isLeaf: true)
 external void Scene_addFilamentAsset(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TFilamentAsset> asset,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)
+>(isLeaf: true)
 external void Camera_setExposure(
   ffi.Pointer<TCamera> camera,
   double aperture,
@@ -2148,34 +2388,22 @@ external void Camera_setExposure(
 );
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(
-  ffi.Pointer<TCamera> camera,
-);
+external double Camera_getAperture(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(
-  ffi.Pointer<TCamera> camera,
-);
+external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(
-  ffi.Pointer<TCamera> camera,
-);
+external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(
-  ffi.Pointer<TCamera> camera,
-);
+external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(
-  ffi.Pointer<TCamera> camera,
-);
+external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
+external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
 external double4x4 Camera_getCullingProjectionMatrix(
@@ -2183,15 +2411,21 @@ external double4x4 Camera_getCullingProjectionMatrix(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Camera_getFrustum(
   ffi.Pointer<TCamera> camera,
   ffi.Pointer<ffi.Double> out,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double,
-        ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.Pointer<ffi.Double>,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void Camera_setProjectionMatrix(
   ffi.Pointer<TCamera> camera,
   ffi.Pointer<ffi.Double> matrix,
@@ -2200,8 +2434,15 @@ external void Camera_setProjectionMatrix(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external void Camera_setProjectionFromFov(
   ffi.Pointer<TCamera> camera,
   double fovInDegrees,
@@ -2212,12 +2453,11 @@ external void Camera_setProjectionFromFov(
 );
 
 @ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(
-  ffi.Pointer<TCamera> camera,
-);
+external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Camera_lookAt(
   ffi.Pointer<TCamera> camera,
   double3 eye,
@@ -2226,25 +2466,16 @@ external void Camera_lookAt(
 );
 
 @ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(
-  ffi.Pointer<TCamera> camera,
-);
+external double Camera_getNear(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(
-  ffi.Pointer<TCamera> camera,
-);
+external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(
-  ffi.Pointer<TCamera> camera,
-  bool horizontal,
-);
+external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
 
 @ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(
-  ffi.Pointer<TCamera> camera,
-);
+external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
 external void Camera_setFocusDistance(
@@ -2253,8 +2484,8 @@ external void Camera_setFocusDistance(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)
+>(isLeaf: true)
 external void Camera_setCustomProjectionWithCulling(
   ffi.Pointer<TCamera> camera,
   double4x4 projectionMatrix,
@@ -2263,15 +2494,22 @@ external void Camera_setCustomProjectionWithCulling(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Camera_setModelMatrix(
   ffi.Pointer<TCamera> camera,
   ffi.Pointer<ffi.Double> tModelMatrix,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void Camera_setLensProjection(
   ffi.Pointer<TCamera> camera,
   double near,
@@ -2281,20 +2519,20 @@ external void Camera_setLensProjection(
 );
 
 @ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(
-  ffi.Pointer<TCamera> camera,
-);
+external int Camera_getEntity(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>,
-        ffi.UnsignedInt,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.UnsignedInt,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void Camera_setProjection(
   ffi.Pointer<TCamera> tCamera,
   int projection,
@@ -2307,22 +2545,24 @@ external void Camera_setProjection(
 );
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double4x4 TransformManager_getLocalTransform(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
 );
 
 @ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external double4x4 TransformManager_getWorldTransform(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TTransformManager>, EntityId, double4x4)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4)
+>(isLeaf: true)
 external void TransformManager_setTransform(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -2330,7 +2570,8 @@ external void TransformManager_setTransform(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool TransformManager_transformToUnitCube(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -2338,8 +2579,13 @@ external bool TransformManager_transformToUnitCube(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTransformManager>,
+    EntityId,
+    EntityId,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external void TransformManager_setParent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
@@ -2348,35 +2594,40 @@ external void TransformManager_setParent(
 );
 
 @ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int TransformManager_getParent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
 );
 
 @ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int TransformManager_getAncestor(
   ffi.Pointer<TTransformManager> tTransformManager,
   int childEntityId,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TransformManager_createComponent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entity,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TransformManager_removeComponent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entity,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool TransformManager_hasComponent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -2393,15 +2644,21 @@ external int TransformManager_getComponentCount(
 );
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int TransformManager_getChildCount(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId,
-        ffi.Pointer<EntityId>, ffi.Int)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTransformManager>,
+    EntityId,
+    ffi.Pointer<EntityId>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external void TransformManager_getChildren(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -2420,8 +2677,17 @@ external void TransformManager_commitLocalTransformTransaction(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Double, ffi.Double,
-        ffi.Double, ffi.Double, ffi.Uint8, ffi.Bool, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external void Renderer_setClearOptions(
   ffi.Pointer<TRenderer> tRenderer,
   double clearR,
@@ -2434,8 +2700,8 @@ external void Renderer_setClearOptions(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>,
-        ffi.Uint64)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)
+>(isLeaf: true)
 external bool Renderer_beginFrame(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -2443,36 +2709,38 @@ external bool Renderer_beginFrame(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-);
+external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Renderer_render(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Renderer_renderStandaloneView(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Pointer<TRenderTarget>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<TRenderTarget>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void Renderer_readPixels(
   ffi.Pointer<TRenderer> tRenderer,
   int width,
@@ -2487,8 +2755,14 @@ external void Renderer_readPixels(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8,
-        ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Uint8,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
 external void Renderer_setFrameInterval(
   ffi.Pointer<TRenderer> tRenderer,
   double headRoomRatio,
@@ -2498,8 +2772,14 @@ external void Renderer_setFrameInterval(
 );
 
 @ffi.Native<
-    ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>,
-        ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)>(isLeaf: true)
+  ffi.Pointer<TEngine> Function(
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Void>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint8,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TEngine> Engine_create(
   int backend,
   ffi.Pointer<ffi.Void> platform,
@@ -2509,14 +2789,10 @@ external ffi.Pointer<TEngine> Engine_create(
 );
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getSupportedFeatureLevel(
-  ffi.Pointer<TEngine> tEngine,
-);
+external int Engine_getSupportedFeatureLevel(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_destroy(
-  ffi.Pointer<TEngine> tEngine,
-);
+external void Engine_destroy(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TRenderer> Engine_createRenderer(
@@ -2524,15 +2800,20 @@ external ffi.Pointer<TRenderer> Engine_createRenderer(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroyRenderer(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderer> tRenderer,
 );
 
 @ffi.Native<
-    ffi.Pointer<TSwapChain> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
+  ffi.Pointer<TSwapChain> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint64,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSwapChain> Engine_createSwapChain(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Void> window,
@@ -2540,8 +2821,13 @@ external ffi.Pointer<TSwapChain> Engine_createSwapChain(
 );
 
 @ffi.Native<
-    ffi.Pointer<TSwapChain> Function(
-        ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
+  ffi.Pointer<TSwapChain> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint64,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
   ffi.Pointer<TEngine> tEngine,
   int width,
@@ -2550,80 +2836,88 @@ external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroySwapChain(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSwapChain> tSwapChain,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroyView(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TView> tView,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroyScene(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TScene> tScene,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)
+>(isLeaf: true)
 external void Engine_destroyColorGrading(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TColorGrading> tColorGrading,
 );
 
 @ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TCamera> Engine_createCamera(
   ffi.Pointer<TEngine> tEngine,
   int entityId,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroyCamera(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TCamera> tCamera,
 );
 
 @ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TView> Engine_createView(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TView> Engine_createView(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TCamera> Engine_getCameraComponent(
   ffi.Pointer<TEngine> tEngine,
   int entityId,
 );
 
 @ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TTransformManager> Engine_getTransformManager(
   ffi.Pointer<TEngine> engine,
 );
 
 @ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
   ffi.Pointer<TEngine> engine,
 );
 
 @ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TLightManager> Engine_getLightManager(
   ffi.Pointer<TEngine> engine,
 );
 
 @ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TEntityManager> Engine_getEntityManager(
   ffi.Pointer<TEngine> engine,
 );
@@ -2635,42 +2929,40 @@ external void Engine_setAutomaticInstancingEnabled(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getMaxAutomaticInstances(
-  ffi.Pointer<TEngine> tEngine,
-);
+external int Engine_getMaxAutomaticInstances(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroyTexture(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
 );
 
 @ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TFence> Engine_createFence(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TFence> Engine_createFence(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroyFence(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TFence> tFence,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_flushAndWait(
-  ffi.Pointer<TEngine> tEngine,
-);
+external void Engine_flushAndWait(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_execute(
-  ffi.Pointer<TEngine> tEngine,
-);
+external void Engine_execute(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<
-    ffi.Pointer<TMaterial> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+  ffi.Pointer<TMaterial> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TMaterial> Engine_buildMaterial(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> materialData,
@@ -2678,36 +2970,41 @@ external ffi.Pointer<TMaterial> Engine_buildMaterial(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroyMaterial(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterial> tMaterial,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)
+>(isLeaf: true)
 external void Engine_destroyMaterialInstance(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
 );
 
 @ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TScene> Engine_createScene(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TScene> Engine_createScene(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<
-    ffi.Pointer<TSkybox> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
+  ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)
+>(isLeaf: true)
 external ffi.Pointer<TSkybox> Engine_buildSkybox(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
 );
 
 @ffi.Native<
-    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float,
-        ffi.Float, ffi.Float)>(isLeaf: true)
+  ffi.Pointer<TSkybox> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
   ffi.Pointer<TEngine> tEngine,
   double r,
@@ -2717,10 +3014,15 @@ external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
 );
 
 @ffi.Native<
-    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)>(isLeaf: true)
+  ffi.Pointer<TIndirectLight> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TIndirectLight>
-    Engine_buildIndirectLightFromIrradianceTexture(
+Engine_buildIndirectLightFromIrradianceTexture(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<TTexture> tIrradianceTexture,
@@ -2728,10 +3030,15 @@ external ffi.Pointer<TIndirectLight>
 );
 
 @ffi.Native<
-    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)>(isLeaf: true)
+  ffi.Pointer<TIndirectLight> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TIndirectLight>
-    Engine_buildIndirectLightFromIrradianceHarmonics(
+Engine_buildIndirectLightFromIrradianceHarmonics(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<ffi.Float> irradianceHarmonics,
@@ -2739,15 +3046,16 @@ external ffi.Pointer<TIndirectLight>
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroySkybox(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSkybox> tSkybox,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)
+>(isLeaf: true)
 external void Engine_destroyIndirectLight(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -2759,34 +3067,38 @@ external int EntityManager_createEntity(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void EntityManager_destroyEntity(
   ffi.Pointer<TEntityManager> tEntityManager,
   int entityId,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
-external void Fence_waitAndDestroy(
-  ffi.Pointer<TFence> tFence,
-);
+external void Fence_waitAndDestroy(ffi.Pointer<TFence> tFence);
 
 @ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)
+>(isLeaf: true)
 external bool DebugRegistry_hasProperty(
   ffi.Pointer<TDebugRegistry> tDebugRegistry,
   ffi.Pointer<ffi.Char> name,
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TDebugRegistry>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external bool DebugRegistry_setProperty_bool(
   ffi.Pointer<TDebugRegistry> tDebugRegistry,
   ffi.Pointer<ffi.Char> name,
@@ -2794,8 +3106,8 @@ external bool DebugRegistry_setProperty_bool(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Int)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Int)
+>(isLeaf: true)
 external bool DebugRegistry_setProperty_int(
   ffi.Pointer<TDebugRegistry> tDebugRegistry,
   ffi.Pointer<ffi.Char> name,
@@ -2803,8 +3115,12 @@ external bool DebugRegistry_setProperty_int(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Float)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TDebugRegistry>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external bool DebugRegistry_setProperty_float(
   ffi.Pointer<TDebugRegistry> tDebugRegistry,
   ffi.Pointer<ffi.Char> name,
@@ -2812,8 +3128,12 @@ external bool DebugRegistry_setProperty_float(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Bool>)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TDebugRegistry>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Bool>,
+  )
+>(isLeaf: true)
 external bool DebugRegistry_getProperty_bool(
   ffi.Pointer<TDebugRegistry> tDebugRegistry,
   ffi.Pointer<ffi.Char> name,
@@ -2821,8 +3141,12 @@ external bool DebugRegistry_getProperty_bool(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Int>)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TDebugRegistry>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Int>,
+  )
+>(isLeaf: true)
 external bool DebugRegistry_getProperty_int(
   ffi.Pointer<TDebugRegistry> tDebugRegistry,
   ffi.Pointer<ffi.Char> name,
@@ -2830,8 +3154,12 @@ external bool DebugRegistry_getProperty_int(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TDebugRegistry>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Float>,
+  )
+>(isLeaf: true)
 external bool DebugRegistry_getProperty_float(
   ffi.Pointer<TDebugRegistry> tDebugRegistry,
   ffi.Pointer<ffi.Char> name,
@@ -2847,25 +3175,25 @@ external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void RenderThread_destroy(
-  ffi.Pointer<ffi.Void> renderThread,
-);
+external void RenderThread_destroy(ffi.Pointer<ffi.Void> renderThread);
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)
+>(isLeaf: true)
 external void RenderThread_addTask(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> task,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TSwapChain>,
-        ffi.Pointer<ffi.Pointer<TView>>,
-        ffi.Uint8,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Pointer<ffi.Pointer<TView>>,
+    ffi.Uint8,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderManager_setRenderableRenderThread(
   ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -2876,8 +3204,13 @@ external void RenderManager_setRenderableRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderManager>,
+    ffi.Uint64,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderManager_renderRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   int frameTimeInNanos,
@@ -2886,8 +3219,13 @@ external void RenderManager_renderRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TAnimationManager>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderManager_addAnimationManagerRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TAnimationManager> tAnimationManager,
@@ -2896,8 +3234,13 @@ external void RenderManager_addAnimationManagerRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TAnimationManager>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderManager_removeAnimationManagerRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TAnimationManager> tAnimationManager,
@@ -2906,8 +3249,13 @@ external void RenderManager_removeAnimationManagerRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderManager_removeSwapChainRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -2916,22 +3264,24 @@ external void RenderManager_removeSwapChainRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TAnimationManager>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>
+    >,
+  )
+>(isLeaf: true)
 external void AnimationManager_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>>
-      onComplete,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>
+  >
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void AnimationManager_destroyRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int requestId,
@@ -2939,15 +3289,15 @@ external void AnimationManager_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.UnsignedInt,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Uint8,
-            ffi.Bool,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Void>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createRenderThread(
   int backend,
   ffi.Pointer<ffi.Void> platform,
@@ -2955,25 +3305,29 @@ external void Engine_createRenderThread(
   int stereoscopicEyeCount,
   bool disableHandleUseAfterFreeCheck,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createRendererRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyRendererRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderer> tRenderer,
@@ -2982,58 +3336,61 @@ external void Engine_destroyRendererRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Uint64,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createSwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Void> window,
   int flags,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint64,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createHeadlessSwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int width,
   int height,
   int flags,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            EntityId,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    EntityId,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createCameraRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int entityId,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TCamera>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyCameraRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TCamera> tCamera,
@@ -3042,36 +3399,36 @@ external void Engine_destroyCameraRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createViewRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<ffi.Uint8>,
-            ffi.Size,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Engine_buildMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> materialData,
   int length,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int requestId,
@@ -3079,8 +3436,13 @@ external void Engine_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroySwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -3089,8 +3451,13 @@ external void Engine_destroySwapChainRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TView>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyViewRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TView> tView,
@@ -3099,8 +3466,13 @@ external void Engine_destroyViewRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TScene>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroySceneRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TScene> tScene,
@@ -3109,8 +3481,13 @@ external void Engine_destroySceneRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TColorGrading>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyColorGradingRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TColorGrading> tColorGrading,
@@ -3119,8 +3496,13 @@ external void Engine_destroyColorGradingRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterial>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterial> tMaterial,
@@ -3129,8 +3511,13 @@ external void Engine_destroyMaterialRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyMaterialInstanceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
@@ -3139,8 +3526,13 @@ external void Engine_destroyMaterialInstanceRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TSkybox>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroySkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSkybox> tSkybox,
@@ -3149,8 +3541,13 @@ external void Engine_destroySkyboxRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TIndirectLight>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyIndirectLightRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -3159,19 +3556,19 @@ external void Engine_destroyIndirectLightRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint8,
-            ffi.Uint16,
-            ffi.IntPtr,
-            ffi.UnsignedInt,
-            ffi.UnsignedInt,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint8,
+    ffi.Uint16,
+    ffi.IntPtr,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
 external void Texture_buildRenderThread(
   ffi.Pointer<TEngine> engine,
   int width,
@@ -3183,12 +3580,18 @@ external void Texture_buildRenderThread(
   int sampler,
   int format,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
-        ffi.Pointer<ffi.Void>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Texture_setExternalImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -3198,8 +3601,13 @@ external void Texture_setExternalImageRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Texture_generateMipMapsRenderThread(
   ffi.Pointer<TTexture> tTexture,
   ffi.Pointer<TEngine> tEngine,
@@ -3208,42 +3616,47 @@ external void Texture_generateMipMapsRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TKtx1Bundle>,
-            ffi.Uint32,
-            VoidCallback,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TKtx1Bundle>,
+    ffi.Uint32,
+    VoidCallback,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
 external void Ktx1Reader_createTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TKtx1Bundle> tBundle,
   int requestId,
   VoidCallback onTextureUploadComplete,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<ffi.Uint8>,
-            ffi.Size,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
 external void Ktx2Reader_createTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> data,
   int size,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyTextureRenderThread(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TTexture> tTexture,
@@ -3252,19 +3665,20 @@ external void Engine_destroyTextureRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createFenceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Fence_waitAndDestroyRenderThread(
   ffi.Pointer<TFence> tFence,
   int requestId,
@@ -3272,8 +3686,13 @@ external void Fence_waitAndDestroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TFence>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Engine_destroyFenceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TFence> tFence,
@@ -3282,7 +3701,8 @@ external void Engine_destroyFenceRenderThread(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_flushAndWaitRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int requestId,
@@ -3290,7 +3710,8 @@ external void Engine_flushAndWaitRenderThread(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Engine_executeRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int requestId,
@@ -3298,29 +3719,29 @@ external void Engine_executeRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TTexture>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
+  )
+>(isLeaf: true)
 external void Engine_buildSkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Float,
-            ffi.Float,
-            ffi.Float,
-            ffi.Float,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
+  )
+>(isLeaf: true)
 external void Engine_buildColoredSkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   double r,
@@ -3328,59 +3749,67 @@ external void Engine_buildColoredSkyboxRenderThread(
   double b,
   double a,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TTexture>,
-        ffi.Float,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TIndirectLight>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
+    ffi.Float,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>
+    >,
+  )
+>(isLeaf: true)
 external void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<TTexture> tIrradianceTexture,
   double intensity,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>
-      onComplete,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>
+  >
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<ffi.Float>,
-        ffi.Float,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TIndirectLight>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Float,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>
+    >,
+  )
+>(isLeaf: true)
 external void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<ffi.Float> harmonics,
   double intensity,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>
-      onComplete,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>
+  >
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Renderer_setClearOptionsRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   double clearR,
@@ -3395,12 +3824,13 @@ external void Renderer_setClearOptionsRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TRenderer>,
-            ffi.Pointer<TSwapChain>,
-            ffi.Uint64,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void Renderer_beginFrameRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -3409,8 +3839,8 @@ external void Renderer_beginFrameRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void Renderer_endFrameRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   int requestId,
@@ -3418,8 +3848,13 @@ external void Renderer_endFrameRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Pointer<TView>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Renderer_renderRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
@@ -3428,8 +3863,13 @@ external void Renderer_renderRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Pointer<TView>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Renderer_renderStandaloneViewRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
@@ -3438,19 +3878,21 @@ external void Renderer_renderStandaloneViewRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Pointer<TRenderTarget>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<TRenderTarget>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Renderer_readPixelsRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   int width,
@@ -3467,27 +3909,31 @@ external void Renderer_readPixelsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TMaterial>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TMaterialInstance>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterial>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>
+    >,
+  )
+>(isLeaf: true)
 external void Material_createInstanceRenderThread(
   ffi.Pointer<TMaterial> tMaterial,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>
-      onComplete,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>
+  >
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TMaterialInstance>,
-        ffi.Pointer<ffi.Char>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TTextureSampler>,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTextureSampler>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterTextureRenderThread(
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -3498,140 +3944,138 @@ external void MaterialInstance_setParameterTextureRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Material_createImageMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Material_createGizmoMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Material_createBoneOverlayMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Material_createSilhouetteMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Material_createEdgeOutlineMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Material_createWireframeMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Material_createTranslationAxisMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TToneMapper>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TColorGrading>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TToneMapper>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>
+    >,
+  )
+>(isLeaf: true)
 external void ColorGrading_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TToneMapper> toneMapper,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>
-      callback,
+  callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TColorGradingBuilder>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>
+    >,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_createRenderThread(
   ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>
-      onComplete,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>
+  >
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TColorGrading>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>
+    >,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_buildRenderThread(
   ffi.Pointer<TColorGradingBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void ColorGradingBuilder_destroyRenderThread(
   ffi.Pointer<TColorGradingBuilder> tBuilder,
   int requestId,
@@ -3639,109 +4083,117 @@ external void ColorGradingBuilder_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createLinearRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createACESRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createACESLegacyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createFilmicRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createPBRNeutralRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createAGXRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Int,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Int,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createAGXWithLookRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int look,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Float,
-            ffi.Float,
-            ffi.Float,
-            ffi.Float,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createGenericRenderThread(
   ffi.Pointer<TEngine> tEngine,
   double contrast,
@@ -3749,25 +4201,26 @@ external void ToneMapper_createGenericRenderThread(
   double midGrayOut,
   double hdrMax,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>
+    >,
+  )
+>(isLeaf: true)
 external void ToneMapper_createDisplayRangeRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void ToneMapper_destroyRenderThread(
   ffi.Pointer<TToneMapper> tToneMapper,
   int requestId,
@@ -3775,8 +4228,14 @@ external void ToneMapper_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
-        PickCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    PickCallback,
+  )
+>(isLeaf: true)
 external void View_pickRenderThread(
   ffi.Pointer<TView> tView,
   int requestId,
@@ -3786,8 +4245,13 @@ external void View_pickRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Pointer<TColorGrading>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setColorGradingRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TColorGrading> tColorGrading,
@@ -3796,8 +4260,14 @@ external void View_setColorGradingRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Double, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Bool,
+    ffi.Double,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setBloomRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3807,8 +4277,13 @@ external void View_setBloomRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Pointer<TCamera>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setCameraRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TCamera> tCamera,
@@ -3817,20 +4292,25 @@ external void View_setCameraRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TView>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>,
+  )
+>(isLeaf: true)
 external void View_getNameRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setNameRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<ffi.Char> name,
@@ -3839,8 +4319,14 @@ external void View_setNameRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setViewportRenderThread(
   ffi.Pointer<TView> tView,
   int width,
@@ -3850,8 +4336,13 @@ external void View_setViewportRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Pointer<TRenderTarget>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setRenderTargetRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TRenderTarget> tRenderTarget,
@@ -3860,8 +4351,15 @@ external void View_setRenderTargetRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setAntiAliasingRenderThread(
   ffi.Pointer<TView> tView,
   bool msaa,
@@ -3872,8 +4370,8 @@ external void View_setAntiAliasingRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setPostProcessingRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3882,8 +4380,8 @@ external void View_setPostProcessingRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setFrustumCullingEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3892,8 +4390,8 @@ external void View_setFrustumCullingEnabledRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setStencilBufferEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3902,8 +4400,8 @@ external void View_setStencilBufferEnabledRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setDitheringEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3912,8 +4410,8 @@ external void View_setDitheringEnabledRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setRenderQualityRenderThread(
   ffi.Pointer<TView> tView,
   int qualityLevel,
@@ -3922,8 +4420,13 @@ external void View_setRenderQualityRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Pointer<TScene>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setSceneRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TScene> tScene,
@@ -3932,8 +4435,14 @@ external void View_setSceneRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setLayerEnabledRenderThread(
   ffi.Pointer<TView> tView,
   int layer,
@@ -3943,8 +4452,8 @@ external void View_setLayerEnabledRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setBlendModeRenderThread(
   ffi.Pointer<TView> tView,
   int blendMode,
@@ -3953,8 +4462,8 @@ external void View_setBlendModeRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setFogOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TFogOptions tFogOptions,
@@ -3963,8 +4472,13 @@ external void View_setFogOptionsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    TAmbientOcclusionOptions,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setAmbientOcclusionOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TAmbientOcclusionOptions options,
@@ -3973,8 +4487,8 @@ external void View_setAmbientOcclusionOptionsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setFrontFaceWindingInvertedRenderThread(
   ffi.Pointer<TView> tView,
   bool inverted,
@@ -3983,8 +4497,8 @@ external void View_setFrontFaceWindingInvertedRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setShadowsEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3993,8 +4507,8 @@ external void View_setShadowsEnabledRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setShadowTypeRenderThread(
   ffi.Pointer<TView> tView,
   int shadowType,
@@ -4003,8 +4517,13 @@ external void View_setShadowTypeRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    TSoftShadowOptions,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setSoftShadowOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TSoftShadowOptions options,
@@ -4013,8 +4532,13 @@ external void View_setSoftShadowOptionsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TView>,
+    TVsmShadowOptions,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void View_setVsmShadowOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TVsmShadowOptions options,
@@ -4023,8 +4547,8 @@ external void View_setVsmShadowOptionsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void View_setTransparentPickingEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -4033,8 +4557,8 @@ external void View_setTransparentPickingEnabledRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void SceneAsset_destroyRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int requestId,
@@ -4042,16 +4566,17 @@ external void SceneAsset_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TGltfAssetLoader>,
-            ffi.Pointer<TNameComponentManager>,
-            ffi.Pointer<TFilamentAsset>,
-            ffi.Bool,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Bool,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>
+    >,
+  )
+>(isLeaf: true)
 external void SceneAsset_createFromFilamentAssetRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -4059,22 +4584,23 @@ external void SceneAsset_createFromFilamentAssetRenderThread(
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
   bool rebuildVertices,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TVertexBuffer>,
-            ffi.Pointer<TIndexBuffer>,
-            ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-            ffi.Int,
-            ffi.UnsignedInt,
-            Aabb3,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.UnsignedInt,
+    Aabb3,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>
+    >,
+  )
+>(isLeaf: true)
 external void SceneAsset_createFromBuffersRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tVertexBuffer,
@@ -4084,29 +4610,30 @@ external void SceneAsset_createFromBuffersRenderThread(
   int tPrimitiveType,
   Aabb3 boundingBox,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-      callback,
+  callback,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TSceneAsset>,
-            ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-            ffi.Int,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>
+    >,
+  )
+>(isLeaf: true)
 external void SceneAsset_createInstanceRenderThread(
   ffi.Pointer<TSceneAsset> asset,
   ffi.Pointer<ffi.Pointer<TMaterialInstance>> tMaterialInstances,
   int materialInstanceCount,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-      callback,
+  callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void SceneAsset_releaseSourceDataRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int requestId,
@@ -4114,8 +4641,13 @@ external void SceneAsset_releaseSourceDataRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Bool,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void SceneAsset_setFlatShadingRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   bool flatShading,
@@ -4124,50 +4656,51 @@ external void SceneAsset_setFlatShadingRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Int,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TMaterialInstance>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>
+    >,
+  )
+>(isLeaf: true)
 external void MaterialProvider_createMaterialInstanceRenderThread(
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
   bool doubleSided,
@@ -4209,13 +4742,19 @@ external void MaterialProvider_createMaterialInstanceRenderThread(
   bool hasIOR,
   bool hasVolume,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>
-      callback,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>
+  >
+  callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Uint64,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void AnimationManager_updateRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int frameTimeInNanos,
@@ -4224,11 +4763,12 @@ external void AnimationManager_updateRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TAnimationManager>,
-            ffi.Pointer<TSceneAsset>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void AnimationManager_updateBoneMatricesRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -4236,13 +4776,14 @@ external void AnimationManager_updateBoneMatricesRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TAnimationManager>,
-            EntityId,
-            ffi.Pointer<ffi.Float>,
-            ffi.Int,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void AnimationManager_setMorphTargetWeightsRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -4252,55 +4793,58 @@ external void AnimationManager_setMorphTargetWeightsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TLinearImage>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>
+    >,
+  )
+>(isLeaf: true)
 external void Image_createEmptyRenderThread(
   int width,
   int height,
   int channel,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Pointer<ffi.Char>,
-        ffi.Bool,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TLinearImage>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.Char>,
+    ffi.Bool,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>
+    >,
+  )
+>(isLeaf: true)
 external void Image_decodeRenderThread(
   ffi.Pointer<ffi.Uint8> data,
   int length,
   ffi.Pointer<ffi.Char> name,
   bool alpha,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TLinearImage>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLinearImage>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>,
+  )
+>(isLeaf: true)
 external void Image_getBytesRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void Image_destroyRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   int requestId,
@@ -4308,42 +4852,49 @@ external void Image_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TLinearImage>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLinearImage>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>,
+  )
+>(isLeaf: true)
 external void Image_getWidthRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TLinearImage>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLinearImage>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>,
+  )
+>(isLeaf: true)
 external void Image_getHeightRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TLinearImage>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLinearImage>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>,
+  )
+>(isLeaf: true)
 external void Image_getChannelsRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TTexture>,
-            ffi.Pointer<TLinearImage>,
-            ffi.UnsignedInt,
-            ffi.UnsignedInt,
-            ffi.Int,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TLinearImage>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void Texture_loadImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -4355,22 +4906,23 @@ external void Texture_loadImageRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TTexture>,
-            ffi.Uint32,
-            ffi.Pointer<ffi.Uint8>,
-            ffi.Size,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Uint32,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void Texture_setImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -4389,36 +4941,43 @@ external void Texture_setImageRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TRenderTarget>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderTarget>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
 external void RenderTarget_getColorTextureRenderThread(
   ffi.Pointer<TRenderTarget> tRenderTarget,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TRenderTarget>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>
+    >,
+  )
+>(isLeaf: true)
 external void RenderTarget_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> color,
   ffi.Pointer<TTexture> depth,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TRenderTarget>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderTarget_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderTarget> tRenderTarget,
@@ -4427,28 +4986,31 @@ external void RenderTarget_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
+    >,
+  )
+>(isLeaf: true)
 external void TextureSampler_createRenderThread(
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
-      onComplete,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
+  >
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
+    >,
+  )
+>(isLeaf: true)
 external void TextureSampler_createWithFilteringRenderThread(
   int minFilter,
   int magFilter,
@@ -4456,29 +5018,37 @@ external void TextureSampler_createWithFilteringRenderThread(
   int wrapT,
   int wrapR,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
-      onComplete,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
+  >
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
+    >,
+  )
+>(isLeaf: true)
 external void TextureSampler_createWithComparisonRenderThread(
   int compareMode,
   int compareFunc,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
-      onComplete,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>
+  >
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTextureSampler>,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TextureSampler_setMinFilterRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
@@ -4487,8 +5057,13 @@ external void TextureSampler_setMinFilterRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTextureSampler>,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TextureSampler_setMagFilterRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
@@ -4497,8 +5072,13 @@ external void TextureSampler_setMagFilterRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTextureSampler>,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TextureSampler_setWrapModeSRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4507,8 +5087,13 @@ external void TextureSampler_setWrapModeSRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTextureSampler>,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TextureSampler_setWrapModeTRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4517,8 +5102,13 @@ external void TextureSampler_setWrapModeTRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTextureSampler>,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TextureSampler_setWrapModeRRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4527,8 +5117,13 @@ external void TextureSampler_setWrapModeRRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTextureSampler>,
+    ffi.Double,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TextureSampler_setAnisotropyRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   double anisotropy,
@@ -4537,8 +5132,14 @@ external void TextureSampler_setAnisotropyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
-        ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTextureSampler>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TextureSampler_setCompareModeRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4548,8 +5149,8 @@ external void TextureSampler_setCompareModeRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void TextureSampler_destroyRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int requestId,
@@ -4557,8 +5158,13 @@ external void TextureSampler_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void AnimationManager_resetToRestPoseRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -4567,26 +5173,28 @@ external void AnimationManager_resetToRestPoseRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TGltfAssetLoader>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>
+    >,
+  )
+>(isLeaf: true)
 external void GltfAssetLoader_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>>
-      callback,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>
+  >
+  callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void GltfAssetLoader_destroyRenderThread(
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   int requestId,
@@ -4594,23 +5202,29 @@ external void GltfAssetLoader_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TGltfResourceLoader>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>
+    >,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>>
-      callback,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>
+  >
+  callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfResourceLoader> tResourceLoader,
@@ -4619,11 +5233,12 @@ external void GltfResourceLoader_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TGltfResourceLoader>,
-            ffi.Pointer<TFilamentAsset>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_loadResourcesRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -4631,13 +5246,15 @@ external void GltfResourceLoader_loadResourcesRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_addResourceDataRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.Char> uri,
@@ -4648,11 +5265,12 @@ external void GltfResourceLoader_addResourceDataRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TGltfResourceLoader>,
-            ffi.Pointer<TFilamentAsset>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_asyncBeginLoadRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -4665,24 +5283,28 @@ external void GltfResourceLoader_asyncUpdateLoadRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TGltfResourceLoader>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_asyncGetLoadProgressRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>> callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>
+    >,
+  )
+>(isLeaf: true)
 external void GltfAssetLoader_loadRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -4690,13 +5312,19 @@ external void GltfAssetLoader_loadRenderThread(
   int length,
   int numInstances,
   ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>
-      callback,
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>
+  >
+  callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TScene>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Scene_addFilamentAssetRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TFilamentAsset> tAsset,
@@ -4705,17 +5333,19 @@ external void Scene_addFilamentAssetRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TFilamentAsset>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>,
+  )
+>(isLeaf: true)
 external void FilamentAsset_getWireframeRenderThread(
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void Scene_addEntityRenderThread(
   ffi.Pointer<TScene> tScene,
   int entityId,
@@ -4724,8 +5354,8 @@ external void Scene_addEntityRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void Scene_removeEntityRenderThread(
   ffi.Pointer<TScene> tScene,
   int entityId,
@@ -4734,8 +5364,13 @@ external void Scene_removeEntityRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<TScene>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void SceneAsset_addToSceneRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
@@ -4744,8 +5379,13 @@ external void SceneAsset_addToSceneRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<TScene>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void SceneAsset_removeFromSceneRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
@@ -4754,8 +5394,13 @@ external void SceneAsset_removeFromSceneRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TScene>,
+    ffi.Pointer<TSkybox>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Scene_setSkyboxRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TSkybox> tSkybox,
@@ -4764,8 +5409,13 @@ external void Scene_setSkyboxRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TScene>,
+    ffi.Pointer<TIndirectLight>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Scene_setIndirectLightRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -4774,17 +5424,17 @@ external void Scene_setIndirectLightRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TGltfAssetLoader>,
-            ffi.Pointer<TGltfResourceLoader>,
-            ffi.Pointer<TNameComponentManager>,
-            ffi.Pointer<TView>,
-            ffi.Pointer<TMaterial>,
-            ffi.UnsignedInt,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TView>,
+    ffi.Pointer<TMaterial>,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>,
+  )
+>(isLeaf: true)
 external void Gizmo_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -4794,26 +5444,33 @@ external void Gizmo_createRenderThread(
   ffi.Pointer<TMaterial> tMaterial,
   int tGizmoType,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>
-      callback,
+  callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TVertexBufferBuilder>,
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>
+    >,
+  )
+>(isLeaf: true)
 external void VertexBufferBuilder_buildRenderThread(
   ffi.Pointer<TVertexBufferBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void VertexBuffer_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -4822,15 +5479,17 @@ external void VertexBuffer_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Uint8,
-        ffi.Pointer<ffi.Void>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void VertexBuffer_setBufferAtRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -4843,22 +5502,29 @@ external void VertexBuffer_setBufferAtRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndexBufferBuilder>,
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TIndexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<
+      ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>
+    >,
+  )
+>(isLeaf: true)
 external void IndexBufferBuilder_buildRenderThread(
   ffi.Pointer<TIndexBufferBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>
-      onComplete,
+  onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void IndexBuffer_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndexBuffer> tBuffer,
@@ -4867,14 +5533,16 @@ external void IndexBuffer_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Void>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void IndexBuffer_setBufferRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndexBuffer> tBuffer,
@@ -4886,12 +5554,13 @@ external void IndexBuffer_setBufferRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TRenderableBuilder>,
-            ffi.Pointer<TEngine>,
-            EntityId,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Pointer<TEngine>,
+    EntityId,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>,
+  )
+>(isLeaf: true)
 external void RenderableBuilder_buildRenderThread(
   ffi.Pointer<TRenderableBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
@@ -4900,17 +5569,24 @@ external void RenderableBuilder_buildRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TEntityManager>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEntityManager>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>,
+  )
+>(isLeaf: true)
 external void EntityManager_createEntityRenderThread(
   ffi.Pointer<TEntityManager> tEntityManager,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEntityManager>,
+    EntityId,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void EntityManager_destroyEntityRenderThread(
   ffi.Pointer<TEntityManager> tEntityManager,
   int entityId,
@@ -4919,8 +5595,14 @@ external void EntityManager_destroyEntityRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTransformManager>,
+    EntityId,
+    double4x4,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TransformManager_setTransformRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -4930,8 +5612,15 @@ external void TransformManager_setTransformRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId,
-        ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTransformManager>,
+    EntityId,
+    EntityId,
+    ffi.Bool,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TransformManager_setParentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
@@ -4942,8 +5631,13 @@ external void TransformManager_setParentRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTransformManager>,
+    EntityId,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TransformManager_createComponentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -4952,8 +5646,13 @@ external void TransformManager_createComponentRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TTransformManager>,
+    EntityId,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void TransformManager_removeComponentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -4962,8 +5661,13 @@ external void TransformManager_removeComponentRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderableManager_destroyEntityRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -4972,14 +5676,16 @@ external void RenderableManager_destroyEntityRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>,
-        EntityId,
-        ffi.Pointer<ffi.Float>,
-        ffi.Size,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderableManager_setBonesFromMat4RenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -4991,14 +5697,16 @@ external void RenderableManager_setBonesFromMat4RenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>,
-        EntityId,
-        ffi.Pointer<ffi.Float>,
-        ffi.Size,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderableManager_setBonesFromBoneRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5010,22 +5718,26 @@ external void RenderableManager_setBonesFromBoneRenderThread(
 );
 
 @ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
   ffi.Pointer<TEngine> tEngine,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)
+>(isLeaf: true)
 external void GltfResourceLoader_destroy(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+  )
+>(isLeaf: true)
 external bool GltfResourceLoader_asyncBeginLoad(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -5042,8 +5754,13 @@ external double GltfResourceLoader_asyncGetLoadProgress(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_addResourceData(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.Char> uri,
@@ -5052,16 +5769,25 @@ external void GltfResourceLoader_addResourceData(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+  )
+>(isLeaf: true)
 external bool GltfResourceLoader_loadResources(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSkybox>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void Skybox_setColor(
   ffi.Pointer<TSkybox> tSkybox,
   double r,
@@ -5071,13 +5797,16 @@ external void Skybox_setColor(
 );
 
 @ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
-external void dummy(
-  TGltfMeshData dummy,
-);
+external void dummy(TGltfMeshData dummy);
 
 @ffi.Native<
-    ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
+  ffi.Int Function(
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TGltfMeshData>,
+  )
+>(isLeaf: true)
 external int GltfParser_parseBuffer(
   ffi.Pointer<ffi.Uint8> data,
   int length,
@@ -5086,19 +5815,19 @@ external int GltfParser_parseBuffer(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
-external void GltfParser_freeMeshData(
-  ffi.Pointer<TGltfMeshData> meshData,
-);
+external void GltfParser_freeMeshData(ffi.Pointer<TGltfMeshData> meshData);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableManager_destroyEntity(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool RenderableManager_hasComponent(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5110,7 +5839,8 @@ external bool RenderableManager_empty(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool RenderableManager_isRenderable(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5122,8 +5852,13 @@ external int RenderableManager_getComponentCount(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int,
-        ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Int,
+    ffi.Pointer<TMaterialInstance>,
+  )
+>(isLeaf: true)
 external bool RenderableManager_setMaterialInstanceAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5132,8 +5867,12 @@ external bool RenderableManager_setMaterialInstanceAt(
 );
 
 @ffi.Native<
-    ffi.Pointer<TMaterialInstance> Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
+  ffi.Pointer<TMaterialInstance> Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5141,8 +5880,8 @@ external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)
+>(isLeaf: true)
 external void RenderableManager_clearMaterialInstanceAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5150,22 +5889,24 @@ external void RenderableManager_clearMaterialInstanceAt(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int RenderableManager_getPrimitiveCount(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external Aabb3 RenderableManager_getAxisAlignedBoundingBox(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, Aabb3)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, Aabb3)
+>(isLeaf: true)
 external void RenderableManager_setAxisAlignedBoundingBox(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5173,22 +5914,29 @@ external void RenderableManager_setAxisAlignedBoundingBox(
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external Aabb3 RenderableManager_getAabb(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external Aabb3 RenderableManager_getBoundingBox(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8,
-        ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Uint8,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
 external void RenderableManager_setLayerMask(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5197,15 +5945,16 @@ external void RenderableManager_setLayerMask(
 );
 
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int RenderableManager_getLayerMask(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)
+>(isLeaf: true)
 external void RenderableManager_setVisibilityLayer(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5213,8 +5962,8 @@ external void RenderableManager_setVisibilityLayer(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)
+>(isLeaf: true)
 external void RenderableManager_setPriority(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5222,15 +5971,16 @@ external void RenderableManager_setPriority(
 );
 
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int RenderableManager_getPriority(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)
+>(isLeaf: true)
 external void RenderableManager_setChannel(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5238,8 +5988,8 @@ external void RenderableManager_setChannel(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
+>(isLeaf: true)
 external void RenderableManager_setCulling(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5247,15 +5997,16 @@ external void RenderableManager_setCulling(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool RenderableManager_getCulling(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
+>(isLeaf: true)
 external void RenderableManager_setFogEnabled(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5263,15 +6014,21 @@ external void RenderableManager_setFogEnabled(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool RenderableManager_getFogEnabled(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.UnsignedInt,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external void RenderableManager_setLightChannel(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5280,8 +6037,8 @@ external void RenderableManager_setLightChannel(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.UnsignedInt)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt)
+>(isLeaf: true)
 external bool RenderableManager_getLightChannel(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5289,8 +6046,8 @@ external bool RenderableManager_getLightChannel(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
+>(isLeaf: true)
 external void RenderableManager_setCastShadows(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5298,15 +6055,16 @@ external void RenderableManager_setCastShadows(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool RenderableManager_isShadowCaster(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
+>(isLeaf: true)
 external void RenderableManager_setReceiveShadows(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5314,15 +6072,16 @@ external void RenderableManager_setReceiveShadows(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool RenderableManager_isShadowReceiver(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)
+>(isLeaf: true)
 external void RenderableManager_setScreenSpaceContactShadows(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5330,8 +6089,13 @@ external void RenderableManager_setScreenSpaceContactShadows(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size,
-        ffi.Uint16)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Size,
+    ffi.Uint16,
+  )
+>(isLeaf: true)
 external void RenderableManager_setBlendOrderAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5340,8 +6104,13 @@ external void RenderableManager_setBlendOrderAt(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Size,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external void RenderableManager_setGlobalBlendOrderEnabledAt(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5350,8 +6119,14 @@ external void RenderableManager_setGlobalBlendOrderEnabledAt(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void RenderableManager_setMorphWeights(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5361,15 +6136,22 @@ external void RenderableManager_setMorphWeights(
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external int RenderableManager_getMorphTargetCount(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void RenderableManager_setBonesFromMat4(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5379,8 +6161,14 @@ external void RenderableManager_setBonesFromMat4(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void RenderableManager_setBonesFromBone(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5400,15 +6188,20 @@ external void RenderableBuilder_destroy(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, Aabb3)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_boundingBox(
   ffi.Pointer<TRenderableBuilder> builder,
   Aabb3 aabb,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
-        ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Size,
+    ffi.Pointer<TMaterialInstance>,
+  )
+>(isLeaf: true)
 external void RenderableBuilder_material(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -5416,14 +6209,16 @@ external void RenderableBuilder_material(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableBuilder>,
-        ffi.Size,
-        ffi.Uint8,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Pointer<TIndexBuffer>,
-        ffi.Size,
-        ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Size,
+    ffi.Uint8,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void RenderableBuilder_geometry(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -5435,50 +6230,56 @@ external void RenderableBuilder_geometry(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_priority(
   ffi.Pointer<TRenderableBuilder> builder,
   int priority,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_channel(
   ffi.Pointer<TRenderableBuilder> builder,
   int channel,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_culling(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_castShadows(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_receiveShadows(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_fog(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt, ffi.Bool)
+>(isLeaf: true)
 external void RenderableBuilder_lightChannel(
   ffi.Pointer<TRenderableBuilder> builder,
   int channel,
@@ -5486,8 +6287,8 @@ external void RenderableBuilder_lightChannel(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)
+>(isLeaf: true)
 external void RenderableBuilder_layerMask(
   ffi.Pointer<TRenderableBuilder> builder,
   int select,
@@ -5495,15 +6296,16 @@ external void RenderableBuilder_layerMask(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_screenSpaceContactShadows(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)
+>(isLeaf: true)
 external void RenderableBuilder_blendOrder(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -5511,8 +6313,8 @@ external void RenderableBuilder_blendOrder(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)
+>(isLeaf: true)
 external void RenderableBuilder_globalBlendOrderEnabled(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -5520,15 +6322,20 @@ external void RenderableBuilder_globalBlendOrderEnabled(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_instances(
   ffi.Pointer<TRenderableBuilder> builder,
   int instanceCount,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
-        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Size,
+    ffi.Pointer<ffi.Float>,
+  )
+>(isLeaf: true)
 external void RenderableBuilder_skinningFromMat4(
   ffi.Pointer<TRenderableBuilder> builder,
   int boneCount,
@@ -5536,8 +6343,12 @@ external void RenderableBuilder_skinningFromMat4(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
-        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Size,
+    ffi.Pointer<ffi.Float>,
+  )
+>(isLeaf: true)
 external void RenderableBuilder_skinningFromBone(
   ffi.Pointer<TRenderableBuilder> builder,
   int boneCount,
@@ -5545,15 +6356,22 @@ external void RenderableBuilder_skinningFromBone(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void RenderableBuilder_enableSkinningBuffers(
   ffi.Pointer<TRenderableBuilder> builder,
   bool enabled,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
-        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Size,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
 external void RenderableBuilder_boneIndicesAndWeights(
   ffi.Pointer<TRenderableBuilder> builder,
   int primitiveIndex,
@@ -5563,8 +6381,12 @@ external void RenderableBuilder_boneIndicesAndWeights(
 );
 
 @ffi.Native<
-    ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>,
-        EntityId)>(isLeaf: true)
+  ffi.Int Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Pointer<TEngine>,
+    EntityId,
+  )
+>(isLeaf: true)
 external int RenderableBuilder_build(
   ffi.Pointer<TRenderableBuilder> builder,
   ffi.Pointer<TEngine> engine,
@@ -5572,14 +6394,16 @@ external int RenderableBuilder_build(
 );
 
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-        ffi.Int,
-        ffi.UnsignedInt,
-        Aabb3)>(isLeaf: true)
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.UnsignedInt,
+    Aabb3,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tVertexBuffer,
@@ -5591,12 +6415,14 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
 );
 
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<TFilamentAsset>,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -5606,39 +6432,36 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
 );
 
 @ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void SceneAsset_addToScene(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void SceneAsset_removeFromScene(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
 );
 
 @ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external int SceneAsset_getChildEntityCount(
@@ -5646,14 +6469,16 @@ external int SceneAsset_getChildEntityCount(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void SceneAsset_getChildEntities(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<EntityId> out,
 );
 
 @ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
@@ -5664,7 +6489,8 @@ external int SceneAsset_getCameraEntityCount(
 );
 
 @ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
@@ -5675,21 +6501,23 @@ external int SceneAsset_getLightEntityCount(
 );
 
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int index,
 );
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>,
-        ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)>(isLeaf: true)
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
   ffi.Pointer<TSceneAsset> asset,
   ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
@@ -5697,21 +6525,19 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(
-  ffi.Pointer<TSceneAsset> asset,
-);
+external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
 
 @ffi.Native<
-    ffi.Pointer<TVertexBuffer> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+  ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
 external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int primitiveIndex,
 );
 
 @ffi.Native<
-    ffi.Pointer<TIndexBuffer> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+  ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
 external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int primitiveIndex,
@@ -5735,8 +6561,8 @@ external void SceneAsset_setFlatShading(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size,
-        ffi.Pointer<EntityId>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)
+>(isLeaf: true)
 external void SceneAsset_getBones(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int skinIndex,
@@ -5750,8 +6576,8 @@ external int SceneAsset_getBoneCount(
 );
 
 @ffi.Native<
-    ffi.Pointer<ffi.Char> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
+  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)
+>(isLeaf: true)
 external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int skinIndex,
@@ -5759,7 +6585,8 @@ external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
 );
 
 @ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external ffi.Pointer<TAnimationManager> AnimationManager_create(
   ffi.Pointer<TEngine> tEngine,
 );
@@ -5770,67 +6597,72 @@ external void AnimationManager_destroy(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void AnimationManager_update(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int frameTimeInNanos,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
+>(isLeaf: true)
 external bool AnimationManager_addGltfAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
+>(isLeaf: true)
 external bool AnimationManager_removeGltfAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void AnimationManager_addMorphAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void AnimationManager_removeMorphAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
+>(isLeaf: true)
 external bool AnimationManager_addBoneAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
+>(isLeaf: true)
 external bool AnimationManager_removeBoneAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>,
-        EntityId,
-        ffi.Pointer<ffi.Float>,
-        ffi.Pointer<ffi.Uint32>,
-        ffi.Int,
-        ffi.Int,
-        ffi.Float)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Pointer<ffi.Uint32>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external bool AnimationManager_setMorphAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -5842,33 +6674,36 @@ external bool AnimationManager_setMorphAnimation(
 );
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external bool AnimationManager_clearMorphAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
+>(isLeaf: true)
 external void AnimationManager_resetToRestPose(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>,
-        ffi.Pointer<TSceneAsset>,
-        ffi.Int,
-        ffi.Int,
-        ffi.Pointer<ffi.Float>,
-        ffi.Int,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external bool AnimationManager_addBoneAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -5884,8 +6719,14 @@ external bool AnimationManager_addBoneAnimation(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external void AnimationManager_getRestLocalTransforms(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -5895,8 +6736,14 @@ external void AnimationManager_getRestLocalTransforms(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Pointer<ffi.Float>,
+  )
+>(isLeaf: true)
 external void AnimationManager_getInverseBindMatrix(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -5906,16 +6753,18 @@ external void AnimationManager_getInverseBindMatrix(
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>,
-        ffi.Pointer<TSceneAsset>,
-        ffi.Int,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external bool AnimationManager_playGltfAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -5929,8 +6778,12 @@ external bool AnimationManager_playGltfAnimation(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external bool AnimationManager_stopGltfAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -5938,8 +6791,12 @@ external bool AnimationManager_stopGltfAnimation(
 );
 
 @ffi.Native<
-    ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int)>(isLeaf: true)
+  ffi.Float Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external double AnimationManager_getGltfAnimationDuration(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -5947,16 +6804,21 @@ external double AnimationManager_getGltfAnimationDuration(
 );
 
 @ffi.Native<
-    ffi.Int Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+  ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
+>(isLeaf: true)
 external int AnimationManager_getGltfAnimationCount(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external void AnimationManager_getGltfAnimationName(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -5965,8 +6827,12 @@ external void AnimationManager_getGltfAnimationName(
 );
 
 @ffi.Native<
-    ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        EntityId)>(isLeaf: true)
+  ffi.Int Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    EntityId,
+  )
+>(isLeaf: true)
 external int AnimationManager_getMorphTargetNameCount(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -5974,8 +6840,14 @@ external int AnimationManager_getMorphTargetNameCount(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        EntityId, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    EntityId,
+    ffi.Pointer<ffi.Char>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external void AnimationManager_getMorphTargetName(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -5985,16 +6857,21 @@ external void AnimationManager_getMorphTargetName(
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+  ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)
+>(isLeaf: true)
 external bool AnimationManager_updateBoneMatrices(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId,
-        ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+  )
+>(isLeaf: true)
 external bool AnimationManager_setMorphTargetWeights(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -6003,8 +6880,13 @@ external bool AnimationManager_setMorphTargetWeights(
 );
 
 @ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int, ffi.Float)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external bool AnimationManager_setGltfAnimationTime(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -6013,14 +6895,19 @@ external bool AnimationManager_setGltfAnimationTime(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void MovementIntentExecutor_destroy(
   ffi.Pointer<TMovementIntentExecutor> executor,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>,
-        ffi.Pointer<TMovementIntent>, ffi.Uint64)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMovementIntentExecutor>,
+    ffi.Pointer<TMovementIntent>,
+    ffi.Uint64,
+  )
+>(isLeaf: true)
 external void MovementIntentExecutor_process(
   ffi.Pointer<TMovementIntentExecutor> executor,
   ffi.Pointer<TMovementIntent> intent,
@@ -6028,19 +6915,25 @@ external void MovementIntentExecutor_process(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void Pipeline_registerMovementIntentExecutor(
   ffi.Pointer<TMovementIntentExecutor> executor,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void TransformPipeline_setEngine(
-  ffi.Pointer<ffi.Void> enginePtr,
-);
+external void TransformPipeline_setEngine(ffi.Pointer<ffi.Void> enginePtr);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Int, ffi.Int, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Int,
+    ffi.Int,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void TransformPipeline_onMouseEvent(
   int eventType,
   int button,
@@ -6066,12 +6959,11 @@ external void TransformPipeline_onScrollEvent(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_update(
-  double deltaTime,
-);
+external void TransformPipeline_update(double deltaTime);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>(
-    isLeaf: true)
+  isLeaf: true,
+)
 external void TransformPipeline_registerPipelineStage(
   ffi.Pointer<ffi.Void> pipelineStageHandle,
   ffi.Pointer<ffi.Char> name,
@@ -6093,14 +6985,10 @@ external void TransformPipeline_addKeyBinding(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForKey(
-  int logicalKey,
-);
+external void TransformPipeline_removeKeyBindingsForKey(int logicalKey);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForAction(
-  int intentAction,
-);
+external void TransformPipeline_removeKeyBindingsForAction(int intentAction);
 
 @ffi.Native<ffi.Void Function()>(isLeaf: true)
 external void TransformPipeline_clearKeyBindings();
@@ -6113,19 +7001,13 @@ external void TransformPipeline_addMouseButtonBinding(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeMouseButtonBindings(
-  int mouseButton,
-);
+external void TransformPipeline_removeMouseButtonBindings(int mouseButton);
 
 @ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_setMouseSensitivity(
-  double sensitivity,
-);
+external void TransformPipeline_setMouseSensitivity(double sensitivity);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_setInvertMouseY(
-  int invert,
-);
+external void TransformPipeline_setInvertMouseY(int invert);
 
 typedef VoidCallbackFunction = ffi.Void Function(ffi.Int32 requestId);
 typedef DartVoidCallbackFunction = void Function(int requestId);
@@ -6752,20 +7634,24 @@ final class TAmbientOcclusionOptions extends ffi.Struct {
   external TSsct ssct;
 }
 
-typedef PickCallbackFunction = ffi.Void Function(
-    ffi.Uint32 requestId,
-    EntityId entityId,
-    ffi.Float depth,
-    ffi.Float fragX,
-    ffi.Float fragY,
-    ffi.Float fragZ);
-typedef DartPickCallbackFunction = void Function(
-    int requestId,
-    DartEntityId entityId,
-    double depth,
-    double fragX,
-    double fragY,
-    double fragZ);
+typedef PickCallbackFunction =
+    ffi.Void Function(
+      ffi.Uint32 requestId,
+      EntityId entityId,
+      ffi.Float depth,
+      ffi.Float fragX,
+      ffi.Float fragY,
+      ffi.Float fragZ,
+    );
+typedef DartPickCallbackFunction =
+    void Function(
+      int requestId,
+      DartEntityId entityId,
+      double depth,
+      double fragX,
+      double fragY,
+      double fragZ,
+    );
 typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
 
 sealed class TTextureSamplerType {
@@ -7027,12 +7913,12 @@ sealed class TSamplerCompareMode {
 typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
 typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
 typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
-typedef PostRenderCallbackFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(
-    ffi.Pointer<ffi.Void> userData);
-typedef PostRenderCallback
-    = ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
+typedef PostRenderCallbackFunction =
+    ffi.Void Function(ffi.Pointer<ffi.Void> userData);
+typedef DartPostRenderCallbackFunction =
+    void Function(ffi.Pointer<ffi.Void> userData);
+typedef PostRenderCallback =
+    ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
 
 sealed class TGizmoAxis {
   static const X = 0;
@@ -7048,12 +7934,17 @@ sealed class TGizmoPickResultType {
   static const None = 4;
 }
 
-typedef GizmoPickCallbackFunction = ffi.Void Function(
-    ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
-typedef DartGizmoPickCallbackFunction = void Function(
-    int resultType, double x, double y, double z);
-typedef GizmoPickCallback
-    = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction =
+    ffi.Void Function(
+      ffi.UnsignedInt resultType,
+      ffi.Float x,
+      ffi.Float y,
+      ffi.Float z,
+    );
+typedef DartGizmoPickCallbackFunction =
+    void Function(int resultType, double x, double y, double z);
+typedef GizmoPickCallback =
+    ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
 
 sealed class TProjection {
   static const Perspective = 0;
@@ -7077,12 +7968,12 @@ sealed class TBackend {
   static const BACKEND_NOOP = 4;
 }
 
-typedef FilamentRenderCallbackFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> owner);
-typedef DartFilamentRenderCallbackFunction = void Function(
-    ffi.Pointer<ffi.Void> owner);
-typedef FilamentRenderCallback
-    = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+typedef FilamentRenderCallbackFunction =
+    ffi.Void Function(ffi.Pointer<ffi.Void> owner);
+typedef DartFilamentRenderCallbackFunction =
+    void Function(ffi.Pointer<ffi.Void> owner);
+typedef FilamentRenderCallback =
+    ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
 
 final class TGltfMeshData extends ffi.Struct {
   external ffi.Pointer<ffi.Float> vertices;

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -2667,11 +2667,6 @@ external void TransformManager_commitLocalTransformTransaction(
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
 external ffi.Pointer<ffi.Void> RenderThread_create();
 
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(
-  ffi.Pointer<ffi.Char> canvasSelector,
-);
-
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
 external void RenderThread_destroy(ffi.Pointer<ffi.Void> renderThread);
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -19,766 +19,362 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 @ffi.Native<ffi.Uint64>()
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TMaterialInstance> Material_createInstance(
-  ffi.Pointer<TMaterial> tMaterial,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createImageMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createGridMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createGizmoMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createSilhouetteMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createEdgeOutlineMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createWireframeMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createTranslationAxisMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(
-  isLeaf: true,
-)
-external bool Material_hasParameter(
-  ffi.Pointer<TMaterial> tMaterial,
-  ffi.Pointer<ffi.Char> propertyName,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external bool MaterialInstance_isStencilWriteEnabled(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setStencilWrite(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setCullingMode(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int culling,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setDoubleSided(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  bool doubleSided,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setDepthWrite(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setDepthCulling(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-);
-
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-  )
+  ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)
 >(isLeaf: true)
-external void MaterialInstance_setParameterFloat(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  double value,
+external void Camera_setExposure(
+  ffi.Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+  isLeaf: true,
+)
+external void Camera_getFrustum(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> out,
 );
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void MaterialInstance_setParameterFloat2(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  double x,
-  double y,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void MaterialInstance_setParameterFloat3(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TCamera>,
     ffi.Pointer<ffi.Double>,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external void MaterialInstance_setParameterFloat3Array(
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  ffi.Pointer<ffi.Double> raw,
-  int length,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-    ffi.Double,
     ffi.Double,
     ffi.Double,
   )
 >(isLeaf: true)
-external void MaterialInstance_setParameterFloat4(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  double x,
-  double y,
-  double w,
-  double z,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Double>,
-  )
->(isLeaf: true)
-external void MaterialInstance_setParameterMat3(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
   ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
 );
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Double>,
-  )
->(isLeaf: true)
-external void MaterialInstance_setParameterMat4(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  ffi.Pointer<ffi.Double> matrix,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Int,
-  )
->(isLeaf: true)
-external void MaterialInstance_setParameterInt(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  int value,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TCamera>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
     ffi.Bool,
   )
 >(isLeaf: true)
-external void MaterialInstance_setParameterBool(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  bool value,
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
+  isLeaf: true,
+)
+external void Camera_lookAt(
+  ffi.Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(
+  ffi.Pointer<TCamera> camera,
+  double focusDistance,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)
+>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+  isLeaf: true,
+)
+external void Camera_setModelMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> tModelMatrix,
 );
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTextureSampler>,
+    ffi.Pointer<TCamera>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
   )
 >(isLeaf: true)
-external void MaterialInstance_setParameterTexture(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  ffi.Pointer<TTexture> texture,
-  ffi.Pointer<TTextureSampler> sampler,
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setDepthFunc(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int depthFunc,
-);
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(ffi.Pointer<TCamera> camera);
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<TCamera>,
     ffi.UnsignedInt,
-    ffi.UnsignedInt,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
   )
 >(isLeaf: true)
-external void MaterialInstance_setStencilOpStencilFail(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external void MaterialInstance_setStencilOpDepthFail(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external void MaterialInstance_setStencilOpDepthStencilPass(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external void MaterialInstance_setStencilCompareFunction(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int func,
-  int face,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8, ffi.UnsignedInt)
->(isLeaf: true)
-external void MaterialInstance_setStencilReferenceValue(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int value,
-  int face,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setStencilReadMask(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int mask,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setStencilWriteMask(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int mask,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void MaterialInstance_setTransparencyMode(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int transparencyMode,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(
-  isLeaf: true,
-)
-external int MaterialInstance_getTransparencyMode(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
-
-@ffi.Native<
-  ffi.Int Function(
+  ffi.Pointer<TSceneAsset> Function(
     ffi.Pointer<TEngine>,
-    ffi.Pointer<TLightManager>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
     ffi.UnsignedInt,
+    Aabb3,
   )
 >(isLeaf: true)
-external int LightManager_createLight(
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external void LightManager_destroyLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_hasComponent(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external int LightManager_getType(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isDirectional(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isPointLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isSpotLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
+  ffi.Pointer<TVertexBuffer> tVertexBuffer,
+  ffi.Pointer<TIndexBuffer> tIndexBuffer,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double3 LightManager_getColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setIntensityCandela(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
->(isLeaf: true)
-external void LightManager_setFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double falloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSpotLightOuterCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSpotLightInnerCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloSize,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-  isLeaf: true,
-)
-external void LightManager_setSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloFalloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external double LightManager_getSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
-  isLeaf: true,
-)
-external void LightManager_setShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool LightManager_isShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)
->(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-);
-
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
-  isLeaf: true,
-)
-external TShadowOptions LightManager_getShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLightManager>,
-    EntityId,
-    ffi.UnsignedInt,
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
     ffi.Bool,
   )
 >(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
 );
 
-@ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)
->(isLeaf: true)
-external bool LightManager_getLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)
->(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<ffi.Float>,
-    ffi.Uint8,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
   isLeaf: true,
 )
-external double LightManager_rgbToColorTemperature(
-  double r,
-  double g,
-  double b,
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+  isLeaf: true,
+)
+external void SceneAsset_addToScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
 );
 
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)
->(isLeaf: true)
-external void FilamentAsset_getEntities(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+  isLeaf: true,
+)
+external void SceneAsset_removeFromScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getChildEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
+  isLeaf: true,
+)
+external void SceneAsset_getChildEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<EntityId> out,
 );
 
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
   isLeaf: true,
 )
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getCameraEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getLightEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int index,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
+  ffi.Pointer<TSceneAsset> asset,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
+
+@ffi.Native<
+  ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<
+  ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
+>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
+external int SceneAsset_getPrimitiveOffsetForEntity(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_releaseSourceData(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
+external void SceneAsset_setFlatShading(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)
+>(isLeaf: true)
+external void SceneAsset_getBones(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
+external int SceneAsset_getBoneCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+);
+
+@ffi.Native<
+  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)
+>(isLeaf: true)
+external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
 );
 
 @ffi.Native<
@@ -844,6 +440,212 @@ external int FilamentAsset_getResourceUriCount(
 >(isLeaf: true)
 external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external void NameComponentManager_destroy(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<
+  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)
+>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientationBuilder>
+SurfaceOrientationBuilder_create();
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_vertexCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_normals(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> normals,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_tangents(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> tangents,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_uvs(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> uvs,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_positions(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> positions,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangleCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Uint32>,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_uint(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint32> triangles,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+    ffi.Pointer<ffi.Uint16>,
+  )
+>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_ushort(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint16> triangles,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSurfaceOrientation> Function(
+    ffi.Pointer<TSurfaceOrientationBuilder>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
+  isLeaf: true,
+)
+external void SurfaceOrientationBuilder_destroy(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external int SurfaceOrientation_getVertexCount(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientation_getQuats_float4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Float> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Int16>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientation_getQuats_short4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Int16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSurfaceOrientation>,
+    ffi.Pointer<ffi.Uint16>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void SurfaceOrientation_getQuats_half4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Uint16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external void SurfaceOrientation_destroy(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)
+>(isLeaf: true)
+external void FilamentAsset_getEntities(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
 );
 
 @ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
@@ -1398,194 +1200,437 @@ external void View_setName(
 @ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
 external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
 
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external void NameComponentManager_destroy(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
-
-@ffi.Native<
-  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)
->(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientationBuilder>
-SurfaceOrientationBuilder_create();
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
->(isLeaf: true)
-external void SurfaceOrientationBuilder_vertexCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
+    ffi.Pointer<TSkybox>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
   )
 >(isLeaf: true)
-external void SurfaceOrientationBuilder_normals(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> normals,
-  int stride,
+external void Skybox_setColor(
+  ffi.Pointer<TSkybox> tSkybox,
+  double r,
+  double g,
+  double b,
+  double a,
 );
 
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_tangents(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> tangents,
-  int stride,
-);
+@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
 
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_uvs(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> uvs,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_positions(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> positions,
-  int stride,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangleCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Uint32>,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_uint(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint32> triangles,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-    ffi.Pointer<ffi.Uint16>,
-  )
->(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_ushort(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint16> triangles,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSurfaceOrientation> Function(
-    ffi.Pointer<TSurfaceOrientationBuilder>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
   isLeaf: true,
 )
-external void SurfaceOrientationBuilder_destroy(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+external void IndexBufferBuilder_indexCount(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int count,
 );
 
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external int SurfaceOrientation_getVertexCount(
-  ffi.Pointer<TSurfaceOrientation> orientation,
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)
+>(isLeaf: true)
+external void IndexBufferBuilder_bufferType(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+);
+
+@ffi.Native<
+  ffi.Pointer<TIndexBuffer> Function(
+    ffi.Pointer<TIndexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
+external void IndexBufferBuilder_destroy(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external void IndexBuffer_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
+  isLeaf: true,
+)
+external void IndexBuffer_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+);
+
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TMaterialInstance> Material_createInstance(
+  ffi.Pointer<TMaterial> tMaterial,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
+external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createImageMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createGridMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createGizmoMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createSilhouetteMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createEdgeOutlineMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createWireframeMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createTranslationAxisMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(
+  isLeaf: true,
+)
+external bool Material_hasParameter(
+  ffi.Pointer<TMaterial> tMaterial,
+  ffi.Pointer<ffi.Char> propertyName,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external bool MaterialInstance_isStencilWriteEnabled(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setStencilWrite(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setCullingMode(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int culling,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setDoubleSided(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  bool doubleSided,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setDepthWrite(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setDepthCulling(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
 );
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
   )
 >(isLeaf: true)
-external void SurfaceOrientation_getQuats_float4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Float> out,
-  int quatCount,
-  int stride,
+external void MaterialInstance_setParameterFloat(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  double value,
 );
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Int16>,
-    ffi.Size,
-    ffi.Size,
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
+    ffi.Double,
   )
 >(isLeaf: true)
-external void SurfaceOrientation_getQuats_short4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Int16> out,
-  int quatCount,
-  int stride,
+external void MaterialInstance_setParameterFloat2(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  double x,
+  double y,
 );
 
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TSurfaceOrientation>,
-    ffi.Pointer<ffi.Uint16>,
-    ffi.Size,
-    ffi.Size,
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
   )
 >(isLeaf: true)
-external void SurfaceOrientation_getQuats_half4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Uint16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external void SurfaceOrientation_destroy(
-  ffi.Pointer<TSurfaceOrientation> orientation,
+external void MaterialInstance_setParameterFloat3(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  double x,
+  double y,
+  double z,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Double>,
+    ffi.Uint32,
+  )
 >(isLeaf: true)
-external void IndirectLight_setRotation(
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-  ffi.Pointer<ffi.Double> rotation,
+external void MaterialInstance_setParameterFloat3Array(
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  ffi.Pointer<ffi.Double> raw,
+  int length,
 );
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setParameterFloat4(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  double x,
+  double y,
+  double w,
+  double z,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Double>,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setParameterMat3(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  ffi.Pointer<ffi.Double> matrix,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Double>,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setParameterMat4(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  ffi.Pointer<ffi.Double> matrix,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Int,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setParameterInt(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  int value,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setParameterBool(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  bool value,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTextureSampler>,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setParameterTexture(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  ffi.Pointer<TTexture> texture,
+  ffi.Pointer<TTextureSampler> sampler,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setDepthFunc(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int depthFunc,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setStencilOpStencilFail(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setStencilOpDepthFail(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setStencilOpDepthStencilPass(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setStencilCompareFunction(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int func,
+  int face,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8, ffi.UnsignedInt)
+>(isLeaf: true)
+external void MaterialInstance_setStencilReferenceValue(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int value,
+  int face,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setStencilReadMask(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int mask,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setStencilWriteMask(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int mask,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
+  isLeaf: true,
+)
+external void MaterialInstance_setTransparencyMode(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int transparencyMode,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(
+  isLeaf: true,
+)
+external int MaterialInstance_getTransparencyMode(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
+external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
 
 @ffi.Native<
   ffi.Pointer<TTexture> Function(
@@ -1909,867 +1954,6 @@ external void TextureSampler_setCompareMode(
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
 external void TextureSampler_destroy(ffi.Pointer<TTextureSampler> sampler);
-
-@ffi.Native<
-  ffi.Pointer<TRenderManager> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TRenderer>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
->(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
->(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
-  isLeaf: true,
-)
-external void RenderManager_render(
-  ffi.Pointer<TRenderManager> tRenderer,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Pointer<ffi.Pointer<TView>>,
-    ffi.Uint8,
-  )
->(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)
->(isLeaf: true)
-external void RenderManager_removeSwapChain(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_detachFromRenderThread(
-  ffi.Pointer<TRenderManager> tRenderManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
-  isLeaf: true,
-)
-external void RenderManager_setPaused(
-  ffi.Pointer<TRenderManager> tRenderer,
-  bool paused,
-);
-
-@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_start(FrameCallback callback, int targetFps);
-
-@ffi.Native<ffi.Void Function()>()
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void FrameScheduler_setRenderThread(
-  ffi.Pointer<ffi.Void> renderThread,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void FrameScheduler_setRenderManager(ffi.Pointer<TRenderManager> rm);
-
-@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
-  isLeaf: true,
-)
-external void FrameScheduler_setPostRenderCallback(
-  PostRenderCallback callback,
-  ffi.Pointer<ffi.Void> userData,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Uint64)>(isLeaf: true)
-external bool FrameScheduler_requestRender(int frameTimeNanos);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startNativeRenderLoop(int targetFps);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(int port, int targetFps);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_setTargetFps(int fps);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
-
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(int t);
-
-@ffi.Native<
-  ffi.Pointer<TGizmo> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TView>,
-    ffi.Pointer<TMaterial>,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGizmo> Gizmo_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> assetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGizmo>,
-    ffi.Uint32,
-    ffi.Uint32,
-    GizmoPickCallback,
-  )
->(isLeaf: true)
-external void Gizmo_pick(
-  ffi.Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  GizmoPickCallback callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
-  isLeaf: true,
-)
-external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
-
-@ffi.Native<
-  ffi.Pointer<TMaterialInstance> Function(
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
-  ffi.Pointer<TMaterialProvider> provider,
-  bool doubleSided,
-  bool unlit,
-  bool hasVertexColors,
-  bool hasBaseColorTexture,
-  bool hasNormalTexture,
-  bool hasOcclusionTexture,
-  bool hasEmissiveTexture,
-  bool useSpecularGlossiness,
-  int alphaMode,
-  bool enableDiagnostics,
-  bool hasMetallicRoughnessTexture,
-  int metallicRoughnessUV,
-  bool hasSpecularGlossinessTexture,
-  int specularGlossinessUV,
-  int baseColorUV,
-  bool hasClearCoatTexture,
-  int clearCoatUV,
-  bool hasClearCoatRoughnessTexture,
-  int clearCoatRoughnessUV,
-  bool hasClearCoatNormalTexture,
-  int clearCoatNormalUV,
-  bool hasClearCoat,
-  bool hasTransmission,
-  bool hasTextureTransforms,
-  int emissiveUV,
-  int aoUV,
-  int normalUV,
-  bool hasTransmissionTexture,
-  int transmissionUV,
-  bool hasSheenColorTexture,
-  int sheenColorUV,
-  bool hasSheenRoughnessTexture,
-  int sheenRoughnessUV,
-  bool hasVolumeThicknessTexture,
-  int volumeThicknessUV,
-  bool hasSheen,
-  bool hasIOR,
-  bool hasVolume,
-);
-
-@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
-  isLeaf: true,
-)
-external void IndexBufferBuilder_indexCount(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)
->(isLeaf: true)
-external void IndexBufferBuilder_bufferType(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndexBuffer> Function(
-    ffi.Pointer<TIndexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
-external void IndexBufferBuilder_destroy(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external void IndexBuffer_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
-  isLeaf: true,
-)
-external void IndexBuffer_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-);
-
-@ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(
-  isLeaf: true,
-)
-external void VertexBufferBuilder_bufferCount(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  int count,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(
-  isLeaf: true,
-)
-external void VertexBufferBuilder_vertexCount(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.UnsignedInt,
-    ffi.Uint8,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    ffi.Uint8,
-  )
->(isLeaf: true)
-external void VertexBufferBuilder_attribute(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  int bufferIndex,
-  int attributeType,
-  int byteOffset,
-  int byteStride,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.UnsignedInt,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void VertexBufferBuilder_normalized(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  bool normalize,
-);
-
-@ffi.Native<
-  ffi.Pointer<TVertexBuffer> Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> VertexBufferBuilder_build(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
-external void VertexBufferBuilder_destroy(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external int VertexBuffer_getVertexCount(ffi.Pointer<TVertexBuffer> buffer);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external void VertexBuffer_setBufferAt(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TVertexBuffer> buffer,
-  int bufferIndex,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)
->(isLeaf: true)
-external void VertexBuffer_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TVertexBuffer> buffer,
-);
-
-@ffi.Native<
-  ffi.Pointer<TRenderTarget> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TRenderTarget> RenderTarget_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> color,
-  ffi.Pointer<TTexture> depth,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)
->(isLeaf: true)
-external void RenderTarget_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
-  isLeaf: true,
-)
-external void Scene_setSkybox(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TSkybox> skybox,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)
->(isLeaf: true)
-external void Scene_setIndirectLight(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)
->(isLeaf: true)
-external void Scene_addFilamentAsset(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TFilamentAsset> asset,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)
->(isLeaf: true)
-external void Camera_setExposure(
-  ffi.Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-  isLeaf: true,
-)
-external void Camera_getFrustum(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> out,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Pointer<ffi.Double>,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
-  isLeaf: true,
-)
-external void Camera_lookAt(
-  ffi.Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(
-  ffi.Pointer<TCamera> camera,
-  double focusDistance,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)
->(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-  isLeaf: true,
-)
-external void Camera_setModelMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> tModelMatrix,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.UnsignedInt,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
-external double4x4 TransformManager_getLocalTransform(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
-external double4x4 TransformManager_getWorldTransform(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4)
->(isLeaf: true)
-external void TransformManager_setTransform(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  double4x4 transform,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(
-  isLeaf: true,
-)
-external bool TransformManager_transformToUnitCube(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  Aabb3 boundingBox,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTransformManager>,
-    EntityId,
-    EntityId,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void TransformManager_setParent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int child,
-  int parent,
-  bool preserveScaling,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
-external int TransformManager_getParent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int child,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
-external int TransformManager_getAncestor(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int childEntityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
-external void TransformManager_createComponent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
-external void TransformManager_removeComponent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
-external bool TransformManager_hasComponent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external bool TransformManager_empty(
-  ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external int TransformManager_getComponentCount(
-  ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(
-  isLeaf: true,
-)
-external int TransformManager_getChildCount(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TTransformManager>,
-    EntityId,
-    ffi.Pointer<EntityId>,
-    ffi.Int,
-  )
->(isLeaf: true)
-external void TransformManager_getChildren(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  ffi.Pointer<EntityId> children,
-  int count,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external void TransformManager_openLocalTransformTransaction(
-  ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external void TransformManager_commitLocalTransformTransaction(
-  ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void Renderer_setClearOptions(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-);
-
-@ffi.Native<
-  ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)
->(isLeaf: true)
-external bool Renderer_beginFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external void Renderer_render(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-  isLeaf: true,
-)
-external void Renderer_renderStandaloneView(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<TRenderTarget>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void Renderer_readPixels(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Uint8,
-    ffi.Uint8,
-  )
->(isLeaf: true)
-external void Renderer_setFrameInterval(
-  ffi.Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-);
 
 @ffi.Native<
   ffi.Pointer<TEngine> Function(
@@ -3164,6 +2348,320 @@ external bool DebugRegistry_getProperty_float(
   ffi.Pointer<TDebugRegistry> tDebugRegistry,
   ffi.Pointer<ffi.Char> name,
   ffi.Pointer<ffi.Float> outValue,
+);
+
+@ffi.Native<
+  ffi.Pointer<TMaterialInstance> Function(
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
+  ffi.Pointer<TMaterialProvider> provider,
+  bool doubleSided,
+  bool unlit,
+  bool hasVertexColors,
+  bool hasBaseColorTexture,
+  bool hasNormalTexture,
+  bool hasOcclusionTexture,
+  bool hasEmissiveTexture,
+  bool useSpecularGlossiness,
+  int alphaMode,
+  bool enableDiagnostics,
+  bool hasMetallicRoughnessTexture,
+  int metallicRoughnessUV,
+  bool hasSpecularGlossinessTexture,
+  int specularGlossinessUV,
+  int baseColorUV,
+  bool hasClearCoatTexture,
+  int clearCoatUV,
+  bool hasClearCoatRoughnessTexture,
+  int clearCoatRoughnessUV,
+  bool hasClearCoatNormalTexture,
+  int clearCoatNormalUV,
+  bool hasClearCoat,
+  bool hasTransmission,
+  bool hasTextureTransforms,
+  int emissiveUV,
+  int aoUV,
+  int normalUV,
+  bool hasTransmissionTexture,
+  int transmissionUV,
+  bool hasSheenColorTexture,
+  int sheenColorUV,
+  bool hasSheenRoughnessTexture,
+  int sheenRoughnessUV,
+  bool hasVolumeThicknessTexture,
+  int volumeThicknessUV,
+  bool hasSheen,
+  bool hasIOR,
+  bool hasVolume,
+);
+
+@ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(
+  isLeaf: true,
+)
+external void VertexBufferBuilder_bufferCount(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  int count,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(
+  isLeaf: true,
+)
+external void VertexBufferBuilder_vertexCount(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.UnsignedInt,
+    ffi.Uint8,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
+external void VertexBufferBuilder_attribute(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  int bufferIndex,
+  int attributeType,
+  int byteOffset,
+  int byteStride,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.UnsignedInt,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void VertexBufferBuilder_normalized(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  bool normalize,
+);
+
+@ffi.Native<
+  ffi.Pointer<TVertexBuffer> Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> VertexBufferBuilder_build(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
+external void VertexBufferBuilder_destroy(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
+external int VertexBuffer_getVertexCount(ffi.Pointer<TVertexBuffer> buffer);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external void VertexBuffer_setBufferAt(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TVertexBuffer> buffer,
+  int bufferIndex,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)
+>(isLeaf: true)
+external void VertexBuffer_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TVertexBuffer> buffer,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
+  isLeaf: true,
+)
+external double4x4 TransformManager_getLocalTransform(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
+  isLeaf: true,
+)
+external double4x4 TransformManager_getWorldTransform(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4)
+>(isLeaf: true)
+external void TransformManager_setTransform(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  double4x4 transform,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(
+  isLeaf: true,
+)
+external bool TransformManager_transformToUnitCube(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  Aabb3 boundingBox,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TTransformManager>,
+    EntityId,
+    EntityId,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void TransformManager_setParent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int child,
+  int parent,
+  bool preserveScaling,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
+  isLeaf: true,
+)
+external int TransformManager_getParent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int child,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
+  isLeaf: true,
+)
+external int TransformManager_getAncestor(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int childEntityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
+  isLeaf: true,
+)
+external void TransformManager_createComponent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
+  isLeaf: true,
+)
+external void TransformManager_removeComponent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool TransformManager_hasComponent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external bool TransformManager_empty(
+  ffi.Pointer<TTransformManager> tTransformManager,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external int TransformManager_getComponentCount(
+  ffi.Pointer<TTransformManager> tTransformManager,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(
+  isLeaf: true,
+)
+external int TransformManager_getChildCount(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TTransformManager>,
+    EntityId,
+    ffi.Pointer<EntityId>,
+    ffi.Int,
+  )
+>(isLeaf: true)
+external void TransformManager_getChildren(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  ffi.Pointer<EntityId> children,
+  int count,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external void TransformManager_openLocalTransformTransaction(
+  ffi.Pointer<TTransformManager> tTransformManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external void TransformManager_commitLocalTransformTransaction(
+  ffi.Pointer<TTransformManager> tTransformManager,
 );
 
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
@@ -5717,85 +5215,6 @@ external void RenderableManager_setBonesFromBoneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)
->(isLeaf: true)
-external void GltfResourceLoader_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-  )
->(isLeaf: true)
-external bool GltfResourceLoader_asyncBeginLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external double GltfResourceLoader_asyncGetLoadProgress(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void GltfResourceLoader_addResourceData(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.Char> uri,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-  )
->(isLeaf: true)
-external bool GltfResourceLoader_loadResources(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSkybox>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Skybox_setColor(
-  ffi.Pointer<TSkybox> tSkybox,
-  double r,
-  double g,
-  double b,
-  double a,
-);
-
 @ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
 external void dummy(TGltfMeshData dummy);
 
@@ -5816,6 +5235,421 @@ external int GltfParser_parseBuffer(
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
 external void GltfParser_freeMeshData(ffi.Pointer<TGltfMeshData> meshData);
+
+@ffi.Native<
+  ffi.Int Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TLightManager>,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external int LightManager_createLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external void LightManager_destroyLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_hasComponent(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external int LightManager_getType(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_isDirectional(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_isPointLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_isSpotLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double3 LightManager_getPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double3 LightManager_getDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void LightManager_setColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double3 LightManager_getColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
+external void LightManager_setIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
+external void LightManager_setIntensityCandela(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double intensity,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)
+>(isLeaf: true)
+external void LightManager_setFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double falloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSpotLightOuterCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSpotLightInnerCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+  isLeaf: true,
+)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+  isLeaf: true,
+)
+external void LightManager_setSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloSize,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+  isLeaf: true,
+)
+external void LightManager_setSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloFalloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external double LightManager_getSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
+  isLeaf: true,
+)
+external void LightManager_setShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external bool LightManager_isShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)
+>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
+  isLeaf: true,
+)
+external TShadowOptions LightManager_getShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLightManager>,
+    EntityId,
+    ffi.UnsignedInt,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<
+  ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)
+>(isLeaf: true)
+external bool LightManager_getLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)
+>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<ffi.Float>,
+    ffi.Uint8,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
+  isLeaf: true,
+)
+external double LightManager_rgbToColorTemperature(
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
+  isLeaf: true,
+)
+external void Scene_setSkybox(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TSkybox> skybox,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)
+>(isLeaf: true)
+external void Scene_setIndirectLight(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)
+>(isLeaf: true)
+external void Scene_addFilamentAsset(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TFilamentAsset> asset,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(
   isLeaf: true,
@@ -6393,196 +6227,114 @@ external int RenderableBuilder_build(
   int entity,
 );
 
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.UnsignedInt,
-    Aabb3,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tVertexBuffer,
-  ffi.Pointer<TIndexBuffer> tIndexBuffer,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
 );
 
 @ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)
+>(isLeaf: true)
+external void GltfResourceLoader_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+  )
+>(isLeaf: true)
+external bool GltfResourceLoader_asyncBeginLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_asyncUpdateLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external double GltfResourceLoader_asyncGetLoadProgress(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void GltfResourceLoader_addResourceData(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.Char> uri,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+  )
+>(isLeaf: true)
+external bool GltfResourceLoader_loadResources(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(int t);
+
+@ffi.Native<
+  ffi.Pointer<TGizmo> Function(
     ffi.Pointer<TEngine>,
     ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TGltfResourceLoader>,
     ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Bool,
+    ffi.Pointer<TView>,
+    ffi.Pointer<TMaterial>,
+    ffi.UnsignedInt,
   )
 >(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+external ffi.Pointer<TGizmo> Gizmo_create(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TGltfAssetLoader> assetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
-);
-
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void SceneAsset_addToScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-  isLeaf: true,
-)
-external void SceneAsset_removeFromScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
-  isLeaf: true,
-)
-external void SceneAsset_getChildEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
 );
 
 @ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int index,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
+  ffi.Void Function(
+    ffi.Pointer<TGizmo>,
+    ffi.Uint32,
+    ffi.Uint32,
+    GizmoPickCallback,
   )
 >(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
-  ffi.Pointer<TSceneAsset> asset,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
+external void Gizmo_pick(
+  ffi.Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  GizmoPickCallback callback,
 );
 
-@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
+  isLeaf: true,
+)
+external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
 
-@ffi.Native<
-  ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int SceneAsset_getPrimitiveOffsetForEntity(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)
->(isLeaf: true)
-external void SceneAsset_getBones(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-);
-
-@ffi.Native<
-  ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)
->(isLeaf: true)
-external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
+external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
 
 @ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(
   isLeaf: true,
@@ -6892,6 +6644,254 @@ external bool AnimationManager_setGltfAnimationTime(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int animationIndex,
   double timeInSeconds,
+);
+
+@ffi.Native<
+  ffi.Pointer<TRenderTarget> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TRenderTarget> RenderTarget_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> color,
+  ffi.Pointer<TTexture> depth,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)
+>(isLeaf: true)
+external void RenderTarget_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)
+>(isLeaf: true)
+external void IndirectLight_setRotation(
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+  ffi.Pointer<ffi.Double> rotation,
+);
+
+@ffi.Native<
+  ffi.Pointer<TRenderManager> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TRenderer>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
+>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)
+>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
+  isLeaf: true,
+)
+external void RenderManager_render(
+  ffi.Pointer<TRenderManager> tRenderer,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Pointer<ffi.Pointer<TView>>,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)
+>(isLeaf: true)
+external void RenderManager_removeSwapChain(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_detachFromRenderThread(
+  ffi.Pointer<TRenderManager> tRenderManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+  isLeaf: true,
+)
+external void RenderManager_setPaused(
+  ffi.Pointer<TRenderManager> tRenderer,
+  bool paused,
+);
+
+@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_start(FrameCallback callback, int targetFps);
+
+@ffi.Native<ffi.Void Function()>()
+external void FrameScheduler_stop();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void FrameScheduler_setRenderThread(
+  ffi.Pointer<ffi.Void> renderThread,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void FrameScheduler_setRenderManager(ffi.Pointer<TRenderManager> rm);
+
+@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(
+  isLeaf: true,
+)
+external void FrameScheduler_setPostRenderCallback(
+  PostRenderCallback callback,
+  ffi.Pointer<ffi.Void> userData,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Uint64)>(isLeaf: true)
+external bool FrameScheduler_requestRender(int frameTimeNanos);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startNativeRenderLoop(int targetFps);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(int port, int targetFps);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_setTargetFps(int fps);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void Renderer_setClearOptions(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+);
+
+@ffi.Native<
+  ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)
+>(isLeaf: true)
+external bool Renderer_beginFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+  isLeaf: true,
+)
+external void Renderer_render(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+  isLeaf: true,
+)
+external void Renderer_renderStandaloneView(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<TRenderTarget>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void Renderer_readPixels(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Uint8,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
+external void Renderer_setFrameInterval(
+  ffi.Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
@@ -7269,155 +7269,9 @@ sealed class TIndexType {
   static const TINDEX_TYPE_UINT = 1;
 }
 
-sealed class TSamplerCompareFunc {
-  /// !< Less or equal
-  static const LE = 0;
-
-  /// !< Greater or equal
-  static const GE = 1;
-
-  /// !< Strictly less than
-  static const L = 2;
-
-  /// !< Strictly greater than
-  static const G = 3;
-
-  /// !< Equal
-  static const E = 4;
-
-  /// !< Not equal
-  static const NE = 5;
-
-  /// !< Always. Depth / stencil testing is deactivated.
-  static const A = 6;
-
-  /// !< Never. The depth / stencil test always fails.
-  static const N = 7;
-}
-
-sealed class TStencilOperation {
-  static const KEEP = 0;
-  static const ZERO = 1;
-  static const REPLACE = 2;
-  static const INCR = 3;
-  static const INCR_WRAP = 4;
-  static const DECR = 5;
-  static const DECR_WRAP = 6;
-  static const INVERT = 7;
-}
-
-sealed class TStencilFace {
-  static const STENCIL_FACE_FRONT = 1;
-  static const STENCIL_FACE_BACK = 2;
-  static const STENCIL_FACE_FRONT_AND_BACK = 3;
-}
-
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
-}
-
-sealed class TTransparencyMode {
-  /// ! the transparent object is drawn honoring the raster state
-  static const DEFAULT = 0;
-
-  /// the transparent object is first drawn in the depth buffer,
-  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
-  static const TWO_PASSES_ONE_SIDE = 1;
-
-  /// the transparent object is drawn twice in the color buffer,
-  /// first with back faces only, then with front faces; the culling
-  /// mode is ignored. Can be combined with two-sided lighting
-  static const TWO_PASSES_TWO_SIDES = 2;
-}
-
-sealed class TBlendingMode {
-  static const BLENDING_MODE_OPAQUE = 0;
-  static const BLENDING_MODE_TRANSPARENT = 1;
-  static const BLENDING_MODE_ADD = 2;
-  static const BLENDING_MODE_MASKED = 3;
-  static const BLENDING_MODE_FADE = 4;
-  static const BLENDING_MODE_MULTIPLY = 5;
-  static const BLENDING_MODE_SCREEN = 6;
-  static const BLENDING_MODE_CUSTOM = 7;
-}
-
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-final class TShadowOptions extends ffi.Struct {
-  @ffi.Uint32()
-  external int mapSize;
-
-  @ffi.Uint8()
-  external int shadowCascades;
-
-  @ffi.Array.multi([3])
-  external ffi.Array<ffi.Float> cascadeSplitPositions;
-
-  @ffi.Float()
-  external double constantBias;
-
-  @ffi.Float()
-  external double normalBias;
-
-  @ffi.Float()
-  external double shadowFar;
-
-  @ffi.Float()
-  external double shadowNearHint;
-
-  @ffi.Float()
-  external double shadowFarHint;
-
-  @ffi.Bool()
-  external bool stable;
-
-  @ffi.Bool()
-  external bool lispsm;
-
-  @ffi.Float()
-  external double polygonOffsetConstant;
-
-  @ffi.Float()
-  external double polygonOffsetSlope;
-
-  @ffi.Bool()
-  external bool screenSpaceContactShadows;
-
-  @ffi.Uint8()
-  external int stepCount;
-
-  @ffi.Float()
-  external double maxShadowDistance;
-
-  @ffi.Bool()
-  external bool vsmElvsm;
-
-  @ffi.Float()
-  external double vsmBlurWidth;
-
-  @ffi.Float()
-  external double shadowBulbRadius;
-
-  @ffi.Float()
-  external double transformX;
-
-  @ffi.Float()
-  external double transformY;
-
-  @ffi.Float()
-  external double transformZ;
-
-  @ffi.Float()
-  external double transformW;
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
 }
 
 final class TViewport extends ffi.Struct {
@@ -7653,6 +7507,81 @@ typedef DartPickCallbackFunction =
       double fragZ,
     );
 typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
+
+sealed class TSamplerCompareFunc {
+  /// !< Less or equal
+  static const LE = 0;
+
+  /// !< Greater or equal
+  static const GE = 1;
+
+  /// !< Strictly less than
+  static const L = 2;
+
+  /// !< Strictly greater than
+  static const G = 3;
+
+  /// !< Equal
+  static const E = 4;
+
+  /// !< Not equal
+  static const NE = 5;
+
+  /// !< Always. Depth / stencil testing is deactivated.
+  static const A = 6;
+
+  /// !< Never. The depth / stencil test always fails.
+  static const N = 7;
+}
+
+sealed class TStencilOperation {
+  static const KEEP = 0;
+  static const ZERO = 1;
+  static const REPLACE = 2;
+  static const INCR = 3;
+  static const INCR_WRAP = 4;
+  static const DECR = 5;
+  static const DECR_WRAP = 6;
+  static const INVERT = 7;
+}
+
+sealed class TStencilFace {
+  static const STENCIL_FACE_FRONT = 1;
+  static const STENCIL_FACE_BACK = 2;
+  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+}
+
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
+sealed class TTransparencyMode {
+  /// ! the transparent object is drawn honoring the raster state
+  static const DEFAULT = 0;
+
+  /// the transparent object is first drawn in the depth buffer,
+  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
+  static const TWO_PASSES_ONE_SIDE = 1;
+
+  /// the transparent object is drawn twice in the color buffer,
+  /// first with back faces only, then with front faces; the culling
+  /// mode is ignored. Can be combined with two-sided lighting
+  static const TWO_PASSES_TWO_SIDES = 2;
+}
+
+sealed class TBlendingMode {
+  static const BLENDING_MODE_OPAQUE = 0;
+  static const BLENDING_MODE_TRANSPARENT = 1;
+  static const BLENDING_MODE_ADD = 2;
+  static const BLENDING_MODE_MASKED = 3;
+  static const BLENDING_MODE_FADE = 4;
+  static const BLENDING_MODE_MULTIPLY = 5;
+  static const BLENDING_MODE_SCREEN = 6;
+  static const BLENDING_MODE_CUSTOM = 7;
+}
 
 sealed class TTextureSamplerType {
   static const SAMPLER_2D = 0;
@@ -7910,47 +7839,6 @@ sealed class TSamplerCompareMode {
   static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
 }
 
-typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
-typedef PostRenderCallbackFunction =
-    ffi.Void Function(ffi.Pointer<ffi.Void> userData);
-typedef DartPostRenderCallbackFunction =
-    void Function(ffi.Pointer<ffi.Void> userData);
-typedef PostRenderCallback =
-    ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-typedef GizmoPickCallbackFunction =
-    ffi.Void Function(
-      ffi.UnsignedInt resultType,
-      ffi.Float x,
-      ffi.Float y,
-      ffi.Float z,
-    );
-typedef DartGizmoPickCallbackFunction =
-    void Function(int resultType, double x, double y, double z);
-typedef GizmoPickCallback =
-    ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
 sealed class TBackend {
   /// !< Automatically selects an appropriate driver for the platform.
   static const BACKEND_DEFAULT = 0;
@@ -7989,6 +7877,117 @@ final class TGltfMeshData extends ffi.Struct {
   @ffi.UnsignedInt()
   external int primitiveType;
 }
+
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+final class TShadowOptions extends ffi.Struct {
+  @ffi.Uint32()
+  external int mapSize;
+
+  @ffi.Uint8()
+  external int shadowCascades;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.Float> cascadeSplitPositions;
+
+  @ffi.Float()
+  external double constantBias;
+
+  @ffi.Float()
+  external double normalBias;
+
+  @ffi.Float()
+  external double shadowFar;
+
+  @ffi.Float()
+  external double shadowNearHint;
+
+  @ffi.Float()
+  external double shadowFarHint;
+
+  @ffi.Bool()
+  external bool stable;
+
+  @ffi.Bool()
+  external bool lispsm;
+
+  @ffi.Float()
+  external double polygonOffsetConstant;
+
+  @ffi.Float()
+  external double polygonOffsetSlope;
+
+  @ffi.Bool()
+  external bool screenSpaceContactShadows;
+
+  @ffi.Uint8()
+  external int stepCount;
+
+  @ffi.Float()
+  external double maxShadowDistance;
+
+  @ffi.Bool()
+  external bool vsmElvsm;
+
+  @ffi.Float()
+  external double vsmBlurWidth;
+
+  @ffi.Float()
+  external double shadowBulbRadius;
+
+  @ffi.Float()
+  external double transformX;
+
+  @ffi.Float()
+  external double transformY;
+
+  @ffi.Float()
+  external double transformZ;
+
+  @ffi.Float()
+  external double transformW;
+}
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+typedef GizmoPickCallbackFunction =
+    ffi.Void Function(
+      ffi.UnsignedInt resultType,
+      ffi.Float x,
+      ffi.Float y,
+      ffi.Float z,
+    );
+typedef DartGizmoPickCallbackFunction =
+    void Function(int resultType, double x, double y, double z);
+typedef GizmoPickCallback =
+    ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
+typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
+typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
+typedef PostRenderCallbackFunction =
+    ffi.Void Function(ffi.Pointer<ffi.Void> userData);
+typedef DartPostRenderCallbackFunction =
+    void Function(ffi.Pointer<ffi.Void> userData);
+typedef PostRenderCallback =
+    ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
 
 final class TMovementIntentCalculator extends ffi.Opaque {}
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -26,7 +26,7 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int height,
   );
   external void _Thermion_destroyCanvas();
-  external int _Thermion_createGLContext(Pointer<Char> canvasSelector);
+  external int _Thermion_createGLContext();
   external int _Thermion_getGLContext();
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_TRANSPARENT;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
@@ -1237,9 +1237,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TTransformManager> tTransformManager,
   );
   external Pointer<Void> _RenderThread_create();
-  external Pointer<Void> _RenderThread_createForCanvas(
-    Pointer<Char> canvasSelector,
-  );
   external void _RenderThread_destroy(Pointer<Void> renderThread);
   external void _RenderThread_addTask(
     Pointer<NativeFunction<void Function()>> task,
@@ -3137,10 +3134,8 @@ void Thermion_destroyCanvas() {
   return result;
 }
 
-int Thermion_createGLContext(Pointer<Char> canvasSelector) {
-  final result = GeneratedBindings.instance._Thermion_createGLContext(
-    canvasSelector,
-  );
+int Thermion_createGLContext() {
+  final result = GeneratedBindings.instance._Thermion_createGLContext();
   return result;
 }
 
@@ -6458,13 +6453,6 @@ void TransformManager_commitLocalTransformTransaction(
 
 Pointer<Void> RenderThread_create() {
   final result = GeneratedBindings.instance._RenderThread_create();
-  return Pointer<Void>(result);
-}
-
-Pointer<Void> RenderThread_createForCanvas(Pointer<Char> canvasSelector) {
-  final result = GeneratedBindings.instance._RenderThread_createForCanvas(
-    canvasSelector,
-  );
   return Pointer<Void>(result);
 }
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -26,193 +26,374 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int height,
   );
   external void _Thermion_destroyCanvas();
-  external int _Thermion_createGLContext();
+  external int _Thermion_createGLContext(Pointer<Char> canvasSelector);
   external int _Thermion_getGLContext();
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_TRANSPARENT;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
-  external void _Camera_setExposure(
-    Pointer<TCamera> camera,
-    double aperture,
-    double shutterSpeed,
-    double sensitivity,
+  external Pointer<TMaterialInstance> _Material_createInstance(
+    Pointer<TMaterial> tMaterial,
   );
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
+  external int _Material_getFeatureLevel(Pointer<TMaterial> tMaterial);
+  external Pointer<TMaterial> _Material_createImageMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _Camera_getViewMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
+  external Pointer<TMaterial> _Material_createGridMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _Camera_getProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
+  external Pointer<TMaterial> _Material_createGizmoMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _Camera_getCullingProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
+  external Pointer<TMaterial> _Material_createSilhouetteMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _Camera_getFrustum(
-    Pointer<TCamera> camera,
-    Pointer<Float64> out,
+  external Pointer<TMaterial> _Material_createEdgeOutlineMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _Camera_setProjectionMatrix(
-    Pointer<TCamera> camera,
+  external Pointer<TMaterial> _Material_createWireframeMaterial(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TMaterial> _Material_createTranslationAxisMaterial(
+    Pointer<TEngine> tEngine,
+  );
+  external Pointer<TMaterial> _Material_createBoneOverlayMaterial(
+    Pointer<TEngine> tEngine,
+  );
+  external int _Material_hasParameter(
+    Pointer<TMaterial> tMaterial,
+    Pointer<Char> propertyName,
+  );
+  external int _MaterialInstance_isStencilWriteEnabled(
+    Pointer<TMaterialInstance> materialInstance,
+  );
+  external void _MaterialInstance_setStencilWrite(
+    Pointer<TMaterialInstance> materialInstance,
+    bool enabled,
+  );
+  external void _MaterialInstance_setCullingMode(
+    Pointer<TMaterialInstance> materialInstance,
+    int culling,
+  );
+  external void _MaterialInstance_setDoubleSided(
+    Pointer<TMaterialInstance> materialInstance,
+    bool doubleSided,
+  );
+  external void _MaterialInstance_setDepthWrite(
+    Pointer<TMaterialInstance> materialInstance,
+    bool enabled,
+  );
+  external void _MaterialInstance_setDepthCulling(
+    Pointer<TMaterialInstance> materialInstance,
+    bool enabled,
+  );
+  external void _MaterialInstance_setParameterFloat(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    double value,
+  );
+  external void _MaterialInstance_setParameterFloat2(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    double x,
+    double y,
+  );
+  external void _MaterialInstance_setParameterFloat3(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    double x,
+    double y,
+    double z,
+  );
+  external void _MaterialInstance_setParameterFloat3Array(
+    Pointer<TMaterialInstance> tMaterialInstance,
+    Pointer<Char> propertyName,
+    Pointer<Float64> raw,
+    int length,
+  );
+  external void _MaterialInstance_setParameterFloat4(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    double x,
+    double y,
+    double w,
+    double z,
+  );
+  external void _MaterialInstance_setParameterMat3(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
     Pointer<Float64> matrix,
-    double near,
-    double far,
   );
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
+  external void _MaterialInstance_setParameterMat4(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    Pointer<Float64> matrix,
   );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
+  external void _MaterialInstance_setParameterInt(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    int value,
   );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(
-    Pointer<TCamera> camera,
-    double focusDistance,
+  external void _MaterialInstance_setParameterBool(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    bool value,
   );
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
+  external void _MaterialInstance_setParameterTexture(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    Pointer<TTexture> texture,
+    Pointer<TTextureSampler> sampler,
   );
-  external void _Camera_setModelMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> tModelMatrix,
+  external void _MaterialInstance_setDepthFunc(
+    Pointer<TMaterialInstance> materialInstance,
+    int depthFunc,
   );
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
+  external void _MaterialInstance_setStencilOpStencilFail(
+    Pointer<TMaterialInstance> materialInstance,
+    int op,
+    int face,
   );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
+  external void _MaterialInstance_setStencilOpDepthFail(
+    Pointer<TMaterialInstance> materialInstance,
+    int op,
+    int face,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+  external void _MaterialInstance_setStencilOpDepthStencilPass(
+    Pointer<TMaterialInstance> materialInstance,
+    int op,
+    int face,
+  );
+  external void _MaterialInstance_setStencilCompareFunction(
+    Pointer<TMaterialInstance> materialInstance,
+    int func,
+    int face,
+  );
+  external void _MaterialInstance_setStencilReferenceValue(
+    Pointer<TMaterialInstance> materialInstance,
+    int value,
+    int face,
+  );
+  external void _MaterialInstance_setStencilReadMask(
+    Pointer<TMaterialInstance> materialInstance,
+    int mask,
+  );
+  external void _MaterialInstance_setStencilWriteMask(
+    Pointer<TMaterialInstance> materialInstance,
+    int mask,
+  );
+  external void _MaterialInstance_setTransparencyMode(
+    Pointer<TMaterialInstance> materialInstance,
+    int transparencyMode,
+  );
+  external int _MaterialInstance_getTransparencyMode(
+    Pointer<TMaterialInstance> materialInstance,
+  );
+  external int _Material_getBlendingMode(Pointer<TMaterial> material);
+  external int _LightManager_createLight(
     Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    Pointer<Aabb3> boundingBoxPtr,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TFilamentAsset> tFilamentAsset,
-    bool rebuildVertices,
-  );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-  );
-  external void _SceneAsset_removeFromScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-  );
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _SceneAsset_getChildEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<Int32> out,
-  );
-  external Pointer<Int32> _SceneAsset_getCameraEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getCameraEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<Int32> _SceneAsset_getLightEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getLightEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-  );
-  external size_t _SceneAsset_getInstanceCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-  );
-  external void _SceneAsset_getBoundingBox(
-    Pointer<Aabb3> Aabb3_out,
-    Pointer<TSceneAsset> asset,
-  );
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external int _SceneAsset_getPrimitiveOffsetForEntity(
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _LightManager_destroyLight(
+    Pointer<TLightManager> tLightManager,
     EntityId entity,
   );
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(
-    Pointer<TSceneAsset> tSceneAsset,
-    bool flatShading,
+  external int _LightManager_hasComponent(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
   );
-  external void _SceneAsset_getBones(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
+  external int _LightManager_getType(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isDirectional(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isPointLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isSpotLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double r,
+    double g,
+    double b,
+  );
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external double _LightManager_getIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double falloff,
+  );
+  external double _LightManager_getFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external double _LightManager_getSpotLightOuterCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external double _LightManager_getSpotLightInnerCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external double _LightManager_getSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloSize,
+  );
+  external double _LightManager_getSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external double _LightManager_getSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    bool enabled,
+  );
+  external int _LightManager_isShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external int _LightManager_getLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+  );
+  external void _LightManager_computeUniformSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+  );
+  external void _LightManager_computeLogSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+  );
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external double _LightManager_rgbToColorTemperature(
+    double r,
+    double g,
+    double b,
+  );
+  external int _FilamentAsset_getEntityCount(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external void _FilamentAsset_getEntities(
+    Pointer<TFilamentAsset> filamentAsset,
     Pointer<Int32> out,
   );
-  external size_t _SceneAsset_getBoneCount(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
+  external EntityId _FilamentAsset_getWireframe(
+    Pointer<TFilamentAsset> filamentAsset,
   );
-  external Pointer<Char> _SceneAsset_getBoneName(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    size_t boneIndex,
+  external Pointer<Void> _FilamentAsset_getSourceAsset(
+    Pointer<TFilamentAsset> filamentAsset,
   );
   external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
     Pointer<TEngine> tEngine,
@@ -241,95 +422,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(
     Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(
-    Pointer<TNameComponentManager> tNameComponentManager,
-  );
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external Pointer<TSurfaceOrientationBuilder>
-  _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
-  );
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_triangleCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
-  );
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
-  );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
-  );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
-    Pointer<TSurfaceOrientationBuilder> builder,
-  );
-  external void _SurfaceOrientationBuilder_destroy(
-    Pointer<TSurfaceOrientationBuilder> builder,
-  );
-  external size_t _SurfaceOrientation_getVertexCount(
-    Pointer<TSurfaceOrientation> orientation,
-  );
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_destroy(
-    Pointer<TSurfaceOrientation> orientation,
-  );
-  external int _FilamentAsset_getEntityCount(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external void _FilamentAsset_getEntities(
-    Pointer<TFilamentAsset> filamentAsset,
-    Pointer<Int32> out,
-  );
-  external EntityId _FilamentAsset_getWireframe(
-    Pointer<TFilamentAsset> filamentAsset,
-  );
-  external Pointer<Void> _FilamentAsset_getSourceAsset(
-    Pointer<TFilamentAsset> filamentAsset,
   );
   external void _View_getViewport(
     Pointer<TViewport> TViewport_out,
@@ -584,199 +676,86 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
   external Pointer<Char> _View_getName(Pointer<TView> tView);
-  external void _Skybox_setColor(
-    Pointer<TSkybox> tSkybox,
-    double r,
-    double g,
-    double b,
-    double a,
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(
+    Pointer<TNameComponentManager> tNameComponentManager,
   );
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(
-    Pointer<TIndexBufferBuilder> builder,
-    int count,
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
   );
-  external void _IndexBufferBuilder_bufferType(
-    Pointer<TIndexBufferBuilder> builder,
-    int indexType,
+  external Pointer<TSurfaceOrientationBuilder>
+  _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
   );
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
   );
-  external void _IndexBufferBuilder_destroy(
-    Pointer<TIndexBufferBuilder> builder,
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
   );
-  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
   );
-  external void _IndexBuffer_destroy(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
   );
-  external Pointer<TMaterialInstance> _Material_createInstance(
-    Pointer<TMaterial> tMaterial,
+  external void _SurfaceOrientationBuilder_triangleCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
   );
-  external int _Material_getFeatureLevel(Pointer<TMaterial> tMaterial);
-  external Pointer<TMaterial> _Material_createImageMaterial(
-    Pointer<TEngine> tEngine,
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
   );
-  external Pointer<TMaterial> _Material_createGridMaterial(
-    Pointer<TEngine> tEngine,
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
   );
-  external Pointer<TMaterial> _Material_createGizmoMaterial(
-    Pointer<TEngine> tEngine,
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
+    Pointer<TSurfaceOrientationBuilder> builder,
   );
-  external Pointer<TMaterial> _Material_createSilhouetteMaterial(
-    Pointer<TEngine> tEngine,
+  external void _SurfaceOrientationBuilder_destroy(
+    Pointer<TSurfaceOrientationBuilder> builder,
   );
-  external Pointer<TMaterial> _Material_createEdgeOutlineMaterial(
-    Pointer<TEngine> tEngine,
+  external size_t _SurfaceOrientation_getVertexCount(
+    Pointer<TSurfaceOrientation> orientation,
   );
-  external Pointer<TMaterial> _Material_createWireframeMaterial(
-    Pointer<TEngine> tEngine,
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Float32> out,
+    size_t quatCount,
+    size_t stride,
   );
-  external Pointer<TMaterial> _Material_createTranslationAxisMaterial(
-    Pointer<TEngine> tEngine,
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
   );
-  external Pointer<TMaterial> _Material_createBoneOverlayMaterial(
-    Pointer<TEngine> tEngine,
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
   );
-  external int _Material_hasParameter(
-    Pointer<TMaterial> tMaterial,
-    Pointer<Char> propertyName,
+  external void _SurfaceOrientation_destroy(
+    Pointer<TSurfaceOrientation> orientation,
   );
-  external int _MaterialInstance_isStencilWriteEnabled(
-    Pointer<TMaterialInstance> materialInstance,
+  external void _IndirectLight_setRotation(
+    Pointer<TIndirectLight> tIndirectLight,
+    Pointer<Float64> rotation,
   );
-  external void _MaterialInstance_setStencilWrite(
-    Pointer<TMaterialInstance> materialInstance,
-    bool enabled,
-  );
-  external void _MaterialInstance_setCullingMode(
-    Pointer<TMaterialInstance> materialInstance,
-    int culling,
-  );
-  external void _MaterialInstance_setDoubleSided(
-    Pointer<TMaterialInstance> materialInstance,
-    bool doubleSided,
-  );
-  external void _MaterialInstance_setDepthWrite(
-    Pointer<TMaterialInstance> materialInstance,
-    bool enabled,
-  );
-  external void _MaterialInstance_setDepthCulling(
-    Pointer<TMaterialInstance> materialInstance,
-    bool enabled,
-  );
-  external void _MaterialInstance_setParameterFloat(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    double value,
-  );
-  external void _MaterialInstance_setParameterFloat2(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    double x,
-    double y,
-  );
-  external void _MaterialInstance_setParameterFloat3(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    double x,
-    double y,
-    double z,
-  );
-  external void _MaterialInstance_setParameterFloat3Array(
-    Pointer<TMaterialInstance> tMaterialInstance,
-    Pointer<Char> propertyName,
-    Pointer<Float64> raw,
-    int length,
-  );
-  external void _MaterialInstance_setParameterFloat4(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    double x,
-    double y,
-    double w,
-    double z,
-  );
-  external void _MaterialInstance_setParameterMat3(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    Pointer<Float64> matrix,
-  );
-  external void _MaterialInstance_setParameterMat4(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    Pointer<Float64> matrix,
-  );
-  external void _MaterialInstance_setParameterInt(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    int value,
-  );
-  external void _MaterialInstance_setParameterBool(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    bool value,
-  );
-  external void _MaterialInstance_setParameterTexture(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    Pointer<TTexture> texture,
-    Pointer<TTextureSampler> sampler,
-  );
-  external void _MaterialInstance_setDepthFunc(
-    Pointer<TMaterialInstance> materialInstance,
-    int depthFunc,
-  );
-  external void _MaterialInstance_setStencilOpStencilFail(
-    Pointer<TMaterialInstance> materialInstance,
-    int op,
-    int face,
-  );
-  external void _MaterialInstance_setStencilOpDepthFail(
-    Pointer<TMaterialInstance> materialInstance,
-    int op,
-    int face,
-  );
-  external void _MaterialInstance_setStencilOpDepthStencilPass(
-    Pointer<TMaterialInstance> materialInstance,
-    int op,
-    int face,
-  );
-  external void _MaterialInstance_setStencilCompareFunction(
-    Pointer<TMaterialInstance> materialInstance,
-    int func,
-    int face,
-  );
-  external void _MaterialInstance_setStencilReferenceValue(
-    Pointer<TMaterialInstance> materialInstance,
-    int value,
-    int face,
-  );
-  external void _MaterialInstance_setStencilReadMask(
-    Pointer<TMaterialInstance> materialInstance,
-    int mask,
-  );
-  external void _MaterialInstance_setStencilWriteMask(
-    Pointer<TMaterialInstance> materialInstance,
-    int mask,
-  );
-  external void _MaterialInstance_setTransparencyMode(
-    Pointer<TMaterialInstance> materialInstance,
-    int transparencyMode,
-  );
-  external int _MaterialInstance_getTransparencyMode(
-    Pointer<TMaterialInstance> materialInstance,
-  );
-  external int _Material_getBlendingMode(Pointer<TMaterial> material);
   external Pointer<TTexture> _Texture_build(
     Pointer<TEngine> engine,
     int width,
@@ -911,6 +890,407 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int func,
   );
   external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
+  external Pointer<TRenderManager> _RenderManager_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderer> tRenderer,
+  );
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_render(
+    Pointer<TRenderManager> tRenderer,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
+  );
+  external void _RenderManager_removeSwapChain(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+  );
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_attachToRenderThread(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_detachFromRenderThread(
+    Pointer<TRenderManager> tRenderManager,
+  );
+  external void _RenderManager_setPaused(
+    Pointer<TRenderManager> tRenderer,
+    bool paused,
+  );
+  external void _FrameScheduler_start(FrameCallback callback, int targetFps);
+  external void _FrameScheduler_stop();
+  external void _FrameScheduler_setRenderThread(Pointer<Void> renderThread);
+  external void _FrameScheduler_setRenderManager(Pointer<TRenderManager> rm);
+  external void _FrameScheduler_setPostRenderCallback(
+    PostRenderCallback callback,
+    Pointer<Void> userData,
+  );
+  external int _FrameScheduler_requestRender(JSBigInt frameTimeNanos);
+  external void _FrameScheduler_startNativeRenderLoop(int targetFps);
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Gizmo_dummy(int t);
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+  );
+  external void _Gizmo_pick(
+    Pointer<TGizmo> tGizmo,
+    int x,
+    int y,
+    GizmoPickCallback callback,
+  );
+  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
+  external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
+    Pointer<TMaterialProvider> provider,
+    bool doubleSided,
+    bool unlit,
+    bool hasVertexColors,
+    bool hasBaseColorTexture,
+    bool hasNormalTexture,
+    bool hasOcclusionTexture,
+    bool hasEmissiveTexture,
+    bool useSpecularGlossiness,
+    int alphaMode,
+    bool enableDiagnostics,
+    bool hasMetallicRoughnessTexture,
+    int metallicRoughnessUV,
+    bool hasSpecularGlossinessTexture,
+    int specularGlossinessUV,
+    int baseColorUV,
+    bool hasClearCoatTexture,
+    int clearCoatUV,
+    bool hasClearCoatRoughnessTexture,
+    int clearCoatRoughnessUV,
+    bool hasClearCoatNormalTexture,
+    int clearCoatNormalUV,
+    bool hasClearCoat,
+    bool hasTransmission,
+    bool hasTextureTransforms,
+    int emissiveUV,
+    int aoUV,
+    int normalUV,
+    bool hasTransmissionTexture,
+    int transmissionUV,
+    bool hasSheenColorTexture,
+    int sheenColorUV,
+    bool hasSheenRoughnessTexture,
+    int sheenRoughnessUV,
+    bool hasVolumeThicknessTexture,
+    int volumeThicknessUV,
+    bool hasSheen,
+    bool hasIOR,
+    bool hasVolume,
+  );
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(
+    Pointer<TIndexBufferBuilder> builder,
+    int count,
+  );
+  external void _IndexBufferBuilder_bufferType(
+    Pointer<TIndexBufferBuilder> builder,
+    int indexType,
+  );
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _IndexBufferBuilder_destroy(
+    Pointer<TIndexBufferBuilder> builder,
+  );
+  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _IndexBuffer_destroy(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+  );
+  external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
+  external void _VertexBufferBuilder_bufferCount(
+    Pointer<TVertexBufferBuilder> builder,
+    int count,
+  );
+  external void _VertexBufferBuilder_vertexCount(
+    Pointer<TVertexBufferBuilder> builder,
+    int count,
+  );
+  external void _VertexBufferBuilder_attribute(
+    Pointer<TVertexBufferBuilder> builder,
+    int attribute,
+    int bufferIndex,
+    int attributeType,
+    int byteOffset,
+    int byteStride,
+  );
+  external void _VertexBufferBuilder_normalized(
+    Pointer<TVertexBufferBuilder> builder,
+    int attribute,
+    bool normalize,
+  );
+  external Pointer<TVertexBuffer> _VertexBufferBuilder_build(
+    Pointer<TVertexBufferBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _VertexBufferBuilder_destroy(
+    Pointer<TVertexBufferBuilder> builder,
+  );
+  external size_t _VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer);
+  external void _VertexBuffer_setBufferAt(
+    Pointer<TEngine> engine,
+    Pointer<TVertexBuffer> buffer,
+    int bufferIndex,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _VertexBuffer_destroy(
+    Pointer<TEngine> engine,
+    Pointer<TVertexBuffer> buffer,
+  );
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
+  );
+  external void _RenderTarget_destroy(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderTarget> tRenderTarget,
+  );
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_setSkybox(
+    Pointer<TScene> tScene,
+    Pointer<TSkybox> skybox,
+  );
+  external void _Scene_setIndirectLight(
+    Pointer<TScene> tScene,
+    Pointer<TIndirectLight> tIndirectLight,
+  );
+  external void _Scene_addFilamentAsset(
+    Pointer<TScene> tScene,
+    Pointer<TFilamentAsset> asset,
+  );
+  external void _Camera_setExposure(
+    Pointer<TCamera> camera,
+    double aperture,
+    double shutterSpeed,
+    double sensitivity,
+  );
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external void _Camera_getModelMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getViewMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getCullingProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
+  );
+  external void _Camera_getFrustum(
+    Pointer<TCamera> camera,
+    Pointer<Float64> out,
+  );
+  external void _Camera_setProjectionMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> matrix,
+    double near,
+    double far,
+  );
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
+  );
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external void _Camera_setFocusDistance(
+    Pointer<TCamera> camera,
+    double focusDistance,
+  );
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> tModelMatrix,
+  );
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
+  external void _TransformManager_getLocalTransform(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external void _TransformManager_getWorldTransform(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external void _TransformManager_setTransform(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<double4x4> transformPtr,
+  );
+  external int _TransformManager_transformToUnitCube(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external void _TransformManager_setParent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId child,
+    EntityId parent,
+    bool preserveScaling,
+  );
+  external EntityId _TransformManager_getParent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId child,
+  );
+  external EntityId _TransformManager_getAncestor(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId childEntityId,
+  );
+  external void _TransformManager_createComponent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entity,
+  );
+  external void _TransformManager_removeComponent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entity,
+  );
+  external int _TransformManager_hasComponent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external int _TransformManager_empty(
+    Pointer<TTransformManager> tTransformManager,
+  );
+  external int _TransformManager_getComponentCount(
+    Pointer<TTransformManager> tTransformManager,
+  );
+  external int _TransformManager_getChildCount(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external void _TransformManager_getChildren(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<Int32> children,
+    int count,
+  );
+  external void _TransformManager_openLocalTransformTransaction(
+    Pointer<TTransformManager> tTransformManager,
+  );
+  external void _TransformManager_commitLocalTransformTransaction(
+    Pointer<TTransformManager> tTransformManager,
+  );
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
+  external void _Renderer_render(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+  );
+  external void _Renderer_renderStandaloneView(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+  );
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
   external Pointer<TEngine> _Engine_create(
     int backend,
     Pointer<Void> platform,
@@ -1085,159 +1465,11 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<Char> name,
     Pointer<Float32> outValue,
   );
-  external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
-    Pointer<TMaterialProvider> provider,
-    bool doubleSided,
-    bool unlit,
-    bool hasVertexColors,
-    bool hasBaseColorTexture,
-    bool hasNormalTexture,
-    bool hasOcclusionTexture,
-    bool hasEmissiveTexture,
-    bool useSpecularGlossiness,
-    int alphaMode,
-    bool enableDiagnostics,
-    bool hasMetallicRoughnessTexture,
-    int metallicRoughnessUV,
-    bool hasSpecularGlossinessTexture,
-    int specularGlossinessUV,
-    int baseColorUV,
-    bool hasClearCoatTexture,
-    int clearCoatUV,
-    bool hasClearCoatRoughnessTexture,
-    int clearCoatRoughnessUV,
-    bool hasClearCoatNormalTexture,
-    int clearCoatNormalUV,
-    bool hasClearCoat,
-    bool hasTransmission,
-    bool hasTextureTransforms,
-    int emissiveUV,
-    int aoUV,
-    int normalUV,
-    bool hasTransmissionTexture,
-    int transmissionUV,
-    bool hasSheenColorTexture,
-    int sheenColorUV,
-    bool hasSheenRoughnessTexture,
-    int sheenRoughnessUV,
-    bool hasVolumeThicknessTexture,
-    int volumeThicknessUV,
-    bool hasSheen,
-    bool hasIOR,
-    bool hasVolume,
-  );
-  external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
-  external void _VertexBufferBuilder_bufferCount(
-    Pointer<TVertexBufferBuilder> builder,
-    int count,
-  );
-  external void _VertexBufferBuilder_vertexCount(
-    Pointer<TVertexBufferBuilder> builder,
-    int count,
-  );
-  external void _VertexBufferBuilder_attribute(
-    Pointer<TVertexBufferBuilder> builder,
-    int attribute,
-    int bufferIndex,
-    int attributeType,
-    int byteOffset,
-    int byteStride,
-  );
-  external void _VertexBufferBuilder_normalized(
-    Pointer<TVertexBufferBuilder> builder,
-    int attribute,
-    bool normalize,
-  );
-  external Pointer<TVertexBuffer> _VertexBufferBuilder_build(
-    Pointer<TVertexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _VertexBufferBuilder_destroy(
-    Pointer<TVertexBufferBuilder> builder,
-  );
-  external size_t _VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer);
-  external void _VertexBuffer_setBufferAt(
-    Pointer<TEngine> engine,
-    Pointer<TVertexBuffer> buffer,
-    int bufferIndex,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _VertexBuffer_destroy(
-    Pointer<TEngine> engine,
-    Pointer<TVertexBuffer> buffer,
-  );
-  external void _TransformManager_getLocalTransform(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external void _TransformManager_getWorldTransform(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external void _TransformManager_setTransform(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<double4x4> transformPtr,
-  );
-  external int _TransformManager_transformToUnitCube(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<Aabb3> boundingBoxPtr,
-  );
-  external void _TransformManager_setParent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId child,
-    EntityId parent,
-    bool preserveScaling,
-  );
-  external EntityId _TransformManager_getParent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId child,
-  );
-  external EntityId _TransformManager_getAncestor(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId childEntityId,
-  );
-  external void _TransformManager_createComponent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entity,
-  );
-  external void _TransformManager_removeComponent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entity,
-  );
-  external int _TransformManager_hasComponent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external int _TransformManager_empty(
-    Pointer<TTransformManager> tTransformManager,
-  );
-  external int _TransformManager_getComponentCount(
-    Pointer<TTransformManager> tTransformManager,
-  );
-  external int _TransformManager_getChildCount(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external void _TransformManager_getChildren(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<Int32> children,
-    int count,
-  );
-  external void _TransformManager_openLocalTransformTransaction(
-    Pointer<TTransformManager> tTransformManager,
-  );
-  external void _TransformManager_commitLocalTransformTransaction(
-    Pointer<TTransformManager> tTransformManager,
-  );
   external Pointer<Void> _RenderThread_create();
-  external void _RenderThread_destroy();
+  external Pointer<Void> _RenderThread_createForCanvas(
+    Pointer<Char> canvasSelector,
+  );
+  external void _RenderThread_destroy(Pointer<Void> renderThread);
   external void _RenderThread_addTask(
     Pointer<NativeFunction<void Function()>> task,
   );
@@ -2282,6 +2514,40 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(
+    Pointer<TEngine> tEngine,
+  );
+  external void _GltfResourceLoader_destroy(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  );
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external void _GltfResourceLoader_asyncUpdateLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  );
+  external double _GltfResourceLoader_asyncGetLoadProgress(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  );
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
+  );
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external void _Skybox_setColor(
+    Pointer<TSkybox> tSkybox,
+    double r,
+    double g,
+    double b,
+    double a,
+  );
   external void _dummy(Pointer<TGltfMeshData> dummyPtr);
   external int _GltfParser_parseBuffer(
     Pointer<Uint8> data,
@@ -2290,212 +2556,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TGltfMeshData> outMeshData,
   );
   external void _GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData);
-  external int _LightManager_createLight(
-    Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
-  );
-  external void _LightManager_destroyLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_hasComponent(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_getType(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isDirectional(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isPointLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isSpotLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double r,
-    double g,
-    double b,
-  );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double falloff,
-  );
-  external double _LightManager_getFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external double _LightManager_getSpotLightInnerCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloSize,
-  );
-  external double _LightManager_getSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    bool enabled,
-  );
-  external int _LightManager_isShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-  );
-  external void _LightManager_computeUniformSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-  );
-  external void _LightManager_computeLogSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-  );
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(
-    double r,
-    double g,
-    double b,
-  );
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(
-    Pointer<TScene> tScene,
-    Pointer<TSkybox> skybox,
-  );
-  external void _Scene_setIndirectLight(
-    Pointer<TScene> tScene,
-    Pointer<TIndirectLight> tIndirectLight,
-  );
-  external void _Scene_addFilamentAsset(
-    Pointer<TScene> tScene,
-    Pointer<TFilamentAsset> asset,
-  );
   external void _RenderableManager_destroyEntity(
     Pointer<TRenderableManager> tRenderableManager,
     EntityId entityId,
@@ -2772,51 +2832,102 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TEngine> engine,
     EntityId entity,
   );
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
     Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    Pointer<Aabb3> boundingBoxPtr,
   );
-  external void _GltfResourceLoader_destroy(
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
     Pointer<TEngine> tEngine,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  );
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external void _GltfResourceLoader_asyncUpdateLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  );
-  external double _GltfResourceLoader_asyncGetLoadProgress(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  );
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
-  );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external void _Gizmo_dummy(int t);
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TGltfAssetLoader> tAssetLoader,
     Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    bool rebuildVertices,
   );
-  external void _Gizmo_pick(
-    Pointer<TGizmo> tGizmo,
-    int x,
-    int y,
-    GizmoPickCallback callback,
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
-  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_addToScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external void _SceneAsset_removeFromScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getChildEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_getChildEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<Int32> out,
+  );
+  external Pointer<Int32> _SceneAsset_getCameraEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getCameraEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<Int32> _SceneAsset_getLightEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getLightEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+  );
+  external size_t _SceneAsset_getInstanceCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+  );
+  external void _SceneAsset_getBoundingBox(
+    Pointer<Aabb3> Aabb3_out,
+    Pointer<TSceneAsset> asset,
+  );
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external int _SceneAsset_getPrimitiveOffsetForEntity(
+    Pointer<TSceneAsset> tSceneAsset,
+    EntityId entity,
+  );
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_setFlatShading(
+    Pointer<TSceneAsset> tSceneAsset,
+    bool flatShading,
+  );
+  external void _SceneAsset_getBones(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    Pointer<Int32> out,
+  );
+  external size_t _SceneAsset_getBoneCount(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+  );
+  external Pointer<Char> _SceneAsset_getBoneName(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    size_t boneIndex,
+  );
   external Pointer<TAnimationManager> _AnimationManager_create(
     Pointer<TEngine> tEngine,
   );
@@ -2954,112 +3065,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int animationIndex,
     double timeInSeconds,
   );
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
-  );
-  external void _RenderTarget_destroy(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderTarget> tRenderTarget,
-  );
-  external void _IndirectLight_setRotation(
-    Pointer<TIndirectLight> tIndirectLight,
-    Pointer<Float64> rotation,
-  );
-  external Pointer<TRenderManager> _RenderManager_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderer> tRenderer,
-  );
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_render(
-    Pointer<TRenderManager> tRenderer,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
-  );
-  external void _RenderManager_removeSwapChain(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-  );
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(
-    Pointer<TRenderManager> tRenderer,
-  );
-  external void _RenderManager_detachFromRenderThread();
-  external void _RenderManager_setPaused(
-    Pointer<TRenderManager> tRenderer,
-    bool paused,
-  );
-  external void _FrameScheduler_start(FrameCallback callback, int targetFps);
-  external void _FrameScheduler_stop();
-  external void _FrameScheduler_setRenderThread(Pointer<Void> renderThread);
-  external void _FrameScheduler_setRenderManager(Pointer<TRenderManager> rm);
-  external void _FrameScheduler_setPostRenderCallback(
-    PostRenderCallback callback,
-    Pointer<Void> userData,
-  );
-  external int _FrameScheduler_requestRender(JSBigInt frameTimeNanos);
-  external void _FrameScheduler_startNativeRenderLoop(int targetFps);
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
-  external void _Renderer_render(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-  );
-  external void _Renderer_renderStandaloneView(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-  );
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
   external void _MovementIntentExecutor_destroy(
     Pointer<TMovementIntentExecutor> executor,
   );
@@ -3132,8 +3137,10 @@ void Thermion_destroyCanvas() {
   return result;
 }
 
-int Thermion_createGLContext() {
-  final result = GeneratedBindings.instance._Thermion_createGLContext();
+int Thermion_createGLContext(Pointer<Char> canvasSelector) {
+  final result = GeneratedBindings.instance._Thermion_createGLContext(
+    canvasSelector,
+  );
   return result;
 }
 
@@ -3174,512 +3181,965 @@ BigInt get TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER {
   return bigIntasUintN(64, value).toDart;
 }
 
-void Camera_setExposure(
-  Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
+Pointer<TMaterialInstance> Material_createInstance(
+  Pointer<TMaterial> tMaterial,
 ) {
-  final result = GeneratedBindings.instance._Camera_setExposure(
-    camera.cast(),
-    aperture,
-    shutterSpeed,
-    sensitivity,
+  final result = GeneratedBindings.instance._Material_createInstance(
+    tMaterial.cast(),
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+int Material_getFeatureLevel(Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Material_getFeatureLevel(
+    tMaterial.cast(),
   );
   return result;
 }
 
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(
-    camera.cast(),
+Pointer<TMaterial> Material_createImageMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createImageMaterial(
+    tEngine.cast(),
   );
-  return result;
+  return Pointer<TMaterial>(result);
 }
 
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(
-    camera.cast(),
+Pointer<TMaterial> Material_createGridMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createGridMaterial(
+    tEngine.cast(),
   );
-  return result;
+  return Pointer<TMaterial>(result);
 }
 
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
+Pointer<TMaterial> Material_createGizmoMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createGizmoMaterial(
+    tEngine.cast(),
   );
-  return double4x4_out.toDart();
+  return Pointer<TMaterial>(result);
 }
 
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
+Pointer<TMaterial> Material_createSilhouetteMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createSilhouetteMaterial(
+    tEngine.cast(),
   );
-  return double4x4_out.toDart();
+  return Pointer<TMaterial>(result);
 }
 
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(
-    camera.cast(),
-    out,
-  );
-  return result;
-}
-
-void Camera_setProjectionMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> matrix,
-  double near,
-  double far,
+Pointer<TMaterial> Material_createEdgeOutlineMaterial(
+  Pointer<TEngine> tEngine,
 ) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(
-    camera.cast(),
-    matrix,
-    near,
-    far,
+  final result = GeneratedBindings.instance._Material_createEdgeOutlineMaterial(
+    tEngine.cast(),
   );
-  return result;
+  return Pointer<TMaterial>(result);
 }
 
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
+Pointer<TMaterial> Material_createWireframeMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createWireframeMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createTranslationAxisMaterial(
+  Pointer<TEngine> tEngine,
 ) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(
-    camera.cast(),
-  );
-  return result;
-}
-
-void Camera_lookAt(
-  Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(
-    camera.cast(),
-    eyePtr.cast(),
-    focusPtr.cast(),
-    upPtr.cast(),
-  );
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(
-    camera.cast(),
-  );
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(
-    camera.cast(),
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(
-    camera.cast(),
-  );
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(
-    camera.cast(),
-    focusDistance,
-  );
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
   final result = GeneratedBindings.instance
-      ._Camera_setCustomProjectionWithCulling(
-        camera.cast(),
-        projectionMatrixPtr.cast(),
-        near,
-        far,
+      ._Material_createTranslationAxisMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createBoneOverlayMaterial(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Material_createBoneOverlayMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+bool Material_hasParameter(
+  Pointer<TMaterial> tMaterial,
+  Pointer<Char> propertyName,
+) {
+  final result = GeneratedBindings.instance._Material_hasParameter(
+    tMaterial.cast(),
+    propertyName,
+  );
+  return result == 1;
+}
+
+bool MaterialInstance_isStencilWriteEnabled(
+  Pointer<TMaterialInstance> materialInstance,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_isStencilWriteEnabled(materialInstance.cast());
+  return result == 1;
+}
+
+void MaterialInstance_setStencilWrite(
+  Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setStencilWrite(
+    materialInstance.cast(),
+    enabled,
+  );
+  return result;
+}
+
+void MaterialInstance_setCullingMode(
+  Pointer<TMaterialInstance> materialInstance,
+  int culling,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setCullingMode(
+    materialInstance.cast(),
+    culling,
+  );
+  return result;
+}
+
+void MaterialInstance_setDoubleSided(
+  Pointer<TMaterialInstance> materialInstance,
+  bool doubleSided,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDoubleSided(
+    materialInstance.cast(),
+    doubleSided,
+  );
+  return result;
+}
+
+void MaterialInstance_setDepthWrite(
+  Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDepthWrite(
+    materialInstance.cast(),
+    enabled,
+  );
+  return result;
+}
+
+void MaterialInstance_setDepthCulling(
+  Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDepthCulling(
+    materialInstance.cast(),
+    enabled,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterFloat(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  double value,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterFloat(
+    materialInstance.cast(),
+    propertyName,
+    value,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterFloat2(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  double x,
+  double y,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterFloat2(
+        materialInstance.cast(),
+        propertyName,
+        x,
+        y,
       );
   return result;
 }
 
-void Camera_setModelMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> tModelMatrix,
-) {
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(
-    camera.cast(),
-    tModelMatrix,
-  );
-  return result;
-}
-
-void Camera_setLensProjection(
-  Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(
-    camera.cast(),
-    near,
-    far,
-    aspect,
-    focalLength,
-  );
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tVertexBuffer,
-  Pointer<TIndexBuffer> tIndexBuffer,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
-) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
-    tEngine.cast(),
-    tVertexBuffer.cast(),
-    tIndexBuffer.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-    tPrimitiveType,
-    boundingBoxPtr.cast(),
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    tNameComponentManager.cast(),
-    tFilamentAsset.cast(),
-    rebuildVertices,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(
-    tSceneAsset.cast(),
-  );
-  return Pointer<TFilamentAsset>(result);
-}
-
-int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getType(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_destroy(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_addToScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_addToScene(
-    tSceneAsset.cast(),
-    tScene.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_removeFromScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(
-    tSceneAsset.cast(),
-    tScene.cast(),
-  );
-  return result;
-}
-
-DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getEntity(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_getChildEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(
-    tSceneAsset.cast(),
-    out,
-  );
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(
-    tSceneAsset.cast(),
-  );
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(
-    tSceneAsset.cast(),
-  );
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_getInstance(
-  Pointer<TSceneAsset> tSceneAsset,
-  int index,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstance(
-    tSceneAsset.cast(),
-    index,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_createInstance(
-  Pointer<TSceneAsset> asset,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createInstance(
-    asset.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(
-    Aabb3_out.cast(),
-    asset.cast(),
-  );
-  return Aabb3_out.toDart();
-}
-
-Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(
-    tSceneAsset.cast(),
-    primitiveIndex,
-  );
-  return Pointer<TVertexBuffer>(result);
-}
-
-Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(
-    tSceneAsset.cast(),
-    primitiveIndex,
-  );
-  return Pointer<TIndexBuffer>(result);
-}
-
-int SceneAsset_getPrimitiveOffsetForEntity(
-  Pointer<TSceneAsset> tSceneAsset,
-  DartEntityId entity,
+void MaterialInstance_setParameterFloat3(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  double x,
+  double y,
+  double z,
 ) {
   final result = GeneratedBindings.instance
-      ._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
+      ._MaterialInstance_setParameterFloat3(
+        materialInstance.cast(),
+        propertyName,
+        x,
+        y,
+        z,
+      );
   return result;
 }
 
-void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_setFlatShading(
-  Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
+void MaterialInstance_setParameterFloat3Array(
+  Pointer<TMaterialInstance> tMaterialInstance,
+  Pointer<Char> propertyName,
+  Pointer<Float64> raw,
+  int length,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(
-    tSceneAsset.cast(),
-    flatShading,
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterFloat3Array(
+        tMaterialInstance.cast(),
+        propertyName,
+        raw,
+        length,
+      );
+  return result;
+}
+
+void MaterialInstance_setParameterFloat4(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  double x,
+  double y,
+  double w,
+  double z,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterFloat4(
+        materialInstance.cast(),
+        propertyName,
+        x,
+        y,
+        w,
+        z,
+      );
+  return result;
+}
+
+void MaterialInstance_setParameterMat3(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  Pointer<Float64> matrix,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterMat3(
+    materialInstance.cast(),
+    propertyName,
+    matrix,
   );
   return result;
 }
 
-void SceneAsset_getBones(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
+void MaterialInstance_setParameterMat4(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  Pointer<Float64> matrix,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterMat4(
+    materialInstance.cast(),
+    propertyName,
+    matrix,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterInt(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  int value,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterInt(
+    materialInstance.cast(),
+    propertyName,
+    value,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterBool(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  bool value,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterBool(
+    materialInstance.cast(),
+    propertyName,
+    value,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterTexture(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  Pointer<TTexture> texture,
+  Pointer<TTextureSampler> sampler,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterTexture(
+        materialInstance.cast(),
+        propertyName,
+        texture.cast(),
+        sampler.cast(),
+      );
+  return result;
+}
+
+void MaterialInstance_setDepthFunc(
+  Pointer<TMaterialInstance> materialInstance,
+  int depthFunc,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDepthFunc(
+    materialInstance.cast(),
+    depthFunc,
+  );
+  return result;
+}
+
+void MaterialInstance_setStencilOpStencilFail(
+  Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilOpStencilFail(
+        materialInstance.cast(),
+        op,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilOpDepthFail(
+  Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilOpDepthFail(
+        materialInstance.cast(),
+        op,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilOpDepthStencilPass(
+  Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilOpDepthStencilPass(
+        materialInstance.cast(),
+        op,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilCompareFunction(
+  Pointer<TMaterialInstance> materialInstance,
+  int func,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilCompareFunction(
+        materialInstance.cast(),
+        func,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilReferenceValue(
+  Pointer<TMaterialInstance> materialInstance,
+  int value,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilReferenceValue(
+        materialInstance.cast(),
+        value,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilReadMask(
+  Pointer<TMaterialInstance> materialInstance,
+  int mask,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilReadMask(materialInstance.cast(), mask);
+  return result;
+}
+
+void MaterialInstance_setStencilWriteMask(
+  Pointer<TMaterialInstance> materialInstance,
+  int mask,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilWriteMask(materialInstance.cast(), mask);
+  return result;
+}
+
+void MaterialInstance_setTransparencyMode(
+  Pointer<TMaterialInstance> materialInstance,
+  int transparencyMode,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setTransparencyMode(
+        materialInstance.cast(),
+        transparencyMode,
+      );
+  return result;
+}
+
+int MaterialInstance_getTransparencyMode(
+  Pointer<TMaterialInstance> materialInstance,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_getTransparencyMode(materialInstance.cast());
+  return result;
+}
+
+int Material_getBlendingMode(Pointer<TMaterial> material) {
+  final result = GeneratedBindings.instance._Material_getBlendingMode(
+    material.cast(),
+  );
+  return result;
+}
+
+int LightManager_createLight(
+  Pointer<TEngine> tEngine,
+  Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
+    tEngine.cast(),
+    tLightManager.cast(),
+    tLightTtype,
+  );
+  return result;
+}
+
+void LightManager_destroyLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+bool LightManager_hasComponent(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+int LightManager_getType(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getType(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+bool LightManager_isDirectional(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+bool LightManager_isPointLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+void LightManager_setPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(
+    tLightManager.cast(),
+    light,
+    x,
+    y,
+    z,
+  );
+  return result;
+}
+
+double3 LightManager_getPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(
+    double3_out.cast(),
+    tLightManager.cast(),
+    light,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(
+    tLightManager.cast(),
+    light,
+    x,
+    y,
+    z,
+  );
+  return result;
+}
+
+double3 LightManager_getDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(
+    double3_out.cast(),
+    tLightManager.cast(),
+    light,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double r,
+  double g,
+  double b,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColor(
+    tLightManager.cast(),
+    entity,
+    r,
+    g,
+    b,
+  );
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+double3 LightManager_getColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(
+    double3_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(
+    tLightManager.cast(),
+    entity,
+    intensity,
+  );
+  return result;
+}
+
+void LightManager_setIntensityCandela(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
+    tLightManager.cast(),
+    entity,
+    intensity,
+  );
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+double LightManager_getIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double falloff,
+) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(
+    tLightManager.cast(),
+    entity,
+    falloff,
+  );
+  return result;
+}
+
+double LightManager_getFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
+    tLightManager.cast(),
+    entity,
+    inner,
+    outer,
+  );
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double angularRadius,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+double LightManager_getSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloSize,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(
+    tLightManager.cast(),
+    entity,
+    haloSize,
+  );
+  return result;
+}
+
+double LightManager_getSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloFalloff,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
+    tLightManager.cast(),
+    entity,
+    haloFalloff,
+  );
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(
+    tLightManager.cast(),
+    entity,
+    enabled,
+  );
+  return result;
+}
+
+bool LightManager_isShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  TShadowOptions options,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool LightManager_getLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+  );
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(
+    splitPositions,
+    cascades,
+  );
+  return result;
+}
+
+void LightManager_computeLogSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+  );
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_computePracticalSplits(
+        splitPositions,
+        cascades,
+        near,
+        far,
+        lambda,
+      );
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(
+    r,
+    g,
+    b,
+  );
+  return result;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(
+    filamentAsset.cast(),
+  );
+  return result;
+}
+
+void FilamentAsset_getEntities(
+  Pointer<TFilamentAsset> filamentAsset,
   Pointer<Int32> out,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_getBones(
-    tSceneAsset.cast(),
-    skinIndex,
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(
+    filamentAsset.cast(),
     out,
   );
   return result;
 }
 
-Dartsize_t SceneAsset_getBoneCount(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(
-    tSceneAsset.cast(),
-    skinIndex,
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(
+    filamentAsset.cast(),
   );
   return result;
 }
 
-Pointer<Char> SceneAsset_getBoneName(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dartsize_t skinIndex,
-  Dartsize_t boneIndex,
+Pointer<Void> FilamentAsset_getSourceAsset(
+  Pointer<TFilamentAsset> filamentAsset,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneName(
-    tSceneAsset.cast(),
-    skinIndex,
-    boneIndex,
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(
+    filamentAsset.cast(),
   );
-  return Pointer<Char>(result);
+  return Pointer<Void>(result);
 }
 
 Pointer<TGltfAssetLoader> GltfAssetLoader_create(
@@ -3706,7 +4166,7 @@ Pointer<TFilamentAsset> GltfAssetLoader_load(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int numInstances,
 ) {
   final result = GeneratedBindings.instance._GltfAssetLoader_load(
@@ -3753,234 +4213,6 @@ Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(
     tFilamentAsset.cast(),
   );
   return Pointer<PointerClass<Char>>(result);
-}
-
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(
-  Pointer<TNameComponentManager> tNameComponentManager,
-) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(
-    tNameComponentManager.cast(),
-  );
-  return result;
-}
-
-Pointer<Char> NameComponentManager_getName(
-  Pointer<TNameComponentManager> tNameComponentManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(
-    tNameComponentManager.cast(),
-    entity,
-  );
-  return Pointer<Char>(result);
-}
-
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(
-    builder.cast(),
-    normals,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(
-    builder.cast(),
-    tangents,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(
-    builder.cast(),
-    uvs,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint32> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(
-    builder.cast(),
-  );
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(
-    builder.cast(),
-  );
-  return result;
-}
-
-Dartsize_t SurfaceOrientation_getVertexCount(
-  Pointer<TSurfaceOrientation> orientation,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(
-    orientation.cast(),
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(
-    orientation.cast(),
-  );
-  return result;
-}
-
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(
-    filamentAsset.cast(),
-  );
-  return result;
-}
-
-void FilamentAsset_getEntities(
-  Pointer<TFilamentAsset> filamentAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(
-    filamentAsset.cast(),
-    out,
-  );
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(
-    filamentAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(
-    filamentAsset.cast(),
-  );
-  return Pointer<Void>(result);
 }
 
 TViewport View_getViewport(Pointer<TView> view) {
@@ -4686,527 +4918,207 @@ Pointer<Char> View_getName(Pointer<TView> tView) {
   return Pointer<Char>(result);
 }
 
-void Skybox_setColor(
-  Pointer<TSkybox> tSkybox,
-  double r,
-  double g,
-  double b,
-  double a,
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(
+  Pointer<TNameComponentManager> tNameComponentManager,
 ) {
-  final result = GeneratedBindings.instance._Skybox_setColor(
-    tSkybox.cast(),
-    r,
-    g,
-    b,
-    a,
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(
+    tNameComponentManager.cast(),
   );
   return result;
 }
 
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
+Pointer<Char> NameComponentManager_getName(
+  Pointer<TNameComponentManager> tNameComponentManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(
+    tNameComponentManager.cast(),
+    entity,
+  );
+  return Pointer<Char>(result);
 }
 
-void IndexBufferBuilder_indexCount(
-  Pointer<TIndexBufferBuilder> builder,
-  int count,
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dart__darwin_size_t count,
 ) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(
     builder.cast(),
-    count,
+    normals,
+    stride,
   );
   return result;
 }
 
-void IndexBufferBuilder_bufferType(
-  Pointer<TIndexBufferBuilder> builder,
-  int indexType,
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dart__darwin_size_t stride,
 ) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(
     builder.cast(),
-    indexType,
+    tangents,
+    stride,
   );
   return result;
 }
 
-Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  Pointer<TIndexBufferBuilder> builder,
-  Pointer<TEngine> engine,
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dart__darwin_size_t stride,
 ) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_build(
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(
     builder.cast(),
-    engine.cast(),
+    uvs,
+    stride,
   );
-  return Pointer<TIndexBuffer>(result);
+  return result;
 }
 
-void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint32> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(
+    builder.cast(),
+  );
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(
     builder.cast(),
   );
   return result;
 }
 
-Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(
-    buffer.cast(),
+Dart__darwin_size_t SurfaceOrientation_getVertexCount(
+  Pointer<TSurfaceOrientation> orientation,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(
+    orientation.cast(),
   );
   return result;
 }
 
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
 ) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
   );
   return result;
 }
 
-void IndexBuffer_destroy(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
 ) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroy(
-    engine.cast(),
-    buffer.cast(),
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
   );
   return result;
 }
 
-Pointer<TMaterialInstance> Material_createInstance(
-  Pointer<TMaterial> tMaterial,
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
 ) {
-  final result = GeneratedBindings.instance._Material_createInstance(
-    tMaterial.cast(),
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-int Material_getFeatureLevel(Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Material_getFeatureLevel(
-    tMaterial.cast(),
-  );
-  return result;
-}
-
-Pointer<TMaterial> Material_createImageMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createImageMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createGridMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createGridMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createGizmoMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createGizmoMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createSilhouetteMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createSilhouetteMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createEdgeOutlineMaterial(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Material_createEdgeOutlineMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createWireframeMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createWireframeMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createTranslationAxisMaterial(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance
-      ._Material_createTranslationAxisMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createBoneOverlayMaterial(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Material_createBoneOverlayMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-bool Material_hasParameter(
-  Pointer<TMaterial> tMaterial,
-  Pointer<Char> propertyName,
-) {
-  final result = GeneratedBindings.instance._Material_hasParameter(
-    tMaterial.cast(),
-    propertyName,
-  );
-  return result == 1;
-}
-
-bool MaterialInstance_isStencilWriteEnabled(
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_isStencilWriteEnabled(materialInstance.cast());
-  return result == 1;
-}
-
-void MaterialInstance_setStencilWrite(
-  Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setStencilWrite(
-    materialInstance.cast(),
-    enabled,
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
   );
   return result;
 }
 
-void MaterialInstance_setCullingMode(
-  Pointer<TMaterialInstance> materialInstance,
-  int culling,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setCullingMode(
-    materialInstance.cast(),
-    culling,
+void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(
+    orientation.cast(),
   );
   return result;
 }
 
-void MaterialInstance_setDoubleSided(
-  Pointer<TMaterialInstance> materialInstance,
-  bool doubleSided,
+void IndirectLight_setRotation(
+  Pointer<TIndirectLight> tIndirectLight,
+  Pointer<Float64> rotation,
 ) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDoubleSided(
-    materialInstance.cast(),
-    doubleSided,
-  );
-  return result;
-}
-
-void MaterialInstance_setDepthWrite(
-  Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDepthWrite(
-    materialInstance.cast(),
-    enabled,
-  );
-  return result;
-}
-
-void MaterialInstance_setDepthCulling(
-  Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDepthCulling(
-    materialInstance.cast(),
-    enabled,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  double value,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterFloat(
-    materialInstance.cast(),
-    propertyName,
-    value,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat2(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  double x,
-  double y,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterFloat2(
-        materialInstance.cast(),
-        propertyName,
-        x,
-        y,
-      );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat3(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterFloat3(
-        materialInstance.cast(),
-        propertyName,
-        x,
-        y,
-        z,
-      );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat3Array(
-  Pointer<TMaterialInstance> tMaterialInstance,
-  Pointer<Char> propertyName,
-  Pointer<Float64> raw,
-  int length,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterFloat3Array(
-        tMaterialInstance.cast(),
-        propertyName,
-        raw,
-        length,
-      );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat4(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  double x,
-  double y,
-  double w,
-  double z,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterFloat4(
-        materialInstance.cast(),
-        propertyName,
-        x,
-        y,
-        w,
-        z,
-      );
-  return result;
-}
-
-void MaterialInstance_setParameterMat3(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  Pointer<Float64> matrix,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterMat3(
-    materialInstance.cast(),
-    propertyName,
-    matrix,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterMat4(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  Pointer<Float64> matrix,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterMat4(
-    materialInstance.cast(),
-    propertyName,
-    matrix,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterInt(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  int value,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterInt(
-    materialInstance.cast(),
-    propertyName,
-    value,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterBool(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  bool value,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterBool(
-    materialInstance.cast(),
-    propertyName,
-    value,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterTexture(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  Pointer<TTexture> texture,
-  Pointer<TTextureSampler> sampler,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterTexture(
-        materialInstance.cast(),
-        propertyName,
-        texture.cast(),
-        sampler.cast(),
-      );
-  return result;
-}
-
-void MaterialInstance_setDepthFunc(
-  Pointer<TMaterialInstance> materialInstance,
-  int depthFunc,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDepthFunc(
-    materialInstance.cast(),
-    depthFunc,
-  );
-  return result;
-}
-
-void MaterialInstance_setStencilOpStencilFail(
-  Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilOpStencilFail(
-        materialInstance.cast(),
-        op,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilOpDepthFail(
-  Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilOpDepthFail(
-        materialInstance.cast(),
-        op,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilOpDepthStencilPass(
-  Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilOpDepthStencilPass(
-        materialInstance.cast(),
-        op,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilCompareFunction(
-  Pointer<TMaterialInstance> materialInstance,
-  int func,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilCompareFunction(
-        materialInstance.cast(),
-        func,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilReferenceValue(
-  Pointer<TMaterialInstance> materialInstance,
-  int value,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilReferenceValue(
-        materialInstance.cast(),
-        value,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilReadMask(
-  Pointer<TMaterialInstance> materialInstance,
-  int mask,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilReadMask(materialInstance.cast(), mask);
-  return result;
-}
-
-void MaterialInstance_setStencilWriteMask(
-  Pointer<TMaterialInstance> materialInstance,
-  int mask,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilWriteMask(materialInstance.cast(), mask);
-  return result;
-}
-
-void MaterialInstance_setTransparencyMode(
-  Pointer<TMaterialInstance> materialInstance,
-  int transparencyMode,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setTransparencyMode(
-        materialInstance.cast(),
-        transparencyMode,
-      );
-  return result;
-}
-
-int MaterialInstance_getTransparencyMode(
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_getTransparencyMode(materialInstance.cast());
-  return result;
-}
-
-int Material_getBlendingMode(Pointer<TMaterial> material) {
-  final result = GeneratedBindings.instance._Material_getBlendingMode(
-    material.cast(),
+  final result = GeneratedBindings.instance._IndirectLight_setRotation(
+    tIndirectLight.cast(),
+    rotation,
   );
   return result;
 }
@@ -5249,7 +5161,7 @@ void Texture_setExternalImage(
   return result;
 }
 
-Dartsize_t Texture_getLevels(Pointer<TTexture> tTexture) {
+Dart__darwin_size_t Texture_getLevels(Pointer<TTexture> tTexture) {
   final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
   return result;
 }
@@ -5278,7 +5190,7 @@ bool Texture_setImage(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -5356,7 +5268,7 @@ void Texture_generateMipMaps(
 
 Pointer<TKtx1Bundle> Ktx1Bundle_create(
   Pointer<Uint8> ktxData,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
 ) {
   final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
   return Pointer<TKtx1Bundle>(result);
@@ -5403,7 +5315,7 @@ Pointer<TTexture> Ktx1Reader_createTexture(
 Pointer<TTexture> Ktx2Reader_createTexture(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
 ) {
   final result = GeneratedBindings.instance._Ktx2Reader_createTexture(
     tEngine.cast(),
@@ -5424,7 +5336,7 @@ Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
 
 Pointer<TLinearImage> Image_decode(
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<Char> name,
   bool alpha,
 ) {
@@ -5586,6 +5498,1131 @@ void TextureSampler_setCompareMode(
 void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
   final result = GeneratedBindings.instance._TextureSampler_destroy(
     sampler.cast(),
+  );
+  return result;
+}
+
+Pointer<TRenderManager> RenderManager_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderer> tRenderer,
+) {
+  final result = GeneratedBindings.instance._RenderManager_create(
+    tEngine.cast(),
+    tRenderer.cast(),
+  );
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_removeAnimationManager(
+        tRenderer.cast(),
+        tAnimationManager.cast(),
+      );
+  return result;
+}
+
+void RenderManager_render(
+  Pointer<TRenderManager> tRenderer,
+  BigInt frameTimeInNanos,
+) {
+  final result = GeneratedBindings.instance._RenderManager_render(
+    tRenderer.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(
+    tRenderer.cast(),
+    swapChain.cast(),
+  );
+  return result;
+}
+
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void RenderManager_detachFromRenderThread(
+  Pointer<TRenderManager> tRenderManager,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_detachFromRenderThread(tRenderManager.cast());
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(
+    tRenderer.cast(),
+    paused,
+  );
+  return result;
+}
+
+void FrameScheduler_start(DartFrameCallback callback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_start(
+    callback as Pointer<NativeFunction<FrameCallbackFunction>>,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+void FrameScheduler_setRenderThread(Pointer<Void> renderThread) {
+  final result = GeneratedBindings.instance._FrameScheduler_setRenderThread(
+    renderThread,
+  );
+  return result;
+}
+
+void FrameScheduler_setRenderManager(Pointer<TRenderManager> rm) {
+  final result = GeneratedBindings.instance._FrameScheduler_setRenderManager(
+    rm.cast(),
+  );
+  return result;
+}
+
+void FrameScheduler_setPostRenderCallback(
+  DartPostRenderCallback callback,
+  Pointer<Void> userData,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_setPostRenderCallback(
+        callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
+        userData,
+      );
+  return result;
+}
+
+bool FrameScheduler_requestRender(BigInt frameTimeNanos) {
+  final result = GeneratedBindings.instance._FrameScheduler_requestRender(
+    frameTimeNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void FrameScheduler_startNativeRenderLoop(int targetFps) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_startNativeRenderLoop(targetFps);
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(
+    port.toJSBigInt,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+    tEngine.cast(),
+    assetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+  );
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(
+  Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  DartGizmoPickCallback callback,
+) {
+  final result = GeneratedBindings.instance._Gizmo_pick(
+    tGizmo.cast(),
+    x,
+    y,
+    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
+  );
+  return result;
+}
+
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(
+    tGizmo.cast(),
+    axis,
+  );
+  return result;
+}
+
+void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
+}
+
+Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
+  Pointer<TMaterialProvider> provider,
+  bool doubleSided,
+  bool unlit,
+  bool hasVertexColors,
+  bool hasBaseColorTexture,
+  bool hasNormalTexture,
+  bool hasOcclusionTexture,
+  bool hasEmissiveTexture,
+  bool useSpecularGlossiness,
+  int alphaMode,
+  bool enableDiagnostics,
+  bool hasMetallicRoughnessTexture,
+  int metallicRoughnessUV,
+  bool hasSpecularGlossinessTexture,
+  int specularGlossinessUV,
+  int baseColorUV,
+  bool hasClearCoatTexture,
+  int clearCoatUV,
+  bool hasClearCoatRoughnessTexture,
+  int clearCoatRoughnessUV,
+  bool hasClearCoatNormalTexture,
+  int clearCoatNormalUV,
+  bool hasClearCoat,
+  bool hasTransmission,
+  bool hasTextureTransforms,
+  int emissiveUV,
+  int aoUV,
+  int normalUV,
+  bool hasTransmissionTexture,
+  int transmissionUV,
+  bool hasSheenColorTexture,
+  int sheenColorUV,
+  bool hasSheenRoughnessTexture,
+  int sheenRoughnessUV,
+  bool hasVolumeThicknessTexture,
+  int volumeThicknessUV,
+  bool hasSheen,
+  bool hasIOR,
+  bool hasVolume,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialProvider_createMaterialInstance(
+        provider.cast(),
+        doubleSided,
+        unlit,
+        hasVertexColors,
+        hasBaseColorTexture,
+        hasNormalTexture,
+        hasOcclusionTexture,
+        hasEmissiveTexture,
+        useSpecularGlossiness,
+        alphaMode,
+        enableDiagnostics,
+        hasMetallicRoughnessTexture,
+        metallicRoughnessUV,
+        hasSpecularGlossinessTexture,
+        specularGlossinessUV,
+        baseColorUV,
+        hasClearCoatTexture,
+        clearCoatUV,
+        hasClearCoatRoughnessTexture,
+        clearCoatRoughnessUV,
+        hasClearCoatNormalTexture,
+        clearCoatNormalUV,
+        hasClearCoat,
+        hasTransmission,
+        hasTextureTransforms,
+        emissiveUV,
+        aoUV,
+        normalUV,
+        hasTransmissionTexture,
+        transmissionUV,
+        hasSheenColorTexture,
+        sheenColorUV,
+        hasSheenRoughnessTexture,
+        sheenRoughnessUV,
+        hasVolumeThicknessTexture,
+        volumeThicknessUV,
+        hasSheen,
+        hasIOR,
+        hasVolume,
+      );
+  return Pointer<TMaterialInstance>(result);
+}
+
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
+}
+
+void IndexBufferBuilder_indexCount(
+  Pointer<TIndexBufferBuilder> builder,
+  int count,
+) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(
+    builder.cast(),
+    count,
+  );
+  return result;
+}
+
+void IndexBufferBuilder_bufferType(
+  Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(
+    builder.cast(),
+    indexType,
+  );
+  return result;
+}
+
+Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  Pointer<TIndexBufferBuilder> builder,
+  Pointer<TEngine> engine,
+) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_build(
+    builder.cast(),
+    engine.cast(),
+  );
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(
+    builder.cast(),
+  );
+  return result;
+}
+
+Dart__darwin_size_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(
+    buffer.cast(),
+  );
+  return result;
+}
+
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dart__darwin_size_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void IndexBuffer_destroy(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_destroy(
+    engine.cast(),
+    buffer.cast(),
+  );
+  return result;
+}
+
+Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_create();
+  return Pointer<TVertexBufferBuilder>(result);
+}
+
+void VertexBufferBuilder_bufferCount(
+  Pointer<TVertexBufferBuilder> builder,
+  int count,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_bufferCount(
+    builder.cast(),
+    count,
+  );
+  return result;
+}
+
+void VertexBufferBuilder_vertexCount(
+  Pointer<TVertexBufferBuilder> builder,
+  int count,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_vertexCount(
+    builder.cast(),
+    count,
+  );
+  return result;
+}
+
+void VertexBufferBuilder_attribute(
+  Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  int bufferIndex,
+  int attributeType,
+  int byteOffset,
+  int byteStride,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_attribute(
+    builder.cast(),
+    attribute,
+    bufferIndex,
+    attributeType,
+    byteOffset,
+    byteStride,
+  );
+  return result;
+}
+
+void VertexBufferBuilder_normalized(
+  Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  bool normalize,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_normalized(
+    builder.cast(),
+    attribute,
+    normalize,
+  );
+  return result;
+}
+
+Pointer<TVertexBuffer> VertexBufferBuilder_build(
+  Pointer<TVertexBufferBuilder> builder,
+  Pointer<TEngine> engine,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_build(
+    builder.cast(),
+    engine.cast(),
+  );
+  return Pointer<TVertexBuffer>(result);
+}
+
+void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_destroy(
+    builder.cast(),
+  );
+  return result;
+}
+
+Dart__darwin_size_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
+  final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(
+    buffer.cast(),
+  );
+  return result;
+}
+
+void VertexBuffer_setBufferAt(
+  Pointer<TEngine> engine,
+  Pointer<TVertexBuffer> buffer,
+  int bufferIndex,
+  Pointer<Void> data,
+  Dart__darwin_size_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
+    engine.cast(),
+    buffer.cast(),
+    bufferIndex,
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void VertexBuffer_destroy(
+  Pointer<TEngine> engine,
+  Pointer<TVertexBuffer> buffer,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_destroy(
+    engine.cast(),
+    buffer.cast(),
+  );
+  return result;
+}
+
+Pointer<TRenderTarget> RenderTarget_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> color,
+  Pointer<TTexture> depth,
+) {
+  final result = GeneratedBindings.instance._RenderTarget_create(
+    tEngine.cast(),
+    color.cast(),
+    depth.cast(),
+  );
+  return Pointer<TRenderTarget>(result);
+}
+
+void RenderTarget_destroy(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderTarget> tRenderTarget,
+) {
+  final result = GeneratedBindings.instance._RenderTarget_destroy(
+    tEngine.cast(),
+    tRenderTarget.cast(),
+  );
+  return result;
+}
+
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(
+    tScene.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(
+    tScene.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(
+    tScene.cast(),
+    skybox.cast(),
+  );
+  return result;
+}
+
+void Scene_setIndirectLight(
+  Pointer<TScene> tScene,
+  Pointer<TIndirectLight> tIndirectLight,
+) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(
+    tScene.cast(),
+    tIndirectLight.cast(),
+  );
+  return result;
+}
+
+void Scene_addFilamentAsset(
+  Pointer<TScene> tScene,
+  Pointer<TFilamentAsset> asset,
+) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(
+    tScene.cast(),
+    asset.cast(),
+  );
+  return result;
+}
+
+void Camera_setExposure(
+  Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+) {
+  final result = GeneratedBindings.instance._Camera_setExposure(
+    camera.cast(),
+    aperture,
+    shutterSpeed,
+    sensitivity,
+  );
+  return result;
+}
+
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(
+    camera.cast(),
+  );
+  return result;
+}
+
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(
+    camera.cast(),
+  );
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(
+    camera.cast(),
+    out,
+  );
+  return result;
+}
+
+void Camera_setProjectionMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> matrix,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(
+    camera.cast(),
+    matrix,
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(
+    camera.cast(),
+  );
+  return result;
+}
+
+void Camera_lookAt(
+  Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(
+    camera.cast(),
+    eyePtr.cast(),
+    focusPtr.cast(),
+    upPtr.cast(),
+  );
+  return result;
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(
+    camera.cast(),
+  );
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(
+    camera.cast(),
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(
+    camera.cast(),
+  );
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(
+    camera.cast(),
+    focusDistance,
+  );
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance
+      ._Camera_setCustomProjectionWithCulling(
+        camera.cast(),
+        projectionMatrixPtr.cast(),
+        near,
+        far,
+      );
+  return result;
+}
+
+void Camera_setModelMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> tModelMatrix,
+) {
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(
+    camera.cast(),
+    tModelMatrix,
+  );
+  return result;
+}
+
+void Camera_setLensProjection(
+  Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(
+    camera.cast(),
+    near,
+    far,
+    aspect,
+    focalLength,
+  );
+  return result;
+}
+
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
+  return result;
+}
+
+double4x4 TransformManager_getLocalTransform(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._TransformManager_getLocalTransform(
+    double4x4_out.cast(),
+    tTransformManager.cast(),
+    entityId,
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 TransformManager_getWorldTransform(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._TransformManager_getWorldTransform(
+    double4x4_out.cast(),
+    tTransformManager.cast(),
+    entityId,
+  );
+  return double4x4_out.toDart();
+}
+
+void TransformManager_setTransform(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  double4x4 transform,
+) {
+  final transformPtr = transform.address;
+  final result = GeneratedBindings.instance._TransformManager_setTransform(
+    tTransformManager.cast(),
+    entityId,
+    transformPtr.cast(),
+  );
+  return result;
+}
+
+bool TransformManager_transformToUnitCube(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  Aabb3 boundingBox,
+) {
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance
+      ._TransformManager_transformToUnitCube(
+        tTransformManager.cast(),
+        entityId,
+        boundingBoxPtr.cast(),
+      );
+  return result == 1;
+}
+
+void TransformManager_setParent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId child,
+  DartEntityId parent,
+  bool preserveScaling,
+) {
+  final result = GeneratedBindings.instance._TransformManager_setParent(
+    tTransformManager.cast(),
+    child,
+    parent,
+    preserveScaling,
+  );
+  return result;
+}
+
+DartEntityId TransformManager_getParent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId child,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getParent(
+    tTransformManager.cast(),
+    child,
+  );
+  return result;
+}
+
+DartEntityId TransformManager_getAncestor(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId childEntityId,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getAncestor(
+    tTransformManager.cast(),
+    childEntityId,
+  );
+  return result;
+}
+
+void TransformManager_createComponent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._TransformManager_createComponent(
+    tTransformManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void TransformManager_removeComponent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._TransformManager_removeComponent(
+    tTransformManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+bool TransformManager_hasComponent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._TransformManager_hasComponent(
+    tTransformManager.cast(),
+    entityId,
+  );
+  return result == 1;
+}
+
+bool TransformManager_empty(Pointer<TTransformManager> tTransformManager) {
+  final result = GeneratedBindings.instance._TransformManager_empty(
+    tTransformManager.cast(),
+  );
+  return result == 1;
+}
+
+int TransformManager_getComponentCount(
+  Pointer<TTransformManager> tTransformManager,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getComponentCount(
+    tTransformManager.cast(),
+  );
+  return result;
+}
+
+int TransformManager_getChildCount(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getChildCount(
+    tTransformManager.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void TransformManager_getChildren(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  Pointer<Int32> children,
+  int count,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getChildren(
+    tTransformManager.cast(),
+    entityId,
+    children,
+    count,
+  );
+  return result;
+}
+
+void TransformManager_openLocalTransformTransaction(
+  Pointer<TTransformManager> tTransformManager,
+) {
+  final result = GeneratedBindings.instance
+      ._TransformManager_openLocalTransformTransaction(
+        tTransformManager.cast(),
+      );
+  return result;
+}
+
+void TransformManager_commitLocalTransformTransaction(
+  Pointer<TTransformManager> tTransformManager,
+) {
+  final result = GeneratedBindings.instance
+      ._TransformManager_commitLocalTransformTransaction(
+        tTransformManager.cast(),
+      );
+  return result;
+}
+
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+  );
+  return result;
+}
+
+bool Renderer_beginFrame(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TSwapChain> tSwapChain,
+  BigInt frameTimeInNanos,
+) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Renderer_endFrame(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_render(
+    tRenderer.cast(),
+    tView.cast(),
+  );
+  return result;
+}
+
+void Renderer_renderStandaloneView(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TView> tView,
+) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(
+    tRenderer.cast(),
+    tView.cast(),
+  );
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dart__darwin_size_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+  );
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+    tRenderer.cast(),
+    headRoomRatio,
+    scaleRate,
+    history,
+    interval,
   );
   return result;
 }
@@ -5777,7 +6814,7 @@ void Engine_setAutomaticInstancingEnabled(
   return result;
 }
 
-Dartsize_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
+Dart__darwin_size_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
   final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(
     tEngine.cast(),
   );
@@ -5823,7 +6860,7 @@ void Engine_execute(Pointer<TEngine> tEngine) {
 Pointer<TMaterial> Engine_buildMaterial(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterial(
     tEngine.cast(),
@@ -6062,400 +7099,20 @@ bool DebugRegistry_getProperty_float(
   return result == 1;
 }
 
-Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
-  Pointer<TMaterialProvider> provider,
-  bool doubleSided,
-  bool unlit,
-  bool hasVertexColors,
-  bool hasBaseColorTexture,
-  bool hasNormalTexture,
-  bool hasOcclusionTexture,
-  bool hasEmissiveTexture,
-  bool useSpecularGlossiness,
-  int alphaMode,
-  bool enableDiagnostics,
-  bool hasMetallicRoughnessTexture,
-  int metallicRoughnessUV,
-  bool hasSpecularGlossinessTexture,
-  int specularGlossinessUV,
-  int baseColorUV,
-  bool hasClearCoatTexture,
-  int clearCoatUV,
-  bool hasClearCoatRoughnessTexture,
-  int clearCoatRoughnessUV,
-  bool hasClearCoatNormalTexture,
-  int clearCoatNormalUV,
-  bool hasClearCoat,
-  bool hasTransmission,
-  bool hasTextureTransforms,
-  int emissiveUV,
-  int aoUV,
-  int normalUV,
-  bool hasTransmissionTexture,
-  int transmissionUV,
-  bool hasSheenColorTexture,
-  int sheenColorUV,
-  bool hasSheenRoughnessTexture,
-  int sheenRoughnessUV,
-  bool hasVolumeThicknessTexture,
-  int volumeThicknessUV,
-  bool hasSheen,
-  bool hasIOR,
-  bool hasVolume,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialProvider_createMaterialInstance(
-        provider.cast(),
-        doubleSided,
-        unlit,
-        hasVertexColors,
-        hasBaseColorTexture,
-        hasNormalTexture,
-        hasOcclusionTexture,
-        hasEmissiveTexture,
-        useSpecularGlossiness,
-        alphaMode,
-        enableDiagnostics,
-        hasMetallicRoughnessTexture,
-        metallicRoughnessUV,
-        hasSpecularGlossinessTexture,
-        specularGlossinessUV,
-        baseColorUV,
-        hasClearCoatTexture,
-        clearCoatUV,
-        hasClearCoatRoughnessTexture,
-        clearCoatRoughnessUV,
-        hasClearCoatNormalTexture,
-        clearCoatNormalUV,
-        hasClearCoat,
-        hasTransmission,
-        hasTextureTransforms,
-        emissiveUV,
-        aoUV,
-        normalUV,
-        hasTransmissionTexture,
-        transmissionUV,
-        hasSheenColorTexture,
-        sheenColorUV,
-        hasSheenRoughnessTexture,
-        sheenRoughnessUV,
-        hasVolumeThicknessTexture,
-        volumeThicknessUV,
-        hasSheen,
-        hasIOR,
-        hasVolume,
-      );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_create();
-  return Pointer<TVertexBufferBuilder>(result);
-}
-
-void VertexBufferBuilder_bufferCount(
-  Pointer<TVertexBufferBuilder> builder,
-  int count,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_bufferCount(
-    builder.cast(),
-    count,
-  );
-  return result;
-}
-
-void VertexBufferBuilder_vertexCount(
-  Pointer<TVertexBufferBuilder> builder,
-  int count,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_vertexCount(
-    builder.cast(),
-    count,
-  );
-  return result;
-}
-
-void VertexBufferBuilder_attribute(
-  Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  int bufferIndex,
-  int attributeType,
-  int byteOffset,
-  int byteStride,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_attribute(
-    builder.cast(),
-    attribute,
-    bufferIndex,
-    attributeType,
-    byteOffset,
-    byteStride,
-  );
-  return result;
-}
-
-void VertexBufferBuilder_normalized(
-  Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  bool normalize,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_normalized(
-    builder.cast(),
-    attribute,
-    normalize,
-  );
-  return result;
-}
-
-Pointer<TVertexBuffer> VertexBufferBuilder_build(
-  Pointer<TVertexBufferBuilder> builder,
-  Pointer<TEngine> engine,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_build(
-    builder.cast(),
-    engine.cast(),
-  );
-  return Pointer<TVertexBuffer>(result);
-}
-
-void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_destroy(
-    builder.cast(),
-  );
-  return result;
-}
-
-Dartsize_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
-  final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(
-    buffer.cast(),
-  );
-  return result;
-}
-
-void VertexBuffer_setBufferAt(
-  Pointer<TEngine> engine,
-  Pointer<TVertexBuffer> buffer,
-  int bufferIndex,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
-    engine.cast(),
-    buffer.cast(),
-    bufferIndex,
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void VertexBuffer_destroy(
-  Pointer<TEngine> engine,
-  Pointer<TVertexBuffer> buffer,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_destroy(
-    engine.cast(),
-    buffer.cast(),
-  );
-  return result;
-}
-
-double4x4 TransformManager_getLocalTransform(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._TransformManager_getLocalTransform(
-    double4x4_out.cast(),
-    tTransformManager.cast(),
-    entityId,
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 TransformManager_getWorldTransform(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._TransformManager_getWorldTransform(
-    double4x4_out.cast(),
-    tTransformManager.cast(),
-    entityId,
-  );
-  return double4x4_out.toDart();
-}
-
-void TransformManager_setTransform(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  double4x4 transform,
-) {
-  final transformPtr = transform.address;
-  final result = GeneratedBindings.instance._TransformManager_setTransform(
-    tTransformManager.cast(),
-    entityId,
-    transformPtr.cast(),
-  );
-  return result;
-}
-
-bool TransformManager_transformToUnitCube(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  Aabb3 boundingBox,
-) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance
-      ._TransformManager_transformToUnitCube(
-        tTransformManager.cast(),
-        entityId,
-        boundingBoxPtr.cast(),
-      );
-  return result == 1;
-}
-
-void TransformManager_setParent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId child,
-  DartEntityId parent,
-  bool preserveScaling,
-) {
-  final result = GeneratedBindings.instance._TransformManager_setParent(
-    tTransformManager.cast(),
-    child,
-    parent,
-    preserveScaling,
-  );
-  return result;
-}
-
-DartEntityId TransformManager_getParent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId child,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getParent(
-    tTransformManager.cast(),
-    child,
-  );
-  return result;
-}
-
-DartEntityId TransformManager_getAncestor(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId childEntityId,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getAncestor(
-    tTransformManager.cast(),
-    childEntityId,
-  );
-  return result;
-}
-
-void TransformManager_createComponent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._TransformManager_createComponent(
-    tTransformManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void TransformManager_removeComponent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._TransformManager_removeComponent(
-    tTransformManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-bool TransformManager_hasComponent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._TransformManager_hasComponent(
-    tTransformManager.cast(),
-    entityId,
-  );
-  return result == 1;
-}
-
-bool TransformManager_empty(Pointer<TTransformManager> tTransformManager) {
-  final result = GeneratedBindings.instance._TransformManager_empty(
-    tTransformManager.cast(),
-  );
-  return result == 1;
-}
-
-int TransformManager_getComponentCount(
-  Pointer<TTransformManager> tTransformManager,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getComponentCount(
-    tTransformManager.cast(),
-  );
-  return result;
-}
-
-int TransformManager_getChildCount(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getChildCount(
-    tTransformManager.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void TransformManager_getChildren(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  Pointer<Int32> children,
-  int count,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getChildren(
-    tTransformManager.cast(),
-    entityId,
-    children,
-    count,
-  );
-  return result;
-}
-
-void TransformManager_openLocalTransformTransaction(
-  Pointer<TTransformManager> tTransformManager,
-) {
-  final result = GeneratedBindings.instance
-      ._TransformManager_openLocalTransformTransaction(
-        tTransformManager.cast(),
-      );
-  return result;
-}
-
-void TransformManager_commitLocalTransformTransaction(
-  Pointer<TTransformManager> tTransformManager,
-) {
-  final result = GeneratedBindings.instance
-      ._TransformManager_commitLocalTransformTransaction(
-        tTransformManager.cast(),
-      );
-  return result;
-}
-
 Pointer<Void> RenderThread_create() {
   final result = GeneratedBindings.instance._RenderThread_create();
   return Pointer<Void>(result);
 }
 
-void RenderThread_destroy() {
-  final result = GeneratedBindings.instance._RenderThread_destroy();
+Pointer<Void> RenderThread_createForCanvas(Pointer<Char> canvasSelector) {
+  final result = GeneratedBindings.instance._RenderThread_createForCanvas(
+    canvasSelector,
+  );
+  return Pointer<Void>(result);
+}
+
+void RenderThread_destroy(Pointer<Void> renderThread) {
+  final result = GeneratedBindings.instance._RenderThread_destroy(renderThread);
   return result;
 }
 
@@ -6690,7 +7347,7 @@ void Engine_createViewRenderThread(
 void Engine_buildMaterialRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
@@ -6922,7 +7579,7 @@ void Ktx1Reader_createTextureRenderThread(
 void Ktx2Reader_createTextureRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
   Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance
@@ -7181,7 +7838,7 @@ void Renderer_readPixelsRenderThread(
   int tPixelBufferFormat,
   int tPixelDataType,
   Pointer<Uint8> out,
-  Dartsize_t outLength,
+  Dart__darwin_size_t outLength,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -8143,7 +8800,7 @@ void Image_createEmptyRenderThread(
 
 void Image_decodeRenderThread(
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<Char> name,
   bool alpha,
   Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
@@ -8241,7 +8898,7 @@ void Texture_setImageRenderThread(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -8571,7 +9228,7 @@ void GltfResourceLoader_addResourceDataRenderThread(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -8627,7 +9284,7 @@ void GltfAssetLoader_loadRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int numInstances,
   Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
 ) {
@@ -8817,7 +9474,7 @@ void VertexBuffer_setBufferAtRenderThread(
   Pointer<TVertexBuffer> tBuffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -8869,7 +9526,7 @@ void IndexBuffer_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TIndexBuffer> tBuffer,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -9021,8 +9678,8 @@ void RenderableManager_setBonesFromMat4RenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -9043,8 +9700,8 @@ void RenderableManager_setBonesFromBoneRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -9061,6 +9718,97 @@ void RenderableManager_setBonesFromBoneRenderThread(
   return result;
 }
 
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(
+    tEngine.cast(),
+  );
+  return Pointer<TGltfResourceLoader>(result);
+}
+
+void GltfResourceLoader_destroy(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(
+    tEngine.cast(),
+    tGltfResourceLoader.cast(),
+  );
+  return result;
+}
+
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void GltfResourceLoader_asyncUpdateLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(
+    tGltfResourceLoader.cast(),
+  );
+  return result;
+}
+
+double GltfResourceLoader_asyncGetLoadProgress(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+) {
+  final result = GeneratedBindings.instance
+      ._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dart__darwin_size_t length,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void Skybox_setColor(
+  Pointer<TSkybox> tSkybox,
+  double r,
+  double g,
+  double b,
+  double a,
+) {
+  final result = GeneratedBindings.instance._Skybox_setColor(
+    tSkybox.cast(),
+    r,
+    g,
+    b,
+    a,
+  );
+  return result;
+}
+
 void dummy(TGltfMeshData dummy) {
   final dummyPtr = dummy.address;
   final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
@@ -9069,7 +9817,7 @@ void dummy(TGltfMeshData dummy) {
 
 int GltfParser_parseBuffer(
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<Char> meshName,
   Pointer<TGltfMeshData> outMeshData,
 ) {
@@ -9085,551 +9833,6 @@ int GltfParser_parseBuffer(
 void GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData) {
   final result = GeneratedBindings.instance._GltfParser_freeMeshData(
     meshData.cast(),
-  );
-  return result;
-}
-
-int LightManager_createLight(
-  Pointer<TEngine> tEngine,
-  Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-    tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
-  );
-  return result;
-}
-
-void LightManager_destroyLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-bool LightManager_hasComponent(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-int LightManager_getType(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getType(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-bool LightManager_isDirectional(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-bool LightManager_isPointLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-void LightManager_setPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(
-    tLightManager.cast(),
-    light,
-    x,
-    y,
-    z,
-  );
-  return result;
-}
-
-double3 LightManager_getPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(
-    double3_out.cast(),
-    tLightManager.cast(),
-    light,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(
-    tLightManager.cast(),
-    light,
-    x,
-    y,
-    z,
-  );
-  return result;
-}
-
-double3 LightManager_getDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(
-    double3_out.cast(),
-    tLightManager.cast(),
-    light,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double r,
-  double g,
-  double b,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColor(
-    tLightManager.cast(),
-    entity,
-    r,
-    g,
-    b,
-  );
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
-  );
-  return result;
-}
-
-double3 LightManager_getColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(
-    double3_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(
-    tLightManager.cast(),
-    entity,
-    intensity,
-  );
-  return result;
-}
-
-void LightManager_setIntensityCandela(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
-    tLightManager.cast(),
-    entity,
-    intensity,
-  );
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
-  );
-  return result;
-}
-
-double LightManager_getIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double falloff,
-) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(
-    tLightManager.cast(),
-    entity,
-    falloff,
-  );
-  return result;
-}
-
-double LightManager_getFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
-    tLightManager.cast(),
-    entity,
-    inner,
-    outer,
-  );
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double angularRadius,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
-  );
-  return result;
-}
-
-double LightManager_getSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloSize,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(
-    tLightManager.cast(),
-    entity,
-    haloSize,
-  );
-  return result;
-}
-
-double LightManager_getSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloFalloff,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
-    tLightManager.cast(),
-    entity,
-    haloFalloff,
-  );
-  return result;
-}
-
-double LightManager_getSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(
-    tLightManager.cast(),
-    entity,
-    enabled,
-  );
-  return result;
-}
-
-bool LightManager_isShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  TShadowOptions options,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-  );
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(
-    splitPositions,
-    cascades,
-  );
-  return result;
-}
-
-void LightManager_computeLogSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(
-    splitPositions,
-    cascades,
-    near,
-    far,
-  );
-  return result;
-}
-
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-) {
-  final result = GeneratedBindings.instance
-      ._LightManager_computePracticalSplits(
-        splitPositions,
-        cascades,
-        near,
-        far,
-        lambda,
-      );
-  return result;
-}
-
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(
-    r,
-    g,
-    b,
-  );
-  return result;
-}
-
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(
-    tScene.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(
-    tScene.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(
-    tScene.cast(),
-    skybox.cast(),
-  );
-  return result;
-}
-
-void Scene_setIndirectLight(
-  Pointer<TScene> tScene,
-  Pointer<TIndirectLight> tIndirectLight,
-) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(
-    tScene.cast(),
-    tIndirectLight.cast(),
-  );
-  return result;
-}
-
-void Scene_addFilamentAsset(
-  Pointer<TScene> tScene,
-  Pointer<TFilamentAsset> asset,
-) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(
-    tScene.cast(),
-    asset.cast(),
   );
   return result;
 }
@@ -9674,7 +9877,7 @@ bool RenderableManager_isRenderable(
   return result == 1;
 }
 
-Dartsize_t RenderableManager_getComponentCount(
+Dart__darwin_size_t RenderableManager_getComponentCount(
   Pointer<TRenderableManager> tRenderableManager,
 ) {
   final result = GeneratedBindings.instance
@@ -9726,7 +9929,7 @@ void RenderableManager_clearMaterialInstanceAt(
   return result;
 }
 
-Dartsize_t RenderableManager_getPrimitiveCount(
+Dart__darwin_size_t RenderableManager_getPrimitiveCount(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
 ) {
@@ -10012,7 +10215,7 @@ void RenderableManager_setScreenSpaceContactShadows(
 void RenderableManager_setBlendOrderAt(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   int order,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
@@ -10027,7 +10230,7 @@ void RenderableManager_setBlendOrderAt(
 void RenderableManager_setGlobalBlendOrderEnabledAt(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
@@ -10044,8 +10247,8 @@ void RenderableManager_setMorphWeights(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> weights,
-  Dartsize_t count,
-  Dartsize_t offset,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
     tRenderableManager.cast(),
@@ -10057,7 +10260,7 @@ void RenderableManager_setMorphWeights(
   return result;
 }
 
-Dartsize_t RenderableManager_getMorphTargetCount(
+Dart__darwin_size_t RenderableManager_getMorphTargetCount(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
 ) {
@@ -10073,8 +10276,8 @@ void RenderableManager_setBonesFromMat4(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
     tRenderableManager.cast(),
@@ -10090,8 +10293,8 @@ void RenderableManager_setBonesFromBone(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
     tRenderableManager.cast(),
@@ -10104,7 +10307,7 @@ void RenderableManager_setBonesFromBone(
 }
 
 Pointer<TRenderableBuilder> RenderableBuilder_create(
-  Dartsize_t primitiveCount,
+  Dart__darwin_size_t primitiveCount,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_create(
     primitiveCount,
@@ -10133,7 +10336,7 @@ void RenderableBuilder_boundingBox(
 
 void RenderableBuilder_material(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   Pointer<TMaterialInstance> materialInstance,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_material(
@@ -10146,12 +10349,12 @@ void RenderableBuilder_material(
 
 void RenderableBuilder_geometry(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   int type,
   Pointer<TVertexBuffer> vertices,
   Pointer<TIndexBuffer> indices,
-  Dartsize_t offset,
-  Dartsize_t count,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_geometry(
     builder.cast(),
@@ -10265,7 +10468,7 @@ void RenderableBuilder_screenSpaceContactShadows(
 
 void RenderableBuilder_blendOrder(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   int order,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(
@@ -10278,7 +10481,7 @@ void RenderableBuilder_blendOrder(
 
 void RenderableBuilder_globalBlendOrderEnabled(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
@@ -10292,7 +10495,7 @@ void RenderableBuilder_globalBlendOrderEnabled(
 
 void RenderableBuilder_instances(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t instanceCount,
+  Dart__darwin_size_t instanceCount,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_instances(
     builder.cast(),
@@ -10303,7 +10506,7 @@ void RenderableBuilder_instances(
 
 void RenderableBuilder_skinningFromMat4(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
+  Dart__darwin_size_t boneCount,
   Pointer<Float32> transforms,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(
@@ -10316,7 +10519,7 @@ void RenderableBuilder_skinningFromMat4(
 
 void RenderableBuilder_skinningFromBone(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
+  Dart__darwin_size_t boneCount,
   Pointer<Float32> bones,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(
@@ -10338,10 +10541,10 @@ void RenderableBuilder_enableSkinningBuffers(
 
 void RenderableBuilder_boneIndicesAndWeights(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
+  Dart__darwin_size_t primitiveIndex,
   Pointer<Float32> indicesAndWeights,
-  Dartsize_t count,
-  Dartsize_t bonesPerVertex,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t bonesPerVertex,
 ) {
   final result = GeneratedBindings.instance
       ._RenderableBuilder_boneIndicesAndWeights(
@@ -10367,132 +10570,273 @@ int RenderableBuilder_build(
   return result;
 }
 
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(
+Pointer<TSceneAsset> SceneAsset_createFromBuffers(
   Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tVertexBuffer,
+  Pointer<TIndexBuffer> tIndexBuffer,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
     tEngine.cast(),
+    tVertexBuffer.cast(),
+    tIndexBuffer.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+    tPrimitiveType,
+    boundingBoxPtr.cast(),
   );
-  return Pointer<TGltfResourceLoader>(result);
+  return Pointer<TSceneAsset>(result);
 }
 
-void GltfResourceLoader_destroy(
+Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
   Pointer<TEngine> tEngine,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(
-    tEngine.cast(),
-    tGltfResourceLoader.cast(),
-  );
-  return result;
-}
-
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
   Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
+  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    tNameComponentManager.cast(),
     tFilamentAsset.cast(),
+    rebuildVertices,
   );
-  return result == 1;
+  return Pointer<TSceneAsset>(result);
 }
 
-void GltfResourceLoader_asyncUpdateLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  Pointer<TSceneAsset> tSceneAsset,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(
-    tGltfResourceLoader.cast(),
+  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(
+    tSceneAsset.cast(),
+  );
+  return Pointer<TFilamentAsset>(result);
+}
+
+int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getType(
+    tSceneAsset.cast(),
   );
   return result;
 }
 
-double GltfResourceLoader_asyncGetLoadProgress(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_destroy(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_addToScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_addToScene(
+    tSceneAsset.cast(),
+    tScene.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_removeFromScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(
+    tSceneAsset.cast(),
+    tScene.cast(),
+  );
+  return result;
+}
+
+DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getEntity(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_getChildEntities(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(
+    tSceneAsset.cast(),
+    out,
+  );
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(
+    tSceneAsset.cast(),
+  );
+  return Pointer<Int32>(result);
+}
+
+Dart__darwin_size_t SceneAsset_getCameraEntityCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(
+    tSceneAsset.cast(),
+  );
+  return Pointer<Int32>(result);
+}
+
+Dart__darwin_size_t SceneAsset_getLightEntityCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_getInstance(
+  Pointer<TSceneAsset> tSceneAsset,
+  int index,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstance(
+    tSceneAsset.cast(),
+    index,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Dart__darwin_size_t SceneAsset_getInstanceCount(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createInstance(
+  Pointer<TSceneAsset> asset,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createInstance(
+    asset.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(
+    Aabb3_out.cast(),
+    asset.cast(),
+  );
+  return Aabb3_out.toDart();
+}
+
+Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(
+    tSceneAsset.cast(),
+    primitiveIndex,
+  );
+  return Pointer<TVertexBuffer>(result);
+}
+
+Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(
+    tSceneAsset.cast(),
+    primitiveIndex,
+  );
+  return Pointer<TIndexBuffer>(result);
+}
+
+int SceneAsset_getPrimitiveOffsetForEntity(
+  Pointer<TSceneAsset> tSceneAsset,
+  DartEntityId entity,
 ) {
   final result = GeneratedBindings.instance
-      ._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+      ._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
   return result;
 }
 
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dartsize_t length,
+void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_setFlatShading(
+  Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
+  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(
+    tSceneAsset.cast(),
+    flatShading,
   );
   return result;
 }
 
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
+void SceneAsset_getBones(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dart__darwin_size_t skinIndex,
+  Pointer<Int32> out,
 ) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
+  final result = GeneratedBindings.instance._SceneAsset_getBones(
+    tSceneAsset.cast(),
+    skinIndex,
+    out,
   );
-  return result == 1;
-}
-
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
   return result;
 }
 
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
+Dart__darwin_size_t SceneAsset_getBoneCount(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dart__darwin_size_t skinIndex,
 ) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-    tEngine.cast(),
-    assetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
+  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(
+    tSceneAsset.cast(),
+    skinIndex,
   );
-  return Pointer<TGizmo>(result);
+  return result;
 }
 
-void Gizmo_pick(
-  Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  DartGizmoPickCallback callback,
+Pointer<Char> SceneAsset_getBoneName(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dart__darwin_size_t skinIndex,
+  Dart__darwin_size_t boneIndex,
 ) {
-  final result = GeneratedBindings.instance._Gizmo_pick(
-    tGizmo.cast(),
-    x,
-    y,
-    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
+  final result = GeneratedBindings.instance._SceneAsset_getBoneName(
+    tSceneAsset.cast(),
+    skinIndex,
+    boneIndex,
   );
-  return result;
-}
-
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(
-    tGizmo.cast(),
-    axis,
-  );
-  return result;
-}
-
-void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
+  return Pointer<Char>(result);
 }
 
 Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
@@ -10857,328 +11201,6 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
-Pointer<TRenderTarget> RenderTarget_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> color,
-  Pointer<TTexture> depth,
-) {
-  final result = GeneratedBindings.instance._RenderTarget_create(
-    tEngine.cast(),
-    color.cast(),
-    depth.cast(),
-  );
-  return Pointer<TRenderTarget>(result);
-}
-
-void RenderTarget_destroy(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderTarget> tRenderTarget,
-) {
-  final result = GeneratedBindings.instance._RenderTarget_destroy(
-    tEngine.cast(),
-    tRenderTarget.cast(),
-  );
-  return result;
-}
-
-void IndirectLight_setRotation(
-  Pointer<TIndirectLight> tIndirectLight,
-  Pointer<Float64> rotation,
-) {
-  final result = GeneratedBindings.instance._IndirectLight_setRotation(
-    tIndirectLight.cast(),
-    rotation,
-  );
-  return result;
-}
-
-Pointer<TRenderManager> RenderManager_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderer> tRenderer,
-) {
-  final result = GeneratedBindings.instance._RenderManager_create(
-    tEngine.cast(),
-    tRenderer.cast(),
-  );
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_removeAnimationManager(
-        tRenderer.cast(),
-        tAnimationManager.cast(),
-      );
-  return result;
-}
-
-void RenderManager_render(
-  Pointer<TRenderManager> tRenderer,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance._RenderManager_render(
-    tRenderer.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(
-    tRenderer.cast(),
-    swapChain.cast(),
-  );
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_detachFromRenderThread() {
-  final result = GeneratedBindings.instance
-      ._RenderManager_detachFromRenderThread();
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(
-    tRenderer.cast(),
-    paused,
-  );
-  return result;
-}
-
-void FrameScheduler_start(DartFrameCallback callback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_start(
-    callback as Pointer<NativeFunction<FrameCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-void FrameScheduler_setRenderThread(Pointer<Void> renderThread) {
-  final result = GeneratedBindings.instance._FrameScheduler_setRenderThread(
-    renderThread,
-  );
-  return result;
-}
-
-void FrameScheduler_setRenderManager(Pointer<TRenderManager> rm) {
-  final result = GeneratedBindings.instance._FrameScheduler_setRenderManager(
-    rm.cast(),
-  );
-  return result;
-}
-
-void FrameScheduler_setPostRenderCallback(
-  DartPostRenderCallback callback,
-  Pointer<Void> userData,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_setPostRenderCallback(
-        callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
-        userData,
-      );
-  return result;
-}
-
-bool FrameScheduler_requestRender(BigInt frameTimeNanos) {
-  final result = GeneratedBindings.instance._FrameScheduler_requestRender(
-    frameTimeNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void FrameScheduler_startNativeRenderLoop(int targetFps) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_startNativeRenderLoop(targetFps);
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(
-    port.toJSBigInt,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
-  );
-  return result;
-}
-
-bool Renderer_beginFrame(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TSwapChain> tSwapChain,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Renderer_endFrame(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_render(
-    tRenderer.cast(),
-    tView.cast(),
-  );
-  return result;
-}
-
-void Renderer_renderStandaloneView(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TView> tView,
-) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(
-    tRenderer.cast(),
-    tView.cast(),
-  );
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dartsize_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
-  );
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-    tRenderer.cast(),
-    headRoomRatio,
-    scaleRate,
-    history,
-    interval,
-  );
-  return result;
-}
-
 void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
   final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(
     executor.cast(),
@@ -11354,105 +11376,194 @@ void TransformPipeline_setInvertMouseY(int invert) {
   return result;
 }
 
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
+extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
+  TMaterialInstance toDart() {
+    return TMaterialInstance(this);
   }
 }
 
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
+final class TMaterialInstance extends Struct {
+  Pointer<TMaterialInstance> get address => super.address.cast();
+  TMaterialInstance(super.address);
 
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-extension double4x4Ext on Pointer<double4x4> {
-  double4x4 toDart() {
-    return double4x4(this);
-  }
-}
-
-final class double4x4 extends Struct {
-  Pointer<double4x4> get address => super.address.cast();
-  Array<Float64> get col1 {
-    final addr = Pointer<double4x4>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 0),
-    ));
-  }
-
-  set col1(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 0),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col2 {
-    final addr = Pointer<double4x4>(this.address.addr + 32);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 32),
-    ));
-  }
-
-  set col2(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 32),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col3 {
-    final addr = Pointer<double4x4>(this.address.addr + 64);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 64),
-    ));
-  }
-
-  set col3(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 64),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col4 {
-    final addr = Pointer<double4x4>(this.address.addr + 96);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 96),
-    ));
-  }
-
-  set col4(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 96),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  double4x4(super.address);
-
-  static Pointer<double4x4> stackAlloc() {
-    return Pointer<double4x4>(
-      NativeLibrary.instance.stackAlloc<double4x4>(128),
+  static Pointer<TMaterialInstance> stackAlloc() {
+    return Pointer<TMaterialInstance>(
+      NativeLibrary.instance.stackAlloc<TMaterialInstance>(0),
     );
   }
 }
+
+extension TMaterialExt on Pointer<TMaterial> {
+  TMaterial toDart() {
+    return TMaterial(this);
+  }
+}
+
+final class TMaterial extends Struct {
+  Pointer<TMaterial> get address => super.address.cast();
+  TMaterial(super.address);
+
+  static Pointer<TMaterial> stackAlloc() {
+    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  }
+}
+
+sealed class TFeatureLevel {
+  static const FEATURE_LEVEL_0 = 0;
+  static const FEATURE_LEVEL_1 = 1;
+  static const FEATURE_LEVEL_2 = 2;
+  static const FEATURE_LEVEL_3 = 3;
+}
+
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
+  }
+}
+
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
+
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  }
+}
+
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
+extension TTextureExt on Pointer<TTexture> {
+  TTexture toDart() {
+    return TTexture(this);
+  }
+}
+
+final class TTexture extends Struct {
+  Pointer<TTexture> get address => super.address.cast();
+  TTexture(super.address);
+
+  static Pointer<TTexture> stackAlloc() {
+    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
+  }
+}
+
+extension TTextureSamplerExt on Pointer<TTextureSampler> {
+  TTextureSampler toDart() {
+    return TTextureSampler(this);
+  }
+}
+
+final class TTextureSampler extends Struct {
+  Pointer<TTextureSampler> get address => super.address.cast();
+  TTextureSampler(super.address);
+
+  static Pointer<TTextureSampler> stackAlloc() {
+    return Pointer<TTextureSampler>(
+      NativeLibrary.instance.stackAlloc<TTextureSampler>(0),
+    );
+  }
+}
+
+sealed class TSamplerCompareFunc {
+  /// !< Less or equal
+  static const LE = 0;
+
+  /// !< Greater or equal
+  static const GE = 1;
+
+  /// !< Strictly less than
+  static const L = 2;
+
+  /// !< Strictly greater than
+  static const G = 3;
+
+  /// !< Equal
+  static const E = 4;
+
+  /// !< Not equal
+  static const NE = 5;
+
+  /// !< Always. Depth / stencil testing is deactivated.
+  static const A = 6;
+
+  /// !< Never. The depth / stencil test always fails.
+  static const N = 7;
+}
+
+sealed class TStencilOperation {
+  static const KEEP = 0;
+  static const ZERO = 1;
+  static const REPLACE = 2;
+  static const INCR = 3;
+  static const INCR_WRAP = 4;
+  static const DECR = 5;
+  static const DECR_WRAP = 6;
+  static const INVERT = 7;
+}
+
+sealed class TStencilFace {
+  static const STENCIL_FACE_FRONT = 1;
+  static const STENCIL_FACE_BACK = 2;
+  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+}
+
+sealed class TTransparencyMode {
+  /// ! the transparent object is drawn honoring the raster state
+  static const DEFAULT = 0;
+
+  /// the transparent object is first drawn in the depth buffer,
+  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
+  static const TWO_PASSES_ONE_SIDE = 1;
+
+  /// the transparent object is drawn twice in the color buffer,
+  /// first with back faces only, then with front faces; the culling
+  /// mode is ignored. Can be combined with two-sided lighting
+  static const TWO_PASSES_TWO_SIDES = 2;
+}
+
+sealed class TBlendingMode {
+  static const BLENDING_MODE_OPAQUE = 0;
+  static const BLENDING_MODE_TRANSPARENT = 1;
+  static const BLENDING_MODE_ADD = 2;
+  static const BLENDING_MODE_MASKED = 3;
+  static const BLENDING_MODE_FADE = 4;
+  static const BLENDING_MODE_MULTIPLY = 5;
+  static const BLENDING_MODE_SCREEN = 6;
+  static const BLENDING_MODE_CUSTOM = 7;
+}
+
+extension TLightManagerExt on Pointer<TLightManager> {
+  TLightManager toDart() {
+    return TLightManager(this);
+  }
+}
+
+final class TLightManager extends Struct {
+  Pointer<TLightManager> get address => super.address.cast();
+  TLightManager(super.address);
+
+  static Pointer<TLightManager> stackAlloc() {
+    return Pointer<TLightManager>(
+      NativeLibrary.instance.stackAlloc<TLightManager>(0),
+    );
+  }
+}
+
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+typedef EntityId = int;
+typedef DartEntityId = int;
 
 extension double3Ext on Pointer<double3> {
   double3 toDart() {
@@ -11511,243 +11622,330 @@ final class double3 extends Struct {
   }
 }
 
-typedef EntityId = int;
-typedef DartEntityId = int;
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-extension TSceneAssetExt on Pointer<TSceneAsset> {
-  TSceneAsset toDart() {
-    return TSceneAsset(this);
+extension TShadowOptionsExt on Pointer<TShadowOptions> {
+  TShadowOptions toDart() {
+    return TShadowOptions(this);
   }
 }
 
-final class TSceneAsset extends Struct {
-  Pointer<TSceneAsset> get address => super.address.cast();
-  TSceneAsset(super.address);
+final class TShadowOptions extends Struct {
+  Pointer<TShadowOptions> get address => super.address.cast();
+  int get mapSize {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
 
-  static Pointer<TSceneAsset> stackAlloc() {
-    return Pointer<TSceneAsset>(
-      NativeLibrary.instance.stackAlloc<TSceneAsset>(0),
+  set mapSize(int val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 0),
+      val.toJS,
+      'i32',
     );
   }
-}
 
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
+  int get shadowCascades {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
   }
-}
 
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
-
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
-  }
-}
-
-extension TVertexBufferExt on Pointer<TVertexBuffer> {
-  TVertexBuffer toDart() {
-    return TVertexBuffer(this);
-  }
-}
-
-final class TVertexBuffer extends Struct {
-  Pointer<TVertexBuffer> get address => super.address.cast();
-  TVertexBuffer(super.address);
-
-  static Pointer<TVertexBuffer> stackAlloc() {
-    return Pointer<TVertexBuffer>(
-      NativeLibrary.instance.stackAlloc<TVertexBuffer>(0),
+  set shadowCascades(int val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 4),
+      val.toJS,
+      'i8',
     );
   }
-}
 
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
+  Array<Float32> get cascadeSplitPositions {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float32>((
+      numElements: 3,
+      addr: Pointer<Float32>(this.address.addr + 5),
+    ));
   }
-}
 
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
-
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(
-      NativeLibrary.instance.stackAlloc<TIndexBuffer>(0),
+  set cascadeSplitPositions(Array<Float32> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 5),
+      val.internal.addr.addr.toJS,
+      '*',
     );
   }
-}
 
-extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
-  TMaterialInstance toDart() {
-    return TMaterialInstance(this);
-  }
-}
-
-final class TMaterialInstance extends Struct {
-  Pointer<TMaterialInstance> get address => super.address.cast();
-  TMaterialInstance(super.address);
-
-  static Pointer<TMaterialInstance> stackAlloc() {
-    return Pointer<TMaterialInstance>(
-      NativeLibrary.instance.stackAlloc<TMaterialInstance>(0),
-    );
-  }
-}
-
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
-}
-
-extension Aabb3Ext on Pointer<Aabb3> {
-  Aabb3 toDart() {
-    return Aabb3(this);
-  }
-}
-
-final class Aabb3 extends Struct {
-  Pointer<Aabb3> get address => super.address.cast();
-  double get centerX {
-    final addr = Pointer<Aabb3>(this.address.addr + 0);
+  double get constantBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set centerX(double val) {
+  set constantBias(double val) {
     NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 0),
+      Pointer<TShadowOptions>(this.address.addr + 17),
       val.toJS,
       'float',
     );
   }
 
-  double get centerY {
-    final addr = Pointer<Aabb3>(this.address.addr + 4);
+  double get normalBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set centerY(double val) {
+  set normalBias(double val) {
     NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 4),
+      Pointer<TShadowOptions>(this.address.addr + 21),
       val.toJS,
       'float',
     );
   }
 
-  double get centerZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 8);
+  double get shadowFar {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set centerZ(double val) {
+  set shadowFar(double val) {
     NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 8),
+      Pointer<TShadowOptions>(this.address.addr + 25),
       val.toJS,
       'float',
     );
   }
 
-  double get halfExtentX {
-    final addr = Pointer<Aabb3>(this.address.addr + 12);
+  double get shadowNearHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set halfExtentX(double val) {
+  set shadowNearHint(double val) {
     NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 12),
+      Pointer<TShadowOptions>(this.address.addr + 29),
       val.toJS,
       'float',
     );
   }
 
-  double get halfExtentY {
-    final addr = Pointer<Aabb3>(this.address.addr + 16);
+  double get shadowFarHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set halfExtentY(double val) {
+  set shadowFarHint(double val) {
     NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 16),
+      Pointer<TShadowOptions>(this.address.addr + 33),
       val.toJS,
       'float',
     );
   }
 
-  double get halfExtentZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 20);
+  bool get stable {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set stable(bool val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 37),
+      (val ? 1 : 0).toJS,
+      'i8',
+    );
+  }
+
+  bool get lispsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set lispsm(bool val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 38),
+      (val ? 1 : 0).toJS,
+      'i8',
+    );
+  }
+
+  double get polygonOffsetConstant {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set halfExtentZ(double val) {
+  set polygonOffsetConstant(double val) {
     NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 20),
+      Pointer<TShadowOptions>(this.address.addr + 39),
       val.toJS,
       'float',
     );
   }
 
-  Aabb3(super.address);
-
-  static Pointer<Aabb3> stackAlloc() {
-    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
+  double get polygonOffsetSlope {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
   }
-}
 
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
-  }
-}
-
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
-
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(
-      NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0),
+  set polygonOffsetSlope(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 43),
+      val.toJS,
+      'float',
     );
   }
-}
 
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
+  bool get screenSpaceContactShadows {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
   }
-}
 
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
+  set screenSpaceContactShadows(bool val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 47),
+      (val ? 1 : 0).toJS,
+      'i8',
+    );
+  }
 
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(
-      NativeLibrary.instance.stackAlloc<TNameComponentManager>(0),
+  int get stepCount {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set stepCount(int val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 48),
+      val.toJS,
+      'i8',
+    );
+  }
+
+  double get maxShadowDistance {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxShadowDistance(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 49),
+      val.toJS,
+      'float',
+    );
+  }
+
+  bool get vsmElvsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set vsmElvsm(bool val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 53),
+      (val ? 1 : 0).toJS,
+      'i8',
+    );
+  }
+
+  double get vsmBlurWidth {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set vsmBlurWidth(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 54),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get shadowBulbRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowBulbRadius(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 58),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 62),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 66),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 70),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 74),
+      val.toJS,
+      'float',
+    );
+  }
+
+  TShadowOptions(super.address);
+
+  static Pointer<TShadowOptions> stackAlloc() {
+    return Pointer<TShadowOptions>(
+      NativeLibrary.instance.stackAlloc<TShadowOptions>(78),
     );
   }
 }
@@ -11769,33 +11967,22 @@ final class TFilamentAsset extends Struct {
   }
 }
 
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
   }
 }
 
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
 
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(
+      NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0),
+    );
   }
 }
-
-typedef size_t = int;
-typedef Dartsize_t = int;
 
 extension TMaterialProviderExt on Pointer<TMaterialProvider> {
   TMaterialProvider toDart() {
@@ -11814,6 +12001,27 @@ final class TMaterialProvider extends Struct {
   }
 }
 
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(
+      NativeLibrary.instance.stackAlloc<TNameComponentManager>(0),
+    );
+  }
+}
+
+typedef size_t = __darwin_size_t;
+typedef __darwin_size_t = int;
+typedef Dart__darwin_size_t = int;
+
 extension TRenderableManagerExt on Pointer<TRenderableManager> {
   TRenderableManager toDart() {
     return TRenderableManager(this);
@@ -11827,40 +12035,6 @@ final class TRenderableManager extends Struct {
   static Pointer<TRenderableManager> stackAlloc() {
     return Pointer<TRenderableManager>(
       NativeLibrary.instance.stackAlloc<TRenderableManager>(0),
-    );
-  }
-}
-
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
-  }
-}
-
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
-
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(
-      NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0),
-    );
-  }
-}
-
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
-  }
-}
-
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
-
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(
-      NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0),
     );
   }
 }
@@ -12183,6 +12357,36 @@ final class TVsmShadowOptions extends Struct {
     return Pointer<TVsmShadowOptions>(
       NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12),
     );
+  }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
   }
 }
 
@@ -12814,21 +13018,6 @@ final class TFogOptions extends Struct {
   }
 }
 
-extension TTextureExt on Pointer<TTexture> {
-  TTexture toDart() {
-    return TTexture(this);
-  }
-}
-
-final class TTexture extends Struct {
-  Pointer<TTexture> get address => super.address.cast();
-  TTexture(super.address);
-
-  static Pointer<TTexture> stackAlloc() {
-    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
-  }
-}
-
 typedef PickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
 typedef DartPickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
 typedef PickCallbackFunction =
@@ -12850,155 +13039,55 @@ typedef DartPickCallbackFunction =
       double fragZ,
     );
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
   }
 }
 
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
 
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
-  }
-}
-
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
-  }
-}
-
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
-
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(
-      NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0),
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(
+      NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0),
     );
   }
 }
 
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TMaterialExt on Pointer<TMaterial> {
-  TMaterial toDart() {
-    return TMaterial(this);
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
   }
 }
 
-final class TMaterial extends Struct {
-  Pointer<TMaterial> get address => super.address.cast();
-  TMaterial(super.address);
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
 
-  static Pointer<TMaterial> stackAlloc() {
-    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
-  }
-}
-
-sealed class TFeatureLevel {
-  static const FEATURE_LEVEL_0 = 0;
-  static const FEATURE_LEVEL_1 = 1;
-  static const FEATURE_LEVEL_2 = 2;
-  static const FEATURE_LEVEL_3 = 3;
-}
-
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
-}
-
-extension TTextureSamplerExt on Pointer<TTextureSampler> {
-  TTextureSampler toDart() {
-    return TTextureSampler(this);
-  }
-}
-
-final class TTextureSampler extends Struct {
-  Pointer<TTextureSampler> get address => super.address.cast();
-  TTextureSampler(super.address);
-
-  static Pointer<TTextureSampler> stackAlloc() {
-    return Pointer<TTextureSampler>(
-      NativeLibrary.instance.stackAlloc<TTextureSampler>(0),
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(
+      NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0),
     );
   }
 }
 
-sealed class TSamplerCompareFunc {
-  /// !< Less or equal
-  static const LE = 0;
-
-  /// !< Greater or equal
-  static const GE = 1;
-
-  /// !< Strictly less than
-  static const L = 2;
-
-  /// !< Strictly greater than
-  static const G = 3;
-
-  /// !< Equal
-  static const E = 4;
-
-  /// !< Not equal
-  static const NE = 5;
-
-  /// !< Always. Depth / stencil testing is deactivated.
-  static const A = 6;
-
-  /// !< Never. The depth / stencil test always fails.
-  static const N = 7;
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
+  }
 }
 
-sealed class TStencilOperation {
-  static const KEEP = 0;
-  static const ZERO = 1;
-  static const REPLACE = 2;
-  static const INCR = 3;
-  static const INCR_WRAP = 4;
-  static const DECR = 5;
-  static const DECR_WRAP = 6;
-  static const INVERT = 7;
-}
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
 
-sealed class TStencilFace {
-  static const STENCIL_FACE_FRONT = 1;
-  static const STENCIL_FACE_BACK = 2;
-  static const STENCIL_FACE_FRONT_AND_BACK = 3;
-}
-
-sealed class TTransparencyMode {
-  /// ! the transparent object is drawn honoring the raster state
-  static const DEFAULT = 0;
-
-  /// the transparent object is first drawn in the depth buffer,
-  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
-  static const TWO_PASSES_ONE_SIDE = 1;
-
-  /// the transparent object is drawn twice in the color buffer,
-  /// first with back faces only, then with front faces; the culling
-  /// mode is ignored. Can be combined with two-sided lighting
-  static const TWO_PASSES_TWO_SIDES = 2;
-}
-
-sealed class TBlendingMode {
-  static const BLENDING_MODE_OPAQUE = 0;
-  static const BLENDING_MODE_TRANSPARENT = 1;
-  static const BLENDING_MODE_ADD = 2;
-  static const BLENDING_MODE_MASKED = 3;
-  static const BLENDING_MODE_FADE = 4;
-  static const BLENDING_MODE_MULTIPLY = 5;
-  static const BLENDING_MODE_SCREEN = 6;
-  static const BLENDING_MODE_CUSTOM = 7;
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(
+      NativeLibrary.instance.stackAlloc<TIndirectLight>(0),
+    );
+  }
 }
 
 sealed class TTextureSamplerType {
@@ -13296,21 +13385,21 @@ sealed class TSamplerCompareMode {
   static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
 }
 
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
+  }
+}
 
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
 
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(
+      NativeLibrary.instance.stackAlloc<TRenderManager>(0),
+    );
+  }
 }
 
 extension TRendererExt on Pointer<TRenderer> {
@@ -13325,6 +13414,23 @@ final class TRenderer extends Struct {
 
   static Pointer<TRenderer> stackAlloc() {
     return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  }
+}
+
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
+  }
+}
+
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
+
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(
+      NativeLibrary.instance.stackAlloc<TAnimationManager>(0),
+    );
   }
 }
 
@@ -13345,102 +13451,111 @@ final class TSwapChain extends Struct {
   }
 }
 
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
+typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
+typedef PostRenderCallback =
+    Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef DartPostRenderCallback =
+    Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
+typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
   }
 }
 
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
 
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(
-      NativeLibrary.instance.stackAlloc<TTransformManager>(0),
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  }
+}
+
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
+  }
+}
+
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
+
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(
+      NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0),
     );
   }
 }
 
-extension TLightManagerExt on Pointer<TLightManager> {
-  TLightManager toDart() {
-    return TLightManager(this);
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback =
+    Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction =
+    void Function(int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction =
+    void Function(int resultType, double x, double y, double z);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
   }
 }
 
-final class TLightManager extends Struct {
-  Pointer<TLightManager> get address => super.address.cast();
-  TLightManager(super.address);
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
 
-  static Pointer<TLightManager> stackAlloc() {
-    return Pointer<TLightManager>(
-      NativeLibrary.instance.stackAlloc<TLightManager>(0),
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(
+      NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0),
     );
   }
 }
 
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(
-      NativeLibrary.instance.stackAlloc<TEntityManager>(0),
-    );
-  }
-}
-
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
-  }
-}
-
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
-
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
-  }
-}
-
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
-  }
-}
-
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
-
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(
-      NativeLibrary.instance.stackAlloc<TIndirectLight>(0),
-    );
-  }
-}
-
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
-  }
-}
-
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
-
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(
-      NativeLibrary.instance.stackAlloc<TDebugRegistry>(0),
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(
+      NativeLibrary.instance.stackAlloc<TIndexBuffer>(0),
     );
   }
 }
@@ -13509,75 +13624,342 @@ sealed class TVertexAttributeType {
   static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
+extension TVertexBufferExt on Pointer<TVertexBuffer> {
+  TVertexBuffer toDart() {
+    return TVertexBuffer(this);
   }
 }
 
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
+final class TVertexBuffer extends Struct {
+  Pointer<TVertexBuffer> get address => super.address.cast();
+  TVertexBuffer(super.address);
 
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(
-      NativeLibrary.instance.stackAlloc<TRenderManager>(0),
+  static Pointer<TVertexBuffer> stackAlloc() {
+    return Pointer<TVertexBuffer>(
+      NativeLibrary.instance.stackAlloc<TVertexBuffer>(0),
     );
   }
 }
 
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(
-      NativeLibrary.instance.stackAlloc<TAnimationManager>(0),
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  }
+}
+
+extension double4x4Ext on Pointer<double4x4> {
+  double4x4 toDart() {
+    return double4x4(this);
+  }
+}
+
+final class double4x4 extends Struct {
+  Pointer<double4x4> get address => super.address.cast();
+  Array<Float64> get col1 {
+    final addr = Pointer<double4x4>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 0),
+    ));
+  }
+
+  set col1(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 0),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col2 {
+    final addr = Pointer<double4x4>(this.address.addr + 32);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 32),
+    ));
+  }
+
+  set col2(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 32),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col3 {
+    final addr = Pointer<double4x4>(this.address.addr + 64);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 64),
+    ));
+  }
+
+  set col3(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 64),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col4 {
+    final addr = Pointer<double4x4>(this.address.addr + 96);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 96),
+    ));
+  }
+
+  set col4(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 96),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  double4x4(super.address);
+
+  static Pointer<double4x4> stackAlloc() {
+    return Pointer<double4x4>(
+      NativeLibrary.instance.stackAlloc<double4x4>(128),
     );
   }
 }
 
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
   }
 }
 
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
 
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(
-      NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0),
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(
+      NativeLibrary.instance.stackAlloc<TTransformManager>(0),
     );
   }
 }
 
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
+extension Aabb3Ext on Pointer<Aabb3> {
+  Aabb3 toDart() {
+    return Aabb3(this);
   }
 }
 
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
-
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+final class Aabb3 extends Struct {
+  Pointer<Aabb3> get address => super.address.cast();
+  double get centerX {
+    final addr = Pointer<Aabb3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
   }
+
+  set centerX(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 0),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get centerY {
+    final addr = Pointer<Aabb3>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerY(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 4),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get centerZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerZ(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 8),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentX {
+    final addr = Pointer<Aabb3>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentX(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 12),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentY {
+    final addr = Pointer<Aabb3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentY(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 16),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 20);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentZ(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 20),
+      val.toJS,
+      'float',
+    );
+  }
+
+  Aabb3(super.address);
+
+  static Pointer<Aabb3> stackAlloc() {
+    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
+  }
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
+  }
+}
+
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
+
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(
+      NativeLibrary.instance.stackAlloc<TEntityManager>(0),
+    );
+  }
+}
+
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
+  }
+}
+
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
+
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  }
+}
+
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
+  }
+}
+
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
+
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(
+      NativeLibrary.instance.stackAlloc<TDebugRegistry>(0),
+    );
+  }
+}
+
+extension TSceneAssetExt on Pointer<TSceneAsset> {
+  TSceneAsset toDart() {
+    return TSceneAsset(this);
+  }
+}
+
+final class TSceneAsset extends Struct {
+  Pointer<TSceneAsset> get address => super.address.cast();
+  TSceneAsset(super.address);
+
+  static Pointer<TSceneAsset> stackAlloc() {
+    return Pointer<TSceneAsset>(
+      NativeLibrary.instance.stackAlloc<TSceneAsset>(0),
+    );
+  }
+}
+
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
@@ -13684,374 +14066,15 @@ final class TGltfMeshData extends Struct {
   }
 }
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
-
-extension TShadowOptionsExt on Pointer<TShadowOptions> {
-  TShadowOptions toDart() {
-    return TShadowOptions(this);
-  }
-}
-
-final class TShadowOptions extends Struct {
-  Pointer<TShadowOptions> get address => super.address.cast();
-  int get mapSize {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set mapSize(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 0),
-      val.toJS,
-      'i32',
-    );
-  }
-
-  int get shadowCascades {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set shadowCascades(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 4),
-      val.toJS,
-      'i8',
-    );
-  }
-
-  Array<Float32> get cascadeSplitPositions {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float32>((
-      numElements: 3,
-      addr: Pointer<Float32>(this.address.addr + 5),
-    ));
-  }
-
-  set cascadeSplitPositions(Array<Float32> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 5),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  double get constantBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constantBias(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 17),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get normalBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set normalBias(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 21),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get shadowFar {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFar(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 25),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get shadowNearHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowNearHint(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 29),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get shadowFarHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFarHint(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 33),
-      val.toJS,
-      'float',
-    );
-  }
-
-  bool get stable {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set stable(bool val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 37),
-      (val ? 1 : 0).toJS,
-      'i8',
-    );
-  }
-
-  bool get lispsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set lispsm(bool val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 38),
-      (val ? 1 : 0).toJS,
-      'i8',
-    );
-  }
-
-  double get polygonOffsetConstant {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetConstant(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 39),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get polygonOffsetSlope {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetSlope(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 43),
-      val.toJS,
-      'float',
-    );
-  }
-
-  bool get screenSpaceContactShadows {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set screenSpaceContactShadows(bool val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 47),
-      (val ? 1 : 0).toJS,
-      'i8',
-    );
-  }
-
-  int get stepCount {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set stepCount(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 48),
-      val.toJS,
-      'i8',
-    );
-  }
-
-  double get maxShadowDistance {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxShadowDistance(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 49),
-      val.toJS,
-      'float',
-    );
-  }
-
-  bool get vsmElvsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set vsmElvsm(bool val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 53),
-      (val ? 1 : 0).toJS,
-      'i8',
-    );
-  }
-
-  double get vsmBlurWidth {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set vsmBlurWidth(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 54),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get shadowBulbRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowBulbRadius(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 58),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get transformX {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformX(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 62),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get transformY {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformY(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 66),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get transformZ {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformZ(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 70),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get transformW {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformW(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 74),
-      val.toJS,
-      'float',
-    );
-  }
-
-  TShadowOptions(super.address);
-
-  static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(
-      NativeLibrary.instance.stackAlloc<TShadowOptions>(78),
-    );
-  }
-}
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback =
-    Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction =
-    void Function(int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction =
-    void Function(int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
-typedef PostRenderCallback =
-    Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef DartPostRenderCallback =
-    Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
   TMovementIntentExecutor toDart() {
@@ -14102,56 +14125,44 @@ const int SPRINT_INTENT_MASK = 8;
 extension StructAllocator on Struct {
   static T create<T>() {
     switch (T) {
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
+      case TMaterialInstance:
+        final ptr = TMaterialInstance.stackAlloc();
         return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
-        return ptr.toDart() as T;
-      case TSceneAsset:
-        final ptr = TSceneAsset.stackAlloc();
+      case TMaterial:
+        final ptr = TMaterial.stackAlloc();
         return ptr.toDart() as T;
       case TEngine:
         final ptr = TEngine.stackAlloc();
         return ptr.toDart() as T;
-      case TVertexBuffer:
-        final ptr = TVertexBuffer.stackAlloc();
+      case TTexture:
+        final ptr = TTexture.stackAlloc();
         return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
+      case TTextureSampler:
+        final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialInstance:
-        final ptr = TMaterialInstance.stackAlloc();
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
         return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
+      case double3:
+        final ptr = double3.stackAlloc();
         return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TFilamentAsset:
         final ptr = TFilamentAsset.stackAlloc();
         return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
         return ptr.toDart() as T;
       case TMaterialProvider:
         final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
+        return ptr.toDart() as T;
       case TRenderableManager:
         final ptr = TRenderableManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientationBuilder:
-        final ptr = TSurfaceOrientationBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientation:
-        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
       case TViewport:
         final ptr = TViewport.stackAlloc();
@@ -14177,6 +14188,12 @@ extension StructAllocator on Struct {
       case TVsmShadowOptions:
         final ptr = TVsmShadowOptions.stackAlloc();
         return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
+        return ptr.toDart() as T;
+      case TScene:
+        final ptr = TScene.stackAlloc();
+        return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
         return ptr.toDart() as T;
@@ -14186,20 +14203,14 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TTexture:
-        final ptr = TTexture.stackAlloc();
+      case TSurfaceOrientationBuilder:
+        final ptr = TSurfaceOrientationBuilder.stackAlloc();
         return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
+      case TSurfaceOrientation:
+        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TMaterial:
-        final ptr = TMaterial.stackAlloc();
-        return ptr.toDart() as T;
-      case TTextureSampler:
-        final ptr = TTextureSampler.stackAlloc();
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
         return ptr.toDart() as T;
       case TLinearImage:
         final ptr = TLinearImage.stackAlloc();
@@ -14207,17 +14218,47 @@ extension StructAllocator on Struct {
       case TKtx1Bundle:
         final ptr = TKtx1Bundle.stackAlloc();
         return ptr.toDart() as T;
+      case TRenderManager:
+        final ptr = TRenderManager.stackAlloc();
+        return ptr.toDart() as T;
       case TRenderer:
         final ptr = TRenderer.stackAlloc();
+        return ptr.toDart() as T;
+      case TAnimationManager:
+        final ptr = TAnimationManager.stackAlloc();
         return ptr.toDart() as T;
       case TSwapChain:
         final ptr = TSwapChain.stackAlloc();
         return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBufferBuilder:
+        final ptr = TVertexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBuffer:
+        final ptr = TVertexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
+        return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
       case TTransformManager:
         final ptr = TTransformManager.stackAlloc();
         return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
         return ptr.toDart() as T;
       case TEntityManager:
         final ptr = TEntityManager.stackAlloc();
@@ -14225,35 +14266,17 @@ extension StructAllocator on Struct {
       case TFence:
         final ptr = TFence.stackAlloc();
         return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
       case TDebugRegistry:
         final ptr = TDebugRegistry.stackAlloc();
         return ptr.toDart() as T;
-      case TVertexBufferBuilder:
-        final ptr = TVertexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderManager:
-        final ptr = TRenderManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TAnimationManager:
-        final ptr = TAnimationManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
+      case TSceneAsset:
+        final ptr = TSceneAsset.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableBuilder:
         final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TGltfMeshData:
         final ptr = TGltfMeshData.stackAlloc();
-        return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -32,368 +32,187 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
-  external Pointer<TMaterialInstance> _Material_createInstance(
-    Pointer<TMaterial> tMaterial,
+  external void _Camera_setExposure(
+    Pointer<TCamera> camera,
+    double aperture,
+    double shutterSpeed,
+    double sensitivity,
   );
-  external int _Material_getFeatureLevel(Pointer<TMaterial> tMaterial);
-  external Pointer<TMaterial> _Material_createImageMaterial(
-    Pointer<TEngine> tEngine,
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external void _Camera_getModelMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
   );
-  external Pointer<TMaterial> _Material_createGridMaterial(
-    Pointer<TEngine> tEngine,
+  external void _Camera_getViewMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
   );
-  external Pointer<TMaterial> _Material_createGizmoMaterial(
-    Pointer<TEngine> tEngine,
+  external void _Camera_getProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
   );
-  external Pointer<TMaterial> _Material_createSilhouetteMaterial(
-    Pointer<TEngine> tEngine,
+  external void _Camera_getCullingProjectionMatrix(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TCamera> camera,
   );
-  external Pointer<TMaterial> _Material_createEdgeOutlineMaterial(
-    Pointer<TEngine> tEngine,
+  external void _Camera_getFrustum(
+    Pointer<TCamera> camera,
+    Pointer<Float64> out,
   );
-  external Pointer<TMaterial> _Material_createWireframeMaterial(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TMaterial> _Material_createTranslationAxisMaterial(
-    Pointer<TEngine> tEngine,
-  );
-  external Pointer<TMaterial> _Material_createBoneOverlayMaterial(
-    Pointer<TEngine> tEngine,
-  );
-  external int _Material_hasParameter(
-    Pointer<TMaterial> tMaterial,
-    Pointer<Char> propertyName,
-  );
-  external int _MaterialInstance_isStencilWriteEnabled(
-    Pointer<TMaterialInstance> materialInstance,
-  );
-  external void _MaterialInstance_setStencilWrite(
-    Pointer<TMaterialInstance> materialInstance,
-    bool enabled,
-  );
-  external void _MaterialInstance_setCullingMode(
-    Pointer<TMaterialInstance> materialInstance,
-    int culling,
-  );
-  external void _MaterialInstance_setDoubleSided(
-    Pointer<TMaterialInstance> materialInstance,
-    bool doubleSided,
-  );
-  external void _MaterialInstance_setDepthWrite(
-    Pointer<TMaterialInstance> materialInstance,
-    bool enabled,
-  );
-  external void _MaterialInstance_setDepthCulling(
-    Pointer<TMaterialInstance> materialInstance,
-    bool enabled,
-  );
-  external void _MaterialInstance_setParameterFloat(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    double value,
-  );
-  external void _MaterialInstance_setParameterFloat2(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    double x,
-    double y,
-  );
-  external void _MaterialInstance_setParameterFloat3(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    double x,
-    double y,
-    double z,
-  );
-  external void _MaterialInstance_setParameterFloat3Array(
-    Pointer<TMaterialInstance> tMaterialInstance,
-    Pointer<Char> propertyName,
-    Pointer<Float64> raw,
-    int length,
-  );
-  external void _MaterialInstance_setParameterFloat4(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    double x,
-    double y,
-    double w,
-    double z,
-  );
-  external void _MaterialInstance_setParameterMat3(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
+  external void _Camera_setProjectionMatrix(
+    Pointer<TCamera> camera,
     Pointer<Float64> matrix,
-  );
-  external void _MaterialInstance_setParameterMat4(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    Pointer<Float64> matrix,
-  );
-  external void _MaterialInstance_setParameterInt(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    int value,
-  );
-  external void _MaterialInstance_setParameterBool(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    bool value,
-  );
-  external void _MaterialInstance_setParameterTexture(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    Pointer<TTexture> texture,
-    Pointer<TTextureSampler> sampler,
-  );
-  external void _MaterialInstance_setDepthFunc(
-    Pointer<TMaterialInstance> materialInstance,
-    int depthFunc,
-  );
-  external void _MaterialInstance_setStencilOpStencilFail(
-    Pointer<TMaterialInstance> materialInstance,
-    int op,
-    int face,
-  );
-  external void _MaterialInstance_setStencilOpDepthFail(
-    Pointer<TMaterialInstance> materialInstance,
-    int op,
-    int face,
-  );
-  external void _MaterialInstance_setStencilOpDepthStencilPass(
-    Pointer<TMaterialInstance> materialInstance,
-    int op,
-    int face,
-  );
-  external void _MaterialInstance_setStencilCompareFunction(
-    Pointer<TMaterialInstance> materialInstance,
-    int func,
-    int face,
-  );
-  external void _MaterialInstance_setStencilReferenceValue(
-    Pointer<TMaterialInstance> materialInstance,
-    int value,
-    int face,
-  );
-  external void _MaterialInstance_setStencilReadMask(
-    Pointer<TMaterialInstance> materialInstance,
-    int mask,
-  );
-  external void _MaterialInstance_setStencilWriteMask(
-    Pointer<TMaterialInstance> materialInstance,
-    int mask,
-  );
-  external void _MaterialInstance_setTransparencyMode(
-    Pointer<TMaterialInstance> materialInstance,
-    int transparencyMode,
-  );
-  external int _MaterialInstance_getTransparencyMode(
-    Pointer<TMaterialInstance> materialInstance,
-  );
-  external int _Material_getBlendingMode(Pointer<TMaterial> material);
-  external int _LightManager_createLight(
-    Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
-  );
-  external void _LightManager_destroyLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_hasComponent(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_getType(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isDirectional(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isPointLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external int _LightManager_isSpotLight(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double r,
-    double g,
-    double b,
-  );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double falloff,
-  );
-  external double _LightManager_getFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external double _LightManager_getSpotLightInnerCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloSize,
-  );
-  external double _LightManager_getSunHaloSize(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    bool enabled,
-  );
-  external int _LightManager_isShadowCaster(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-  );
-  external void _LightManager_computeUniformSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-  );
-  external void _LightManager_computeLogSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
     double near,
     double far,
   );
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
     double near,
     double far,
-    double lambda,
+    bool horizontal,
   );
-  external double _LightManager_rgbToColorTemperature(
-    double r,
-    double g,
-    double b,
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
   );
-  external int _FilamentAsset_getEntityCount(
-    Pointer<TFilamentAsset> filamentAsset,
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external void _Camera_setFocusDistance(
+    Pointer<TCamera> camera,
+    double focusDistance,
   );
-  external void _FilamentAsset_getEntities(
-    Pointer<TFilamentAsset> filamentAsset,
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(
+    Pointer<TCamera> camera,
+    Pointer<Float64> tModelMatrix,
+  );
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    bool rebuildVertices,
+  );
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_addToScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external void _SceneAsset_removeFromScene(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+  );
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getChildEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _SceneAsset_getChildEntities(
+    Pointer<TSceneAsset> tSceneAsset,
     Pointer<Int32> out,
   );
-  external EntityId _FilamentAsset_getWireframe(
-    Pointer<TFilamentAsset> filamentAsset,
+  external Pointer<Int32> _SceneAsset_getCameraEntities(
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external Pointer<Void> _FilamentAsset_getSourceAsset(
-    Pointer<TFilamentAsset> filamentAsset,
+  external size_t _SceneAsset_getCameraEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<Int32> _SceneAsset_getLightEntities(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external size_t _SceneAsset_getLightEntityCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+  );
+  external size_t _SceneAsset_getInstanceCount(
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+  );
+  external void _SceneAsset_getBoundingBox(
+    Pointer<Aabb3> Aabb3_out,
+    Pointer<TSceneAsset> asset,
+  );
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
+    Pointer<TSceneAsset> tSceneAsset,
+    int primitiveIndex,
+  );
+  external int _SceneAsset_getPrimitiveOffsetForEntity(
+    Pointer<TSceneAsset> tSceneAsset,
+    EntityId entity,
+  );
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_setFlatShading(
+    Pointer<TSceneAsset> tSceneAsset,
+    bool flatShading,
+  );
+  external void _SceneAsset_getBones(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    Pointer<Int32> out,
+  );
+  external size_t _SceneAsset_getBoneCount(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+  );
+  external Pointer<Char> _SceneAsset_getBoneName(
+    Pointer<TSceneAsset> tSceneAsset,
+    size_t skinIndex,
+    size_t boneIndex,
   );
   external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
     Pointer<TEngine> tEngine,
@@ -422,6 +241,95 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(
     Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(
+    Pointer<TNameComponentManager> tNameComponentManager,
+  );
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external Pointer<TSurfaceOrientationBuilder>
+  _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
+  );
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_triangleCount(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    size_t count,
+  );
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
+  );
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
+  );
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
+    Pointer<TSurfaceOrientationBuilder> builder,
+  );
+  external void _SurfaceOrientationBuilder_destroy(
+    Pointer<TSurfaceOrientationBuilder> builder,
+  );
+  external size_t _SurfaceOrientation_getVertexCount(
+    Pointer<TSurfaceOrientation> orientation,
+  );
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Float32> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_destroy(
+    Pointer<TSurfaceOrientation> orientation,
+  );
+  external int _FilamentAsset_getEntityCount(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external void _FilamentAsset_getEntities(
+    Pointer<TFilamentAsset> filamentAsset,
+    Pointer<Int32> out,
+  );
+  external EntityId _FilamentAsset_getWireframe(
+    Pointer<TFilamentAsset> filamentAsset,
+  );
+  external Pointer<Void> _FilamentAsset_getSourceAsset(
+    Pointer<TFilamentAsset> filamentAsset,
   );
   external void _View_getViewport(
     Pointer<TViewport> TViewport_out,
@@ -676,86 +584,199 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
   external Pointer<Char> _View_getName(Pointer<TView> tView);
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(
-    Pointer<TNameComponentManager> tNameComponentManager,
+  external void _Skybox_setColor(
+    Pointer<TSkybox> tSkybox,
+    double r,
+    double g,
+    double b,
+    double a,
   );
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(
+    Pointer<TIndexBufferBuilder> builder,
+    int count,
   );
-  external Pointer<TSurfaceOrientationBuilder>
-  _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
+  external void _IndexBufferBuilder_bufferType(
+    Pointer<TIndexBufferBuilder> builder,
+    int indexType,
   );
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
+  external void _IndexBufferBuilder_destroy(
+    Pointer<TIndexBufferBuilder> builder,
   );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
+  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
   );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
+  external void _IndexBuffer_destroy(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
   );
-  external void _SurfaceOrientationBuilder_triangleCount(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    size_t count,
+  external Pointer<TMaterialInstance> _Material_createInstance(
+    Pointer<TMaterial> tMaterial,
   );
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
+  external int _Material_getFeatureLevel(Pointer<TMaterial> tMaterial);
+  external Pointer<TMaterial> _Material_createImageMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
+  external Pointer<TMaterial> _Material_createGridMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(
-    Pointer<TSurfaceOrientationBuilder> builder,
+  external Pointer<TMaterial> _Material_createGizmoMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _SurfaceOrientationBuilder_destroy(
-    Pointer<TSurfaceOrientationBuilder> builder,
+  external Pointer<TMaterial> _Material_createSilhouetteMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external size_t _SurfaceOrientation_getVertexCount(
-    Pointer<TSurfaceOrientation> orientation,
+  external Pointer<TMaterial> _Material_createEdgeOutlineMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
+  external Pointer<TMaterial> _Material_createWireframeMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
+  external Pointer<TMaterial> _Material_createTranslationAxisMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
+  external Pointer<TMaterial> _Material_createBoneOverlayMaterial(
+    Pointer<TEngine> tEngine,
   );
-  external void _SurfaceOrientation_destroy(
-    Pointer<TSurfaceOrientation> orientation,
+  external int _Material_hasParameter(
+    Pointer<TMaterial> tMaterial,
+    Pointer<Char> propertyName,
   );
-  external void _IndirectLight_setRotation(
-    Pointer<TIndirectLight> tIndirectLight,
-    Pointer<Float64> rotation,
+  external int _MaterialInstance_isStencilWriteEnabled(
+    Pointer<TMaterialInstance> materialInstance,
   );
+  external void _MaterialInstance_setStencilWrite(
+    Pointer<TMaterialInstance> materialInstance,
+    bool enabled,
+  );
+  external void _MaterialInstance_setCullingMode(
+    Pointer<TMaterialInstance> materialInstance,
+    int culling,
+  );
+  external void _MaterialInstance_setDoubleSided(
+    Pointer<TMaterialInstance> materialInstance,
+    bool doubleSided,
+  );
+  external void _MaterialInstance_setDepthWrite(
+    Pointer<TMaterialInstance> materialInstance,
+    bool enabled,
+  );
+  external void _MaterialInstance_setDepthCulling(
+    Pointer<TMaterialInstance> materialInstance,
+    bool enabled,
+  );
+  external void _MaterialInstance_setParameterFloat(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    double value,
+  );
+  external void _MaterialInstance_setParameterFloat2(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    double x,
+    double y,
+  );
+  external void _MaterialInstance_setParameterFloat3(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    double x,
+    double y,
+    double z,
+  );
+  external void _MaterialInstance_setParameterFloat3Array(
+    Pointer<TMaterialInstance> tMaterialInstance,
+    Pointer<Char> propertyName,
+    Pointer<Float64> raw,
+    int length,
+  );
+  external void _MaterialInstance_setParameterFloat4(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    double x,
+    double y,
+    double w,
+    double z,
+  );
+  external void _MaterialInstance_setParameterMat3(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    Pointer<Float64> matrix,
+  );
+  external void _MaterialInstance_setParameterMat4(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    Pointer<Float64> matrix,
+  );
+  external void _MaterialInstance_setParameterInt(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    int value,
+  );
+  external void _MaterialInstance_setParameterBool(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    bool value,
+  );
+  external void _MaterialInstance_setParameterTexture(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    Pointer<TTexture> texture,
+    Pointer<TTextureSampler> sampler,
+  );
+  external void _MaterialInstance_setDepthFunc(
+    Pointer<TMaterialInstance> materialInstance,
+    int depthFunc,
+  );
+  external void _MaterialInstance_setStencilOpStencilFail(
+    Pointer<TMaterialInstance> materialInstance,
+    int op,
+    int face,
+  );
+  external void _MaterialInstance_setStencilOpDepthFail(
+    Pointer<TMaterialInstance> materialInstance,
+    int op,
+    int face,
+  );
+  external void _MaterialInstance_setStencilOpDepthStencilPass(
+    Pointer<TMaterialInstance> materialInstance,
+    int op,
+    int face,
+  );
+  external void _MaterialInstance_setStencilCompareFunction(
+    Pointer<TMaterialInstance> materialInstance,
+    int func,
+    int face,
+  );
+  external void _MaterialInstance_setStencilReferenceValue(
+    Pointer<TMaterialInstance> materialInstance,
+    int value,
+    int face,
+  );
+  external void _MaterialInstance_setStencilReadMask(
+    Pointer<TMaterialInstance> materialInstance,
+    int mask,
+  );
+  external void _MaterialInstance_setStencilWriteMask(
+    Pointer<TMaterialInstance> materialInstance,
+    int mask,
+  );
+  external void _MaterialInstance_setTransparencyMode(
+    Pointer<TMaterialInstance> materialInstance,
+    int transparencyMode,
+  );
+  external int _MaterialInstance_getTransparencyMode(
+    Pointer<TMaterialInstance> materialInstance,
+  );
+  external int _Material_getBlendingMode(Pointer<TMaterial> material);
   external Pointer<TTexture> _Texture_build(
     Pointer<TEngine> engine,
     int width,
@@ -890,407 +911,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int func,
   );
   external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
-  external Pointer<TRenderManager> _RenderManager_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderer> tRenderer,
-  );
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_render(
-    Pointer<TRenderManager> tRenderer,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
-  );
-  external void _RenderManager_removeSwapChain(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-  );
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(
-    Pointer<TRenderManager> tRenderer,
-  );
-  external void _RenderManager_detachFromRenderThread(
-    Pointer<TRenderManager> tRenderManager,
-  );
-  external void _RenderManager_setPaused(
-    Pointer<TRenderManager> tRenderer,
-    bool paused,
-  );
-  external void _FrameScheduler_start(FrameCallback callback, int targetFps);
-  external void _FrameScheduler_stop();
-  external void _FrameScheduler_setRenderThread(Pointer<Void> renderThread);
-  external void _FrameScheduler_setRenderManager(Pointer<TRenderManager> rm);
-  external void _FrameScheduler_setPostRenderCallback(
-    PostRenderCallback callback,
-    Pointer<Void> userData,
-  );
-  external int _FrameScheduler_requestRender(JSBigInt frameTimeNanos);
-  external void _FrameScheduler_startNativeRenderLoop(int targetFps);
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external void _Gizmo_dummy(int t);
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(
-    Pointer<TGizmo> tGizmo,
-    int x,
-    int y,
-    GizmoPickCallback callback,
-  );
-  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
-  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
-  external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
-    Pointer<TMaterialProvider> provider,
-    bool doubleSided,
-    bool unlit,
-    bool hasVertexColors,
-    bool hasBaseColorTexture,
-    bool hasNormalTexture,
-    bool hasOcclusionTexture,
-    bool hasEmissiveTexture,
-    bool useSpecularGlossiness,
-    int alphaMode,
-    bool enableDiagnostics,
-    bool hasMetallicRoughnessTexture,
-    int metallicRoughnessUV,
-    bool hasSpecularGlossinessTexture,
-    int specularGlossinessUV,
-    int baseColorUV,
-    bool hasClearCoatTexture,
-    int clearCoatUV,
-    bool hasClearCoatRoughnessTexture,
-    int clearCoatRoughnessUV,
-    bool hasClearCoatNormalTexture,
-    int clearCoatNormalUV,
-    bool hasClearCoat,
-    bool hasTransmission,
-    bool hasTextureTransforms,
-    int emissiveUV,
-    int aoUV,
-    int normalUV,
-    bool hasTransmissionTexture,
-    int transmissionUV,
-    bool hasSheenColorTexture,
-    int sheenColorUV,
-    bool hasSheenRoughnessTexture,
-    int sheenRoughnessUV,
-    bool hasVolumeThicknessTexture,
-    int volumeThicknessUV,
-    bool hasSheen,
-    bool hasIOR,
-    bool hasVolume,
-  );
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(
-    Pointer<TIndexBufferBuilder> builder,
-    int count,
-  );
-  external void _IndexBufferBuilder_bufferType(
-    Pointer<TIndexBufferBuilder> builder,
-    int indexType,
-  );
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _IndexBufferBuilder_destroy(
-    Pointer<TIndexBufferBuilder> builder,
-  );
-  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _IndexBuffer_destroy(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-  );
-  external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
-  external void _VertexBufferBuilder_bufferCount(
-    Pointer<TVertexBufferBuilder> builder,
-    int count,
-  );
-  external void _VertexBufferBuilder_vertexCount(
-    Pointer<TVertexBufferBuilder> builder,
-    int count,
-  );
-  external void _VertexBufferBuilder_attribute(
-    Pointer<TVertexBufferBuilder> builder,
-    int attribute,
-    int bufferIndex,
-    int attributeType,
-    int byteOffset,
-    int byteStride,
-  );
-  external void _VertexBufferBuilder_normalized(
-    Pointer<TVertexBufferBuilder> builder,
-    int attribute,
-    bool normalize,
-  );
-  external Pointer<TVertexBuffer> _VertexBufferBuilder_build(
-    Pointer<TVertexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _VertexBufferBuilder_destroy(
-    Pointer<TVertexBufferBuilder> builder,
-  );
-  external size_t _VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer);
-  external void _VertexBuffer_setBufferAt(
-    Pointer<TEngine> engine,
-    Pointer<TVertexBuffer> buffer,
-    int bufferIndex,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _VertexBuffer_destroy(
-    Pointer<TEngine> engine,
-    Pointer<TVertexBuffer> buffer,
-  );
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
-  );
-  external void _RenderTarget_destroy(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderTarget> tRenderTarget,
-  );
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(
-    Pointer<TScene> tScene,
-    Pointer<TSkybox> skybox,
-  );
-  external void _Scene_setIndirectLight(
-    Pointer<TScene> tScene,
-    Pointer<TIndirectLight> tIndirectLight,
-  );
-  external void _Scene_addFilamentAsset(
-    Pointer<TScene> tScene,
-    Pointer<TFilamentAsset> asset,
-  );
-  external void _Camera_setExposure(
-    Pointer<TCamera> camera,
-    double aperture,
-    double shutterSpeed,
-    double sensitivity,
-  );
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getViewMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getCullingProjectionMatrix(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TCamera> camera,
-  );
-  external void _Camera_getFrustum(
-    Pointer<TCamera> camera,
-    Pointer<Float64> out,
-  );
-  external void _Camera_setProjectionMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> matrix,
-    double near,
-    double far,
-  );
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
-  );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(
-    Pointer<TCamera> camera,
-    double focusDistance,
-  );
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(
-    Pointer<TCamera> camera,
-    Pointer<Float64> tModelMatrix,
-  );
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
-  external void _TransformManager_getLocalTransform(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external void _TransformManager_getWorldTransform(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external void _TransformManager_setTransform(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<double4x4> transformPtr,
-  );
-  external int _TransformManager_transformToUnitCube(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<Aabb3> boundingBoxPtr,
-  );
-  external void _TransformManager_setParent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId child,
-    EntityId parent,
-    bool preserveScaling,
-  );
-  external EntityId _TransformManager_getParent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId child,
-  );
-  external EntityId _TransformManager_getAncestor(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId childEntityId,
-  );
-  external void _TransformManager_createComponent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entity,
-  );
-  external void _TransformManager_removeComponent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entity,
-  );
-  external int _TransformManager_hasComponent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external int _TransformManager_empty(
-    Pointer<TTransformManager> tTransformManager,
-  );
-  external int _TransformManager_getComponentCount(
-    Pointer<TTransformManager> tTransformManager,
-  );
-  external int _TransformManager_getChildCount(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external void _TransformManager_getChildren(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<Int32> children,
-    int count,
-  );
-  external void _TransformManager_openLocalTransformTransaction(
-    Pointer<TTransformManager> tTransformManager,
-  );
-  external void _TransformManager_commitLocalTransformTransaction(
-    Pointer<TTransformManager> tTransformManager,
-  );
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
-  external void _Renderer_render(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-  );
-  external void _Renderer_renderStandaloneView(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-  );
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
   external Pointer<TEngine> _Engine_create(
     int backend,
     Pointer<Void> platform,
@@ -1464,6 +1084,157 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TDebugRegistry> tDebugRegistry,
     Pointer<Char> name,
     Pointer<Float32> outValue,
+  );
+  external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
+    Pointer<TMaterialProvider> provider,
+    bool doubleSided,
+    bool unlit,
+    bool hasVertexColors,
+    bool hasBaseColorTexture,
+    bool hasNormalTexture,
+    bool hasOcclusionTexture,
+    bool hasEmissiveTexture,
+    bool useSpecularGlossiness,
+    int alphaMode,
+    bool enableDiagnostics,
+    bool hasMetallicRoughnessTexture,
+    int metallicRoughnessUV,
+    bool hasSpecularGlossinessTexture,
+    int specularGlossinessUV,
+    int baseColorUV,
+    bool hasClearCoatTexture,
+    int clearCoatUV,
+    bool hasClearCoatRoughnessTexture,
+    int clearCoatRoughnessUV,
+    bool hasClearCoatNormalTexture,
+    int clearCoatNormalUV,
+    bool hasClearCoat,
+    bool hasTransmission,
+    bool hasTextureTransforms,
+    int emissiveUV,
+    int aoUV,
+    int normalUV,
+    bool hasTransmissionTexture,
+    int transmissionUV,
+    bool hasSheenColorTexture,
+    int sheenColorUV,
+    bool hasSheenRoughnessTexture,
+    int sheenRoughnessUV,
+    bool hasVolumeThicknessTexture,
+    int volumeThicknessUV,
+    bool hasSheen,
+    bool hasIOR,
+    bool hasVolume,
+  );
+  external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
+  external void _VertexBufferBuilder_bufferCount(
+    Pointer<TVertexBufferBuilder> builder,
+    int count,
+  );
+  external void _VertexBufferBuilder_vertexCount(
+    Pointer<TVertexBufferBuilder> builder,
+    int count,
+  );
+  external void _VertexBufferBuilder_attribute(
+    Pointer<TVertexBufferBuilder> builder,
+    int attribute,
+    int bufferIndex,
+    int attributeType,
+    int byteOffset,
+    int byteStride,
+  );
+  external void _VertexBufferBuilder_normalized(
+    Pointer<TVertexBufferBuilder> builder,
+    int attribute,
+    bool normalize,
+  );
+  external Pointer<TVertexBuffer> _VertexBufferBuilder_build(
+    Pointer<TVertexBufferBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _VertexBufferBuilder_destroy(
+    Pointer<TVertexBufferBuilder> builder,
+  );
+  external size_t _VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer);
+  external void _VertexBuffer_setBufferAt(
+    Pointer<TEngine> engine,
+    Pointer<TVertexBuffer> buffer,
+    int bufferIndex,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _VertexBuffer_destroy(
+    Pointer<TEngine> engine,
+    Pointer<TVertexBuffer> buffer,
+  );
+  external void _TransformManager_getLocalTransform(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external void _TransformManager_getWorldTransform(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external void _TransformManager_setTransform(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<double4x4> transformPtr,
+  );
+  external int _TransformManager_transformToUnitCube(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external void _TransformManager_setParent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId child,
+    EntityId parent,
+    bool preserveScaling,
+  );
+  external EntityId _TransformManager_getParent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId child,
+  );
+  external EntityId _TransformManager_getAncestor(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId childEntityId,
+  );
+  external void _TransformManager_createComponent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entity,
+  );
+  external void _TransformManager_removeComponent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entity,
+  );
+  external int _TransformManager_hasComponent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external int _TransformManager_empty(
+    Pointer<TTransformManager> tTransformManager,
+  );
+  external int _TransformManager_getComponentCount(
+    Pointer<TTransformManager> tTransformManager,
+  );
+  external int _TransformManager_getChildCount(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external void _TransformManager_getChildren(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<Int32> children,
+    int count,
+  );
+  external void _TransformManager_openLocalTransformTransaction(
+    Pointer<TTransformManager> tTransformManager,
+  );
+  external void _TransformManager_commitLocalTransformTransaction(
+    Pointer<TTransformManager> tTransformManager,
   );
   external Pointer<Void> _RenderThread_create();
   external Pointer<Void> _RenderThread_createForCanvas(
@@ -2514,40 +2285,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(
-    Pointer<TEngine> tEngine,
-  );
-  external void _GltfResourceLoader_destroy(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  );
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external void _GltfResourceLoader_asyncUpdateLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  );
-  external double _GltfResourceLoader_asyncGetLoadProgress(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  );
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
-  );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external void _Skybox_setColor(
-    Pointer<TSkybox> tSkybox,
-    double r,
-    double g,
-    double b,
-    double a,
-  );
   external void _dummy(Pointer<TGltfMeshData> dummyPtr);
   external int _GltfParser_parseBuffer(
     Pointer<Uint8> data,
@@ -2556,6 +2293,212 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TGltfMeshData> outMeshData,
   );
   external void _GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData);
+  external int _LightManager_createLight(
+    Pointer<TEngine> tEngine,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
+  );
+  external void _LightManager_destroyLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_hasComponent(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_getType(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isDirectional(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isPointLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external int _LightManager_isSpotLight(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double r,
+    double g,
+    double b,
+  );
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external double _LightManager_getIntensity(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double falloff,
+  );
+  external double _LightManager_getFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external double _LightManager_getSpotLightOuterCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external double _LightManager_getSpotLightInnerCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external double _LightManager_getSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloSize,
+  );
+  external double _LightManager_getSunHaloSize(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external double _LightManager_getSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    bool enabled,
+  );
+  external int _LightManager_isShadowCaster(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external int _LightManager_getLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+  );
+  external void _LightManager_computeUniformSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+  );
+  external void _LightManager_computeLogSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+  );
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external double _LightManager_rgbToColorTemperature(
+    double r,
+    double g,
+    double b,
+  );
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_setSkybox(
+    Pointer<TScene> tScene,
+    Pointer<TSkybox> skybox,
+  );
+  external void _Scene_setIndirectLight(
+    Pointer<TScene> tScene,
+    Pointer<TIndirectLight> tIndirectLight,
+  );
+  external void _Scene_addFilamentAsset(
+    Pointer<TScene> tScene,
+    Pointer<TFilamentAsset> asset,
+  );
   external void _RenderableManager_destroyEntity(
     Pointer<TRenderableManager> tRenderableManager,
     EntityId entityId,
@@ -2832,102 +2775,51 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TEngine> engine,
     EntityId entity,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(
     Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    Pointer<Aabb3> boundingBoxPtr,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+  external void _GltfResourceLoader_destroy(
     Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  );
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
     Pointer<TFilamentAsset> tFilamentAsset,
-    bool rebuildVertices,
   );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _GltfResourceLoader_asyncUpdateLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
   );
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
+  external double _GltfResourceLoader_asyncGetLoadProgress(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
   );
-  external void _SceneAsset_removeFromScene(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
   );
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
   );
-  external void _SceneAsset_getChildEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<Int32> out,
+  external void _Gizmo_dummy(int t);
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
   );
-  external Pointer<Int32> _SceneAsset_getCameraEntities(
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _Gizmo_pick(
+    Pointer<TGizmo> tGizmo,
+    int x,
+    int y,
+    GizmoPickCallback callback,
   );
-  external size_t _SceneAsset_getCameraEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<Int32> _SceneAsset_getLightEntities(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external size_t _SceneAsset_getLightEntityCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-  );
-  external size_t _SceneAsset_getInstanceCount(
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-  );
-  external void _SceneAsset_getBoundingBox(
-    Pointer<Aabb3> Aabb3_out,
-    Pointer<TSceneAsset> asset,
-  );
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(
-    Pointer<TSceneAsset> tSceneAsset,
-    int primitiveIndex,
-  );
-  external int _SceneAsset_getPrimitiveOffsetForEntity(
-    Pointer<TSceneAsset> tSceneAsset,
-    EntityId entity,
-  );
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(
-    Pointer<TSceneAsset> tSceneAsset,
-    bool flatShading,
-  );
-  external void _SceneAsset_getBones(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    Pointer<Int32> out,
-  );
-  external size_t _SceneAsset_getBoneCount(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-  );
-  external Pointer<Char> _SceneAsset_getBoneName(
-    Pointer<TSceneAsset> tSceneAsset,
-    size_t skinIndex,
-    size_t boneIndex,
-  );
+  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
   external Pointer<TAnimationManager> _AnimationManager_create(
     Pointer<TEngine> tEngine,
   );
@@ -3065,6 +2957,114 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int animationIndex,
     double timeInSeconds,
   );
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
+  );
+  external void _RenderTarget_destroy(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderTarget> tRenderTarget,
+  );
+  external void _IndirectLight_setRotation(
+    Pointer<TIndirectLight> tIndirectLight,
+    Pointer<Float64> rotation,
+  );
+  external Pointer<TRenderManager> _RenderManager_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderer> tRenderer,
+  );
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_render(
+    Pointer<TRenderManager> tRenderer,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
+  );
+  external void _RenderManager_removeSwapChain(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+  );
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_attachToRenderThread(
+    Pointer<TRenderManager> tRenderer,
+  );
+  external void _RenderManager_detachFromRenderThread(
+    Pointer<TRenderManager> tRenderManager,
+  );
+  external void _RenderManager_setPaused(
+    Pointer<TRenderManager> tRenderer,
+    bool paused,
+  );
+  external void _FrameScheduler_start(FrameCallback callback, int targetFps);
+  external void _FrameScheduler_stop();
+  external void _FrameScheduler_setRenderThread(Pointer<Void> renderThread);
+  external void _FrameScheduler_setRenderManager(Pointer<TRenderManager> rm);
+  external void _FrameScheduler_setPostRenderCallback(
+    PostRenderCallback callback,
+    Pointer<Void> userData,
+  );
+  external int _FrameScheduler_requestRender(JSBigInt frameTimeNanos);
+  external void _FrameScheduler_startNativeRenderLoop(int targetFps);
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
+  external void _Renderer_render(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+  );
+  external void _Renderer_renderStandaloneView(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+  );
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
   external void _MovementIntentExecutor_destroy(
     Pointer<TMovementIntentExecutor> executor,
   );
@@ -3181,965 +3181,512 @@ BigInt get TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER {
   return bigIntasUintN(64, value).toDart;
 }
 
-Pointer<TMaterialInstance> Material_createInstance(
-  Pointer<TMaterial> tMaterial,
+void Camera_setExposure(
+  Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
 ) {
-  final result = GeneratedBindings.instance._Material_createInstance(
-    tMaterial.cast(),
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-int Material_getFeatureLevel(Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Material_getFeatureLevel(
-    tMaterial.cast(),
-  );
-  return result;
-}
-
-Pointer<TMaterial> Material_createImageMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createImageMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createGridMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createGridMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createGizmoMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createGizmoMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createSilhouetteMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createSilhouetteMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createEdgeOutlineMaterial(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Material_createEdgeOutlineMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createWireframeMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createWireframeMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createTranslationAxisMaterial(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance
-      ._Material_createTranslationAxisMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
-}
-
-Pointer<TMaterial> Material_createBoneOverlayMaterial(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._Material_createBoneOverlayMaterial(
-    tEngine.cast(),
-  );
-  return Pointer<TMaterial>(result);
-}
-
-bool Material_hasParameter(
-  Pointer<TMaterial> tMaterial,
-  Pointer<Char> propertyName,
-) {
-  final result = GeneratedBindings.instance._Material_hasParameter(
-    tMaterial.cast(),
-    propertyName,
-  );
-  return result == 1;
-}
-
-bool MaterialInstance_isStencilWriteEnabled(
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_isStencilWriteEnabled(materialInstance.cast());
-  return result == 1;
-}
-
-void MaterialInstance_setStencilWrite(
-  Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setStencilWrite(
-    materialInstance.cast(),
-    enabled,
+  final result = GeneratedBindings.instance._Camera_setExposure(
+    camera.cast(),
+    aperture,
+    shutterSpeed,
+    sensitivity,
   );
   return result;
 }
 
-void MaterialInstance_setCullingMode(
-  Pointer<TMaterialInstance> materialInstance,
-  int culling,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setCullingMode(
-    materialInstance.cast(),
-    culling,
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(
+    camera.cast(),
   );
   return result;
 }
 
-void MaterialInstance_setDoubleSided(
-  Pointer<TMaterialInstance> materialInstance,
-  bool doubleSided,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDoubleSided(
-    materialInstance.cast(),
-    doubleSided,
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(
+    camera.cast(),
   );
   return result;
 }
 
-void MaterialInstance_setDepthWrite(
-  Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDepthWrite(
-    materialInstance.cast(),
-    enabled,
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(
+    double4x4_out.cast(),
+    camera.cast(),
+  );
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(
+    camera.cast(),
+    out,
   );
   return result;
 }
 
-void MaterialInstance_setDepthCulling(
-  Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDepthCulling(
-    materialInstance.cast(),
-    enabled,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  double value,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterFloat(
-    materialInstance.cast(),
-    propertyName,
-    value,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat2(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  double x,
-  double y,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterFloat2(
-        materialInstance.cast(),
-        propertyName,
-        x,
-        y,
-      );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat3(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterFloat3(
-        materialInstance.cast(),
-        propertyName,
-        x,
-        y,
-        z,
-      );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat3Array(
-  Pointer<TMaterialInstance> tMaterialInstance,
-  Pointer<Char> propertyName,
-  Pointer<Float64> raw,
-  int length,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterFloat3Array(
-        tMaterialInstance.cast(),
-        propertyName,
-        raw,
-        length,
-      );
-  return result;
-}
-
-void MaterialInstance_setParameterFloat4(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  double x,
-  double y,
-  double w,
-  double z,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterFloat4(
-        materialInstance.cast(),
-        propertyName,
-        x,
-        y,
-        w,
-        z,
-      );
-  return result;
-}
-
-void MaterialInstance_setParameterMat3(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
+void Camera_setProjectionMatrix(
+  Pointer<TCamera> camera,
   Pointer<Float64> matrix,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterMat3(
-    materialInstance.cast(),
-    propertyName,
-    matrix,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterMat4(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  Pointer<Float64> matrix,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterMat4(
-    materialInstance.cast(),
-    propertyName,
-    matrix,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterInt(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  int value,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterInt(
-    materialInstance.cast(),
-    propertyName,
-    value,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterBool(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  bool value,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterBool(
-    materialInstance.cast(),
-    propertyName,
-    value,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterTexture(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  Pointer<TTexture> texture,
-  Pointer<TTextureSampler> sampler,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setParameterTexture(
-        materialInstance.cast(),
-        propertyName,
-        texture.cast(),
-        sampler.cast(),
-      );
-  return result;
-}
-
-void MaterialInstance_setDepthFunc(
-  Pointer<TMaterialInstance> materialInstance,
-  int depthFunc,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDepthFunc(
-    materialInstance.cast(),
-    depthFunc,
-  );
-  return result;
-}
-
-void MaterialInstance_setStencilOpStencilFail(
-  Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilOpStencilFail(
-        materialInstance.cast(),
-        op,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilOpDepthFail(
-  Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilOpDepthFail(
-        materialInstance.cast(),
-        op,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilOpDepthStencilPass(
-  Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilOpDepthStencilPass(
-        materialInstance.cast(),
-        op,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilCompareFunction(
-  Pointer<TMaterialInstance> materialInstance,
-  int func,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilCompareFunction(
-        materialInstance.cast(),
-        func,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilReferenceValue(
-  Pointer<TMaterialInstance> materialInstance,
-  int value,
-  int face,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilReferenceValue(
-        materialInstance.cast(),
-        value,
-        face,
-      );
-  return result;
-}
-
-void MaterialInstance_setStencilReadMask(
-  Pointer<TMaterialInstance> materialInstance,
-  int mask,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilReadMask(materialInstance.cast(), mask);
-  return result;
-}
-
-void MaterialInstance_setStencilWriteMask(
-  Pointer<TMaterialInstance> materialInstance,
-  int mask,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setStencilWriteMask(materialInstance.cast(), mask);
-  return result;
-}
-
-void MaterialInstance_setTransparencyMode(
-  Pointer<TMaterialInstance> materialInstance,
-  int transparencyMode,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_setTransparencyMode(
-        materialInstance.cast(),
-        transparencyMode,
-      );
-  return result;
-}
-
-int MaterialInstance_getTransparencyMode(
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialInstance_getTransparencyMode(materialInstance.cast());
-  return result;
-}
-
-int Material_getBlendingMode(Pointer<TMaterial> material) {
-  final result = GeneratedBindings.instance._Material_getBlendingMode(
-    material.cast(),
-  );
-  return result;
-}
-
-int LightManager_createLight(
-  Pointer<TEngine> tEngine,
-  Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-    tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
-  );
-  return result;
-}
-
-void LightManager_destroyLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-bool LightManager_hasComponent(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-int LightManager_getType(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getType(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-bool LightManager_isDirectional(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-bool LightManager_isPointLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-void LightManager_setPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(
-    tLightManager.cast(),
-    light,
-    x,
-    y,
-    z,
-  );
-  return result;
-}
-
-double3 LightManager_getPosition(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(
-    double3_out.cast(),
-    tLightManager.cast(),
-    light,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-  double x,
-  double y,
-  double z,
-) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(
-    tLightManager.cast(),
-    light,
-    x,
-    y,
-    z,
-  );
-  return result;
-}
-
-double3 LightManager_getDirection(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId light,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(
-    double3_out.cast(),
-    tLightManager.cast(),
-    light,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double r,
-  double g,
-  double b,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColor(
-    tLightManager.cast(),
-    entity,
-    r,
-    g,
-    b,
-  );
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
-  );
-  return result;
-}
-
-double3 LightManager_getColor(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(
-    double3_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(
-    tLightManager.cast(),
-    entity,
-    intensity,
-  );
-  return result;
-}
-
-void LightManager_setIntensityCandela(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
-    tLightManager.cast(),
-    entity,
-    intensity,
-  );
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
-  );
-  return result;
-}
-
-double LightManager_getIntensity(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double falloff,
-) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(
-    tLightManager.cast(),
-    entity,
-    falloff,
-  );
-  return result;
-}
-
-double LightManager_getFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
-    tLightManager.cast(),
-    entity,
-    inner,
-    outer,
-  );
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double angularRadius,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
-  );
-  return result;
-}
-
-double LightManager_getSunAngularRadius(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloSize,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(
-    tLightManager.cast(),
-    entity,
-    haloSize,
-  );
-  return result;
-}
-
-double LightManager_getSunHaloSize(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double haloFalloff,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
-    tLightManager.cast(),
-    entity,
-    haloFalloff,
-  );
-  return result;
-}
-
-double LightManager_getSunHaloFalloff(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(
-    tLightManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void LightManager_setShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(
-    tLightManager.cast(),
-    entity,
-    enabled,
-  );
-  return result;
-}
-
-bool LightManager_isShadowCaster(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(
-    tLightManager.cast(),
-    entity,
-  );
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  TShadowOptions options,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  int channel,
-) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-  );
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(
-    splitPositions,
-    cascades,
-  );
-  return result;
-}
-
-void LightManager_computeLogSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
   double near,
   double far,
 ) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(
-    splitPositions,
-    cascades,
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(
+    camera.cast(),
+    matrix,
     near,
     far,
   );
   return result;
 }
 
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
   double near,
   double far,
-  double lambda,
+  bool horizontal,
 ) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(
+    camera.cast(),
+  );
+  return result;
+}
+
+void Camera_lookAt(
+  Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(
+    camera.cast(),
+    eyePtr.cast(),
+    focusPtr.cast(),
+    upPtr.cast(),
+  );
+  return result;
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(
+    camera.cast(),
+  );
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(
+    camera.cast(),
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(
+    camera.cast(),
+  );
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(
+    camera.cast(),
+    focusDistance,
+  );
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
   final result = GeneratedBindings.instance
-      ._LightManager_computePracticalSplits(
-        splitPositions,
-        cascades,
+      ._Camera_setCustomProjectionWithCulling(
+        camera.cast(),
+        projectionMatrixPtr.cast(),
         near,
         far,
-        lambda,
       );
   return result;
 }
 
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(
-    r,
-    g,
-    b,
+void Camera_setModelMatrix(
+  Pointer<TCamera> camera,
+  Pointer<Float64> tModelMatrix,
+) {
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(
+    camera.cast(),
+    tModelMatrix,
   );
   return result;
 }
 
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(
-    filamentAsset.cast(),
+void Camera_setLensProjection(
+  Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(
+    camera.cast(),
+    near,
+    far,
+    aspect,
+    focalLength,
   );
   return result;
 }
 
-void FilamentAsset_getEntities(
-  Pointer<TFilamentAsset> filamentAsset,
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tVertexBuffer,
+  Pointer<TIndexBuffer> tIndexBuffer,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  Aabb3 boundingBox,
+) {
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
+    tEngine.cast(),
+    tVertexBuffer.cast(),
+    tIndexBuffer.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+    tPrimitiveType,
+    boundingBoxPtr.cast(),
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  bool rebuildVertices,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    tNameComponentManager.cast(),
+    tFilamentAsset.cast(),
+    rebuildVertices,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(
+    tSceneAsset.cast(),
+  );
+  return Pointer<TFilamentAsset>(result);
+}
+
+int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getType(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_destroy(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_addToScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_addToScene(
+    tSceneAsset.cast(),
+    tScene.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_removeFromScene(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(
+    tSceneAsset.cast(),
+    tScene.cast(),
+  );
+  return result;
+}
+
+DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getEntity(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_getChildEntities(
+  Pointer<TSceneAsset> tSceneAsset,
   Pointer<Int32> out,
 ) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(
-    filamentAsset.cast(),
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(
+    tSceneAsset.cast(),
     out,
   );
   return result;
 }
 
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(
-    filamentAsset.cast(),
+Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(
+    tSceneAsset.cast(),
+  );
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(
+    tSceneAsset.cast(),
   );
   return result;
 }
 
-Pointer<Void> FilamentAsset_getSourceAsset(
-  Pointer<TFilamentAsset> filamentAsset,
-) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(
-    filamentAsset.cast(),
+Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(
+    tSceneAsset.cast(),
   );
-  return Pointer<Void>(result);
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_getInstance(
+  Pointer<TSceneAsset> tSceneAsset,
+  int index,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstance(
+    tSceneAsset.cast(),
+    index,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createInstance(
+  Pointer<TSceneAsset> asset,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createInstance(
+    asset.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(
+    Aabb3_out.cast(),
+    asset.cast(),
+  );
+  return Aabb3_out.toDart();
+}
+
+Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(
+    tSceneAsset.cast(),
+    primitiveIndex,
+  );
+  return Pointer<TVertexBuffer>(result);
+}
+
+Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(
+    tSceneAsset.cast(),
+    primitiveIndex,
+  );
+  return Pointer<TIndexBuffer>(result);
+}
+
+int SceneAsset_getPrimitiveOffsetForEntity(
+  Pointer<TSceneAsset> tSceneAsset,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance
+      ._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
+  return result;
+}
+
+void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(
+    tSceneAsset.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_setFlatShading(
+  Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(
+    tSceneAsset.cast(),
+    flatShading,
+  );
+  return result;
+}
+
+void SceneAsset_getBones(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getBones(
+    tSceneAsset.cast(),
+    skinIndex,
+    out,
+  );
+  return result;
+}
+
+Dartsize_t SceneAsset_getBoneCount(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(
+    tSceneAsset.cast(),
+    skinIndex,
+  );
+  return result;
+}
+
+Pointer<Char> SceneAsset_getBoneName(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dartsize_t skinIndex,
+  Dartsize_t boneIndex,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_getBoneName(
+    tSceneAsset.cast(),
+    skinIndex,
+    boneIndex,
+  );
+  return Pointer<Char>(result);
 }
 
 Pointer<TGltfAssetLoader> GltfAssetLoader_create(
@@ -4166,7 +3713,7 @@ Pointer<TFilamentAsset> GltfAssetLoader_load(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int numInstances,
 ) {
   final result = GeneratedBindings.instance._GltfAssetLoader_load(
@@ -4213,6 +3760,234 @@ Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(
     tFilamentAsset.cast(),
   );
   return Pointer<PointerClass<Char>>(result);
+}
+
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(
+    tNameComponentManager.cast(),
+  );
+  return result;
+}
+
+Pointer<Char> NameComponentManager_getName(
+  Pointer<TNameComponentManager> tNameComponentManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(
+    tNameComponentManager.cast(),
+    entity,
+  );
+  return Pointer<Char>(result);
+}
+
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(
+    builder.cast(),
+    normals,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(
+    builder.cast(),
+    tangents,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(
+    builder.cast(),
+    uvs,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint32> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance
+      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(
+    builder.cast(),
+  );
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(
+  Pointer<TSurfaceOrientationBuilder> builder,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(
+    builder.cast(),
+  );
+  return result;
+}
+
+Dartsize_t SurfaceOrientation_getVertexCount(
+  Pointer<TSurfaceOrientation> orientation,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(
+    orientation.cast(),
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(
+    orientation.cast(),
+  );
+  return result;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(
+    filamentAsset.cast(),
+  );
+  return result;
+}
+
+void FilamentAsset_getEntities(
+  Pointer<TFilamentAsset> filamentAsset,
+  Pointer<Int32> out,
+) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(
+    filamentAsset.cast(),
+    out,
+  );
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(
+    filamentAsset.cast(),
+  );
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(
+  Pointer<TFilamentAsset> filamentAsset,
+) {
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(
+    filamentAsset.cast(),
+  );
+  return Pointer<Void>(result);
 }
 
 TViewport View_getViewport(Pointer<TView> view) {
@@ -4918,207 +4693,527 @@ Pointer<Char> View_getName(Pointer<TView> tView) {
   return Pointer<Char>(result);
 }
 
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(
-  Pointer<TNameComponentManager> tNameComponentManager,
+void Skybox_setColor(
+  Pointer<TSkybox> tSkybox,
+  double r,
+  double g,
+  double b,
+  double a,
 ) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(
-    tNameComponentManager.cast(),
+  final result = GeneratedBindings.instance._Skybox_setColor(
+    tSkybox.cast(),
+    r,
+    g,
+    b,
+    a,
   );
   return result;
 }
 
-Pointer<Char> NameComponentManager_getName(
-  Pointer<TNameComponentManager> tNameComponentManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(
-    tNameComponentManager.cast(),
-    entity,
-  );
-  return Pointer<Char>(result);
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
 }
 
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dart__darwin_size_t count,
+void IndexBufferBuilder_indexCount(
+  Pointer<TIndexBufferBuilder> builder,
+  int count,
 ) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(
+  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(
     builder.cast(),
-    normals,
-    stride,
+    count,
   );
   return result;
 }
 
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dart__darwin_size_t stride,
+void IndexBufferBuilder_bufferType(
+  Pointer<TIndexBufferBuilder> builder,
+  int indexType,
 ) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(
+  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(
     builder.cast(),
-    tangents,
-    stride,
+    indexType,
   );
   return result;
 }
 
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dart__darwin_size_t stride,
+Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  Pointer<TIndexBufferBuilder> builder,
+  Pointer<TEngine> engine,
 ) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(
+  final result = GeneratedBindings.instance._IndexBufferBuilder_build(
     builder.cast(),
-    uvs,
-    stride,
+    engine.cast(),
   );
-  return result;
+  return Pointer<TIndexBuffer>(result);
 }
 
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint32> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance
-      ._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(
-    builder.cast(),
-  );
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(
-  Pointer<TSurfaceOrientationBuilder> builder,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(
+void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(
     builder.cast(),
   );
   return result;
 }
 
-Dart__darwin_size_t SurfaceOrientation_getVertexCount(
-  Pointer<TSurfaceOrientation> orientation,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(
-    orientation.cast(),
+Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(
+    buffer.cast(),
   );
   return result;
 }
 
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
 ) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
   );
   return result;
 }
 
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
+void IndexBuffer_destroy(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
 ) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
+  final result = GeneratedBindings.instance._IndexBuffer_destroy(
+    engine.cast(),
+    buffer.cast(),
   );
   return result;
 }
 
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
+Pointer<TMaterialInstance> Material_createInstance(
+  Pointer<TMaterial> tMaterial,
 ) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
+  final result = GeneratedBindings.instance._Material_createInstance(
+    tMaterial.cast(),
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+int Material_getFeatureLevel(Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Material_getFeatureLevel(
+    tMaterial.cast(),
   );
   return result;
 }
 
-void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(
-    orientation.cast(),
+Pointer<TMaterial> Material_createImageMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createImageMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createGridMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createGridMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createGizmoMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createGizmoMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createSilhouetteMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createSilhouetteMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createEdgeOutlineMaterial(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Material_createEdgeOutlineMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createWireframeMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createWireframeMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createTranslationAxisMaterial(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance
+      ._Material_createTranslationAxisMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createBoneOverlayMaterial(
+  Pointer<TEngine> tEngine,
+) {
+  final result = GeneratedBindings.instance._Material_createBoneOverlayMaterial(
+    tEngine.cast(),
+  );
+  return Pointer<TMaterial>(result);
+}
+
+bool Material_hasParameter(
+  Pointer<TMaterial> tMaterial,
+  Pointer<Char> propertyName,
+) {
+  final result = GeneratedBindings.instance._Material_hasParameter(
+    tMaterial.cast(),
+    propertyName,
+  );
+  return result == 1;
+}
+
+bool MaterialInstance_isStencilWriteEnabled(
+  Pointer<TMaterialInstance> materialInstance,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_isStencilWriteEnabled(materialInstance.cast());
+  return result == 1;
+}
+
+void MaterialInstance_setStencilWrite(
+  Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setStencilWrite(
+    materialInstance.cast(),
+    enabled,
   );
   return result;
 }
 
-void IndirectLight_setRotation(
-  Pointer<TIndirectLight> tIndirectLight,
-  Pointer<Float64> rotation,
+void MaterialInstance_setCullingMode(
+  Pointer<TMaterialInstance> materialInstance,
+  int culling,
 ) {
-  final result = GeneratedBindings.instance._IndirectLight_setRotation(
-    tIndirectLight.cast(),
-    rotation,
+  final result = GeneratedBindings.instance._MaterialInstance_setCullingMode(
+    materialInstance.cast(),
+    culling,
+  );
+  return result;
+}
+
+void MaterialInstance_setDoubleSided(
+  Pointer<TMaterialInstance> materialInstance,
+  bool doubleSided,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDoubleSided(
+    materialInstance.cast(),
+    doubleSided,
+  );
+  return result;
+}
+
+void MaterialInstance_setDepthWrite(
+  Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDepthWrite(
+    materialInstance.cast(),
+    enabled,
+  );
+  return result;
+}
+
+void MaterialInstance_setDepthCulling(
+  Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDepthCulling(
+    materialInstance.cast(),
+    enabled,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterFloat(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  double value,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterFloat(
+    materialInstance.cast(),
+    propertyName,
+    value,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterFloat2(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  double x,
+  double y,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterFloat2(
+        materialInstance.cast(),
+        propertyName,
+        x,
+        y,
+      );
+  return result;
+}
+
+void MaterialInstance_setParameterFloat3(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterFloat3(
+        materialInstance.cast(),
+        propertyName,
+        x,
+        y,
+        z,
+      );
+  return result;
+}
+
+void MaterialInstance_setParameterFloat3Array(
+  Pointer<TMaterialInstance> tMaterialInstance,
+  Pointer<Char> propertyName,
+  Pointer<Float64> raw,
+  int length,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterFloat3Array(
+        tMaterialInstance.cast(),
+        propertyName,
+        raw,
+        length,
+      );
+  return result;
+}
+
+void MaterialInstance_setParameterFloat4(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  double x,
+  double y,
+  double w,
+  double z,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterFloat4(
+        materialInstance.cast(),
+        propertyName,
+        x,
+        y,
+        w,
+        z,
+      );
+  return result;
+}
+
+void MaterialInstance_setParameterMat3(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  Pointer<Float64> matrix,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterMat3(
+    materialInstance.cast(),
+    propertyName,
+    matrix,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterMat4(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  Pointer<Float64> matrix,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterMat4(
+    materialInstance.cast(),
+    propertyName,
+    matrix,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterInt(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  int value,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterInt(
+    materialInstance.cast(),
+    propertyName,
+    value,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterBool(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  bool value,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterBool(
+    materialInstance.cast(),
+    propertyName,
+    value,
+  );
+  return result;
+}
+
+void MaterialInstance_setParameterTexture(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  Pointer<TTexture> texture,
+  Pointer<TTextureSampler> sampler,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setParameterTexture(
+        materialInstance.cast(),
+        propertyName,
+        texture.cast(),
+        sampler.cast(),
+      );
+  return result;
+}
+
+void MaterialInstance_setDepthFunc(
+  Pointer<TMaterialInstance> materialInstance,
+  int depthFunc,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDepthFunc(
+    materialInstance.cast(),
+    depthFunc,
+  );
+  return result;
+}
+
+void MaterialInstance_setStencilOpStencilFail(
+  Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilOpStencilFail(
+        materialInstance.cast(),
+        op,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilOpDepthFail(
+  Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilOpDepthFail(
+        materialInstance.cast(),
+        op,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilOpDepthStencilPass(
+  Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilOpDepthStencilPass(
+        materialInstance.cast(),
+        op,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilCompareFunction(
+  Pointer<TMaterialInstance> materialInstance,
+  int func,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilCompareFunction(
+        materialInstance.cast(),
+        func,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilReferenceValue(
+  Pointer<TMaterialInstance> materialInstance,
+  int value,
+  int face,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilReferenceValue(
+        materialInstance.cast(),
+        value,
+        face,
+      );
+  return result;
+}
+
+void MaterialInstance_setStencilReadMask(
+  Pointer<TMaterialInstance> materialInstance,
+  int mask,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilReadMask(materialInstance.cast(), mask);
+  return result;
+}
+
+void MaterialInstance_setStencilWriteMask(
+  Pointer<TMaterialInstance> materialInstance,
+  int mask,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setStencilWriteMask(materialInstance.cast(), mask);
+  return result;
+}
+
+void MaterialInstance_setTransparencyMode(
+  Pointer<TMaterialInstance> materialInstance,
+  int transparencyMode,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_setTransparencyMode(
+        materialInstance.cast(),
+        transparencyMode,
+      );
+  return result;
+}
+
+int MaterialInstance_getTransparencyMode(
+  Pointer<TMaterialInstance> materialInstance,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialInstance_getTransparencyMode(materialInstance.cast());
+  return result;
+}
+
+int Material_getBlendingMode(Pointer<TMaterial> material) {
+  final result = GeneratedBindings.instance._Material_getBlendingMode(
+    material.cast(),
   );
   return result;
 }
@@ -5161,7 +5256,7 @@ void Texture_setExternalImage(
   return result;
 }
 
-Dart__darwin_size_t Texture_getLevels(Pointer<TTexture> tTexture) {
+Dartsize_t Texture_getLevels(Pointer<TTexture> tTexture) {
   final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
   return result;
 }
@@ -5190,7 +5285,7 @@ bool Texture_setImage(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -5268,7 +5363,7 @@ void Texture_generateMipMaps(
 
 Pointer<TKtx1Bundle> Ktx1Bundle_create(
   Pointer<Uint8> ktxData,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
 ) {
   final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
   return Pointer<TKtx1Bundle>(result);
@@ -5315,7 +5410,7 @@ Pointer<TTexture> Ktx1Reader_createTexture(
 Pointer<TTexture> Ktx2Reader_createTexture(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
 ) {
   final result = GeneratedBindings.instance._Ktx2Reader_createTexture(
     tEngine.cast(),
@@ -5336,7 +5431,7 @@ Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
 
 Pointer<TLinearImage> Image_decode(
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<Char> name,
   bool alpha,
 ) {
@@ -5498,1131 +5593,6 @@ void TextureSampler_setCompareMode(
 void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
   final result = GeneratedBindings.instance._TextureSampler_destroy(
     sampler.cast(),
-  );
-  return result;
-}
-
-Pointer<TRenderManager> RenderManager_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderer> tRenderer,
-) {
-  final result = GeneratedBindings.instance._RenderManager_create(
-    tEngine.cast(),
-    tRenderer.cast(),
-  );
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_removeAnimationManager(
-        tRenderer.cast(),
-        tAnimationManager.cast(),
-      );
-  return result;
-}
-
-void RenderManager_render(
-  Pointer<TRenderManager> tRenderer,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance._RenderManager_render(
-    tRenderer.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(
-    tRenderer.cast(),
-    swapChain.cast(),
-  );
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void RenderManager_detachFromRenderThread(
-  Pointer<TRenderManager> tRenderManager,
-) {
-  final result = GeneratedBindings.instance
-      ._RenderManager_detachFromRenderThread(tRenderManager.cast());
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(
-    tRenderer.cast(),
-    paused,
-  );
-  return result;
-}
-
-void FrameScheduler_start(DartFrameCallback callback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_start(
-    callback as Pointer<NativeFunction<FrameCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-void FrameScheduler_setRenderThread(Pointer<Void> renderThread) {
-  final result = GeneratedBindings.instance._FrameScheduler_setRenderThread(
-    renderThread,
-  );
-  return result;
-}
-
-void FrameScheduler_setRenderManager(Pointer<TRenderManager> rm) {
-  final result = GeneratedBindings.instance._FrameScheduler_setRenderManager(
-    rm.cast(),
-  );
-  return result;
-}
-
-void FrameScheduler_setPostRenderCallback(
-  DartPostRenderCallback callback,
-  Pointer<Void> userData,
-) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_setPostRenderCallback(
-        callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
-        userData,
-      );
-  return result;
-}
-
-bool FrameScheduler_requestRender(BigInt frameTimeNanos) {
-  final result = GeneratedBindings.instance._FrameScheduler_requestRender(
-    frameTimeNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void FrameScheduler_startNativeRenderLoop(int targetFps) {
-  final result = GeneratedBindings.instance
-      ._FrameScheduler_startNativeRenderLoop(targetFps);
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(
-    port.toJSBigInt,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-    tEngine.cast(),
-    assetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
-  );
-  return Pointer<TGizmo>(result);
-}
-
-void Gizmo_pick(
-  Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  DartGizmoPickCallback callback,
-) {
-  final result = GeneratedBindings.instance._Gizmo_pick(
-    tGizmo.cast(),
-    x,
-    y,
-    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
-  );
-  return result;
-}
-
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(
-    tGizmo.cast(),
-    axis,
-  );
-  return result;
-}
-
-void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
-}
-
-Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
-  Pointer<TMaterialProvider> provider,
-  bool doubleSided,
-  bool unlit,
-  bool hasVertexColors,
-  bool hasBaseColorTexture,
-  bool hasNormalTexture,
-  bool hasOcclusionTexture,
-  bool hasEmissiveTexture,
-  bool useSpecularGlossiness,
-  int alphaMode,
-  bool enableDiagnostics,
-  bool hasMetallicRoughnessTexture,
-  int metallicRoughnessUV,
-  bool hasSpecularGlossinessTexture,
-  int specularGlossinessUV,
-  int baseColorUV,
-  bool hasClearCoatTexture,
-  int clearCoatUV,
-  bool hasClearCoatRoughnessTexture,
-  int clearCoatRoughnessUV,
-  bool hasClearCoatNormalTexture,
-  int clearCoatNormalUV,
-  bool hasClearCoat,
-  bool hasTransmission,
-  bool hasTextureTransforms,
-  int emissiveUV,
-  int aoUV,
-  int normalUV,
-  bool hasTransmissionTexture,
-  int transmissionUV,
-  bool hasSheenColorTexture,
-  int sheenColorUV,
-  bool hasSheenRoughnessTexture,
-  int sheenRoughnessUV,
-  bool hasVolumeThicknessTexture,
-  int volumeThicknessUV,
-  bool hasSheen,
-  bool hasIOR,
-  bool hasVolume,
-) {
-  final result = GeneratedBindings.instance
-      ._MaterialProvider_createMaterialInstance(
-        provider.cast(),
-        doubleSided,
-        unlit,
-        hasVertexColors,
-        hasBaseColorTexture,
-        hasNormalTexture,
-        hasOcclusionTexture,
-        hasEmissiveTexture,
-        useSpecularGlossiness,
-        alphaMode,
-        enableDiagnostics,
-        hasMetallicRoughnessTexture,
-        metallicRoughnessUV,
-        hasSpecularGlossinessTexture,
-        specularGlossinessUV,
-        baseColorUV,
-        hasClearCoatTexture,
-        clearCoatUV,
-        hasClearCoatRoughnessTexture,
-        clearCoatRoughnessUV,
-        hasClearCoatNormalTexture,
-        clearCoatNormalUV,
-        hasClearCoat,
-        hasTransmission,
-        hasTextureTransforms,
-        emissiveUV,
-        aoUV,
-        normalUV,
-        hasTransmissionTexture,
-        transmissionUV,
-        hasSheenColorTexture,
-        sheenColorUV,
-        hasSheenRoughnessTexture,
-        sheenRoughnessUV,
-        hasVolumeThicknessTexture,
-        volumeThicknessUV,
-        hasSheen,
-        hasIOR,
-        hasVolume,
-      );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
-}
-
-void IndexBufferBuilder_indexCount(
-  Pointer<TIndexBufferBuilder> builder,
-  int count,
-) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(
-    builder.cast(),
-    count,
-  );
-  return result;
-}
-
-void IndexBufferBuilder_bufferType(
-  Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(
-    builder.cast(),
-    indexType,
-  );
-  return result;
-}
-
-Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  Pointer<TIndexBufferBuilder> builder,
-  Pointer<TEngine> engine,
-) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_build(
-    builder.cast(),
-    engine.cast(),
-  );
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(
-    builder.cast(),
-  );
-  return result;
-}
-
-Dart__darwin_size_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(
-    buffer.cast(),
-  );
-  return result;
-}
-
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void IndexBuffer_destroy(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroy(
-    engine.cast(),
-    buffer.cast(),
-  );
-  return result;
-}
-
-Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_create();
-  return Pointer<TVertexBufferBuilder>(result);
-}
-
-void VertexBufferBuilder_bufferCount(
-  Pointer<TVertexBufferBuilder> builder,
-  int count,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_bufferCount(
-    builder.cast(),
-    count,
-  );
-  return result;
-}
-
-void VertexBufferBuilder_vertexCount(
-  Pointer<TVertexBufferBuilder> builder,
-  int count,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_vertexCount(
-    builder.cast(),
-    count,
-  );
-  return result;
-}
-
-void VertexBufferBuilder_attribute(
-  Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  int bufferIndex,
-  int attributeType,
-  int byteOffset,
-  int byteStride,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_attribute(
-    builder.cast(),
-    attribute,
-    bufferIndex,
-    attributeType,
-    byteOffset,
-    byteStride,
-  );
-  return result;
-}
-
-void VertexBufferBuilder_normalized(
-  Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  bool normalize,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_normalized(
-    builder.cast(),
-    attribute,
-    normalize,
-  );
-  return result;
-}
-
-Pointer<TVertexBuffer> VertexBufferBuilder_build(
-  Pointer<TVertexBufferBuilder> builder,
-  Pointer<TEngine> engine,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_build(
-    builder.cast(),
-    engine.cast(),
-  );
-  return Pointer<TVertexBuffer>(result);
-}
-
-void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_destroy(
-    builder.cast(),
-  );
-  return result;
-}
-
-Dart__darwin_size_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
-  final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(
-    buffer.cast(),
-  );
-  return result;
-}
-
-void VertexBuffer_setBufferAt(
-  Pointer<TEngine> engine,
-  Pointer<TVertexBuffer> buffer,
-  int bufferIndex,
-  Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
-    engine.cast(),
-    buffer.cast(),
-    bufferIndex,
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void VertexBuffer_destroy(
-  Pointer<TEngine> engine,
-  Pointer<TVertexBuffer> buffer,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_destroy(
-    engine.cast(),
-    buffer.cast(),
-  );
-  return result;
-}
-
-Pointer<TRenderTarget> RenderTarget_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> color,
-  Pointer<TTexture> depth,
-) {
-  final result = GeneratedBindings.instance._RenderTarget_create(
-    tEngine.cast(),
-    color.cast(),
-    depth.cast(),
-  );
-  return Pointer<TRenderTarget>(result);
-}
-
-void RenderTarget_destroy(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderTarget> tRenderTarget,
-) {
-  final result = GeneratedBindings.instance._RenderTarget_destroy(
-    tEngine.cast(),
-    tRenderTarget.cast(),
-  );
-  return result;
-}
-
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(
-    tScene.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(
-    tScene.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(
-    tScene.cast(),
-    skybox.cast(),
-  );
-  return result;
-}
-
-void Scene_setIndirectLight(
-  Pointer<TScene> tScene,
-  Pointer<TIndirectLight> tIndirectLight,
-) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(
-    tScene.cast(),
-    tIndirectLight.cast(),
-  );
-  return result;
-}
-
-void Scene_addFilamentAsset(
-  Pointer<TScene> tScene,
-  Pointer<TFilamentAsset> asset,
-) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(
-    tScene.cast(),
-    asset.cast(),
-  );
-  return result;
-}
-
-void Camera_setExposure(
-  Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-) {
-  final result = GeneratedBindings.instance._Camera_setExposure(
-    camera.cast(),
-    aperture,
-    shutterSpeed,
-    sensitivity,
-  );
-  return result;
-}
-
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(
-    camera.cast(),
-  );
-  return result;
-}
-
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(
-    camera.cast(),
-  );
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(
-    double4x4_out.cast(),
-    camera.cast(),
-  );
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(
-    camera.cast(),
-    out,
-  );
-  return result;
-}
-
-void Camera_setProjectionMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> matrix,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(
-    camera.cast(),
-    matrix,
-    near,
-    far,
-  );
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(
-    camera.cast(),
-  );
-  return result;
-}
-
-void Camera_lookAt(
-  Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(
-    camera.cast(),
-    eyePtr.cast(),
-    focusPtr.cast(),
-    upPtr.cast(),
-  );
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(
-    camera.cast(),
-  );
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(
-    camera.cast(),
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(
-    camera.cast(),
-  );
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(
-    camera.cast(),
-    focusDistance,
-  );
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance
-      ._Camera_setCustomProjectionWithCulling(
-        camera.cast(),
-        projectionMatrixPtr.cast(),
-        near,
-        far,
-      );
-  return result;
-}
-
-void Camera_setModelMatrix(
-  Pointer<TCamera> camera,
-  Pointer<Float64> tModelMatrix,
-) {
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(
-    camera.cast(),
-    tModelMatrix,
-  );
-  return result;
-}
-
-void Camera_setLensProjection(
-  Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(
-    camera.cast(),
-    near,
-    far,
-    aspect,
-    focalLength,
-  );
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
-  return result;
-}
-
-double4x4 TransformManager_getLocalTransform(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._TransformManager_getLocalTransform(
-    double4x4_out.cast(),
-    tTransformManager.cast(),
-    entityId,
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 TransformManager_getWorldTransform(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._TransformManager_getWorldTransform(
-    double4x4_out.cast(),
-    tTransformManager.cast(),
-    entityId,
-  );
-  return double4x4_out.toDart();
-}
-
-void TransformManager_setTransform(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  double4x4 transform,
-) {
-  final transformPtr = transform.address;
-  final result = GeneratedBindings.instance._TransformManager_setTransform(
-    tTransformManager.cast(),
-    entityId,
-    transformPtr.cast(),
-  );
-  return result;
-}
-
-bool TransformManager_transformToUnitCube(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  Aabb3 boundingBox,
-) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance
-      ._TransformManager_transformToUnitCube(
-        tTransformManager.cast(),
-        entityId,
-        boundingBoxPtr.cast(),
-      );
-  return result == 1;
-}
-
-void TransformManager_setParent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId child,
-  DartEntityId parent,
-  bool preserveScaling,
-) {
-  final result = GeneratedBindings.instance._TransformManager_setParent(
-    tTransformManager.cast(),
-    child,
-    parent,
-    preserveScaling,
-  );
-  return result;
-}
-
-DartEntityId TransformManager_getParent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId child,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getParent(
-    tTransformManager.cast(),
-    child,
-  );
-  return result;
-}
-
-DartEntityId TransformManager_getAncestor(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId childEntityId,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getAncestor(
-    tTransformManager.cast(),
-    childEntityId,
-  );
-  return result;
-}
-
-void TransformManager_createComponent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._TransformManager_createComponent(
-    tTransformManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-void TransformManager_removeComponent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entity,
-) {
-  final result = GeneratedBindings.instance._TransformManager_removeComponent(
-    tTransformManager.cast(),
-    entity,
-  );
-  return result;
-}
-
-bool TransformManager_hasComponent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._TransformManager_hasComponent(
-    tTransformManager.cast(),
-    entityId,
-  );
-  return result == 1;
-}
-
-bool TransformManager_empty(Pointer<TTransformManager> tTransformManager) {
-  final result = GeneratedBindings.instance._TransformManager_empty(
-    tTransformManager.cast(),
-  );
-  return result == 1;
-}
-
-int TransformManager_getComponentCount(
-  Pointer<TTransformManager> tTransformManager,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getComponentCount(
-    tTransformManager.cast(),
-  );
-  return result;
-}
-
-int TransformManager_getChildCount(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getChildCount(
-    tTransformManager.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void TransformManager_getChildren(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  Pointer<Int32> children,
-  int count,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getChildren(
-    tTransformManager.cast(),
-    entityId,
-    children,
-    count,
-  );
-  return result;
-}
-
-void TransformManager_openLocalTransformTransaction(
-  Pointer<TTransformManager> tTransformManager,
-) {
-  final result = GeneratedBindings.instance
-      ._TransformManager_openLocalTransformTransaction(
-        tTransformManager.cast(),
-      );
-  return result;
-}
-
-void TransformManager_commitLocalTransformTransaction(
-  Pointer<TTransformManager> tTransformManager,
-) {
-  final result = GeneratedBindings.instance
-      ._TransformManager_commitLocalTransformTransaction(
-        tTransformManager.cast(),
-      );
-  return result;
-}
-
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
-  );
-  return result;
-}
-
-bool Renderer_beginFrame(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TSwapChain> tSwapChain,
-  BigInt frameTimeInNanos,
-) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Renderer_endFrame(
-    tRenderer.cast(),
-  );
-  return result;
-}
-
-void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_render(
-    tRenderer.cast(),
-    tView.cast(),
-  );
-  return result;
-}
-
-void Renderer_renderStandaloneView(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TView> tView,
-) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(
-    tRenderer.cast(),
-    tView.cast(),
-  );
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dart__darwin_size_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
-  );
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-    tRenderer.cast(),
-    headRoomRatio,
-    scaleRate,
-    history,
-    interval,
   );
   return result;
 }
@@ -6814,7 +5784,7 @@ void Engine_setAutomaticInstancingEnabled(
   return result;
 }
 
-Dart__darwin_size_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
+Dartsize_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
   final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(
     tEngine.cast(),
   );
@@ -6860,7 +5830,7 @@ void Engine_execute(Pointer<TEngine> tEngine) {
 Pointer<TMaterial> Engine_buildMaterial(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterial(
     tEngine.cast(),
@@ -7097,6 +6067,393 @@ bool DebugRegistry_getProperty_float(
     outValue,
   );
   return result == 1;
+}
+
+Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
+  Pointer<TMaterialProvider> provider,
+  bool doubleSided,
+  bool unlit,
+  bool hasVertexColors,
+  bool hasBaseColorTexture,
+  bool hasNormalTexture,
+  bool hasOcclusionTexture,
+  bool hasEmissiveTexture,
+  bool useSpecularGlossiness,
+  int alphaMode,
+  bool enableDiagnostics,
+  bool hasMetallicRoughnessTexture,
+  int metallicRoughnessUV,
+  bool hasSpecularGlossinessTexture,
+  int specularGlossinessUV,
+  int baseColorUV,
+  bool hasClearCoatTexture,
+  int clearCoatUV,
+  bool hasClearCoatRoughnessTexture,
+  int clearCoatRoughnessUV,
+  bool hasClearCoatNormalTexture,
+  int clearCoatNormalUV,
+  bool hasClearCoat,
+  bool hasTransmission,
+  bool hasTextureTransforms,
+  int emissiveUV,
+  int aoUV,
+  int normalUV,
+  bool hasTransmissionTexture,
+  int transmissionUV,
+  bool hasSheenColorTexture,
+  int sheenColorUV,
+  bool hasSheenRoughnessTexture,
+  int sheenRoughnessUV,
+  bool hasVolumeThicknessTexture,
+  int volumeThicknessUV,
+  bool hasSheen,
+  bool hasIOR,
+  bool hasVolume,
+) {
+  final result = GeneratedBindings.instance
+      ._MaterialProvider_createMaterialInstance(
+        provider.cast(),
+        doubleSided,
+        unlit,
+        hasVertexColors,
+        hasBaseColorTexture,
+        hasNormalTexture,
+        hasOcclusionTexture,
+        hasEmissiveTexture,
+        useSpecularGlossiness,
+        alphaMode,
+        enableDiagnostics,
+        hasMetallicRoughnessTexture,
+        metallicRoughnessUV,
+        hasSpecularGlossinessTexture,
+        specularGlossinessUV,
+        baseColorUV,
+        hasClearCoatTexture,
+        clearCoatUV,
+        hasClearCoatRoughnessTexture,
+        clearCoatRoughnessUV,
+        hasClearCoatNormalTexture,
+        clearCoatNormalUV,
+        hasClearCoat,
+        hasTransmission,
+        hasTextureTransforms,
+        emissiveUV,
+        aoUV,
+        normalUV,
+        hasTransmissionTexture,
+        transmissionUV,
+        hasSheenColorTexture,
+        sheenColorUV,
+        hasSheenRoughnessTexture,
+        sheenRoughnessUV,
+        hasVolumeThicknessTexture,
+        volumeThicknessUV,
+        hasSheen,
+        hasIOR,
+        hasVolume,
+      );
+  return Pointer<TMaterialInstance>(result);
+}
+
+Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_create();
+  return Pointer<TVertexBufferBuilder>(result);
+}
+
+void VertexBufferBuilder_bufferCount(
+  Pointer<TVertexBufferBuilder> builder,
+  int count,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_bufferCount(
+    builder.cast(),
+    count,
+  );
+  return result;
+}
+
+void VertexBufferBuilder_vertexCount(
+  Pointer<TVertexBufferBuilder> builder,
+  int count,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_vertexCount(
+    builder.cast(),
+    count,
+  );
+  return result;
+}
+
+void VertexBufferBuilder_attribute(
+  Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  int bufferIndex,
+  int attributeType,
+  int byteOffset,
+  int byteStride,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_attribute(
+    builder.cast(),
+    attribute,
+    bufferIndex,
+    attributeType,
+    byteOffset,
+    byteStride,
+  );
+  return result;
+}
+
+void VertexBufferBuilder_normalized(
+  Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  bool normalize,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_normalized(
+    builder.cast(),
+    attribute,
+    normalize,
+  );
+  return result;
+}
+
+Pointer<TVertexBuffer> VertexBufferBuilder_build(
+  Pointer<TVertexBufferBuilder> builder,
+  Pointer<TEngine> engine,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_build(
+    builder.cast(),
+    engine.cast(),
+  );
+  return Pointer<TVertexBuffer>(result);
+}
+
+void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_destroy(
+    builder.cast(),
+  );
+  return result;
+}
+
+Dartsize_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
+  final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(
+    buffer.cast(),
+  );
+  return result;
+}
+
+void VertexBuffer_setBufferAt(
+  Pointer<TEngine> engine,
+  Pointer<TVertexBuffer> buffer,
+  int bufferIndex,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
+    engine.cast(),
+    buffer.cast(),
+    bufferIndex,
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void VertexBuffer_destroy(
+  Pointer<TEngine> engine,
+  Pointer<TVertexBuffer> buffer,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_destroy(
+    engine.cast(),
+    buffer.cast(),
+  );
+  return result;
+}
+
+double4x4 TransformManager_getLocalTransform(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._TransformManager_getLocalTransform(
+    double4x4_out.cast(),
+    tTransformManager.cast(),
+    entityId,
+  );
+  return double4x4_out.toDart();
+}
+
+double4x4 TransformManager_getWorldTransform(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._TransformManager_getWorldTransform(
+    double4x4_out.cast(),
+    tTransformManager.cast(),
+    entityId,
+  );
+  return double4x4_out.toDart();
+}
+
+void TransformManager_setTransform(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  double4x4 transform,
+) {
+  final transformPtr = transform.address;
+  final result = GeneratedBindings.instance._TransformManager_setTransform(
+    tTransformManager.cast(),
+    entityId,
+    transformPtr.cast(),
+  );
+  return result;
+}
+
+bool TransformManager_transformToUnitCube(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  Aabb3 boundingBox,
+) {
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance
+      ._TransformManager_transformToUnitCube(
+        tTransformManager.cast(),
+        entityId,
+        boundingBoxPtr.cast(),
+      );
+  return result == 1;
+}
+
+void TransformManager_setParent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId child,
+  DartEntityId parent,
+  bool preserveScaling,
+) {
+  final result = GeneratedBindings.instance._TransformManager_setParent(
+    tTransformManager.cast(),
+    child,
+    parent,
+    preserveScaling,
+  );
+  return result;
+}
+
+DartEntityId TransformManager_getParent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId child,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getParent(
+    tTransformManager.cast(),
+    child,
+  );
+  return result;
+}
+
+DartEntityId TransformManager_getAncestor(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId childEntityId,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getAncestor(
+    tTransformManager.cast(),
+    childEntityId,
+  );
+  return result;
+}
+
+void TransformManager_createComponent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._TransformManager_createComponent(
+    tTransformManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void TransformManager_removeComponent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._TransformManager_removeComponent(
+    tTransformManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+bool TransformManager_hasComponent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._TransformManager_hasComponent(
+    tTransformManager.cast(),
+    entityId,
+  );
+  return result == 1;
+}
+
+bool TransformManager_empty(Pointer<TTransformManager> tTransformManager) {
+  final result = GeneratedBindings.instance._TransformManager_empty(
+    tTransformManager.cast(),
+  );
+  return result == 1;
+}
+
+int TransformManager_getComponentCount(
+  Pointer<TTransformManager> tTransformManager,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getComponentCount(
+    tTransformManager.cast(),
+  );
+  return result;
+}
+
+int TransformManager_getChildCount(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getChildCount(
+    tTransformManager.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void TransformManager_getChildren(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  Pointer<Int32> children,
+  int count,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getChildren(
+    tTransformManager.cast(),
+    entityId,
+    children,
+    count,
+  );
+  return result;
+}
+
+void TransformManager_openLocalTransformTransaction(
+  Pointer<TTransformManager> tTransformManager,
+) {
+  final result = GeneratedBindings.instance
+      ._TransformManager_openLocalTransformTransaction(
+        tTransformManager.cast(),
+      );
+  return result;
+}
+
+void TransformManager_commitLocalTransformTransaction(
+  Pointer<TTransformManager> tTransformManager,
+) {
+  final result = GeneratedBindings.instance
+      ._TransformManager_commitLocalTransformTransaction(
+        tTransformManager.cast(),
+      );
+  return result;
 }
 
 Pointer<Void> RenderThread_create() {
@@ -7347,7 +6704,7 @@ void Engine_createViewRenderThread(
 void Engine_buildMaterialRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
@@ -7579,7 +6936,7 @@ void Ktx1Reader_createTextureRenderThread(
 void Ktx2Reader_createTextureRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
   Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance
@@ -7838,7 +7195,7 @@ void Renderer_readPixelsRenderThread(
   int tPixelBufferFormat,
   int tPixelDataType,
   Pointer<Uint8> out,
-  Dart__darwin_size_t outLength,
+  Dartsize_t outLength,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -8800,7 +8157,7 @@ void Image_createEmptyRenderThread(
 
 void Image_decodeRenderThread(
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<Char> name,
   bool alpha,
   Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
@@ -8898,7 +8255,7 @@ void Texture_setImageRenderThread(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -9228,7 +8585,7 @@ void GltfResourceLoader_addResourceDataRenderThread(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -9284,7 +8641,7 @@ void GltfAssetLoader_loadRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int numInstances,
   Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
 ) {
@@ -9474,7 +8831,7 @@ void VertexBuffer_setBufferAtRenderThread(
   Pointer<TVertexBuffer> tBuffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -9526,7 +8883,7 @@ void IndexBuffer_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TIndexBuffer> tBuffer,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -9678,8 +9035,8 @@ void RenderableManager_setBonesFromMat4RenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -9700,8 +9057,8 @@ void RenderableManager_setBonesFromBoneRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -9718,97 +9075,6 @@ void RenderableManager_setBonesFromBoneRenderThread(
   return result;
 }
 
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(
-  Pointer<TEngine> tEngine,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(
-    tEngine.cast(),
-  );
-  return Pointer<TGltfResourceLoader>(result);
-}
-
-void GltfResourceLoader_destroy(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(
-    tEngine.cast(),
-    tGltfResourceLoader.cast(),
-  );
-  return result;
-}
-
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void GltfResourceLoader_asyncUpdateLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(
-    tGltfResourceLoader.cast(),
-  );
-  return result;
-}
-
-double GltfResourceLoader_asyncGetLoadProgress(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-) {
-  final result = GeneratedBindings.instance
-      ._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
-  return result;
-}
-
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
-  );
-  return result;
-}
-
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void Skybox_setColor(
-  Pointer<TSkybox> tSkybox,
-  double r,
-  double g,
-  double b,
-  double a,
-) {
-  final result = GeneratedBindings.instance._Skybox_setColor(
-    tSkybox.cast(),
-    r,
-    g,
-    b,
-    a,
-  );
-  return result;
-}
-
 void dummy(TGltfMeshData dummy) {
   final dummyPtr = dummy.address;
   final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
@@ -9817,7 +9083,7 @@ void dummy(TGltfMeshData dummy) {
 
 int GltfParser_parseBuffer(
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<Char> meshName,
   Pointer<TGltfMeshData> outMeshData,
 ) {
@@ -9833,6 +9099,551 @@ int GltfParser_parseBuffer(
 void GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData) {
   final result = GeneratedBindings.instance._GltfParser_freeMeshData(
     meshData.cast(),
+  );
+  return result;
+}
+
+int LightManager_createLight(
+  Pointer<TEngine> tEngine,
+  Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
+    tEngine.cast(),
+    tLightManager.cast(),
+    tLightTtype,
+  );
+  return result;
+}
+
+void LightManager_destroyLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+bool LightManager_hasComponent(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+int LightManager_getType(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getType(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+bool LightManager_isDirectional(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+bool LightManager_isPointLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+void LightManager_setPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(
+    tLightManager.cast(),
+    light,
+    x,
+    y,
+    z,
+  );
+  return result;
+}
+
+double3 LightManager_getPosition(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(
+    double3_out.cast(),
+    tLightManager.cast(),
+    light,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+  double x,
+  double y,
+  double z,
+) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(
+    tLightManager.cast(),
+    light,
+    x,
+    y,
+    z,
+  );
+  return result;
+}
+
+double3 LightManager_getDirection(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId light,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(
+    double3_out.cast(),
+    tLightManager.cast(),
+    light,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double r,
+  double g,
+  double b,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColor(
+    tLightManager.cast(),
+    entity,
+    r,
+    g,
+    b,
+  );
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+double3 LightManager_getColor(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(
+    double3_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(
+    tLightManager.cast(),
+    entity,
+    intensity,
+  );
+  return result;
+}
+
+void LightManager_setIntensityCandela(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(
+    tLightManager.cast(),
+    entity,
+    intensity,
+  );
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+double LightManager_getIntensity(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double falloff,
+) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(
+    tLightManager.cast(),
+    entity,
+    falloff,
+  );
+  return result;
+}
+
+double LightManager_getFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(
+    tLightManager.cast(),
+    entity,
+    inner,
+    outer,
+  );
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double angularRadius,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+double LightManager_getSunAngularRadius(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloSize,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(
+    tLightManager.cast(),
+    entity,
+    haloSize,
+  );
+  return result;
+}
+
+double LightManager_getSunHaloSize(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double haloFalloff,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(
+    tLightManager.cast(),
+    entity,
+    haloFalloff,
+  );
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(
+    tLightManager.cast(),
+    entity,
+  );
+  return result;
+}
+
+void LightManager_setShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(
+    tLightManager.cast(),
+    entity,
+    enabled,
+  );
+  return result;
+}
+
+bool LightManager_isShadowCaster(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(
+    tLightManager.cast(),
+    entity,
+  );
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  TShadowOptions options,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool LightManager_getLightChannel(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  int channel,
+) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+  );
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(
+    splitPositions,
+    cascades,
+  );
+  return result;
+}
+
+void LightManager_computeLogSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+  );
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance
+      ._LightManager_computePracticalSplits(
+        splitPositions,
+        cascades,
+        near,
+        far,
+        lambda,
+      );
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(
+    r,
+    g,
+    b,
+  );
+  return result;
+}
+
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(
+    tScene.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(
+    tScene.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(
+    tScene.cast(),
+    skybox.cast(),
+  );
+  return result;
+}
+
+void Scene_setIndirectLight(
+  Pointer<TScene> tScene,
+  Pointer<TIndirectLight> tIndirectLight,
+) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(
+    tScene.cast(),
+    tIndirectLight.cast(),
+  );
+  return result;
+}
+
+void Scene_addFilamentAsset(
+  Pointer<TScene> tScene,
+  Pointer<TFilamentAsset> asset,
+) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(
+    tScene.cast(),
+    asset.cast(),
   );
   return result;
 }
@@ -9877,7 +9688,7 @@ bool RenderableManager_isRenderable(
   return result == 1;
 }
 
-Dart__darwin_size_t RenderableManager_getComponentCount(
+Dartsize_t RenderableManager_getComponentCount(
   Pointer<TRenderableManager> tRenderableManager,
 ) {
   final result = GeneratedBindings.instance
@@ -9929,7 +9740,7 @@ void RenderableManager_clearMaterialInstanceAt(
   return result;
 }
 
-Dart__darwin_size_t RenderableManager_getPrimitiveCount(
+Dartsize_t RenderableManager_getPrimitiveCount(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
 ) {
@@ -10215,7 +10026,7 @@ void RenderableManager_setScreenSpaceContactShadows(
 void RenderableManager_setBlendOrderAt(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   int order,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
@@ -10230,7 +10041,7 @@ void RenderableManager_setBlendOrderAt(
 void RenderableManager_setGlobalBlendOrderEnabledAt(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
@@ -10247,8 +10058,8 @@ void RenderableManager_setMorphWeights(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> weights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t offset,
+  Dartsize_t count,
+  Dartsize_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
     tRenderableManager.cast(),
@@ -10260,7 +10071,7 @@ void RenderableManager_setMorphWeights(
   return result;
 }
 
-Dart__darwin_size_t RenderableManager_getMorphTargetCount(
+Dartsize_t RenderableManager_getMorphTargetCount(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
 ) {
@@ -10276,8 +10087,8 @@ void RenderableManager_setBonesFromMat4(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
     tRenderableManager.cast(),
@@ -10293,8 +10104,8 @@ void RenderableManager_setBonesFromBone(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
     tRenderableManager.cast(),
@@ -10307,7 +10118,7 @@ void RenderableManager_setBonesFromBone(
 }
 
 Pointer<TRenderableBuilder> RenderableBuilder_create(
-  Dart__darwin_size_t primitiveCount,
+  Dartsize_t primitiveCount,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_create(
     primitiveCount,
@@ -10336,7 +10147,7 @@ void RenderableBuilder_boundingBox(
 
 void RenderableBuilder_material(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   Pointer<TMaterialInstance> materialInstance,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_material(
@@ -10349,12 +10160,12 @@ void RenderableBuilder_material(
 
 void RenderableBuilder_geometry(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   int type,
   Pointer<TVertexBuffer> vertices,
   Pointer<TIndexBuffer> indices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
+  Dartsize_t offset,
+  Dartsize_t count,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_geometry(
     builder.cast(),
@@ -10468,7 +10279,7 @@ void RenderableBuilder_screenSpaceContactShadows(
 
 void RenderableBuilder_blendOrder(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   int order,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(
@@ -10481,7 +10292,7 @@ void RenderableBuilder_blendOrder(
 
 void RenderableBuilder_globalBlendOrderEnabled(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   bool enabled,
 ) {
   final result = GeneratedBindings.instance
@@ -10495,7 +10306,7 @@ void RenderableBuilder_globalBlendOrderEnabled(
 
 void RenderableBuilder_instances(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t instanceCount,
+  Dartsize_t instanceCount,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_instances(
     builder.cast(),
@@ -10506,7 +10317,7 @@ void RenderableBuilder_instances(
 
 void RenderableBuilder_skinningFromMat4(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t boneCount,
+  Dartsize_t boneCount,
   Pointer<Float32> transforms,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(
@@ -10519,7 +10330,7 @@ void RenderableBuilder_skinningFromMat4(
 
 void RenderableBuilder_skinningFromBone(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t boneCount,
+  Dartsize_t boneCount,
   Pointer<Float32> bones,
 ) {
   final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(
@@ -10541,10 +10352,10 @@ void RenderableBuilder_enableSkinningBuffers(
 
 void RenderableBuilder_boneIndicesAndWeights(
   Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
+  Dartsize_t primitiveIndex,
   Pointer<Float32> indicesAndWeights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t bonesPerVertex,
+  Dartsize_t count,
+  Dartsize_t bonesPerVertex,
 ) {
   final result = GeneratedBindings.instance
       ._RenderableBuilder_boneIndicesAndWeights(
@@ -10570,273 +10381,132 @@ int RenderableBuilder_build(
   return result;
 }
 
-Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(
   Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tVertexBuffer,
-  Pointer<TIndexBuffer> tIndexBuffer,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  Aabb3 boundingBox,
 ) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(
     tEngine.cast(),
-    tVertexBuffer.cast(),
-    tIndexBuffer.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-    tPrimitiveType,
-    boundingBoxPtr.cast(),
   );
-  return Pointer<TSceneAsset>(result);
+  return Pointer<TGltfResourceLoader>(result);
 }
 
-Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+void GltfResourceLoader_destroy(
   Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(
+    tEngine.cast(),
+    tGltfResourceLoader.cast(),
+  );
+  return result;
+}
+
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<TFilamentAsset> tFilamentAsset,
-  bool rebuildVertices,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    tNameComponentManager.cast(),
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
     tFilamentAsset.cast(),
-    rebuildVertices,
   );
-  return Pointer<TSceneAsset>(result);
+  return result == 1;
 }
 
-Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  Pointer<TSceneAsset> tSceneAsset,
+void GltfResourceLoader_asyncUpdateLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(
-    tSceneAsset.cast(),
-  );
-  return Pointer<TFilamentAsset>(result);
-}
-
-int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getType(
-    tSceneAsset.cast(),
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(
+    tGltfResourceLoader.cast(),
   );
   return result;
 }
 
-void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_destroy(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_addToScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_addToScene(
-    tSceneAsset.cast(),
-    tScene.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_removeFromScene(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(
-    tSceneAsset.cast(),
-    tScene.cast(),
-  );
-  return result;
-}
-
-DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getEntity(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_getChildEntities(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<Int32> out,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(
-    tSceneAsset.cast(),
-    out,
-  );
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(
-    tSceneAsset.cast(),
-  );
-  return Pointer<Int32>(result);
-}
-
-Dart__darwin_size_t SceneAsset_getCameraEntityCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(
-    tSceneAsset.cast(),
-  );
-  return Pointer<Int32>(result);
-}
-
-Dart__darwin_size_t SceneAsset_getLightEntityCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_getInstance(
-  Pointer<TSceneAsset> tSceneAsset,
-  int index,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstance(
-    tSceneAsset.cast(),
-    index,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Dart__darwin_size_t SceneAsset_getInstanceCount(
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_createInstance(
-  Pointer<TSceneAsset> asset,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createInstance(
-    asset.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(
-    Aabb3_out.cast(),
-    asset.cast(),
-  );
-  return Aabb3_out.toDart();
-}
-
-Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(
-    tSceneAsset.cast(),
-    primitiveIndex,
-  );
-  return Pointer<TVertexBuffer>(result);
-}
-
-Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(
-    tSceneAsset.cast(),
-    primitiveIndex,
-  );
-  return Pointer<TIndexBuffer>(result);
-}
-
-int SceneAsset_getPrimitiveOffsetForEntity(
-  Pointer<TSceneAsset> tSceneAsset,
-  DartEntityId entity,
+double GltfResourceLoader_asyncGetLoadProgress(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
 ) {
   final result = GeneratedBindings.instance
-      ._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
+      ._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
   return result;
 }
 
-void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(
-    tSceneAsset.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_setFlatShading(
-  Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dartsize_t length,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(
-    tSceneAsset.cast(),
-    flatShading,
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
   );
   return result;
 }
 
-void SceneAsset_getBones(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dart__darwin_size_t skinIndex,
-  Pointer<Int32> out,
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
 ) {
-  final result = GeneratedBindings.instance._SceneAsset_getBones(
-    tSceneAsset.cast(),
-    skinIndex,
-    out,
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+    tEngine.cast(),
+    assetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+  );
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(
+  Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  DartGizmoPickCallback callback,
+) {
+  final result = GeneratedBindings.instance._Gizmo_pick(
+    tGizmo.cast(),
+    x,
+    y,
+    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
   );
   return result;
 }
 
-Dart__darwin_size_t SceneAsset_getBoneCount(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dart__darwin_size_t skinIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(
-    tSceneAsset.cast(),
-    skinIndex,
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(
+    tGizmo.cast(),
+    axis,
   );
   return result;
 }
 
-Pointer<Char> SceneAsset_getBoneName(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dart__darwin_size_t skinIndex,
-  Dart__darwin_size_t boneIndex,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneName(
-    tSceneAsset.cast(),
-    skinIndex,
-    boneIndex,
-  );
-  return Pointer<Char>(result);
+void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
 }
 
 Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
@@ -11201,6 +10871,330 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
+Pointer<TRenderTarget> RenderTarget_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> color,
+  Pointer<TTexture> depth,
+) {
+  final result = GeneratedBindings.instance._RenderTarget_create(
+    tEngine.cast(),
+    color.cast(),
+    depth.cast(),
+  );
+  return Pointer<TRenderTarget>(result);
+}
+
+void RenderTarget_destroy(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderTarget> tRenderTarget,
+) {
+  final result = GeneratedBindings.instance._RenderTarget_destroy(
+    tEngine.cast(),
+    tRenderTarget.cast(),
+  );
+  return result;
+}
+
+void IndirectLight_setRotation(
+  Pointer<TIndirectLight> tIndirectLight,
+  Pointer<Float64> rotation,
+) {
+  final result = GeneratedBindings.instance._IndirectLight_setRotation(
+    tIndirectLight.cast(),
+    rotation,
+  );
+  return result;
+}
+
+Pointer<TRenderManager> RenderManager_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderer> tRenderer,
+) {
+  final result = GeneratedBindings.instance._RenderManager_create(
+    tEngine.cast(),
+    tRenderer.cast(),
+  );
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_removeAnimationManager(
+        tRenderer.cast(),
+        tAnimationManager.cast(),
+      );
+  return result;
+}
+
+void RenderManager_render(
+  Pointer<TRenderManager> tRenderer,
+  BigInt frameTimeInNanos,
+) {
+  final result = GeneratedBindings.instance._RenderManager_render(
+    tRenderer.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(
+    tRenderer.cast(),
+    swapChain.cast(),
+  );
+  return result;
+}
+
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void RenderManager_detachFromRenderThread(
+  Pointer<TRenderManager> tRenderManager,
+) {
+  final result = GeneratedBindings.instance
+      ._RenderManager_detachFromRenderThread(tRenderManager.cast());
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(
+    tRenderer.cast(),
+    paused,
+  );
+  return result;
+}
+
+void FrameScheduler_start(DartFrameCallback callback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_start(
+    callback as Pointer<NativeFunction<FrameCallbackFunction>>,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+void FrameScheduler_setRenderThread(Pointer<Void> renderThread) {
+  final result = GeneratedBindings.instance._FrameScheduler_setRenderThread(
+    renderThread,
+  );
+  return result;
+}
+
+void FrameScheduler_setRenderManager(Pointer<TRenderManager> rm) {
+  final result = GeneratedBindings.instance._FrameScheduler_setRenderManager(
+    rm.cast(),
+  );
+  return result;
+}
+
+void FrameScheduler_setPostRenderCallback(
+  DartPostRenderCallback callback,
+  Pointer<Void> userData,
+) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_setPostRenderCallback(
+        callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
+        userData,
+      );
+  return result;
+}
+
+bool FrameScheduler_requestRender(BigInt frameTimeNanos) {
+  final result = GeneratedBindings.instance._FrameScheduler_requestRender(
+    frameTimeNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void FrameScheduler_startNativeRenderLoop(int targetFps) {
+  final result = GeneratedBindings.instance
+      ._FrameScheduler_startNativeRenderLoop(targetFps);
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(
+    port.toJSBigInt,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+  );
+  return result;
+}
+
+bool Renderer_beginFrame(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TSwapChain> tSwapChain,
+  BigInt frameTimeInNanos,
+) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Renderer_endFrame(
+    tRenderer.cast(),
+  );
+  return result;
+}
+
+void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_render(
+    tRenderer.cast(),
+    tView.cast(),
+  );
+  return result;
+}
+
+void Renderer_renderStandaloneView(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TView> tView,
+) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(
+    tRenderer.cast(),
+    tView.cast(),
+  );
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dartsize_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+  );
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+    tRenderer.cast(),
+    headRoomRatio,
+    scaleRate,
+    history,
+    interval,
+  );
+  return result;
+}
+
 void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
   final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(
     executor.cast(),
@@ -11376,194 +11370,105 @@ void TransformPipeline_setInvertMouseY(int invert) {
   return result;
 }
 
-extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
-  TMaterialInstance toDart() {
-    return TMaterialInstance(this);
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
   }
 }
 
-final class TMaterialInstance extends Struct {
-  Pointer<TMaterialInstance> get address => super.address.cast();
-  TMaterialInstance(super.address);
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
 
-  static Pointer<TMaterialInstance> stackAlloc() {
-    return Pointer<TMaterialInstance>(
-      NativeLibrary.instance.stackAlloc<TMaterialInstance>(0),
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+extension double4x4Ext on Pointer<double4x4> {
+  double4x4 toDart() {
+    return double4x4(this);
+  }
+}
+
+final class double4x4 extends Struct {
+  Pointer<double4x4> get address => super.address.cast();
+  Array<Float64> get col1 {
+    final addr = Pointer<double4x4>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 0),
+    ));
+  }
+
+  set col1(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 0),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col2 {
+    final addr = Pointer<double4x4>(this.address.addr + 32);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 32),
+    ));
+  }
+
+  set col2(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 32),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col3 {
+    final addr = Pointer<double4x4>(this.address.addr + 64);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 64),
+    ));
+  }
+
+  set col3(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 64),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  Array<Float64> get col4 {
+    final addr = Pointer<double4x4>(this.address.addr + 96);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((
+      numElements: 4,
+      addr: Pointer<Float64>(this.address.addr + 96),
+    ));
+  }
+
+  set col4(Array<Float64> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<double4x4>(this.address.addr + 96),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  double4x4(super.address);
+
+  static Pointer<double4x4> stackAlloc() {
+    return Pointer<double4x4>(
+      NativeLibrary.instance.stackAlloc<double4x4>(128),
     );
   }
 }
-
-extension TMaterialExt on Pointer<TMaterial> {
-  TMaterial toDart() {
-    return TMaterial(this);
-  }
-}
-
-final class TMaterial extends Struct {
-  Pointer<TMaterial> get address => super.address.cast();
-  TMaterial(super.address);
-
-  static Pointer<TMaterial> stackAlloc() {
-    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
-  }
-}
-
-sealed class TFeatureLevel {
-  static const FEATURE_LEVEL_0 = 0;
-  static const FEATURE_LEVEL_1 = 1;
-  static const FEATURE_LEVEL_2 = 2;
-  static const FEATURE_LEVEL_3 = 3;
-}
-
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
-  }
-}
-
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
-
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
-  }
-}
-
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
-}
-
-extension TTextureExt on Pointer<TTexture> {
-  TTexture toDart() {
-    return TTexture(this);
-  }
-}
-
-final class TTexture extends Struct {
-  Pointer<TTexture> get address => super.address.cast();
-  TTexture(super.address);
-
-  static Pointer<TTexture> stackAlloc() {
-    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
-  }
-}
-
-extension TTextureSamplerExt on Pointer<TTextureSampler> {
-  TTextureSampler toDart() {
-    return TTextureSampler(this);
-  }
-}
-
-final class TTextureSampler extends Struct {
-  Pointer<TTextureSampler> get address => super.address.cast();
-  TTextureSampler(super.address);
-
-  static Pointer<TTextureSampler> stackAlloc() {
-    return Pointer<TTextureSampler>(
-      NativeLibrary.instance.stackAlloc<TTextureSampler>(0),
-    );
-  }
-}
-
-sealed class TSamplerCompareFunc {
-  /// !< Less or equal
-  static const LE = 0;
-
-  /// !< Greater or equal
-  static const GE = 1;
-
-  /// !< Strictly less than
-  static const L = 2;
-
-  /// !< Strictly greater than
-  static const G = 3;
-
-  /// !< Equal
-  static const E = 4;
-
-  /// !< Not equal
-  static const NE = 5;
-
-  /// !< Always. Depth / stencil testing is deactivated.
-  static const A = 6;
-
-  /// !< Never. The depth / stencil test always fails.
-  static const N = 7;
-}
-
-sealed class TStencilOperation {
-  static const KEEP = 0;
-  static const ZERO = 1;
-  static const REPLACE = 2;
-  static const INCR = 3;
-  static const INCR_WRAP = 4;
-  static const DECR = 5;
-  static const DECR_WRAP = 6;
-  static const INVERT = 7;
-}
-
-sealed class TStencilFace {
-  static const STENCIL_FACE_FRONT = 1;
-  static const STENCIL_FACE_BACK = 2;
-  static const STENCIL_FACE_FRONT_AND_BACK = 3;
-}
-
-sealed class TTransparencyMode {
-  /// ! the transparent object is drawn honoring the raster state
-  static const DEFAULT = 0;
-
-  /// the transparent object is first drawn in the depth buffer,
-  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
-  static const TWO_PASSES_ONE_SIDE = 1;
-
-  /// the transparent object is drawn twice in the color buffer,
-  /// first with back faces only, then with front faces; the culling
-  /// mode is ignored. Can be combined with two-sided lighting
-  static const TWO_PASSES_TWO_SIDES = 2;
-}
-
-sealed class TBlendingMode {
-  static const BLENDING_MODE_OPAQUE = 0;
-  static const BLENDING_MODE_TRANSPARENT = 1;
-  static const BLENDING_MODE_ADD = 2;
-  static const BLENDING_MODE_MASKED = 3;
-  static const BLENDING_MODE_FADE = 4;
-  static const BLENDING_MODE_MULTIPLY = 5;
-  static const BLENDING_MODE_SCREEN = 6;
-  static const BLENDING_MODE_CUSTOM = 7;
-}
-
-extension TLightManagerExt on Pointer<TLightManager> {
-  TLightManager toDart() {
-    return TLightManager(this);
-  }
-}
-
-final class TLightManager extends Struct {
-  Pointer<TLightManager> get address => super.address.cast();
-  TLightManager(super.address);
-
-  static Pointer<TLightManager> stackAlloc() {
-    return Pointer<TLightManager>(
-      NativeLibrary.instance.stackAlloc<TLightManager>(0),
-    );
-  }
-}
-
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-typedef EntityId = int;
-typedef DartEntityId = int;
 
 extension double3Ext on Pointer<double3> {
   double3 toDart() {
@@ -11622,348 +11527,210 @@ final class double3 extends Struct {
   }
 }
 
-extension TShadowOptionsExt on Pointer<TShadowOptions> {
-  TShadowOptions toDart() {
-    return TShadowOptions(this);
+typedef EntityId = int;
+typedef DartEntityId = int;
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+extension TSceneAssetExt on Pointer<TSceneAsset> {
+  TSceneAsset toDart() {
+    return TSceneAsset(this);
   }
 }
 
-final class TShadowOptions extends Struct {
-  Pointer<TShadowOptions> get address => super.address.cast();
-  int get mapSize {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
+final class TSceneAsset extends Struct {
+  Pointer<TSceneAsset> get address => super.address.cast();
+  TSceneAsset(super.address);
 
-  set mapSize(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 0),
-      val.toJS,
-      'i32',
-    );
-  }
-
-  int get shadowCascades {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set shadowCascades(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 4),
-      val.toJS,
-      'i8',
-    );
-  }
-
-  Array<Float32> get cascadeSplitPositions {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float32>((
-      numElements: 3,
-      addr: Pointer<Float32>(this.address.addr + 5),
-    ));
-  }
-
-  set cascadeSplitPositions(Array<Float32> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 5),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  double get constantBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constantBias(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 17),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get normalBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set normalBias(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 21),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get shadowFar {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFar(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 25),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get shadowNearHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowNearHint(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 29),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get shadowFarHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFarHint(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 33),
-      val.toJS,
-      'float',
-    );
-  }
-
-  bool get stable {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set stable(bool val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 37),
-      (val ? 1 : 0).toJS,
-      'i8',
-    );
-  }
-
-  bool get lispsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set lispsm(bool val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 38),
-      (val ? 1 : 0).toJS,
-      'i8',
-    );
-  }
-
-  double get polygonOffsetConstant {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetConstant(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 39),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get polygonOffsetSlope {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetSlope(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 43),
-      val.toJS,
-      'float',
-    );
-  }
-
-  bool get screenSpaceContactShadows {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set screenSpaceContactShadows(bool val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 47),
-      (val ? 1 : 0).toJS,
-      'i8',
-    );
-  }
-
-  int get stepCount {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set stepCount(int val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 48),
-      val.toJS,
-      'i8',
-    );
-  }
-
-  double get maxShadowDistance {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxShadowDistance(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 49),
-      val.toJS,
-      'float',
-    );
-  }
-
-  bool get vsmElvsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set vsmElvsm(bool val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 53),
-      (val ? 1 : 0).toJS,
-      'i8',
-    );
-  }
-
-  double get vsmBlurWidth {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set vsmBlurWidth(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 54),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get shadowBulbRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowBulbRadius(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 58),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get transformX {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformX(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 62),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get transformY {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformY(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 66),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get transformZ {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformZ(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 70),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get transformW {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformW(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<TShadowOptions>(this.address.addr + 74),
-      val.toJS,
-      'float',
-    );
-  }
-
-  TShadowOptions(super.address);
-
-  static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(
-      NativeLibrary.instance.stackAlloc<TShadowOptions>(78),
+  static Pointer<TSceneAsset> stackAlloc() {
+    return Pointer<TSceneAsset>(
+      NativeLibrary.instance.stackAlloc<TSceneAsset>(0),
     );
   }
 }
 
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
   }
 }
 
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
 
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(
-      NativeLibrary.instance.stackAlloc<TFilamentAsset>(0),
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  }
+}
+
+extension TVertexBufferExt on Pointer<TVertexBuffer> {
+  TVertexBuffer toDart() {
+    return TVertexBuffer(this);
+  }
+}
+
+final class TVertexBuffer extends Struct {
+  Pointer<TVertexBuffer> get address => super.address.cast();
+  TVertexBuffer(super.address);
+
+  static Pointer<TVertexBuffer> stackAlloc() {
+    return Pointer<TVertexBuffer>(
+      NativeLibrary.instance.stackAlloc<TVertexBuffer>(0),
     );
+  }
+}
+
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
+  }
+}
+
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
+
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(
+      NativeLibrary.instance.stackAlloc<TIndexBuffer>(0),
+    );
+  }
+}
+
+extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
+  TMaterialInstance toDart() {
+    return TMaterialInstance(this);
+  }
+}
+
+final class TMaterialInstance extends Struct {
+  Pointer<TMaterialInstance> get address => super.address.cast();
+  TMaterialInstance(super.address);
+
+  static Pointer<TMaterialInstance> stackAlloc() {
+    return Pointer<TMaterialInstance>(
+      NativeLibrary.instance.stackAlloc<TMaterialInstance>(0),
+    );
+  }
+}
+
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
+}
+
+extension Aabb3Ext on Pointer<Aabb3> {
+  Aabb3 toDart() {
+    return Aabb3(this);
+  }
+}
+
+final class Aabb3 extends Struct {
+  Pointer<Aabb3> get address => super.address.cast();
+  double get centerX {
+    final addr = Pointer<Aabb3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerX(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 0),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get centerY {
+    final addr = Pointer<Aabb3>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerY(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 4),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get centerZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set centerZ(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 8),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentX {
+    final addr = Pointer<Aabb3>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentX(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 12),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentY {
+    final addr = Pointer<Aabb3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentY(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 16),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get halfExtentZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 20);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set halfExtentZ(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<Aabb3>(this.address.addr + 20),
+      val.toJS,
+      'float',
+    );
+  }
+
+  Aabb3(super.address);
+
+  static Pointer<Aabb3> stackAlloc() {
+    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
   }
 }
 
@@ -11980,23 +11747,6 @@ final class TGltfAssetLoader extends Struct {
   static Pointer<TGltfAssetLoader> stackAlloc() {
     return Pointer<TGltfAssetLoader>(
       NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0),
-    );
-  }
-}
-
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
-  }
-}
-
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
-
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(
-      NativeLibrary.instance.stackAlloc<TMaterialProvider>(0),
     );
   }
 }
@@ -12018,9 +11768,67 @@ final class TNameComponentManager extends Struct {
   }
 }
 
-typedef size_t = __darwin_size_t;
-typedef __darwin_size_t = int;
-typedef Dart__darwin_size_t = int;
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
+  }
+}
+
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
+
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(
+      NativeLibrary.instance.stackAlloc<TFilamentAsset>(0),
+    );
+  }
+}
+
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
+  }
+}
+
+typedef size_t = int;
+typedef Dartsize_t = int;
+
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
+  }
+}
+
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
+
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(
+      NativeLibrary.instance.stackAlloc<TMaterialProvider>(0),
+    );
+  }
+}
 
 extension TRenderableManagerExt on Pointer<TRenderableManager> {
   TRenderableManager toDart() {
@@ -12035,6 +11843,40 @@ final class TRenderableManager extends Struct {
   static Pointer<TRenderableManager> stackAlloc() {
     return Pointer<TRenderableManager>(
       NativeLibrary.instance.stackAlloc<TRenderableManager>(0),
+    );
+  }
+}
+
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
+  }
+}
+
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
+
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(
+      NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0),
+    );
+  }
+}
+
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
+  }
+}
+
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
+
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(
+      NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0),
     );
   }
 }
@@ -12357,36 +12199,6 @@ final class TVsmShadowOptions extends Struct {
     return Pointer<TVsmShadowOptions>(
       NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12),
     );
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
-
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
-
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
   }
 }
 
@@ -13018,6 +12830,21 @@ final class TFogOptions extends Struct {
   }
 }
 
+extension TTextureExt on Pointer<TTexture> {
+  TTexture toDart() {
+    return TTexture(this);
+  }
+}
+
+final class TTexture extends Struct {
+  Pointer<TTexture> get address => super.address.cast();
+  TTexture(super.address);
+
+  static Pointer<TTexture> stackAlloc() {
+    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
+  }
+}
+
 typedef PickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
 typedef DartPickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
 typedef PickCallbackFunction =
@@ -13039,55 +12866,155 @@ typedef DartPickCallbackFunction =
       double fragZ,
     );
 
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(
-      NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0),
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  }
+}
+
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
+  }
+}
+
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
+
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(
+      NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0),
     );
   }
 }
 
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
+extension TMaterialExt on Pointer<TMaterial> {
+  TMaterial toDart() {
+    return TMaterial(this);
   }
 }
 
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
+final class TMaterial extends Struct {
+  Pointer<TMaterial> get address => super.address.cast();
+  TMaterial(super.address);
 
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(
-      NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0),
+  static Pointer<TMaterial> stackAlloc() {
+    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  }
+}
+
+sealed class TFeatureLevel {
+  static const FEATURE_LEVEL_0 = 0;
+  static const FEATURE_LEVEL_1 = 1;
+  static const FEATURE_LEVEL_2 = 2;
+  static const FEATURE_LEVEL_3 = 3;
+}
+
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
+extension TTextureSamplerExt on Pointer<TTextureSampler> {
+  TTextureSampler toDart() {
+    return TTextureSampler(this);
+  }
+}
+
+final class TTextureSampler extends Struct {
+  Pointer<TTextureSampler> get address => super.address.cast();
+  TTextureSampler(super.address);
+
+  static Pointer<TTextureSampler> stackAlloc() {
+    return Pointer<TTextureSampler>(
+      NativeLibrary.instance.stackAlloc<TTextureSampler>(0),
     );
   }
 }
 
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
-  }
+sealed class TSamplerCompareFunc {
+  /// !< Less or equal
+  static const LE = 0;
+
+  /// !< Greater or equal
+  static const GE = 1;
+
+  /// !< Strictly less than
+  static const L = 2;
+
+  /// !< Strictly greater than
+  static const G = 3;
+
+  /// !< Equal
+  static const E = 4;
+
+  /// !< Not equal
+  static const NE = 5;
+
+  /// !< Always. Depth / stencil testing is deactivated.
+  static const A = 6;
+
+  /// !< Never. The depth / stencil test always fails.
+  static const N = 7;
 }
 
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
+sealed class TStencilOperation {
+  static const KEEP = 0;
+  static const ZERO = 1;
+  static const REPLACE = 2;
+  static const INCR = 3;
+  static const INCR_WRAP = 4;
+  static const DECR = 5;
+  static const DECR_WRAP = 6;
+  static const INVERT = 7;
+}
 
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(
-      NativeLibrary.instance.stackAlloc<TIndirectLight>(0),
-    );
-  }
+sealed class TStencilFace {
+  static const STENCIL_FACE_FRONT = 1;
+  static const STENCIL_FACE_BACK = 2;
+  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+}
+
+sealed class TTransparencyMode {
+  /// ! the transparent object is drawn honoring the raster state
+  static const DEFAULT = 0;
+
+  /// the transparent object is first drawn in the depth buffer,
+  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
+  static const TWO_PASSES_ONE_SIDE = 1;
+
+  /// the transparent object is drawn twice in the color buffer,
+  /// first with back faces only, then with front faces; the culling
+  /// mode is ignored. Can be combined with two-sided lighting
+  static const TWO_PASSES_TWO_SIDES = 2;
+}
+
+sealed class TBlendingMode {
+  static const BLENDING_MODE_OPAQUE = 0;
+  static const BLENDING_MODE_TRANSPARENT = 1;
+  static const BLENDING_MODE_ADD = 2;
+  static const BLENDING_MODE_MASKED = 3;
+  static const BLENDING_MODE_FADE = 4;
+  static const BLENDING_MODE_MULTIPLY = 5;
+  static const BLENDING_MODE_SCREEN = 6;
+  static const BLENDING_MODE_CUSTOM = 7;
 }
 
 sealed class TTextureSamplerType {
@@ -13385,21 +13312,21 @@ sealed class TSamplerCompareMode {
   static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
-  }
-}
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
 
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
 
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(
-      NativeLibrary.instance.stackAlloc<TRenderManager>(0),
-    );
-  }
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
 }
 
 extension TRendererExt on Pointer<TRenderer> {
@@ -13414,23 +13341,6 @@ final class TRenderer extends Struct {
 
   static Pointer<TRenderer> stackAlloc() {
     return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
-  }
-}
-
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
-  }
-}
-
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
-
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(
-      NativeLibrary.instance.stackAlloc<TAnimationManager>(0),
-    );
   }
 }
 
@@ -13451,111 +13361,102 @@ final class TSwapChain extends Struct {
   }
 }
 
-typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
-typedef PostRenderCallback =
-    Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef DartPostRenderCallback =
-    Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
   }
 }
 
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
 
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
-  }
-}
-
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
-  }
-}
-
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
-
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(
-      NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0),
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(
+      NativeLibrary.instance.stackAlloc<TTransformManager>(0),
     );
   }
 }
 
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback =
-    Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction =
-    void Function(int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction =
-    void Function(int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
+extension TLightManagerExt on Pointer<TLightManager> {
+  TLightManager toDart() {
+    return TLightManager(this);
   }
 }
 
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
+final class TLightManager extends Struct {
+  Pointer<TLightManager> get address => super.address.cast();
+  TLightManager(super.address);
 
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(
-      NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0),
+  static Pointer<TLightManager> stackAlloc() {
+    return Pointer<TLightManager>(
+      NativeLibrary.instance.stackAlloc<TLightManager>(0),
     );
   }
 }
 
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
   }
 }
 
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
 
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(
-      NativeLibrary.instance.stackAlloc<TIndexBuffer>(0),
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(
+      NativeLibrary.instance.stackAlloc<TEntityManager>(0),
+    );
+  }
+}
+
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
+  }
+}
+
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
+
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  }
+}
+
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
+  }
+}
+
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
+
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(
+      NativeLibrary.instance.stackAlloc<TIndirectLight>(0),
+    );
+  }
+}
+
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
+  }
+}
+
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
+
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(
+      NativeLibrary.instance.stackAlloc<TDebugRegistry>(0),
     );
   }
 }
@@ -13624,342 +13525,75 @@ sealed class TVertexAttributeType {
   static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-extension TVertexBufferExt on Pointer<TVertexBuffer> {
-  TVertexBuffer toDart() {
-    return TVertexBuffer(this);
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
   }
 }
 
-final class TVertexBuffer extends Struct {
-  Pointer<TVertexBuffer> get address => super.address.cast();
-  TVertexBuffer(super.address);
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
 
-  static Pointer<TVertexBuffer> stackAlloc() {
-    return Pointer<TVertexBuffer>(
-      NativeLibrary.instance.stackAlloc<TVertexBuffer>(0),
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(
+      NativeLibrary.instance.stackAlloc<TRenderManager>(0),
     );
   }
 }
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
   }
 }
 
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
 
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
-  }
-}
-
-extension double4x4Ext on Pointer<double4x4> {
-  double4x4 toDart() {
-    return double4x4(this);
-  }
-}
-
-final class double4x4 extends Struct {
-  Pointer<double4x4> get address => super.address.cast();
-  Array<Float64> get col1 {
-    final addr = Pointer<double4x4>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 0),
-    ));
-  }
-
-  set col1(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 0),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col2 {
-    final addr = Pointer<double4x4>(this.address.addr + 32);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 32),
-    ));
-  }
-
-  set col2(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 32),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col3 {
-    final addr = Pointer<double4x4>(this.address.addr + 64);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 64),
-    ));
-  }
-
-  set col3(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 64),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  Array<Float64> get col4 {
-    final addr = Pointer<double4x4>(this.address.addr + 96);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((
-      numElements: 4,
-      addr: Pointer<Float64>(this.address.addr + 96),
-    ));
-  }
-
-  set col4(Array<Float64> val) {
-    NativeLibrary.instance.setValue(
-      Pointer<double4x4>(this.address.addr + 96),
-      val.internal.addr.addr.toJS,
-      '*',
-    );
-  }
-
-  double4x4(super.address);
-
-  static Pointer<double4x4> stackAlloc() {
-    return Pointer<double4x4>(
-      NativeLibrary.instance.stackAlloc<double4x4>(128),
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(
+      NativeLibrary.instance.stackAlloc<TAnimationManager>(0),
     );
   }
 }
 
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
   }
 }
 
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
 
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(
-      NativeLibrary.instance.stackAlloc<TTransformManager>(0),
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(
+      NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0),
     );
   }
 }
 
-extension Aabb3Ext on Pointer<Aabb3> {
-  Aabb3 toDart() {
-    return Aabb3(this);
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
   }
 }
 
-final class Aabb3 extends Struct {
-  Pointer<Aabb3> get address => super.address.cast();
-  double get centerX {
-    final addr = Pointer<Aabb3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
+
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
   }
-
-  set centerX(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 0),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get centerY {
-    final addr = Pointer<Aabb3>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerY(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 4),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get centerZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerZ(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 8),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get halfExtentX {
-    final addr = Pointer<Aabb3>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentX(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 12),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get halfExtentY {
-    final addr = Pointer<Aabb3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentY(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 16),
-      val.toJS,
-      'float',
-    );
-  }
-
-  double get halfExtentZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 20);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentZ(double val) {
-    NativeLibrary.instance.setValue(
-      Pointer<Aabb3>(this.address.addr + 20),
-      val.toJS,
-      'float',
-    );
-  }
-
-  Aabb3(super.address);
-
-  static Pointer<Aabb3> stackAlloc() {
-    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
-  }
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
-  }
-}
-
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
-
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(
-      NativeLibrary.instance.stackAlloc<TEntityManager>(0),
-    );
-  }
-}
-
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
-  }
-}
-
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
-
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
-  }
-}
-
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
-  }
-}
-
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
-
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(
-      NativeLibrary.instance.stackAlloc<TDebugRegistry>(0),
-    );
-  }
-}
-
-extension TSceneAssetExt on Pointer<TSceneAsset> {
-  TSceneAsset toDart() {
-    return TSceneAsset(this);
-  }
-}
-
-final class TSceneAsset extends Struct {
-  Pointer<TSceneAsset> get address => super.address.cast();
-  TSceneAsset(super.address);
-
-  static Pointer<TSceneAsset> stackAlloc() {
-    return Pointer<TSceneAsset>(
-      NativeLibrary.instance.stackAlloc<TSceneAsset>(0),
-    );
-  }
-}
-
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
@@ -14066,15 +13700,374 @@ final class TGltfMeshData extends Struct {
   }
 }
 
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
 }
+
+extension TShadowOptionsExt on Pointer<TShadowOptions> {
+  TShadowOptions toDart() {
+    return TShadowOptions(this);
+  }
+}
+
+final class TShadowOptions extends Struct {
+  Pointer<TShadowOptions> get address => super.address.cast();
+  int get mapSize {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set mapSize(int val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 0),
+      val.toJS,
+      'i32',
+    );
+  }
+
+  int get shadowCascades {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set shadowCascades(int val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 4),
+      val.toJS,
+      'i8',
+    );
+  }
+
+  Array<Float32> get cascadeSplitPositions {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float32>((
+      numElements: 3,
+      addr: Pointer<Float32>(this.address.addr + 5),
+    ));
+  }
+
+  set cascadeSplitPositions(Array<Float32> val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 5),
+      val.internal.addr.addr.toJS,
+      '*',
+    );
+  }
+
+  double get constantBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set constantBias(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 17),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get normalBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set normalBias(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 21),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get shadowFar {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFar(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 25),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get shadowNearHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowNearHint(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 29),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get shadowFarHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFarHint(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 33),
+      val.toJS,
+      'float',
+    );
+  }
+
+  bool get stable {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set stable(bool val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 37),
+      (val ? 1 : 0).toJS,
+      'i8',
+    );
+  }
+
+  bool get lispsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set lispsm(bool val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 38),
+      (val ? 1 : 0).toJS,
+      'i8',
+    );
+  }
+
+  double get polygonOffsetConstant {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetConstant(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 39),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get polygonOffsetSlope {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetSlope(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 43),
+      val.toJS,
+      'float',
+    );
+  }
+
+  bool get screenSpaceContactShadows {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set screenSpaceContactShadows(bool val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 47),
+      (val ? 1 : 0).toJS,
+      'i8',
+    );
+  }
+
+  int get stepCount {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set stepCount(int val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 48),
+      val.toJS,
+      'i8',
+    );
+  }
+
+  double get maxShadowDistance {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxShadowDistance(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 49),
+      val.toJS,
+      'float',
+    );
+  }
+
+  bool get vsmElvsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set vsmElvsm(bool val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 53),
+      (val ? 1 : 0).toJS,
+      'i8',
+    );
+  }
+
+  double get vsmBlurWidth {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set vsmBlurWidth(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 54),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get shadowBulbRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowBulbRadius(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 58),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 62),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 66),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 70),
+      val.toJS,
+      'float',
+    );
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(
+      Pointer<TShadowOptions>(this.address.addr + 74),
+      val.toJS,
+      'float',
+    );
+  }
+
+  TShadowOptions(super.address);
+
+  static Pointer<TShadowOptions> stackAlloc() {
+    return Pointer<TShadowOptions>(
+      NativeLibrary.instance.stackAlloc<TShadowOptions>(78),
+    );
+  }
+}
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback =
+    Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction =
+    void Function(int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction =
+    void Function(int resultType, double x, double y, double z);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
+typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
+typedef PostRenderCallback =
+    Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef DartPostRenderCallback =
+    Pointer<NativeFunction<PostRenderCallbackFunction>>;
+typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
+typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
   TMovementIntentExecutor toDart() {
@@ -14125,44 +14118,56 @@ const int SPRINT_INTENT_MASK = 8;
 extension StructAllocator on Struct {
   static T create<T>() {
     switch (T) {
-      case TMaterialInstance:
-        final ptr = TMaterialInstance.stackAlloc();
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterial:
-        final ptr = TMaterial.stackAlloc();
-        return ptr.toDart() as T;
-      case TEngine:
-        final ptr = TEngine.stackAlloc();
-        return ptr.toDart() as T;
-      case TTexture:
-        final ptr = TTexture.stackAlloc();
-        return ptr.toDart() as T;
-      case TTextureSampler:
-        final ptr = TTextureSampler.stackAlloc();
-        return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
         return ptr.toDart() as T;
       case double3:
         final ptr = double3.stackAlloc();
         return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
+      case TSceneAsset:
+        final ptr = TSceneAsset.stackAlloc();
         return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
+      case TEngine:
+        final ptr = TEngine.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBuffer:
+        final ptr = TVertexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TMaterialInstance:
+        final ptr = TMaterialInstance.stackAlloc();
+        return ptr.toDart() as T;
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
         return ptr.toDart() as T;
       case TGltfAssetLoader:
         final ptr = TGltfAssetLoader.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
-        return ptr.toDart() as T;
       case TNameComponentManager:
         final ptr = TNameComponentManager.stackAlloc();
         return ptr.toDart() as T;
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TScene:
+        final ptr = TScene.stackAlloc();
+        return ptr.toDart() as T;
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
+        return ptr.toDart() as T;
       case TRenderableManager:
         final ptr = TRenderableManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientationBuilder:
+        final ptr = TSurfaceOrientationBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientation:
+        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
       case TViewport:
         final ptr = TViewport.stackAlloc();
@@ -14188,12 +14193,6 @@ extension StructAllocator on Struct {
       case TVsmShadowOptions:
         final ptr = TVsmShadowOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
-        return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
         return ptr.toDart() as T;
@@ -14203,14 +14202,20 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TSurfaceOrientationBuilder:
-        final ptr = TSurfaceOrientationBuilder.stackAlloc();
+      case TTexture:
+        final ptr = TTexture.stackAlloc();
         return ptr.toDart() as T;
-      case TSurfaceOrientation:
-        final ptr = TSurfaceOrientation.stackAlloc();
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
         return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TMaterial:
+        final ptr = TMaterial.stackAlloc();
+        return ptr.toDart() as T;
+      case TTextureSampler:
+        final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
       case TLinearImage:
         final ptr = TLinearImage.stackAlloc();
@@ -14218,47 +14223,17 @@ extension StructAllocator on Struct {
       case TKtx1Bundle:
         final ptr = TKtx1Bundle.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderManager:
-        final ptr = TRenderManager.stackAlloc();
-        return ptr.toDart() as T;
       case TRenderer:
         final ptr = TRenderer.stackAlloc();
-        return ptr.toDart() as T;
-      case TAnimationManager:
-        final ptr = TAnimationManager.stackAlloc();
         return ptr.toDart() as T;
       case TSwapChain:
         final ptr = TSwapChain.stackAlloc();
         return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBufferBuilder:
-        final ptr = TVertexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBuffer:
-        final ptr = TVertexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
       case TTransformManager:
         final ptr = TTransformManager.stackAlloc();
         return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
         return ptr.toDart() as T;
       case TEntityManager:
         final ptr = TEntityManager.stackAlloc();
@@ -14266,17 +14241,35 @@ extension StructAllocator on Struct {
       case TFence:
         final ptr = TFence.stackAlloc();
         return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
       case TDebugRegistry:
         final ptr = TDebugRegistry.stackAlloc();
         return ptr.toDart() as T;
-      case TSceneAsset:
-        final ptr = TSceneAsset.stackAlloc();
+      case TVertexBufferBuilder:
+        final ptr = TVertexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderManager:
+        final ptr = TRenderManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TAnimationManager:
+        final ptr = TAnimationManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableBuilder:
         final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TGltfMeshData:
         final ptr = TGltfMeshData.stackAlloc();
+        return ptr.toDart() as T;
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();

--- a/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
@@ -9,6 +9,7 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_view.dart';
 import 'package:thermion_dart/src/filament/src/interface/scene.dart';
 import 'package:thermion_dart/src/filament/src/interface/skybox.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 /// Manages the edge detection pass for outline rendering.
 ///
@@ -59,8 +60,11 @@ class EdgeDetectionView extends FFIView {
   final ColorGrading _linearColorGrading;
   final ToneMapper _linearToneMapper;
 
+  final FFIFilamentApp _app;
+
   EdgeDetectionView._(
-    super.view, {
+    Pointer<TView> view, {
+    required FFIFilamentApp app,
     required FFIMaterial material,
     required Scene scene,
     required Skybox skybox,
@@ -75,7 +79,8 @@ class EdgeDetectionView extends FFIView {
     required FFITextureSampler mainSceneSampler,
     required ColorGrading linearColorGrading,
     required ToneMapper linearToneMapper,
-  }) : _silhouetteTexture = silhouetteTexture,
+  }) : _app = app,
+       _silhouetteTexture = silhouetteTexture,
        _mainSceneTexture = mainSceneTexture,
        _mainSceneSampler = mainSceneSampler,
        _edgeMaterial = material,
@@ -88,31 +93,32 @@ class EdgeDetectionView extends FFIView {
        _fullscreenQuadEntity = fullscreenQuadEntity,
        _edgeSampler = edgeSampler,
        _linearColorGrading = linearColorGrading,
-       _linearToneMapper = linearToneMapper;
+       _linearToneMapper = linearToneMapper,
+       super(view, app);
 
   /// Creates and initializes a new [EdgeDetectionView].
-  static Future<EdgeDetectionView> create({
+  static Future<EdgeDetectionView> create(FFIFilamentApp app, {
     required Texture silhouetteTexture,
     required int width,
     required int height,
   }) async {
     // Create view
     final viewPtr = await withPointerCallback<TView>(
-      (cb) => Engine_createViewRenderThread(FilamentApp.instance!.engine, cb),
+      (cb) => Engine_createViewRenderThread(app.engine, cb),
     );
 
     // Create edge material
     final materialPtr = await withPointerCallback<TMaterial>(
       (cb) => Material_createEdgeOutlineMaterialRenderThread(
-        FilamentApp.instance!.engine,
+        app.engine,
         cb,
       ),
     );
-    final edgeMaterial = FFIMaterial(materialPtr);
+    final edgeMaterial = FFIMaterial(materialPtr, app);
 
     // Create scene with transparent skybox
-    final edgeScene = await FilamentApp.instance!.createScene();
-    final skybox = await FilamentApp.instance!.createColoredSkybox(
+    final edgeScene = await app.createScene();
+    final skybox = await app.createColoredSkybox(
       r: 0.0,
       g: 0.0,
       b: 0.0,
@@ -121,7 +127,7 @@ class EdgeDetectionView extends FFIView {
     await edgeScene.setSkybox(skybox);
 
     // Create camera entity with orthographic projection
-    final camera = await FilamentApp.instance!.createCamera();
+    final camera = await app.createCamera();
     await camera.setProjection(
       Projection.Orthographic,
       -1.0,
@@ -148,7 +154,7 @@ class EdgeDetectionView extends FFIView {
     ]);
 
     // Create vertex buffer
-    final vbBuilder = FilamentApp.instance!.renderableManager
+    final vbBuilder = app.renderableManager
         .createVertexBufferBuilder();
     vbBuilder.vertexCount(3);
     vbBuilder.bufferCount(1);
@@ -164,7 +170,7 @@ class EdgeDetectionView extends FFIView {
 
     // Create index buffer
     final indices = Uint16List.fromList([0, 1, 2]);
-    final ibBuilder = FilamentApp.instance!.renderableManager
+    final ibBuilder = app.renderableManager
         .createIndexBufferBuilder();
     ibBuilder.indexCount(3);
     ibBuilder.bufferType(IndexType.USHORT);
@@ -177,7 +183,7 @@ class EdgeDetectionView extends FFIView {
 
     // Create texture sampler for edge detection
     final edgeSampler =
-        await FilamentApp.instance!.createTextureSampler(
+        await app.createTextureSampler(
               minFilter: TextureMinFilter.NEAREST,
               magFilter: TextureMagFilter.NEAREST,
               wrapS: TextureWrapMode.CLAMP_TO_EDGE,
@@ -189,7 +195,7 @@ class EdgeDetectionView extends FFIView {
     // setMainSceneTexture is called). This ensures the shader has a valid
     // texture to sample before initialization completes
     final defaultMainSceneTexture =
-        await FilamentApp.instance!.createTexture(
+        await app.createTexture(
               1,
               1,
               flags: {TextureUsage.TEXTURE_USAGE_SAMPLEABLE},
@@ -202,7 +208,7 @@ class EdgeDetectionView extends FFIView {
     // would blur anti-aliased features (like grid lines) making them appear
     // thicker.
     final mainSceneSampler =
-        await FilamentApp.instance!.createTextureSampler(
+        await app.createTextureSampler(
               minFilter: TextureMinFilter.NEAREST,
               magFilter: TextureMagFilter.NEAREST,
               wrapS: TextureWrapMode.CLAMP_TO_EDGE,
@@ -211,9 +217,9 @@ class EdgeDetectionView extends FFIView {
             as FFITextureSampler;
 
     // Create fullscreen quad entity
-    final fullscreenQuadEntity = await FilamentApp.instance!.createEntity();
+    final fullscreenQuadEntity = await app.createEntity();
 
-    final builder = FilamentApp.instance!.renderableManager.createBuilder(1);
+    final builder = app.renderableManager.createBuilder(1);
     builder.boundingBox(Aabb3.minMax(Vector3(-2, -2, 0), Vector3(4, 4, 1)));
     builder.geometry(0, PrimitiveType.TRIANGLES, quadVB, quadIB, 0, 3);
     builder.material(0, edgeMaterialInstance);
@@ -229,11 +235,12 @@ class EdgeDetectionView extends FFIView {
     // In composite mode, the main scene texture is already tone-mapped, so we
     // use a pass-through (linear) tone mapper to preserve colors while still
     // benefiting from other post-processing effects (anti-aliasing, dithering).
-    final linearToneMapper = await ToneMapper.linear();
+    final linearToneMapper = await ToneMapper.linear(app);
     final colorGradingBuilder = FFIColorGradingBuilder(
       await withPointerCallback<TColorGradingBuilder>(
         (cb) => ColorGradingBuilder_createRenderThread(cb),
       ),
+      app,
     );
     colorGradingBuilder.toneMapper(linearToneMapper);
     final linearColorGrading = await colorGradingBuilder.build();
@@ -241,6 +248,7 @@ class EdgeDetectionView extends FFIView {
     // Create the EdgeDetectionView with all resources
     final edgeDetectionView = EdgeDetectionView._(
       viewPtr,
+      app: app,
       material: edgeMaterial,
       scene: edgeScene,
       skybox: skybox,
@@ -388,7 +396,7 @@ class EdgeDetectionView extends FFIView {
 
     // Destroy fullscreen quad
     await _edgeScene.removeEntity(_fullscreenQuadEntity);
-    await FilamentApp.instance!.destroyEntity(_fullscreenQuadEntity);
+    await _app.destroyEntity(_fullscreenQuadEntity);
 
     await _edgeMaterialInstance.destroy();
     await _quadVB.destroy();

--- a/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
@@ -97,7 +97,8 @@ class EdgeDetectionView extends FFIView {
        super(view, app);
 
   /// Creates and initializes a new [EdgeDetectionView].
-  static Future<EdgeDetectionView> create(FFIFilamentApp app, {
+  static Future<EdgeDetectionView> create(
+    FFIFilamentApp app, {
     required Texture silhouetteTexture,
     required int width,
     required int height,
@@ -109,10 +110,7 @@ class EdgeDetectionView extends FFIView {
 
     // Create edge material
     final materialPtr = await withPointerCallback<TMaterial>(
-      (cb) => Material_createEdgeOutlineMaterialRenderThread(
-        app.engine,
-        cb,
-      ),
+      (cb) => Material_createEdgeOutlineMaterialRenderThread(app.engine, cb),
     );
     final edgeMaterial = FFIMaterial(materialPtr, app);
 
@@ -154,8 +152,7 @@ class EdgeDetectionView extends FFIView {
     ]);
 
     // Create vertex buffer
-    final vbBuilder = app.renderableManager
-        .createVertexBufferBuilder();
+    final vbBuilder = app.renderableManager.createVertexBufferBuilder();
     vbBuilder.vertexCount(3);
     vbBuilder.bufferCount(1);
     vbBuilder.attribute(
@@ -170,8 +167,7 @@ class EdgeDetectionView extends FFIView {
 
     // Create index buffer
     final indices = Uint16List.fromList([0, 1, 2]);
-    final ibBuilder = app.renderableManager
-        .createIndexBufferBuilder();
+    final ibBuilder = app.renderableManager.createIndexBufferBuilder();
     ibBuilder.indexCount(3);
     ibBuilder.bufferType(IndexType.USHORT);
     final quadIB = await ibBuilder.build() as FFIIndexBuffer;

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_material.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_vertex_buffer.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 import 'package:vector_math/vector_math_64.dart' as v64;
 
 class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
@@ -31,7 +32,13 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   bool get _sourceDataReleased =>
       isInstance ? instanceOwner!._sourceDataReleased : _released;
 
-  FFIAsset(this.asset, {this.instanceOwner = null}) {
+  final FFIFilamentApp _app;
+
+  FFIAsset(
+    this.asset, {
+    this.instanceOwner = null,
+    required FFIFilamentApp app,
+  }) : _app = app {
     entity = SceneAsset_getEntity(asset);
   }
 
@@ -91,7 +98,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     final childEntities = await getChildEntities();
     var names = <String?>[];
     for (final entity in childEntities) {
-      var name = await FilamentApp.instance!.getNameForEntity(entity);
+      var name = await _app.getNameForEntity(entity);
       names.add(name);
     }
     return names;
@@ -102,7 +109,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   Future<ThermionEntity?> getChildEntity(String childName) async {
     final childEntities = await getChildEntities();
     for (final entity in childEntities) {
-      var name = FilamentApp.instance!.getNameForEntity(entity);
+      var name = _app.getNameForEntity(entity);
       if (name == childName) {
         return entity;
       }
@@ -123,7 +130,11 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     if (instance == nullptr) {
       throw Exception("No instance available at index $index");
     }
-    return FFIAsset(instance, instanceOwner: this);
+    return FFIAsset(
+      instance,
+      instanceOwner: this,
+      app: _app,
+    );
   }
 
   //
@@ -177,7 +188,11 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     if (created == nullptr) {
       throw Exception("Failed to create instance");
     }
-    return FFIAsset(created, instanceOwner: this);
+    return FFIAsset(
+      created,
+      instanceOwner: this,
+      app: _app,
+    );
   }
 
   //
@@ -196,7 +211,11 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       if (instance == nullptr) {
         throw Exception("Failed to get asset instance at index $i");
       }
-      return FFIAsset(instance, instanceOwner: this);
+      return FFIAsset(
+        instance,
+        instanceOwner: this,
+        app: _app,
+      );
     });
 
     return result;
@@ -233,7 +252,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   //
   Future<v64.Aabb3> getBoundingBox() async {
     final entities = <ThermionEntity>[];
-    if (FilamentApp.instance!.renderableManager.isRenderable(entity)) {
+    if (_app.renderableManager.isRenderable(entity)) {
       entities.add(entity);
     } else {
       entities.addAll(await getChildEntities());
@@ -242,7 +261,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     var boundingBox = v64.Aabb3();
 
     for (final entity in entities) {
-      final aabb3 = FilamentApp.instance!.renderableManager.getBoundingBox(
+      final aabb3 = _app.renderableManager.getBoundingBox(
         entity,
       );
       boundingBox.hull(aabb3);
@@ -257,11 +276,11 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     int index = 0,
   }) async {
     if (entity == null) {
-      if (FilamentApp.instance!.renderableManager.isRenderable(this.entity)) {
+      if (_app.renderableManager.isRenderable(this.entity)) {
         entity ??= this.entity;
       } else {
         for (final child in await getChildEntities()) {
-          if (FilamentApp.instance!.renderableManager.isRenderable(child)) {
+          if (_app.renderableManager.isRenderable(child)) {
             entity = child;
             break;
           }
@@ -273,7 +292,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       throw Exception("Failed to find renderable entity");
     }
 
-    var instance = await FilamentApp.instance!.renderableManager
+    var instance = await _app.renderableManager
         .getMaterialInstanceAt(entity, 0);
     if (instance == null) {
       throw Exception("Failed to get material instance for asset");
@@ -284,7 +303,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   //
   Future setMaterialInstanceForAll(FFIMaterialInstance instance) async {
     for (int i = 0; i < await getPrimitiveCount(entity: entity); i++) {
-      if (FilamentApp.instance!.renderableManager.isRenderable(entity)) {
+      if (_app.renderableManager.isRenderable(entity)) {
         await setMaterialInstanceAt(
           instance,
           entity: entity,
@@ -293,7 +312,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       }
     }
     for (final entity in await getChildEntities()) {
-      if (!FilamentApp.instance!.renderableManager.isRenderable(entity)) {
+      if (!_app.renderableManager.isRenderable(entity)) {
         continue;
       }
       for (int i = 0; i < await getPrimitiveCount(entity: entity); i++) {
@@ -331,7 +350,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     var entities = [entity, ...await getChildEntities()];
 
     for (final entity in entities) {
-      if (FilamentApp.instance!.renderableManager.isRenderable(entity)) {
+      if (_app.renderableManager.isRenderable(entity)) {
         result[entity] = [];
         for (int i = 0; i < await getPrimitiveCount(entity: entity); i++) {
           result[entity]!.add(
@@ -348,7 +367,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     Map<ThermionEntity, List<MaterialInstance>> materialInstances,
   ) async {
     for (final entity in materialInstances.keys) {
-      if (FilamentApp.instance!.renderableManager.isRenderable(entity)) {
+      if (_app.renderableManager.isRenderable(entity)) {
         for (int i = 0; i < materialInstances[entity]!.length; i++) {
           final mi = materialInstances[entity]![i];
           await setMaterialInstanceAt(
@@ -369,17 +388,17 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     int primitiveIndex = 0,
   }) async {
     if (entity != null &&
-        !FilamentApp.instance!.renderableManager.isRenderable(entity)) {
+        !_app.renderableManager.isRenderable(entity)) {
       _logger.warning("Provided entity is not renderable");
       return;
     }
 
     if (entity == null) {
-      if (FilamentApp.instance!.renderableManager.isRenderable(this.entity)) {
+      if (_app.renderableManager.isRenderable(this.entity)) {
         entity ??= this.entity;
       } else {
         for (final child in await getChildEntities()) {
-          if (FilamentApp.instance!.renderableManager.isRenderable(child)) {
+          if (_app.renderableManager.isRenderable(child)) {
             entity = child;
             break;
           }
@@ -391,7 +410,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       throw Exception("Failed to find renderable entity");
     }
 
-    if (!await FilamentApp.instance!.renderableManager.setMaterialInstanceAt(
+    if (!await _app.renderableManager.setMaterialInstanceAt(
       entity,
       primitiveIndex,
       instance,
@@ -404,12 +423,12 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future setCastShadows(bool castShadows) async {
-    await FilamentApp.instance!.renderableManager.setCastShadows(
+    await _app.renderableManager.setCastShadows(
       this.entity,
       castShadows,
     );
     for (final entity in await this.getChildEntities()) {
-      await FilamentApp.instance!.renderableManager.setCastShadows(
+      await _app.renderableManager.setCastShadows(
         entity,
         castShadows,
       );
@@ -418,12 +437,12 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future setReceiveShadows(bool receiveShadows) async {
-    await FilamentApp.instance!.renderableManager.setReceiveShadows(
+    await _app.renderableManager.setReceiveShadows(
       this.entity,
       receiveShadows,
     );
     for (final entity in await this.getChildEntities()) {
-      await FilamentApp.instance!.renderableManager.setReceiveShadows(
+      await _app.renderableManager.setReceiveShadows(
         entity,
         receiveShadows,
       );
@@ -433,18 +452,18 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   //
   Future<bool> isCastShadowsEnabled({ThermionEntity? entity}) async {
     entity ??= this.entity;
-    return FilamentApp.instance!.renderableManager.isShadowCaster(entity);
+    return _app.renderableManager.isShadowCaster(entity);
   }
 
   //
   Future<bool> isReceiveShadowsEnabled({ThermionEntity? entity}) async {
     entity ??= this.entity;
-    return FilamentApp.instance!.renderableManager.isShadowReceiver(entity);
+    return _app.renderableManager.isShadowReceiver(entity);
   }
 
   //
   Future transformToUnitCube() async {
-    FilamentApp.instance!.transformManager.transformToUnitCube(
+    _app.transformManager.transformToUnitCube(
       entity,
       await getBoundingBox(),
     );
@@ -455,7 +474,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     ThermionEntity entity,
     VisibilityLayers layer,
   ) async {
-    await FilamentApp.instance!.renderableManager.setVisibilityLayer(
+    await _app.renderableManager.setVisibilityLayer(
       entity,
       layer.value,
     );
@@ -471,7 +490,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       throw Exception("Weights must not be empty");
     }
 
-    final success = await FilamentApp.instance!.animationManager
+    final success = await _app.animationManager
         .setMorphTargetWeights(entity, weights);
     if (!success) {
       throw Exception(
@@ -486,13 +505,13 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     entity ??= this.entity;
 
     var names = <String>[];
-    var count = FilamentApp.instance!.animationManager.getMorphTargetNameCount(
+    var count = _app.animationManager.getMorphTargetNameCount(
       this,
       entity,
     );
 
     for (int i = 0; i < count; i++) {
-      final name = FilamentApp.instance!.animationManager.getMorphTargetName(
+      final name = _app.animationManager.getMorphTargetName(
         this,
         entity,
         i,
@@ -539,12 +558,12 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       return [];
     }
     if (_gltfAnimationNames == null) {
-      var animationCount = FilamentApp.instance!.animationManager
+      var animationCount = _app.animationManager
           .getGltfAnimationCount(this);
 
       _gltfAnimationNames = [];
       for (int i = 0; i < animationCount; i++) {
-        final name = FilamentApp.instance!.animationManager
+        final name = _app.animationManager
             .getGltfAnimationName(this, i);
         if (name != null) {
           _gltfAnimationNames!.add(name);
@@ -563,7 +582,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         "getGltfAnimationDuration can only be called on glTF assets",
       );
     }
-    final duration = FilamentApp.instance!.animationManager
+    final duration = _app.animationManager
         .getGltfAnimationDuration(this, animationIndex);
     return duration;
   }
@@ -585,7 +604,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future clearMorphAnimationData(ThermionEntity entity) async {
-    if (!FilamentApp.instance!.animationManager.clearMorphAnimation(entity)) {
+    if (!_app.animationManager.clearMorphAnimation(entity)) {
       throw Exception("Failed to clear morph animation");
     }
   }
@@ -599,7 +618,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     var childEntities = await getChildEntities();
 
     var childNames = childEntities
-        .map((e) => FilamentApp.instance!.getNameForEntity(e))
+        .map((e) => _app.getNameForEntity(e))
         .toList();
     if (targetMeshNames != null) {
       for (final targetMeshName in targetMeshNames) {
@@ -656,7 +675,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         frameData.data.length == animation.numFrames * intersection.length,
       );
 
-      var result = FilamentApp.instance!.animationManager.setMorphAnimation(
+      var result = _app.animationManager.setMorphAnimation(
         meshEntity,
         frameData.data,
         indices,
@@ -704,7 +723,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       }
     }
     var boneNames = await instanceAsset.getBoneNames(skinIndex: skinIndex);
-    var restLocalTransformsData = await FilamentApp.instance!.animationManager
+    var restLocalTransformsData = await _app.animationManager
         .getRestLocalTransforms(instanceAsset, skinIndex);
     var restLocalTransforms = <Matrix4>[];
     for (int i = 0; i < boneNames.length; i++) {
@@ -736,7 +755,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         var world = Matrix4.identity();
         // this odd use of ! is intentional, without it, the WASM optimizer gets
         // in trouble
-        var parentBoneEntity = (await FilamentApp.instance!.getParent(
+        var parentBoneEntity = (await _app.getParent(
           boneEntity,
         ))!;
         while (true) {
@@ -744,7 +763,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
             break;
           }
           world = restLocalTransforms[bones.indexOf(parentBoneEntity!)] * world;
-          parentBoneEntity = (await FilamentApp.instance!.getParent(
+          parentBoneEntity = (await _app.getParent(
             parentBoneEntity,
           ))!;
         }
@@ -777,7 +796,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
           frameDataList.add(data[i]);
         }
 
-        await FilamentApp.instance!.animationManager.addBoneAnimation(
+        await _app.animationManager.addBoneAnimation(
           this,
           skinIndex,
           entityBoneIndex,
@@ -798,7 +817,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   //
   Future<Matrix4> getLocalTransform({ThermionEntity? entity}) async {
     entity ??= this.entity;
-    final transform = FilamentApp.instance!.transformManager.getLocalTransform(
+    final transform = _app.transformManager.getLocalTransform(
       entity,
     );
     return transform;
@@ -806,12 +825,12 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future<Matrix4> getWorldTransform({ThermionEntity? entity}) async {
-    return FilamentApp.instance!.getWorldTransform(entity ?? this.entity);
+    return _app.getWorldTransform(entity ?? this.entity);
   }
 
   //
   Future setTransform(Matrix4 transform, {ThermionEntity? entity}) async {
-    await FilamentApp.instance!.setTransform(entity ?? this.entity, transform);
+    await _app.setTransform(entity ?? this.entity, transform);
   }
 
   //
@@ -824,7 +843,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         "getInverseBindMatrix can only be called on an instance of an asset",
       );
     }
-    var matrixData = await FilamentApp.instance!.animationManager
+    var matrixData = await _app.animationManager
         .getInverseBindMatrix(this, skinIndex, boneIndex);
     var matrixOut = Matrix4.fromList(matrixData);
     return matrixOut;
@@ -851,7 +870,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     if (skinIndex != 0) {
       throw UnimplementedError("TODO - support skinIndex != 0");
     }
-    final renderableManager = FilamentApp.instance!.renderableManager;
+    final renderableManager = _app.renderableManager;
 
     ThermionEntity? meshEntity = entity;
     if (meshEntity == null) {
@@ -885,7 +904,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   //
   @override
   Future resetBones() async {
-    FilamentApp.instance!.animationManager.resetToRestPose(this);
+    _app.animationManager.resetToRestPose(this);
   }
 
   //
@@ -899,7 +918,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     double startOffset = 0.0,
     double speed = 1.0,
   }) async {
-    final success = FilamentApp.instance!.animationManager.playGltfAnimation(
+    final success = _app.animationManager.playGltfAnimation(
       this,
       index,
       loop: loop,
@@ -917,7 +936,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   //
   @override
   Future stopGltfAnimation(int animationIndex) async {
-    final success = FilamentApp.instance!.animationManager.stopGltfAnimation(
+    final success = _app.animationManager.stopGltfAnimation(
       this,
       animationIndex,
     );
@@ -963,7 +982,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   //
   @override
   Future setGltfAnimationTime(int index, double timeInSeconds) async {
-    await FilamentApp.instance!.animationManager.setGltfAnimationTime(
+    await _app.animationManager.setGltfAnimationTime(
       this,
       index,
       timeInSeconds,
@@ -983,7 +1002,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         "components",
       );
     }
-    FilamentApp.instance!.animationManager.addGltfAnimationComponent(this);
+    _app.animationManager.addGltfAnimationComponent(this);
   }
 
   //
@@ -997,20 +1016,20 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     }
 
     if (type == SceneAssetType.gltf &&
-        !await FilamentApp.instance!.animationManager
+        !await _app.animationManager
             .removeGltfAnimationComponent(this)) {
       _logger.warning("Failed to remove glTF animation component");
     }
-    if (!await FilamentApp.instance!.animationManager
+    if (!await _app.animationManager
         .removeBoneAnimationComponent(this)) {
       _logger.warning("Failed to remove bone animation component");
     }
-    FilamentApp.instance!.animationManager.removeMorphAnimationComponent(
+    _app.animationManager.removeMorphAnimationComponent(
       entity,
     );
 
     for (final child in await getChildEntities()) {
-      FilamentApp.instance!.animationManager.removeMorphAnimationComponent(
+      _app.animationManager.removeMorphAnimationComponent(
         child,
       );
     }
@@ -1018,7 +1037,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future<int> getPrimitiveCount({ThermionEntity? entity}) async {
-    return FilamentApp.instance!.getPrimitiveCount(entity ??= this.entity);
+    return _app.getPrimitiveCount(entity ??= this.entity);
   }
 
   /// Returns the starting primitive offset for the given entity, or -1 if
@@ -1045,6 +1064,6 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     if (vbPtr == nullptr) {
       return null;
     }
-    return FFIVertexBuffer(vbPtr, FilamentApp.instance!.engine);
+    return FFIVertexBuffer(vbPtr, _app.engine);
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -34,11 +34,8 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   final FFIFilamentApp _app;
 
-  FFIAsset(
-    this.asset, {
-    this.instanceOwner = null,
-    required FFIFilamentApp app,
-  }) : _app = app {
+  FFIAsset(this.asset, {this.instanceOwner = null, required FFIFilamentApp app})
+    : _app = app {
     entity = SceneAsset_getEntity(asset);
   }
 
@@ -130,11 +127,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     if (instance == nullptr) {
       throw Exception("No instance available at index $index");
     }
-    return FFIAsset(
-      instance,
-      instanceOwner: this,
-      app: _app,
-    );
+    return FFIAsset(instance, instanceOwner: this, app: _app);
   }
 
   //
@@ -188,11 +181,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     if (created == nullptr) {
       throw Exception("Failed to create instance");
     }
-    return FFIAsset(
-      created,
-      instanceOwner: this,
-      app: _app,
-    );
+    return FFIAsset(created, instanceOwner: this, app: _app);
   }
 
   //
@@ -211,11 +200,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       if (instance == nullptr) {
         throw Exception("Failed to get asset instance at index $i");
       }
-      return FFIAsset(
-        instance,
-        instanceOwner: this,
-        app: _app,
-      );
+      return FFIAsset(instance, instanceOwner: this, app: _app);
     });
 
     return result;
@@ -261,9 +246,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     var boundingBox = v64.Aabb3();
 
     for (final entity in entities) {
-      final aabb3 = _app.renderableManager.getBoundingBox(
-        entity,
-      );
+      final aabb3 = _app.renderableManager.getBoundingBox(entity);
       boundingBox.hull(aabb3);
     }
     return boundingBox;
@@ -292,8 +275,10 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       throw Exception("Failed to find renderable entity");
     }
 
-    var instance = await _app.renderableManager
-        .getMaterialInstanceAt(entity, 0);
+    var instance = await _app.renderableManager.getMaterialInstanceAt(
+      entity,
+      0,
+    );
     if (instance == null) {
       throw Exception("Failed to get material instance for asset");
     }
@@ -387,8 +372,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     int? entity = null,
     int primitiveIndex = 0,
   }) async {
-    if (entity != null &&
-        !_app.renderableManager.isRenderable(entity)) {
+    if (entity != null && !_app.renderableManager.isRenderable(entity)) {
       _logger.warning("Provided entity is not renderable");
       return;
     }
@@ -423,29 +407,17 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future setCastShadows(bool castShadows) async {
-    await _app.renderableManager.setCastShadows(
-      this.entity,
-      castShadows,
-    );
+    await _app.renderableManager.setCastShadows(this.entity, castShadows);
     for (final entity in await this.getChildEntities()) {
-      await _app.renderableManager.setCastShadows(
-        entity,
-        castShadows,
-      );
+      await _app.renderableManager.setCastShadows(entity, castShadows);
     }
   }
 
   //
   Future setReceiveShadows(bool receiveShadows) async {
-    await _app.renderableManager.setReceiveShadows(
-      this.entity,
-      receiveShadows,
-    );
+    await _app.renderableManager.setReceiveShadows(this.entity, receiveShadows);
     for (final entity in await this.getChildEntities()) {
-      await _app.renderableManager.setReceiveShadows(
-        entity,
-        receiveShadows,
-      );
+      await _app.renderableManager.setReceiveShadows(entity, receiveShadows);
     }
   }
 
@@ -463,10 +435,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future transformToUnitCube() async {
-    _app.transformManager.transformToUnitCube(
-      entity,
-      await getBoundingBox(),
-    );
+    _app.transformManager.transformToUnitCube(entity, await getBoundingBox());
   }
 
   //
@@ -474,10 +443,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     ThermionEntity entity,
     VisibilityLayers layer,
   ) async {
-    await _app.renderableManager.setVisibilityLayer(
-      entity,
-      layer.value,
-    );
+    await _app.renderableManager.setVisibilityLayer(entity, layer.value);
   }
 
   //
@@ -490,8 +456,10 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       throw Exception("Weights must not be empty");
     }
 
-    final success = await _app.animationManager
-        .setMorphTargetWeights(entity, weights);
+    final success = await _app.animationManager.setMorphTargetWeights(
+      entity,
+      weights,
+    );
     if (!success) {
       throw Exception(
         "Failed to set morph target weights, check logs for details",
@@ -505,17 +473,10 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     entity ??= this.entity;
 
     var names = <String>[];
-    var count = _app.animationManager.getMorphTargetNameCount(
-      this,
-      entity,
-    );
+    var count = _app.animationManager.getMorphTargetNameCount(this, entity);
 
     for (int i = 0; i < count; i++) {
-      final name = _app.animationManager.getMorphTargetName(
-        this,
-        entity,
-        i,
-      );
+      final name = _app.animationManager.getMorphTargetName(this, entity, i);
       if (name != null) {
         names.add(name);
       }
@@ -558,13 +519,11 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       return [];
     }
     if (_gltfAnimationNames == null) {
-      var animationCount = _app.animationManager
-          .getGltfAnimationCount(this);
+      var animationCount = _app.animationManager.getGltfAnimationCount(this);
 
       _gltfAnimationNames = [];
       for (int i = 0; i < animationCount; i++) {
-        final name = _app.animationManager
-            .getGltfAnimationName(this, i);
+        final name = _app.animationManager.getGltfAnimationName(this, i);
         if (name != null) {
           _gltfAnimationNames!.add(name);
         }
@@ -582,8 +541,10 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         "getGltfAnimationDuration can only be called on glTF assets",
       );
     }
-    final duration = _app.animationManager
-        .getGltfAnimationDuration(this, animationIndex);
+    final duration = _app.animationManager.getGltfAnimationDuration(
+      this,
+      animationIndex,
+    );
     return duration;
   }
 
@@ -755,17 +716,13 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         var world = Matrix4.identity();
         // this odd use of ! is intentional, without it, the WASM optimizer gets
         // in trouble
-        var parentBoneEntity = (await _app.getParent(
-          boneEntity,
-        ))!;
+        var parentBoneEntity = (await _app.getParent(boneEntity))!;
         while (true) {
           if (!bones.contains(parentBoneEntity!)) {
             break;
           }
           world = restLocalTransforms[bones.indexOf(parentBoneEntity!)] * world;
-          parentBoneEntity = (await _app.getParent(
-            parentBoneEntity,
-          ))!;
+          parentBoneEntity = (await _app.getParent(parentBoneEntity))!;
         }
 
         world = Matrix4.identity()..setRotation(world.getRotation());
@@ -817,9 +774,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
   //
   Future<Matrix4> getLocalTransform({ThermionEntity? entity}) async {
     entity ??= this.entity;
-    final transform = _app.transformManager.getLocalTransform(
-      entity,
-    );
+    final transform = _app.transformManager.getLocalTransform(entity);
     return transform;
   }
 
@@ -843,8 +798,11 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         "getInverseBindMatrix can only be called on an instance of an asset",
       );
     }
-    var matrixData = await _app.animationManager
-        .getInverseBindMatrix(this, skinIndex, boneIndex);
+    var matrixData = await _app.animationManager.getInverseBindMatrix(
+      this,
+      skinIndex,
+      boneIndex,
+    );
     var matrixOut = Matrix4.fromList(matrixData);
     return matrixOut;
   }
@@ -1016,22 +974,16 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     }
 
     if (type == SceneAssetType.gltf &&
-        !await _app.animationManager
-            .removeGltfAnimationComponent(this)) {
+        !await _app.animationManager.removeGltfAnimationComponent(this)) {
       _logger.warning("Failed to remove glTF animation component");
     }
-    if (!await _app.animationManager
-        .removeBoneAnimationComponent(this)) {
+    if (!await _app.animationManager.removeBoneAnimationComponent(this)) {
       _logger.warning("Failed to remove bone animation component");
     }
-    _app.animationManager.removeMorphAnimationComponent(
-      entity,
-    );
+    _app.animationManager.removeMorphAnimationComponent(entity);
 
     for (final child in await getChildEntities()) {
-      _app.animationManager.removeMorphAnimationComponent(
-        child,
-      );
+      _app.animationManager.removeMorphAnimationComponent(child);
     }
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
@@ -1,4 +1,5 @@
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 import '../../../utils/src/matrix.dart';
 
@@ -12,7 +13,9 @@ class FFICamera extends Camera<Pointer<TCamera>> {
 
   late ThermionEntity _entity;
 
-  FFICamera(this.camera) {
+  final FFIFilamentApp _app;
+
+  FFICamera(this.camera, this._app) {
     _entity = Camera_getEntity(camera);
   }
 
@@ -162,7 +165,7 @@ class FFICamera extends Camera<Pointer<TCamera>> {
   @override
   Future setTransform(Matrix4 transform) async {
     var entity = Camera_getEntity(camera);
-    FilamentApp.instance!.transformManager.setTransform(entity, transform);
+    _app.transformManager.setTransform(entity, transform);
   }
 
   @override
@@ -403,7 +406,7 @@ class FFICamera extends Camera<Pointer<TCamera>> {
   Future destroy() async {
     await withVoidCallback(
       (requestId, cb) => Engine_destroyCameraRenderThread(
-        FilamentApp.instance!.engine,
+        _app.engine,
         camera,
         requestId,
         cb,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
@@ -405,12 +405,8 @@ class FFICamera extends Camera<Pointer<TCamera>> {
 
   Future destroy() async {
     await withVoidCallback(
-      (requestId, cb) => Engine_destroyCameraRenderThread(
-        _app.engine,
-        camera,
-        requestId,
-        cb,
-      ),
+      (requestId, cb) =>
+          Engine_destroyCameraRenderThread(_app.engine, camera, requestId, cb),
     );
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 /// FFI implementation of ColorGrading
 class FFIColorGrading extends ColorGrading {
   final Pointer<TColorGrading> pointer;
 
-  FFIColorGrading(this.pointer);
+  final FFIFilamentApp _app;
+
+  FFIColorGrading(this.pointer, this._app);
 
   @override
   Pointer<TColorGrading> getNativeHandle() => pointer;
@@ -14,7 +17,7 @@ class FFIColorGrading extends ColorGrading {
   Future dispose() async {
     await withVoidCallback(
       (requestId, cb) => Engine_destroyColorGradingRenderThread(
-        FilamentApp.instance!.engine,
+        _app.engine,
         pointer,
         requestId,
         cb,
@@ -28,7 +31,9 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
   final Pointer<TColorGradingBuilder> _builder;
   bool _built = false;
 
-  FFIColorGradingBuilder(this._builder);
+  final FFIFilamentApp _app;
+
+  FFIColorGradingBuilder(this._builder, this._app);
 
   void _checkNotBuilt() {
     if (_built) {
@@ -225,7 +230,7 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
     final ptr = await withPointerCallback<TColorGrading>(
       (cb) => ColorGradingBuilder_buildRenderThread(
         _builder,
-        FilamentApp.instance!.engine,
+        _app.engine,
         cb,
       ),
     );
@@ -236,6 +241,6 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
     if (ptr == nullptr) {
       throw Exception('Failed to build ColorGrading');
     }
-    return FFIColorGrading(ptr);
+    return FFIColorGrading(ptr, _app);
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
@@ -228,11 +228,7 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
     _checkNotBuilt();
     _built = true;
     final ptr = await withPointerCallback<TColorGrading>(
-      (cb) => ColorGradingBuilder_buildRenderThread(
-        _builder,
-        _app.engine,
-        cb,
-      ),
+      (cb) => ColorGradingBuilder_buildRenderThread(_builder, _app.engine, cb),
     );
     await withVoidCallback(
       (requestId, cb) =>

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -112,15 +112,26 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     return FFIDebugRegistry(debugRegistryPtr);
   }
 
-  static Future create({FFIFilamentConfig? config}) async {
+  static Future create({FFIFilamentConfig? config, String? canvasSelector}) async {
     config ??= FFIFilamentConfig();
 
     if (FilamentApp.instance != null) {
       await FilamentApp.instance!.destroy();
     }
 
-    RenderThread_destroy();
-    final renderThreadHandle = RenderThread_create();
+    // Web multi-viewer: each engine gets its own RenderThread, which
+    // transfers its own canvas element to the worker. The selector is the
+    // CSS id of that viewer's canvas; native passes null and gets the
+    // default thread.
+    RenderThread_destroy(nullptr);
+    late final Pointer<Void> renderThreadHandle;
+    if (canvasSelector != null) {
+      final selectorPtr = canvasSelector.toNativeUtf8().cast<Char>();
+      renderThreadHandle = RenderThread_createForCanvas(selectorPtr);
+      free(selectorPtr);
+    } else {
+      renderThreadHandle = RenderThread_create();
+    }
 
     if (renderThreadHandle == nullptr) {
       throw Exception("Failed to create render thread");
@@ -409,7 +420,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     // the worker pthread effectively dead but with its mimalloc arena still
     // owned, so every subsequent FilamentApp.create() spawns a fresh worker
     // on top of the leaked one.
-    RenderManager_detachFromRenderThread();
+    RenderManager_detachFromRenderThread(renderManager.getNativeHandle());
     renderManager.destroy();
 
     // Filament's contract is: tear down everything created on top of the
@@ -438,7 +449,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       Engine_destroyRenderThread(engine, requestId, cb);
     });
 
-    RenderThread_destroy();
+    RenderThread_destroy(renderThreadHandle);
     for (final callback in _onDestroy) {
       await callback.call();
     }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -114,7 +114,6 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
   static Future create({
     FFIFilamentConfig? config,
-    String? canvasSelector,
     bool destroyExisting = true,
   }) async {
     config ??= FFIFilamentConfig();
@@ -127,19 +126,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       await FilamentApp.instance!.destroy();
     }
 
-    // Web multi-viewer: each engine gets its own RenderThread, which
-    // transfers its own canvas element to the worker. The selector is the
-    // CSS id of that viewer's canvas; native passes null and gets the
-    // default thread.
     RenderThread_destroy(nullptr);
-    late final Pointer<Void> renderThreadHandle;
-    if (canvasSelector != null) {
-      final selectorPtr = canvasSelector.toNativeUtf8().cast<Char>();
-      renderThreadHandle = RenderThread_createForCanvas(selectorPtr);
-      free(selectorPtr);
-    } else {
-      renderThreadHandle = RenderThread_create();
-    }
+    final renderThreadHandle = RenderThread_create();
 
     if (renderThreadHandle == nullptr) {
       throw Exception("Failed to create render thread");

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -112,10 +112,18 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     return FFIDebugRegistry(debugRegistryPtr);
   }
 
-  static Future create({FFIFilamentConfig? config, String? canvasSelector}) async {
+  static Future create({
+    FFIFilamentConfig? config,
+    String? canvasSelector,
+    bool destroyExisting = true,
+  }) async {
     config ??= FFIFilamentConfig();
 
-    if (FilamentApp.instance != null) {
+    // Multi-engine web (engine per viewer) creates additional engines while
+    // an existing one is still rendering. destroyExisting: false leaves the
+    // current app untouched — the caller owns it (the web plugin's per-viewer
+    // bundle) and must NOT have it torn down underneath its render loop.
+    if (destroyExisting && FilamentApp.instance != null) {
       await FilamentApp.instance!.destroy();
     }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -281,7 +281,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
   //
   Future<View> createView({bool createScene = false}) async {
-    final view = await FFIView.create();
+    final view = await FFIView.create(this);
     await view.setName("unnamed_view");
     await view.setFrustumCullingEnabled(true);
     await view.setBloom(false, 0.0);
@@ -301,7 +301,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
   //
   Future<Scene> createScene() async {
-    return FFIScene(Engine_createScene(engine));
+    return FFIScene(Engine_createScene(engine), this);
   }
 
   //
@@ -311,6 +311,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       await withPointerCallback<TCamera>(
         (cb) => Engine_createCameraRenderThread(engine, targetEntity!, cb),
       ),
+      this,
     );
   }
 
@@ -545,7 +546,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       throw Exception("Failed to create RenderTarget");
     }
 
-    return FFIRenderTarget(renderTarget);
+    return FFIRenderTarget(renderTarget, this);
   }
 
   //
@@ -581,7 +582,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     if (texturePtr == nullptr) {
       throw Exception("Failed to create texture");
     }
-    return FFITexture(engine, texturePtr);
+    return FFITexture(engine, texturePtr, this);
   }
 
   Future<void> setExternalImage(Texture texture, int externalImagePtr) async {
@@ -674,6 +675,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       await withPointerCallback<TMaterial>((cb) {
         Material_createGizmoMaterialRenderThread(engine, cb);
       }),
+      this,
     );
     return _gizmoMaterial!;
   }
@@ -688,6 +690,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       await withPointerCallback<TMaterial>((cb) {
         Material_createBoneOverlayMaterialRenderThread(engine, cb);
       }),
+      this,
     );
     return _boneOverlayMaterial!;
   }
@@ -705,7 +708,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       //stackRestore(stackPtr);
       data.free();
     }
-    return FFIMaterial(ptr);
+    return FFIMaterial(ptr, this);
   }
 
   //
@@ -801,7 +804,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       throw Exception("Failed to create material instance");
     }
 
-    var instance = FFIMaterialInstance(materialInstance);
+    var instance = FFIMaterialInstance(materialInstance, this);
     return instance;
   }
 
@@ -819,6 +822,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       await withPointerCallback<TMaterial>((cb) {
         Material_createWireframeMaterialRenderThread(engine, cb);
       }),
+      this,
     );
     final mi = await material.createInstance();
     return WireframeMaterialInstance(mi);
@@ -1431,7 +1435,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
         ),
       );
 
-      final ffiAsset = FFIAsset(asset);
+      final ffiAsset = FFIAsset(asset, app: this);
       if (releaseSourceData) {
         await ffiAsset.releaseSourceData();
       }
@@ -1468,7 +1472,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
   //
   Future<GizmoAsset> createGizmo(View view, GizmoType gizmoType) async {
-    return FFIGizmo.create(view, gizmoType);
+    return FFIGizmo.create(this, view, gizmoType);
   }
 
   //
@@ -1725,7 +1729,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       throw Exception("Failed to create geometry");
     }
 
-    return FFIAsset(assetPtr);
+    return FFIAsset(assetPtr, app: this);
   }
 
   //
@@ -1858,7 +1862,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
         cb,
       );
     });
-    return FFISkybox(ptr);
+    return FFISkybox(ptr, this);
   }
 
   // Creates a [Skybox] with a solid color. This will not be attached to any
@@ -1875,7 +1879,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     final ptr = await withPointerCallback<TSkybox>((cb) {
       Engine_buildColoredSkyboxRenderThread(engine, r, g, b, a, cb);
     });
-    return FFISkybox(ptr);
+    return FFISkybox(ptr, this);
   }
 
   //
@@ -1900,7 +1904,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     if (texturePtr == nullptr) {
       throw Exception("Failed to load KTX2 texture");
     }
-    return FFITexture(engine, texturePtr);
+    return FFITexture(engine, texturePtr, this);
   }
 
   @override
@@ -1909,7 +1913,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       var ptr = await withPointerCallback<TMaterial>(
         (cb) => Material_createImageMaterialRenderThread(engine, cb),
       );
-      _imageMaterial = FFIMaterial(ptr);
+      _imageMaterial = FFIMaterial(ptr, this);
     }
     var mi = await _imageMaterial!.createInstance() as FFIMaterialInstance;
 
@@ -1921,7 +1925,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     await mi.setParameterMat4("transform", transform);
 
     await quad.setMaterialInstanceAt(mi);
-    return FFITexturedQuad(asset: quad, mi: mi);
+    return FFITexturedQuad(asset: quad, mi: mi, app: this);
   }
 
   //

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_gizmo.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_gizmo.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 import 'ffi_material.dart';
 import 'ffi_view.dart';
 
@@ -14,7 +15,14 @@ class FFIGizmo extends GizmoAsset {
 
   final Pointer<TGizmo> handle;
 
-  FFIGizmo({required this.handle, required this.view, required this.entities}) {
+  final FFIFilamentApp _app;
+
+  FFIGizmo({
+    required this.handle,
+    required this.view,
+    required this.entities,
+    required FFIFilamentApp app,
+  }) : _app = app {
     _callbackHolder = _onPickResult.asCallback();
   }
 
@@ -24,17 +32,17 @@ class FFIGizmo extends GizmoAsset {
 
   static FFIMaterial? _gizmoMaterial;
 
-  static Future<GizmoAsset> create(View view, GizmoType gizmoType) async {
+  static Future<GizmoAsset> create(FFIFilamentApp app, View view, GizmoType gizmoType) async {
     late Pointer stackPtr;
     if (FILAMENT_WASM) {
       //stackPtr = stackSave();
     }
-    final engine = FilamentApp.instance!.engine;
+    final engine = app.engine;
     if (_gizmoMaterial == null) {
       final materialPtr = await withPointerCallback<TMaterial>((cb) {
         Material_createGizmoMaterialRenderThread(engine, cb);
       });
-      _gizmoMaterial ??= FFIMaterial(materialPtr);
+      _gizmoMaterial ??= FFIMaterial(materialPtr, app);
     }
 
     var gltfResourceLoader = await withPointerCallback<TGltfResourceLoader>(
@@ -44,7 +52,7 @@ class FFIGizmo extends GizmoAsset {
     final gizmo = await withPointerCallback<TGizmo>((cb) {
       Gizmo_createRenderThread(
         engine,
-        FilamentApp.instance!.gltfAssetLoader,
+        app.gltfAssetLoader,
         gltfResourceLoader,
         nullptr,
         view.getNativeHandle(),
@@ -68,6 +76,7 @@ class FFIGizmo extends GizmoAsset {
     final gizmoAsset = FFIGizmo(
       handle: gizmo,
       view: view,
+      app: app,
       entities: gizmoEntities.toSet()
         ..add(SceneAsset_getEntity(gizmo.cast<TSceneAsset>())),
     );

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_gizmo.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_gizmo.dart
@@ -32,7 +32,11 @@ class FFIGizmo extends GizmoAsset {
 
   static FFIMaterial? _gizmoMaterial;
 
-  static Future<GizmoAsset> create(FFIFilamentApp app, View view, GizmoType gizmoType) async {
+  static Future<GizmoAsset> create(
+    FFIFilamentApp app,
+    View view,
+    GizmoType gizmoType,
+  ) async {
     late Pointer stackPtr;
     if (FILAMENT_WASM) {
       //stackPtr = stackSave();

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_indirect_light.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_indirect_light.dart
@@ -67,7 +67,13 @@ class FFIIndirectLight extends IndirectLight {
     if (indirectLight == nullptr) {
       throw Exception("Failed to create indirect light");
     }
-    return FFIIndirectLight._(engine, indirectLight, null, reflectionsTexture, app);
+    return FFIIndirectLight._(
+      engine,
+      indirectLight,
+      null,
+      reflectionsTexture,
+      app,
+    );
   }
 
   Future rotate(Matrix3 rotation) async {

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_indirect_light.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_indirect_light.dart
@@ -1,6 +1,7 @@
 import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 class FFIIndirectLight extends IndirectLight {
   final Pointer<TEngine> engine;
@@ -8,19 +9,23 @@ class FFIIndirectLight extends IndirectLight {
   final Texture? _irradianceTexture;
   final Texture? _reflectionsTexture;
 
+  final FFIFilamentApp _app;
+
   FFIIndirectLight._(
     this.engine,
     this.pointer,
     this._irradianceTexture,
     this._reflectionsTexture,
+    this._app,
   );
 
   static Future<FFIIndirectLight> fromIrradianceTexture(
+    FFIFilamentApp app,
     Texture irradianceTexture, {
     Texture? reflectionsTexture,
     double intensity = 30000,
   }) async {
-    final engine = (FilamentApp.instance as FFIFilamentApp).engine;
+    final engine = app.engine;
     var indirectLight = await withPointerCallback<TIndirectLight>((cb) {
       Engine_buildIndirectLightFromIrradianceTextureRenderThread(
         engine,
@@ -38,15 +43,17 @@ class FFIIndirectLight extends IndirectLight {
       indirectLight,
       irradianceTexture,
       reflectionsTexture,
+      app,
     );
   }
 
   static Future<FFIIndirectLight> fromIrradianceHarmonics(
+    FFIFilamentApp app,
     Float32List irradianceHarmonics, {
     Texture? reflectionsTexture,
     double intensity = 30000,
   }) async {
-    final engine = (FilamentApp.instance as FFIFilamentApp).engine;
+    final engine = app.engine;
 
     var indirectLight = await withPointerCallback<TIndirectLight>((cb) {
       Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
@@ -60,7 +67,7 @@ class FFIIndirectLight extends IndirectLight {
     if (indirectLight == nullptr) {
       throw Exception("Failed to create indirect light");
     }
-    return FFIIndirectLight._(engine, indirectLight, null, reflectionsTexture);
+    return FFIIndirectLight._(engine, indirectLight, null, reflectionsTexture, app);
   }
 
   Future rotate(Matrix3 rotation) async {

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_ktx1_bundle.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_ktx1_bundle.dart
@@ -2,11 +2,14 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.d
 import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/src/filament/src/interface/ktx1_bundle.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 class FFIKtx1Bundle extends Ktx1Bundle {
   final Pointer<TKtx1Bundle> pointer;
 
-  FFIKtx1Bundle(this.pointer);
+  final FFIFilamentApp _app;
+
+  FFIKtx1Bundle(this.pointer, this._app);
 
   ///
   ///
@@ -34,14 +37,14 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   ///
   ///
   ///
-  static Future<Ktx1Bundle> create(Uint8List data) async {
+  static Future<Ktx1Bundle> create(FFIFilamentApp app, Uint8List data) async {
     var bundle = Ktx1Bundle_create(data.address, data.length);
 
     if (bundle == nullptr) {
       throw Exception("Failed to decode KTX texture");
     }
 
-    return FFIKtx1Bundle(bundle);
+    return FFIKtx1Bundle(bundle, app);
   }
 
   Future<Texture> createTexture({
@@ -50,13 +53,13 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   }) async {
     final texturePtr = await withPointerCallback<TTexture>((cb) {
       Ktx1Reader_createTextureRenderThread(
-        (FilamentApp.instance as FFIFilamentApp).engine,
+        _app.engine,
         pointer,
         textureUploadCompleteRequestId ?? 0,
         onTextureUploadComplete ?? nullptr,
         cb,
       );
     });
-    return FFITexture(FilamentApp.instance!.engine, texturePtr);
+    return FFITexture(_app.engine, texturePtr, _app);
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_material.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_material.dart
@@ -1,24 +1,27 @@
 import 'dart:async';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 class FFIMaterial extends Material<Pointer<TMaterial>> {
   final Pointer<TMaterial> pointer;
 
-  FFIMaterial(this.pointer);
+  final FFIFilamentApp _app;
+
+  FFIMaterial(this.pointer, this._app);
 
   @override
   Future<MaterialInstance> createInstance() async {
     var ptr = await withPointerCallback<TMaterialInstance>((cb) {
       Material_createInstanceRenderThread(pointer, cb);
     });
-    return FFIMaterialInstance(ptr);
+    return FFIMaterialInstance(ptr, _app);
   }
 
   Future destroy() async {
     await withVoidCallback((requestId, cb) {
       Engine_destroyMaterialRenderThread(
-        FilamentApp.instance!.engine,
+        _app.engine,
         pointer,
         requestId,
         cb,
@@ -48,7 +51,9 @@ class FFIMaterial extends Material<Pointer<TMaterial>> {
 class FFIMaterialInstance extends MaterialInstance<Pointer<TMaterialInstance>> {
   final Pointer<TMaterialInstance> pointer;
 
-  FFIMaterialInstance(this.pointer) {
+  final FFIFilamentApp _app;
+
+  FFIMaterialInstance(this.pointer, this._app) {
     if (pointer == nullptr) {
       throw Exception("MaterialInstance not found");
     }
@@ -235,7 +240,7 @@ class FFIMaterialInstance extends MaterialInstance<Pointer<TMaterialInstance>> {
   Future destroy() async {
     await withVoidCallback((requestId, cb) {
       Engine_destroyMaterialInstanceRenderThread(
-        FilamentApp.instance!.engine,
+        _app.engine,
         this.pointer,
         requestId,
         cb,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_material.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_material.dart
@@ -20,12 +20,7 @@ class FFIMaterial extends Material<Pointer<TMaterial>> {
 
   Future destroy() async {
     await withVoidCallback((requestId, cb) {
-      Engine_destroyMaterialRenderThread(
-        _app.engine,
-        pointer,
-        requestId,
-        cb,
-      );
+      Engine_destroyMaterialRenderThread(_app.engine, pointer, requestId, cb);
     });
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
@@ -78,7 +78,17 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
 
   FFIRenderManager(this.pointer);
 
-  static final _attachmentState = RenderAttachmentState();
+  /// Per-engine view/swapchain attachment state.
+  ///
+  /// This must NOT be static: on web each viewer owns its own engine and its
+  /// own `FFIRenderManager`, and `_syncViews` pushes every entry in this map
+  /// into `pointer`'s native RenderManager. A shared map makes app1's attach
+  /// push app0's swapchain/view into app1's render manager; app1's worker then
+  /// calls `beginFrame` on a swapchain owned by a different engine/WebGL
+  /// context and wedges on its next rAF tick, so every subsequent op on app1
+  /// hangs (the second-viewer quickstart hang). Per-engine state also means
+  /// `destroy()` on one app no longer clears another app's attachments.
+  final _attachmentState = RenderAttachmentState();
 
   /// Serialises every operation that mutates attachment state and runs
   /// `_syncViews` (attach / detach / detachAll). Concurrent calls from
@@ -94,6 +104,11 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
   /// view of the world for the duration of its setRenderable round-
   /// trips. View destruction (which awaits `detach(view)` first via
   /// `destroyView`) cannot interleave inside another viewer's sync.
+  ///
+  /// Deliberately static (module-wide, not per-engine): cross-engine attach /
+  /// detach ordering was the source of the original multi-viewer SIGSEGV, and
+  /// with per-engine attachment state the chain only orders quick per-engine
+  /// round-trips — each op still dispatches to its own worker via `pointer`.
   static Future<void> _opChain = Future.value();
 
   Future<T> _serialize<T>(Future<T> Function() op) {

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_target.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_target.dart
@@ -1,29 +1,32 @@
 import 'package:thermion_dart/src/bindings/bindings.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 class FFIRenderTarget extends RenderTarget<Pointer<TRenderTarget>> {
   final Pointer<TRenderTarget> renderTarget;
 
-  FFIRenderTarget(this.renderTarget);
+  final FFIFilamentApp _app;
+
+  FFIRenderTarget(this.renderTarget, this._app);
 
   @override
   Future<Texture> getColorTexture() async {
     final ptr = RenderTarget_getColorTexture(renderTarget);
-    return FFITexture(FilamentApp.instance!.engine, ptr);
+    return FFITexture(_app.engine, ptr, _app);
   }
 
   @override
   Future<Texture> getDepthTexture() async {
     final ptr = RenderTarget_getDepthTexture(renderTarget);
-    return FFITexture(FilamentApp.instance!.engine, ptr);
+    return FFITexture(_app.engine, ptr, _app);
   }
 
   @override
   Future destroy() async {
     await withVoidCallback(
       (requestId, cb) => RenderTarget_destroyRenderThread(
-        FilamentApp.instance!.engine,
+        _app.engine,
         renderTarget,
         requestId,
         cb,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
@@ -5,6 +5,7 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_material.dart'
 import 'package:thermion_dart/src/filament/src/implementation/ffi_vertex_buffer.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_index_buffer.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 /// FFI implementation of RenderableManager for native platforms.
 ///
@@ -79,7 +80,7 @@ class FFIRenderableManager
       return null;
     }
 
-    return FFIMaterialInstance(instancePtr);
+    return FFIMaterialInstance(instancePtr, app);
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_scene.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_scene.dart
@@ -111,12 +111,8 @@ class FFIScene extends Scene<Pointer<TScene>> {
   ///
   Future destroy() async {
     await withVoidCallback(
-      (requestId, cb) => Engine_destroySceneRenderThread(
-        _app.engine,
-        scene,
-        requestId,
-        cb,
-      ),
+      (requestId, cb) =>
+          Engine_destroySceneRenderThread(_app.engine, scene, requestId, cb),
     );
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_scene.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_scene.dart
@@ -3,11 +3,14 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_skybox.dart';
 import 'package:thermion_dart/src/filament/src/interface/scene.dart';
 import 'package:thermion_dart/src/filament/src/interface/skybox.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 class FFIScene extends Scene<Pointer<TScene>> {
   final Pointer<TScene> scene;
 
-  FFIScene(this.scene);
+  final FFIFilamentApp _app;
+
+  FFIScene(this.scene, this._app);
 
   Pointer<TScene> getNativeHandle() {
     return scene;
@@ -109,7 +112,7 @@ class FFIScene extends Scene<Pointer<TScene>> {
   Future destroy() async {
     await withVoidCallback(
       (requestId, cb) => Engine_destroySceneRenderThread(
-        FilamentApp.instance!.engine,
+        _app.engine,
         scene,
         requestId,
         cb,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_skybox.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_skybox.dart
@@ -1,11 +1,14 @@
 import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/src/filament/src/interface/skybox.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 class FFISkybox extends Skybox {
   final Pointer<TSkybox> pointer;
 
-  FFISkybox(this.pointer);
+  final FFIFilamentApp _app;
+
+  FFISkybox(this.pointer, this._app);
 
   @override
   Future setColor(double r, double g, double b, double a) async {
@@ -16,7 +19,7 @@ class FFISkybox extends Skybox {
   Future destroy() async {
     await withVoidCallback(
       (requestId, cb) => Engine_destroySkyboxRenderThread(
-        (FilamentApp.instance as FFIFilamentApp).engine,
+        _app.engine,
         pointer,
         requestId,
         cb,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_skybox.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_skybox.dart
@@ -18,12 +18,8 @@ class FFISkybox extends Skybox {
   @override
   Future destroy() async {
     await withVoidCallback(
-      (requestId, cb) => Engine_destroySkyboxRenderThread(
-        _app.engine,
-        pointer,
-        requestId,
-        cb,
-      ),
+      (requestId, cb) =>
+          Engine_destroySkyboxRenderThread(_app.engine, pointer, requestId, cb),
     );
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_texture.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_texture.dart
@@ -1,10 +1,13 @@
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 class FFITexture extends Texture<Pointer<TRenderTarget>> {
   final Pointer<TEngine> _engine;
   final Pointer<TTexture> pointer;
 
-  FFITexture(this._engine, this.pointer);
+  final FFIFilamentApp _app;
+
+  FFITexture(this._engine, this.pointer, this._app);
 
   Future<void> setLinearImage(
     covariant FFILinearImage image,
@@ -163,12 +166,12 @@ class FFILinearImage extends LinearImage {
     return FFILinearImage(imagePtr);
   }
 
-  static Future<FFILinearImage> decode(
+  static Future<FFILinearImage> decode(FFIFilamentApp app,
     Uint8List data, {
     String name = "image",
     bool requireAlpha = false,
   }) async {
-    final image = await FilamentApp.instance!.decodeImage(
+    final image = await app.decodeImage(
       data,
       name: name,
       requireAlpha: requireAlpha,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_texture.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_texture.dart
@@ -166,7 +166,8 @@ class FFILinearImage extends LinearImage {
     return FFILinearImage(imagePtr);
   }
 
-  static Future<FFILinearImage> decode(FFIFilamentApp app,
+  static Future<FFILinearImage> decode(
+    FFIFilamentApp app,
     Uint8List data, {
     String name = "image",
     bool requireAlpha = false,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_textured_quad.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_textured_quad.dart
@@ -74,9 +74,7 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
     final texture = await bundle.createTexture();
 
     if (bundle.isCubemap()) {
-      sampler ??=
-          await _app.createTextureSampler()
-              as FFITextureSampler;
+      sampler ??= await _app.createTextureSampler() as FFITextureSampler;
       this.texture = texture;
       await mi.setParameterTexture(
         "cubeMap",
@@ -103,10 +101,7 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
     // RGBA32F texture. So on Windows force an alpha channel at decode time:
     // this yields 4-channel RGBA source data that uploads cleanly into RGBA32F.
     // Other platforms keep the tighter 3-channel RGB32F path.
-    final image = await _app.decodeImage(
-      imageData,
-      requireAlpha: IS_WINDOWS,
-    );
+    final image = await _app.decodeImage(imageData, requireAlpha: IS_WINDOWS);
     final channels = await image.getChannels();
     if (channels != 3 && channels != 4) {
       throw UnimplementedError("Currently only 3 or 4 channels are supported");
@@ -136,8 +131,7 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
   ///
   Future setImageFromTexture(Texture texture) async {
     this.texture = texture;
-    sampler ??=
-        await _app.createTextureSampler() as FFITextureSampler;
+    sampler ??= await _app.createTextureSampler() as FFITextureSampler;
     await mi.setParameterInt("isCubeMap", 0);
     await mi.setParameterTexture(
       "image",

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_textured_quad.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_textured_quad.dart
@@ -2,6 +2,8 @@ import 'package:thermion_dart/src/filament/src/interface/ktx1_bundle.dart';
 import 'package:vector_math/vector_math_64.dart' as v64;
 import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_asset.dart';
+import 'ffi_filament_app.dart';
 
 class FFITexturedQuad<T> extends TexturedQuad<T> {
   final ThermionAsset<T> asset;
@@ -17,12 +19,15 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
   int? width;
   int? height;
 
+  final FFIFilamentApp _app;
+
   FFITexturedQuad({
     required this.asset,
     this.texture,
     this.sampler,
     required this.mi,
-  });
+    required FFIFilamentApp app,
+  }) : _app = app;
 
   T getNativeHandle() {
     return asset.getNativeHandle();
@@ -32,7 +37,7 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
   ///
   ///
   Future destroy() async {
-    await FilamentApp.instance!.destroyAsset(asset);
+    await _app.destroyAsset(asset as FFIAsset);
     await texture?.dispose();
     await sampler?.dispose();
     await mi.destroy();
@@ -70,7 +75,7 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
 
     if (bundle.isCubemap()) {
       sampler ??=
-          await FilamentApp.instance!.createTextureSampler()
+          await _app.createTextureSampler()
               as FFITextureSampler;
       this.texture = texture;
       await mi.setParameterTexture(
@@ -98,7 +103,7 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
     // RGBA32F texture. So on Windows force an alpha channel at decode time:
     // this yields 4-channel RGBA source data that uploads cleanly into RGBA32F.
     // Other platforms keep the tighter 3-channel RGB32F path.
-    final image = await FilamentApp.instance!.decodeImage(
+    final image = await _app.decodeImage(
       imageData,
       requireAlpha: IS_WINDOWS,
     );
@@ -113,7 +118,7 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
         ? PixelDataFormat.RGBA
         : PixelDataFormat.RGB;
 
-    final texture = await FilamentApp.instance!.createTexture(
+    final texture = await _app.createTexture(
       await image.getWidth(),
       await image.getHeight(),
       flags: {
@@ -132,7 +137,7 @@ class FFITexturedQuad<T> extends TexturedQuad<T> {
   Future setImageFromTexture(Texture texture) async {
     this.texture = texture;
     sampler ??=
-        await FilamentApp.instance!.createTextureSampler() as FFITextureSampler;
+        await _app.createTextureSampler() as FFITextureSampler;
     await mi.setParameterInt("isCubeMap", 0);
     await mi.setParameterTexture(
       "image",

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
@@ -66,7 +66,10 @@ class FFIToneMapper extends ToneMapper {
   ///   - AgxLook.none: Base contrast with no look applied
   ///   - AgxLook.punchy: More chroma laden look for sRGB displays
   ///   - AgxLook.golden: Golden tinted look for BT.1886 displays
-  static Future<ToneMapper> agx(FFIFilamentApp app, {AgxLook look = AgxLook.none}) async {
+  static Future<ToneMapper> agx(
+    FFIFilamentApp app, {
+    AgxLook look = AgxLook.none,
+  }) async {
     final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createAGXWithLookRenderThread(
@@ -88,7 +91,8 @@ class FFIToneMapper extends ToneMapper {
   /// [midGrayIn] - Input middle gray value (0.0..1.0, default: 0.18)
   /// [midGrayOut] - Output middle gray value (0.0..1.0, default: 0.215)
   /// [hdrMax] - Maximum input value mapped to output white (>= 1.0, default: 10.0)
-  static Future<ToneMapper> generic(FFIFilamentApp app, {
+  static Future<ToneMapper> generic(
+    FFIFilamentApp app, {
     double contrast = 1.55,
     double midGrayIn = 0.18,
     double midGrayOut = 0.215,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
@@ -12,8 +12,8 @@ class FFIToneMapper extends ToneMapper {
 
   /// Create a LinearToneMapper - returns input color clamped to 0..1 range
   /// Useful for debugging
-  static Future<ToneMapper> linear() async {
-    final filamentApp = FilamentApp.instance as FFIFilamentApp;
+  static Future<ToneMapper> linear(FFIFilamentApp app) async {
+    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createLinearRenderThread(filamentApp.engine, cb),
     );
@@ -22,8 +22,8 @@ class FFIToneMapper extends ToneMapper {
 
   /// Create an ACESToneMapper - ACES Reference Rendering Transform (RRT)
   /// combined with the Output Device Transform (ODT) for sRGB monitors
-  static Future<ToneMapper> aces() async {
-    final filamentApp = FilamentApp.instance as FFIFilamentApp;
+  static Future<ToneMapper> aces(FFIFilamentApp app) async {
+    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createACESRenderThread(filamentApp.engine, cb),
     );
@@ -32,8 +32,8 @@ class FFIToneMapper extends ToneMapper {
 
   /// Create an ACESLegacyToneMapper - ACES tone mapper modified to match
   /// the perceived brightness of FilmicToneMapper (applies ~1.6x brightness)
-  static Future<ToneMapper> acesLegacy() async {
-    final filamentApp = FilamentApp.instance as FFIFilamentApp;
+  static Future<ToneMapper> acesLegacy(FFIFilamentApp app) async {
+    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createACESLegacyRenderThread(filamentApp.engine, cb),
     );
@@ -42,8 +42,8 @@ class FFIToneMapper extends ToneMapper {
 
   /// Create a FilmicToneMapper - designed to approximate ACES RRT + ODT
   /// for Rec.709. Exists for backward compatibility.
-  static Future<ToneMapper> filmic() async {
-    final filamentApp = FilamentApp.instance as FFIFilamentApp;
+  static Future<ToneMapper> filmic(FFIFilamentApp app) async {
+    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createFilmicRenderThread(filamentApp.engine, cb),
     );
@@ -52,8 +52,8 @@ class FFIToneMapper extends ToneMapper {
 
   /// Create a PBRNeutralToneMapper - Khronos PBR Neutral tone mapper
   /// designed to preserve material appearance across lighting conditions
-  static Future<ToneMapper> pbrNeutral() async {
-    final filamentApp = FilamentApp.instance as FFIFilamentApp;
+  static Future<ToneMapper> pbrNeutral(FFIFilamentApp app) async {
+    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createPBRNeutralRenderThread(filamentApp.engine, cb),
     );
@@ -66,8 +66,8 @@ class FFIToneMapper extends ToneMapper {
   ///   - AgxLook.none: Base contrast with no look applied
   ///   - AgxLook.punchy: More chroma laden look for sRGB displays
   ///   - AgxLook.golden: Golden tinted look for BT.1886 displays
-  static Future<ToneMapper> agx({AgxLook look = AgxLook.none}) async {
-    final filamentApp = FilamentApp.instance as FFIFilamentApp;
+  static Future<ToneMapper> agx(FFIFilamentApp app, {AgxLook look = AgxLook.none}) async {
+    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createAGXWithLookRenderThread(
         filamentApp.engine,
@@ -88,13 +88,13 @@ class FFIToneMapper extends ToneMapper {
   /// [midGrayIn] - Input middle gray value (0.0..1.0, default: 0.18)
   /// [midGrayOut] - Output middle gray value (0.0..1.0, default: 0.215)
   /// [hdrMax] - Maximum input value mapped to output white (>= 1.0, default: 10.0)
-  static Future<ToneMapper> generic({
+  static Future<ToneMapper> generic(FFIFilamentApp app, {
     double contrast = 1.55,
     double midGrayIn = 0.18,
     double midGrayOut = 0.215,
     double hdrMax = 10.0,
   }) async {
-    final filamentApp = FilamentApp.instance as FFIFilamentApp;
+    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createGenericRenderThread(
         filamentApp.engine,
@@ -110,8 +110,8 @@ class FFIToneMapper extends ToneMapper {
 
   /// Create a DisplayRangeToneMapper - converts HDR RGB to 16 debug colors
   /// representing pixel exposure levels. Useful for validating scene lighting.
-  static Future<ToneMapper> displayRange() async {
-    final filamentApp = FilamentApp.instance as FFIFilamentApp;
+  static Future<ToneMapper> displayRange(FFIFilamentApp app) async {
+    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createDisplayRangeRenderThread(filamentApp.engine, cb),
     );

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -53,12 +53,8 @@ class FFIView extends View<Pointer<TView>> {
       );
     }
     await withVoidCallback(
-      (requestId, cb) => Engine_destroyViewRenderThread(
-        _app.engine,
-        view,
-        requestId,
-        cb,
-      ),
+      (requestId, cb) =>
+          Engine_destroyViewRenderThread(_app.engine, view, requestId, cb),
     );
   }
 
@@ -796,10 +792,7 @@ class FFIView extends View<Pointer<TView>> {
       }
 
       final indexCount = IndexBuffer_getIndexCount(indexBuffer);
-      final ffiIndexBuffer = FFIIndexBuffer(
-        indexBuffer,
-        _app.engine,
-      );
+      final ffiIndexBuffer = FFIIndexBuffer(indexBuffer, _app.engine);
 
       // Create silhouette for this primitive
       await _highlightOverlayManager!.addHighlight(

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -10,6 +10,7 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_render_target.
 import 'package:thermion_dart/src/filament/src/implementation/ffi_scene.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_color_grading.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 import 'ffi_camera.dart';
 
@@ -17,6 +18,7 @@ class FFIView extends View<Pointer<TView>> {
   late final _logger = Logger(this.runtimeType.toString());
 
   final Pointer<TView> view;
+  final FFIFilamentApp _app;
 
   Pointer<TView> getNativeHandle() => view;
 
@@ -24,10 +26,10 @@ class FFIView extends View<Pointer<TView>> {
 
   late CallbackHolder<PickCallbackFunction> _onPickResultHolder;
 
-  FFIView(this.view) {
+  FFIView(this.view, this._app) {
     final renderTargetPtr = View_getRenderTarget(view);
     if (renderTargetPtr != nullptr) {
-      renderTarget = FFIRenderTarget(renderTargetPtr);
+      renderTarget = FFIRenderTarget(renderTargetPtr, _app);
     }
 
     _onPickResultHolder = _onPickResult.asCallback();
@@ -43,7 +45,7 @@ class FFIView extends View<Pointer<TView>> {
     if (_colorGrading != null && _colorGrading != nullptr) {
       await withVoidCallback(
         (requestId, cb) => Engine_destroyColorGradingRenderThread(
-          FilamentApp.instance!.engine,
+          _app.engine,
           _colorGrading!,
           requestId,
           cb,
@@ -52,7 +54,7 @@ class FFIView extends View<Pointer<TView>> {
     }
     await withVoidCallback(
       (requestId, cb) => Engine_destroyViewRenderThread(
-        FilamentApp.instance!.engine,
+        _app.engine,
         view,
         requestId,
         cb,
@@ -142,7 +144,7 @@ class FFIView extends View<Pointer<TView>> {
   @override
   Future<Camera> getCamera() async {
     final cameraPtr = View_getCamera(view);
-    return FFICamera(cameraPtr);
+    return FFICamera(cameraPtr, _app);
   }
 
   @override
@@ -192,7 +194,7 @@ class FFIView extends View<Pointer<TView>> {
   Future setToneMapper(ToneMapper mapper) async {
     final colorGrading = await withPointerCallback<TColorGrading>(
       (cb) => ColorGrading_createRenderThread(
-        FilamentApp.instance!.engine,
+        _app.engine,
         mapper.getNativeHandle(),
         cb,
       ),
@@ -209,7 +211,7 @@ class FFIView extends View<Pointer<TView>> {
     if (_colorGrading != null) {
       await withVoidCallback(
         (requestId, cb) => Engine_destroyColorGradingRenderThread(
-          FilamentApp.instance!.engine,
+          _app.engine,
           _colorGrading!,
           requestId,
           cb,
@@ -227,7 +229,7 @@ class FFIView extends View<Pointer<TView>> {
     if (builderPtr == nullptr) {
       throw Exception('Failed to create ColorGradingBuilder');
     }
-    return FFIColorGradingBuilder(builderPtr);
+    return FFIColorGradingBuilder(builderPtr, _app);
   }
 
   @override
@@ -257,7 +259,7 @@ class FFIView extends View<Pointer<TView>> {
     if (colorGradingPtr == nullptr) {
       return null;
     }
-    return FFIColorGrading(colorGradingPtr);
+    return FFIColorGrading(colorGradingPtr, _app);
   }
 
   Future setStencilBufferEnabled(bool enabled) async {
@@ -330,7 +332,7 @@ class FFIView extends View<Pointer<TView>> {
   @override
   Future<Scene> getScene() async {
     if (_scene == null) {
-      _scene = FFIScene(View_getScene(view));
+      _scene = FFIScene(View_getScene(view), _app);
     }
     return _scene!;
   }
@@ -436,7 +438,7 @@ class FFIView extends View<Pointer<TView>> {
 
     Texture? skyColor;
     if (tOptions.skyColor != nullptr) {
-      skyColor = FFITexture(FilamentApp.instance!.engine, tOptions.skyColor);
+      skyColor = FFITexture(_app.engine, tOptions.skyColor, _app);
     }
 
     return FogOptions(
@@ -639,7 +641,7 @@ class FFIView extends View<Pointer<TView>> {
 
   //
   Future _enableHighlightOverlay() async {
-    final rm = FilamentApp.instance!.renderManager;
+    final rm = _app.renderManager;
     final swapChains = rm.getAttachedSwapChains(this).toList();
     if (swapChains.isEmpty) {
       throw Exception("View must be attached to a swapchain first");
@@ -652,6 +654,7 @@ class FFIView extends View<Pointer<TView>> {
 
       // Create manager if not exists
       _highlightOverlayManager = await HighlightOverlayManager.create(
+        _app,
         width,
         height,
       );
@@ -690,7 +693,7 @@ class FFIView extends View<Pointer<TView>> {
       return;
     }
 
-    final rm = FilamentApp.instance!.renderManager;
+    final rm = _app.renderManager;
 
     await rm.detach(_highlightOverlayManager!.silhouetteView);
     await rm.detach(_highlightOverlayManager!.overlayView);
@@ -764,7 +767,7 @@ class FFIView extends View<Pointer<TView>> {
     }
 
     // Get the primitive count for this entity
-    final primCount = await FilamentApp.instance!.getPrimitiveCount(entity);
+    final primCount = await _app.getPrimitiveCount(entity);
 
     // Iterate all primitives for this entity and create silhouettes
     for (int i = 0; i < primCount; i++) {
@@ -795,7 +798,7 @@ class FFIView extends View<Pointer<TView>> {
       final indexCount = IndexBuffer_getIndexCount(indexBuffer);
       final ffiIndexBuffer = FFIIndexBuffer(
         indexBuffer,
-        FilamentApp.instance!.engine,
+        _app.engine,
       );
 
       // Create silhouette for this primitive
@@ -867,10 +870,10 @@ class FFIView extends View<Pointer<TView>> {
     return View_isTransparentPickingEnabled(getNativeHandle());
   }
 
-  static Future<View> create() async {
+  static Future<View> create(FFIFilamentApp app) async {
     final ptr = await withPointerCallback<TView>(
-      (cb) => Engine_createViewRenderThread(FilamentApp.instance!.engine, cb),
+      (cb) => Engine_createViewRenderThread(app.engine, cb),
     );
-    return FFIView(ptr);
+    return FFIView(ptr, app);
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/grid_overlay.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/grid_overlay.dart
@@ -137,7 +137,8 @@ class GridOverlay {
   /// - [spacing]: Interval between grid lines for each LOD level
   /// - [fadeInStart]/[fadeInEnd]: Camera distances where each level fades in
   /// - [fadeOutStart]/[fadeOutEnd]: Camera distances where each level fades out
-  static Future<GridOverlay> create(FFIFilamentApp app, {
+  static Future<GridOverlay> create(
+    FFIFilamentApp app, {
     List<LinearColor> axisColors = kDefaultAxisColors,
     LinearColor gridColor = kDefaultGridColor,
     List<double> spacing = const [1.0, 10.0, 100.0, 1000.0, 10000.0],

--- a/thermion_dart/lib/src/filament/src/implementation/grid_overlay.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/grid_overlay.dart
@@ -2,6 +2,7 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_material.dart'
 import 'package:thermion_dart/src/filament/src/interface/defaults.dart';
 import 'package:thermion_dart/src/filament/src/interface/scene.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 /// Represents a single LOD level of the grid overlay.
 class _GridLevel {
@@ -21,13 +22,17 @@ class GridOverlay {
   final VertexBuffer _vertexBuffer;
   final IndexBuffer _indexBuffer;
 
+  final FFIFilamentApp _app;
+
   GridOverlay._({
     required List<_GridLevel> levels,
     required VertexBuffer vertexBuffer,
     required IndexBuffer indexBuffer,
+    required FFIFilamentApp app,
   }) : _levels = levels,
        _vertexBuffer = vertexBuffer,
-       _indexBuffer = indexBuffer;
+       _indexBuffer = indexBuffer,
+       _app = app;
 
   static GridOverlay? _instance;
   static Material? _gridMaterial;
@@ -113,7 +118,7 @@ class GridOverlay {
   /// Destroys all resources held by this grid overlay.
   Future destroy() async {
     for (final level in _levels) {
-      await FilamentApp.instance!.destroyEntity(level.entity);
+      await _app.destroyEntity(level.entity);
       await level.materialInstance.destroy();
     }
     await _vertexBuffer.destroy();
@@ -132,7 +137,7 @@ class GridOverlay {
   /// - [spacing]: Interval between grid lines for each LOD level
   /// - [fadeInStart]/[fadeInEnd]: Camera distances where each level fades in
   /// - [fadeOutStart]/[fadeOutEnd]: Camera distances where each level fades out
-  static Future<GridOverlay> create({
+  static Future<GridOverlay> create(FFIFilamentApp app, {
     List<LinearColor> axisColors = kDefaultAxisColors,
     LinearColor gridColor = kDefaultGridColor,
     List<double> spacing = const [1.0, 10.0, 100.0, 1000.0, 10000.0],
@@ -151,11 +156,10 @@ class GridOverlay {
       return _instance!;
     }
 
-    final app = FilamentApp.instance!;
     final rm = app.renderableManager;
 
     // Create or reuse the grid material
-    _gridMaterial ??= FFIMaterial(Material_createGridMaterial(app.engine));
+    _gridMaterial ??= FFIMaterial(Material_createGridMaterial(app.engine), app);
 
     // Generate shared geometry
     final (positions, indices) = _generateGridGeometry();
@@ -268,6 +272,7 @@ class GridOverlay {
       levels: levels,
       vertexBuffer: vertexBuffer,
       indexBuffer: indexBuffer,
+      app: app,
     );
 
     return _instance!;

--- a/thermion_dart/lib/src/filament/src/implementation/highlight_overlay_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/highlight_overlay_manager.dart
@@ -29,7 +29,11 @@ abstract class HighlightOverlayManager {
   });
   Future<void> removeHighlight(ThermionEntity target);
 
-  static Future<HighlightOverlayManager> create(FFIFilamentApp app, int width, int height) {
+  static Future<HighlightOverlayManager> create(
+    FFIFilamentApp app,
+    int width,
+    int height,
+  ) {
     return FFIHighlightOverlayManager.create(app, width: width, height: height);
   }
 }
@@ -189,7 +193,8 @@ class FFIHighlightOverlayManager extends HighlightOverlayManager {
   }) : _app = app;
 
   /// Creates and initializes a new [HighlightOverlayManager].
-  static Future<HighlightOverlayManager> create(FFIFilamentApp app, {
+  static Future<HighlightOverlayManager> create(
+    FFIFilamentApp app, {
     required int width,
     required int height,
   }) async {
@@ -198,14 +203,16 @@ class FFIHighlightOverlayManager extends HighlightOverlayManager {
     final actualHeight = height > 0 ? height : 1;
 
     // Create silhouette view (first pass)
-    final silhouetteView = await SilhouetteView.create(app,
+    final silhouetteView = await SilhouetteView.create(
+      app,
       width: actualWidth,
       height: actualHeight,
     );
     await silhouetteView.setBlendMode(BlendMode.transparent);
 
     // Create edge detection view (second pass)
-    final edgeDetectionView = await EdgeDetectionView.create(app,
+    final edgeDetectionView = await EdgeDetectionView.create(
+      app,
       width: actualWidth,
       height: actualHeight,
       silhouetteTexture: silhouetteView.colorTexture,

--- a/thermion_dart/lib/src/filament/src/implementation/highlight_overlay_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/highlight_overlay_manager.dart
@@ -4,6 +4,7 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/src/filament/src/implementation/edge_detection_view.dart';
 import 'package:thermion_dart/src/filament/src/implementation/silhouette_view.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 abstract class HighlightOverlayManager {
   View get silhouetteView;
@@ -28,8 +29,8 @@ abstract class HighlightOverlayManager {
   });
   Future<void> removeHighlight(ThermionEntity target);
 
-  static Future<HighlightOverlayManager> create(int width, int height) {
-    return FFIHighlightOverlayManager.create(width: width, height: height);
+  static Future<HighlightOverlayManager> create(FFIFilamentApp app, int width, int height) {
+    return FFIHighlightOverlayManager.create(app, width: width, height: height);
   }
 }
 
@@ -179,13 +180,16 @@ class FFIHighlightOverlayManager extends HighlightOverlayManager {
     return rt == _mainViewRenderTarget;
   }
 
+  final FFIFilamentApp _app;
+
   FFIHighlightOverlayManager._({
     required this.silhouetteView,
     required this.overlayView,
-  });
+    required FFIFilamentApp app,
+  }) : _app = app;
 
   /// Creates and initializes a new [HighlightOverlayManager].
-  static Future<HighlightOverlayManager> create({
+  static Future<HighlightOverlayManager> create(FFIFilamentApp app, {
     required int width,
     required int height,
   }) async {
@@ -194,14 +198,14 @@ class FFIHighlightOverlayManager extends HighlightOverlayManager {
     final actualHeight = height > 0 ? height : 1;
 
     // Create silhouette view (first pass)
-    final silhouetteView = await SilhouetteView.create(
+    final silhouetteView = await SilhouetteView.create(app,
       width: actualWidth,
       height: actualHeight,
     );
     await silhouetteView.setBlendMode(BlendMode.transparent);
 
     // Create edge detection view (second pass)
-    final edgeDetectionView = await EdgeDetectionView.create(
+    final edgeDetectionView = await EdgeDetectionView.create(app,
       width: actualWidth,
       height: actualHeight,
       silhouetteTexture: silhouetteView.colorTexture,
@@ -218,6 +222,7 @@ class FFIHighlightOverlayManager extends HighlightOverlayManager {
     final manager = FFIHighlightOverlayManager._(
       silhouetteView: silhouetteView,
       overlayView: edgeDetectionView,
+      app: app,
     );
 
     manager._logger.info("Highlight overlay manager initialized");

--- a/thermion_dart/lib/src/filament/src/implementation/silhouette_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/silhouette_view.dart
@@ -6,6 +6,7 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_view.dart';
 import 'package:thermion_dart/src/filament/src/interface/skybox.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 /// Component data for highlighted entities
 class _SilhouetteComponent {
@@ -49,42 +50,47 @@ class SilhouetteView extends FFIView {
   // Highlighted entities tracking
   final Map<ThermionEntity, _SilhouetteComponent> _components = {};
 
+  final FFIFilamentApp _app;
+
   SilhouetteView._(
-    super.view, {
+    Pointer<TView> view, {
+    required FFIFilamentApp app,
     required FFIMaterial material,
     required FFITexture colorTexture,
     required FFITexture depthTexture,
     required FFIRenderTarget renderTarget,
     required FFIScene scene,
     required Skybox skybox,
-  }) : _silhouetteMaterial = material,
+  }) : _app = app,
+       _silhouetteMaterial = material,
        _colorTexture = colorTexture,
        _depthTexture = depthTexture,
        _renderTarget = renderTarget,
        _silhouetteScene = scene,
-       _skybox = skybox;
+       _skybox = skybox,
+       super(view, app);
 
   /// Creates and initializes a new [SilhouetteView].
-  static Future<SilhouetteView> create({
+  static Future<SilhouetteView> create(FFIFilamentApp app, {
     required int width,
     required int height,
   }) async {
     final viewPtr = await withPointerCallback<TView>(
-      (cb) => Engine_createViewRenderThread(FilamentApp.instance!.engine, cb),
+      (cb) => Engine_createViewRenderThread(app.engine, cb),
     );
 
     // Create silhouette material
     final materialPtr = await withPointerCallback<TMaterial>(
       (cb) => Material_createSilhouetteMaterialRenderThread(
-        FilamentApp.instance!.engine,
+        app.engine,
         cb,
       ),
     );
-    final silhouetteMaterial = FFIMaterial(materialPtr);
+    final silhouetteMaterial = FFIMaterial(materialPtr, app);
 
     // Create textures and render target
     final colorTexture =
-        await FilamentApp.instance!.createTexture(
+        await app.createTexture(
               width,
               height,
               flags: {
@@ -95,7 +101,7 @@ class SilhouetteView extends FFIView {
             )
             as FFITexture;
     final depthTexture =
-        await FilamentApp.instance!.createTexture(
+        await app.createTexture(
               width,
               height,
               flags: {TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT},
@@ -103,7 +109,7 @@ class SilhouetteView extends FFIView {
             )
             as FFITexture;
     final renderTarget =
-        await FilamentApp.instance!.createRenderTarget(
+        await app.createRenderTarget(
               width,
               height,
               color: colorTexture,
@@ -113,8 +119,8 @@ class SilhouetteView extends FFIView {
 
     // Create scene with black skybox to clear render target
     final silhouetteScene =
-        await FilamentApp.instance!.createScene() as FFIScene;
-    final skybox = await FilamentApp.instance!.createColoredSkybox(
+        await app.createScene() as FFIScene;
+    final skybox = await app.createColoredSkybox(
       r: 0.0,
       g: 0.0,
       b: 0.0,
@@ -125,6 +131,7 @@ class SilhouetteView extends FFIView {
     // Create the SilhouetteView with all resources
     final silhouetteView = SilhouetteView._(
       viewPtr,
+      app: app,
       material: silhouetteMaterial,
       colorTexture: colorTexture,
       depthTexture: depthTexture,
@@ -176,7 +183,7 @@ class SilhouetteView extends FFIView {
 
     // Create new textures
     _colorTexture =
-        await FilamentApp.instance!.createTexture(
+        await _app.createTexture(
               width,
               height,
               flags: {
@@ -188,7 +195,7 @@ class SilhouetteView extends FFIView {
             as FFITexture;
 
     _depthTexture =
-        await FilamentApp.instance!.createTexture(
+        await _app.createTexture(
               width,
               height,
               flags: {TextureUsage.TEXTURE_USAGE_DEPTH_ATTACHMENT},
@@ -197,7 +204,7 @@ class SilhouetteView extends FFIView {
             as FFITexture;
 
     _renderTarget =
-        await FilamentApp.instance!.createRenderTarget(
+        await _app.createRenderTarget(
               width,
               height,
               color: _colorTexture,
@@ -217,7 +224,7 @@ class SilhouetteView extends FFIView {
 
     // Flush render thread to ensure new textures are bound before destroying old ones
     // This prevents "Invalid texture still bound to MaterialInstance" errors
-    await FilamentApp.instance!.flush();
+    await _app.flush();
 
     // Destroy old resources
     await oldRenderTarget.destroy();
@@ -265,7 +272,7 @@ class SilhouetteView extends FFIView {
   }) async {
     if (_components.containsKey(target)) return;
 
-    if (!FilamentApp.instance!.renderableManager.hasComponent(target)) {
+    if (!_app.renderableManager.hasComponent(target)) {
       _logger.warning('Entity $target is not renderable');
       return;
     }
@@ -274,14 +281,14 @@ class SilhouetteView extends FFIView {
     final silhouetteMi = await _silhouetteMaterial.createInstance();
 
     // Create silhouette entity
-    final silhouetteEntity = await FilamentApp.instance!.createEntity();
+    final silhouetteEntity = await _app.createEntity();
 
     // Get original bounding box
-    final boundingBox = FilamentApp.instance!.renderableManager
+    final boundingBox = _app.renderableManager
         .getAxisAlignedBoundingBox(target);
 
     // Build silhouette renderable
-    final builder = FilamentApp.instance!.renderableManager.createBuilder(1);
+    final builder = _app.renderableManager.createBuilder(1);
     builder.boundingBox(boundingBox);
     builder.geometry(
       0,
@@ -298,7 +305,7 @@ class SilhouetteView extends FFIView {
     await builder.build(silhouetteEntity);
 
     // Parent silhouette entity to target so it follows transforms
-    FilamentApp.instance!.transformManager.setParent(silhouetteEntity, target);
+    _app.transformManager.setParent(silhouetteEntity, target);
 
     // Add to silhouette scene
     await _silhouetteScene.addEntity(silhouetteEntity);
@@ -321,7 +328,7 @@ class SilhouetteView extends FFIView {
     await _silhouetteScene.removeEntity(component.silhouetteEntity);
 
     // Destroy entity
-    await FilamentApp.instance!.destroyEntity(component.silhouetteEntity);
+    await _app.destroyEntity(component.silhouetteEntity);
 
     // Destroy material instance
     await component.silhouetteMaterialInstance.destroy();

--- a/thermion_dart/lib/src/filament/src/implementation/silhouette_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/silhouette_view.dart
@@ -71,7 +71,8 @@ class SilhouetteView extends FFIView {
        super(view, app);
 
   /// Creates and initializes a new [SilhouetteView].
-  static Future<SilhouetteView> create(FFIFilamentApp app, {
+  static Future<SilhouetteView> create(
+    FFIFilamentApp app, {
     required int width,
     required int height,
   }) async {
@@ -81,10 +82,7 @@ class SilhouetteView extends FFIView {
 
     // Create silhouette material
     final materialPtr = await withPointerCallback<TMaterial>(
-      (cb) => Material_createSilhouetteMaterialRenderThread(
-        app.engine,
-        cb,
-      ),
+      (cb) => Material_createSilhouetteMaterialRenderThread(app.engine, cb),
     );
     final silhouetteMaterial = FFIMaterial(materialPtr, app);
 
@@ -118,8 +116,7 @@ class SilhouetteView extends FFIView {
             as FFIRenderTarget;
 
     // Create scene with black skybox to clear render target
-    final silhouetteScene =
-        await app.createScene() as FFIScene;
+    final silhouetteScene = await app.createScene() as FFIScene;
     final skybox = await app.createColoredSkybox(
       r: 0.0,
       g: 0.0,
@@ -284,8 +281,9 @@ class SilhouetteView extends FFIView {
     final silhouetteEntity = await _app.createEntity();
 
     // Get original bounding box
-    final boundingBox = _app.renderableManager
-        .getAxisAlignedBoundingBox(target);
+    final boundingBox = _app.renderableManager.getAxisAlignedBoundingBox(
+      target,
+    );
 
     // Build silhouette renderable
     final builder = _app.renderableManager.createBuilder(1);

--- a/thermion_dart/lib/src/filament/src/implementation/translation_axis_material.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/translation_axis_material.dart
@@ -1,5 +1,6 @@
 import 'package:thermion_dart/src/filament/src/implementation/ffi_material.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'ffi_filament_app.dart';
 
 /// FFI implementation for creating translation axis material instances.
 class FFITranslationAxisMaterial {
@@ -16,6 +17,7 @@ class FFITranslationAxisMaterial {
   ///
   /// Returns a configured [MaterialInstance] ready to use.
   static Future<MaterialInstance> createTranslationAxisMaterialInstance({
+    required FFIFilamentApp app,
     required double originX,
     required double originY,
     required double originZ,
@@ -31,6 +33,7 @@ class FFITranslationAxisMaterial {
           callback,
         ),
       ),
+      app,
     );
 
     // Create and configure material instance

--- a/thermion_dart/lib/src/filament/src/interface/tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/interface/tone_mapper.dart
@@ -22,32 +22,32 @@ enum AgxLook {
 abstract class ToneMapper extends NativeHandle<dynamic> {
   /// Create a LinearToneMapper - returns input color clamped to 0..1 range
   /// Useful for debugging
-  static Future<ToneMapper> linear() async {
-    return FFIToneMapper.linear();
+  static Future<ToneMapper> linear(FFIFilamentApp app) async {
+    return FFIToneMapper.linear(app);
   }
 
   /// Create an ACESToneMapper - ACES Reference Rendering Transform (RRT)
   /// combined with the Output Device Transform (ODT) for sRGB monitors
-  static Future<ToneMapper> aces() async {
-    return FFIToneMapper.aces();
+  static Future<ToneMapper> aces(FFIFilamentApp app) async {
+    return FFIToneMapper.aces(app);
   }
 
   /// Create an ACESLegacyToneMapper - ACES tone mapper modified to match
   /// the perceived brightness of FilmicToneMapper (applies ~1.6x brightness)
-  static Future<ToneMapper> acesLegacy() async {
-    return FFIToneMapper.acesLegacy();
+  static Future<ToneMapper> acesLegacy(FFIFilamentApp app) async {
+    return FFIToneMapper.acesLegacy(app);
   }
 
   /// Create a FilmicToneMapper - designed to approximate ACES RRT + ODT
   /// for Rec.709. Exists for backward compatibility.
-  static Future<ToneMapper> filmic() async {
-    return FFIToneMapper.filmic();
+  static Future<ToneMapper> filmic(FFIFilamentApp app) async {
+    return FFIToneMapper.filmic(app);
   }
 
   /// Create a PBRNeutralToneMapper - Khronos PBR Neutral tone mapper
   /// designed to preserve material appearance across lighting conditions
-  static Future<ToneMapper> pbrNeutral() async {
-    return FFIToneMapper.pbrNeutral();
+  static Future<ToneMapper> pbrNeutral(FFIFilamentApp app) async {
+    return FFIToneMapper.pbrNeutral(app);
   }
 
   /// Create an AgxToneMapper with optional look
@@ -56,8 +56,8 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
   ///   - AgxLook.none: Base contrast with no look applied
   ///   - AgxLook.punchy: More chroma laden look for sRGB displays
   ///   - AgxLook.golden: Golden tinted look for BT.1886 displays
-  static Future<ToneMapper> agx({AgxLook look = AgxLook.none}) async {
-    return FFIToneMapper.agx(look: look);
+  static Future<ToneMapper> agx(FFIFilamentApp app, {AgxLook look = AgxLook.none}) async {
+    return FFIToneMapper.agx(app,look: look);
   }
 
   /// Create a GenericToneMapper with configurable parameters
@@ -70,13 +70,13 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
   /// [midGrayIn] - Input middle gray value (0.0..1.0, default: 0.18)
   /// [midGrayOut] - Output middle gray value (0.0..1.0, default: 0.215)
   /// [hdrMax] - Maximum input value mapped to output white (>= 1.0, default: 10.0)
-  static Future<ToneMapper> generic({
+  static Future<ToneMapper> generic(FFIFilamentApp app, {
     double contrast = 1.55,
     double midGrayIn = 0.18,
     double midGrayOut = 0.215,
     double hdrMax = 10.0,
   }) async {
-    return FFIToneMapper.generic(
+    return FFIToneMapper.generic(app,
       contrast: contrast,
       midGrayIn: midGrayIn,
       midGrayOut: midGrayOut,
@@ -104,8 +104,8 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
   /// - +8EV: magenta
   /// - +9EV: purple
   /// - +10EV: white
-  static Future<ToneMapper> displayRange() async {
-    return FFIToneMapper.displayRange();
+  static Future<ToneMapper> displayRange(FFIFilamentApp app) async {
+    return FFIToneMapper.displayRange(app);
   }
 
   /// Destroy the tone mapper and free its resources

--- a/thermion_dart/lib/src/filament/src/interface/tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/interface/tone_mapper.dart
@@ -56,8 +56,11 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
   ///   - AgxLook.none: Base contrast with no look applied
   ///   - AgxLook.punchy: More chroma laden look for sRGB displays
   ///   - AgxLook.golden: Golden tinted look for BT.1886 displays
-  static Future<ToneMapper> agx(FFIFilamentApp app, {AgxLook look = AgxLook.none}) async {
-    return FFIToneMapper.agx(app,look: look);
+  static Future<ToneMapper> agx(
+    FFIFilamentApp app, {
+    AgxLook look = AgxLook.none,
+  }) async {
+    return FFIToneMapper.agx(app, look: look);
   }
 
   /// Create a GenericToneMapper with configurable parameters
@@ -70,13 +73,15 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
   /// [midGrayIn] - Input middle gray value (0.0..1.0, default: 0.18)
   /// [midGrayOut] - Output middle gray value (0.0..1.0, default: 0.215)
   /// [hdrMax] - Maximum input value mapped to output white (>= 1.0, default: 10.0)
-  static Future<ToneMapper> generic(FFIFilamentApp app, {
+  static Future<ToneMapper> generic(
+    FFIFilamentApp app, {
     double contrast = 1.55,
     double midGrayIn = 0.18,
     double midGrayOut = 0.215,
     double hdrMax = 10.0,
   }) async {
-    return FFIToneMapper.generic(app,
+    return FFIToneMapper.generic(
+      app,
       contrast: contrast,
       midGrayIn: midGrayIn,
       midGrayOut: midGrayOut,

--- a/thermion_dart/lib/src/filament/src/interface/translation_axis_material.dart
+++ b/thermion_dart/lib/src/filament/src/interface/translation_axis_material.dart
@@ -1,4 +1,5 @@
 import 'package:thermion_dart/thermion_dart.dart';
+import '../implementation/ffi_filament_app.dart';
 
 import '../implementation/translation_axis_material.dart';
 
@@ -41,7 +42,7 @@ class TranslationAxisMaterial {
     double lineWidth = 5.0,
     double lineLength = 100.0,
   }) {
-    return FFITranslationAxisMaterial.createTranslationAxisMaterialInstance(
+    return FFITranslationAxisMaterial.createTranslationAxisMaterialInstance(app: FilamentApp.instance as FFIFilamentApp, 
       originX: originX,
       originY: originY,
       originZ: originZ,

--- a/thermion_dart/lib/src/filament/src/interface/translation_axis_material.dart
+++ b/thermion_dart/lib/src/filament/src/interface/translation_axis_material.dart
@@ -42,7 +42,8 @@ class TranslationAxisMaterial {
     double lineWidth = 5.0,
     double lineLength = 100.0,
   }) {
-    return FFITranslationAxisMaterial.createTranslationAxisMaterialInstance(app: FilamentApp.instance as FFIFilamentApp, 
+    return FFITranslationAxisMaterial.createTranslationAxisMaterialInstance(
+      app: FilamentApp.instance as FFIFilamentApp,
       originX: originX,
       originY: originY,
       originZ: originZ,

--- a/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
+++ b/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
@@ -8,6 +8,9 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/src/filament/src/interface/scene.dart';
 import '../../../../filament/src/implementation/grid_overlay.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import '../../../../filament/src/implementation/ffi_asset.dart';
+import '../../../../filament/src/implementation/ffi_scene.dart';
+import '../../../../filament/src/implementation/ffi_filament_app.dart';
 import 'package:vector_math/vector_math_64.dart' as v64;
 import 'package:logging/logging.dart';
 
@@ -30,12 +33,12 @@ class ThermionViewerFFI extends ThermionViewer {
 
   final bool _createOverlay;
 
+  final FFIFilamentApp _app;
+
   //
-  ThermionViewerFFI({bool createOverlay = false})
-    : _createOverlay = createOverlay {
-    if (FilamentApp.instance == null) {
-      throw Exception("FilamentApp has not been created");
-    }
+  ThermionViewerFFI({bool createOverlay = false, required FFIFilamentApp app})
+    : _createOverlay = createOverlay,
+      _app = app {
     _initialize();
   }
 
@@ -68,14 +71,14 @@ class ThermionViewerFFI extends ThermionViewer {
   }
 
   Future _initialize() async {
-    view = await FilamentApp.instance!.createView(createScene: true);
+    view = await _app.createView(createScene: true);
 
     await view.setName("main_view");
-    await FilamentApp.instance!.setClearOptions(0.0, 0.0, 0.0, 0.0);
+    await _app.setClearOptions(0.0, 0.0, 0.0, 0.0);
     scene = await view.getScene();
 
     await view.setScene(scene);
-    final camera = await FilamentApp.instance!.createCamera();
+    final camera = await _app.createCamera();
 
     _cameras.add(camera);
     await camera.setLensProjection();
@@ -98,20 +101,20 @@ class ThermionViewerFFI extends ThermionViewer {
   //
   @override
   Future setRendering(bool render) async {
-    await FilamentApp.instance!.renderManager.setRenderable(view, render);
+    await _app.renderManager.setRenderable(view, render);
     _rendering = render;
   }
 
   //
   Future renderSingleFrame() async {
-    final swapChains = await FilamentApp.instance!.getSwapChains();
+    final swapChains = await _app.getSwapChains();
     if (swapChains.isEmpty) {
       throw Exception("No swapchain available");
     }
     for (final swapChain in swapChains) {
       await withBoolCallback(
         (cb) => Renderer_beginFrameRenderThread(
-          FilamentApp.instance!.renderer,
+          _app.renderer,
           swapChain.getNativeHandle(),
           0.toBigInt,
           cb,
@@ -120,7 +123,7 @@ class ThermionViewerFFI extends ThermionViewer {
 
       await withVoidCallback(
         (requestId, cb) => Renderer_renderRenderThread(
-          FilamentApp.instance!.renderer,
+          _app.renderer,
           view.getNativeHandle(),
           requestId,
           cb,
@@ -128,19 +131,19 @@ class ThermionViewerFFI extends ThermionViewer {
       );
       await withVoidCallback(
         (requestId, cb) => Renderer_endFrameRenderThread(
-          FilamentApp.instance!.renderer,
+          _app.renderer,
           requestId,
           cb,
         ),
       );
-      await FilamentApp.instance!.flush();
+      await _app.flush();
     }
   }
 
-  @Deprecated('Use FilamentApp.instance!.setTargetFramerate(framerate)')
+  @Deprecated('Use _app.setTargetFramerate(framerate)')
   @override
   Future<void> setFrameRate(int framerate) async {
-    FilamentApp.instance?.setTargetFramerate(framerate);
+    _app.setTargetFramerate(framerate);
   }
 
   final _onDispose = <Future Function()>[];
@@ -202,8 +205,8 @@ class ThermionViewerFFI extends ThermionViewer {
 
     await view.setScene(null);
 
-    await FilamentApp.instance!.destroyScene(scene);
-    await FilamentApp.instance!.destroyView(view);
+    await _app.destroyScene(scene as FFIScene);
+    await _app.destroyView(view);
 
     _onDispose.clear();
   }
@@ -233,7 +236,7 @@ class ThermionViewerFFI extends ThermionViewer {
   //
   Future<TexturedQuad> getBackgroundImage() async {
     if (_backgroundImage == null) {
-      _backgroundImage ??= await FilamentApp.instance!.createTexturedQuad();
+      _backgroundImage ??= await _app.createTexturedQuad();
       await scene.add(_backgroundImage!);
     }
     return _backgroundImage!;
@@ -248,16 +251,16 @@ class ThermionViewerFFI extends ThermionViewer {
   //
   @override
   Future setBackgroundImage(String path, {bool fillHeight = false}) async {
-    final imageData = await FilamentApp.instance!.loadResource(path);
+    final imageData = await _app.loadResource(path);
     await getBackgroundImage();
 
     bool isKtx = path.endsWith(".ktx");
     if (isKtx) {
-      final bundle = await FFIKtx1Bundle.create(imageData);
+      final bundle = await FFIKtx1Bundle.create(_app, imageData);
       try {
         await _backgroundImage!.setImageFromKtxBundle(bundle);
         // Ktx1Reader borrows the bundle's blobs until the upload completes.
-        await FilamentApp.instance!.flush();
+        await _app.flush();
       } finally {
         await bundle.destroy();
       }
@@ -273,7 +276,7 @@ class ThermionViewerFFI extends ThermionViewer {
     _throwIfDisposed();
     return _serializeSceneResourceOperation(() async {
       await _removeSkybox();
-      _skybox = await FilamentApp.instance!.buildSkybox() as FFISkybox;
+      _skybox = await _app.buildSkybox() as FFISkybox;
       await scene.setSkybox(_skybox!);
       await _skybox!.setColor(r, g, b, a);
     });
@@ -282,7 +285,7 @@ class ThermionViewerFFI extends ThermionViewer {
   Future<void> _loadSkybox(String skyboxPath) async {
     await _removeSkybox();
 
-    var data = await FilamentApp.instance!.loadResource(skyboxPath);
+    var data = await _app.loadResource(skyboxPath);
 
     final completer = Completer<void>();
     FFIKtx1Bundle? bundle;
@@ -291,7 +294,7 @@ class ThermionViewerFFI extends ThermionViewer {
       requestId,
       onTextureUploadComplete,
     ) async {
-      bundle = await FFIKtx1Bundle.create(data) as FFIKtx1Bundle;
+      bundle = await FFIKtx1Bundle.create(_app, data) as FFIKtx1Bundle;
 
       _skyboxTexture =
           await bundle!.createTexture(
@@ -301,7 +304,7 @@ class ThermionViewerFFI extends ThermionViewer {
               as FFITexture;
 
       _skybox =
-          await FilamentApp.instance!.buildSkybox(texture: _skyboxTexture)
+          await _app.buildSkybox(texture: _skyboxTexture)
               as FFISkybox;
 
       await scene.setSkybox(_skybox!);
@@ -340,9 +343,9 @@ class ThermionViewerFFI extends ThermionViewer {
       requestId,
       onTextureUploadComplete,
     ) async {
-      var data = await FilamentApp.instance!.loadResource(lightingPath);
+      var data = await _app.loadResource(lightingPath);
 
-      bundle = await FFIKtx1Bundle.create(data) as FFIKtx1Bundle;
+      bundle = await FFIKtx1Bundle.create(_app, data) as FFIKtx1Bundle;
 
       final texture = await bundle!.createTexture(
         onTextureUploadComplete: onTextureUploadComplete,
@@ -351,6 +354,7 @@ class ThermionViewerFFI extends ThermionViewer {
       final harmonics = bundle!.getSphericalHarmonics();
 
       final ibl = await FFIIndirectLight.fromIrradianceHarmonics(
+        _app,
         harmonics,
         reflectionsTexture: texture,
         intensity: intensity,
@@ -387,6 +391,7 @@ class ThermionViewerFFI extends ThermionViewer {
     await _removeIbl(destroy: destroyExisting);
 
     final ibl = await FFIIndirectLight.fromIrradianceTexture(
+      _app,
       texture,
       reflectionsTexture: reflectionsTexture,
       intensity: intensity,
@@ -398,7 +403,7 @@ class ThermionViewerFFI extends ThermionViewer {
   Future<void> _removeSkybox() async {
     final upload = _skyboxTextureUploadComplete;
     if (upload != null) {
-      await FilamentApp.instance!.flush();
+      await _app.flush();
       await upload;
     }
 
@@ -407,7 +412,7 @@ class ThermionViewerFFI extends ThermionViewer {
     if (_skybox != null && _skyboxTexture != null) {
       // Engine::destroy queues the skybox destruction. Ensure the skybox has
       // released its environment texture before destroying that texture.
-      await FilamentApp.instance!.flush();
+      await _app.flush();
     }
     await _skyboxTexture?.destroy();
     _skybox = null;
@@ -484,7 +489,7 @@ class ThermionViewerFFI extends ThermionViewer {
   Future<void> _removeIbl({bool destroy = true}) async {
     final upload = _iblTextureUploadComplete;
     if (upload != null) {
-      await FilamentApp.instance!.flush();
+      await _app.flush();
       await upload;
     }
 
@@ -507,7 +512,7 @@ class ThermionViewerFFI extends ThermionViewer {
   //
   @override
   Future<ThermionEntity> addDirectLight(DirectLight directLight) async {
-    var light = await FilamentApp.instance!.createDirectLight(directLight);
+    var light = await _app.createDirectLight(directLight);
 
     await scene.addEntity(light);
 
@@ -520,7 +525,7 @@ class ThermionViewerFFI extends ThermionViewer {
   @override
   Future removeLight(ThermionEntity entity) async {
     await scene.removeEntity(entity);
-    FilamentApp.instance!.lightManager.destroyLight(entity);
+    _app.lightManager.destroyLight(entity);
     _lights.remove(entity);
   }
 
@@ -546,7 +551,7 @@ class ThermionViewerFFI extends ThermionViewer {
     String? resourceUri,
     bool loadAsync = false,
   }) async {
-    final data = await FilamentApp.instance!.loadResource(path);
+    final data = await _app.loadResource(path);
     if (resourceUri == null) {
       var normalised = path.replaceAll("\\", "/");
       var split = normalised.split("/");
@@ -579,7 +584,7 @@ class ThermionViewerFFI extends ThermionViewer {
     bool loadResourcesAsync = false,
     String? resourceUri,
   }) async {
-    var asset = await FilamentApp.instance!.loadGltfFromBuffer(
+    var asset = await _app.loadGltfFromBuffer(
       data,
       initialInstances: initialInstances,
       releaseSourceData: releaseSourceData,
@@ -605,7 +610,7 @@ class ThermionViewerFFI extends ThermionViewer {
 
     await hideBoundingBox(asset, destroy: true);
 
-    await FilamentApp.instance!.destroyAsset(asset);
+    await _app.destroyAsset(asset as FFIAsset);
   }
 
   //
@@ -621,7 +626,7 @@ class ThermionViewerFFI extends ThermionViewer {
         await scene.remove(instance);
         await hideBoundingBox(instance, destroy: true);
       }
-      await FilamentApp.instance!.destroyAsset(asset);
+      await _app.destroyAsset(asset as FFIAsset);
       _logger.info("Destroyed asset");
     }
     _assets.clear();
@@ -679,7 +684,7 @@ class ThermionViewerFFI extends ThermionViewer {
     double y,
     double z,
   ) async {
-    FilamentApp.instance!.lightManager.setPosition(lightEntity, x, y, z);
+    _app.lightManager.setPosition(lightEntity, x, y, z);
   }
 
   //
@@ -689,7 +694,7 @@ class ThermionViewerFFI extends ThermionViewer {
     Vector3 direction,
   ) async {
     direction.normalize();
-    FilamentApp.instance!.lightManager.setDirection(
+    _app.lightManager.setDirection(
       lightEntity,
       direction.x,
       direction.y,
@@ -700,16 +705,16 @@ class ThermionViewerFFI extends ThermionViewer {
   //
   @override
   Future setPriority(ThermionEntity entity, int priority) async {
-    return FilamentApp.instance!.setPriority(entity, priority);
+    return _app.setPriority(entity, priority);
   }
 
   //
   @override
   @Deprecated(
-    "Call FilamentApp.instance!.renderableManager.getBoundingBox instead",
+    "Call _app.renderableManager.getBoundingBox instead",
   )
   Future<v64.Aabb3> getRenderableBoundingBox(ThermionEntity entityId) async {
-    return FilamentApp.instance!.renderableManager.getBoundingBox(entityId);
+    return _app.renderableManager.getBoundingBox(entityId);
   }
 
   //
@@ -731,7 +736,7 @@ class ThermionViewerFFI extends ThermionViewer {
     List<double> fadeOutStart = const [10.0, 500.0, 5000.0],
     List<double> fadeOutEnd = const [200.0, 2000.0, 20000.0],
   }) async {
-    _grid ??= await GridOverlay.create(
+    _grid ??= await GridOverlay.create(_app,
       axisColors: axisColors,
       gridColor: gridColor,
       spacing: spacing,
@@ -795,11 +800,11 @@ class ThermionViewerFFI extends ThermionViewer {
       if (origin != null) {
         worldPosition = origin;
       } else {
-        final worldTransform = await FilamentApp.instance!.getWorldTransform(
+        final worldTransform = await _app.getWorldTransform(
           entity!,
         );
         worldPosition = worldTransform.getTranslation();
-        await FilamentApp.instance!.setPriority(entity, 0);
+        await _app.setPriority(entity, 0);
       }
 
       // Remove existing if any
@@ -845,7 +850,7 @@ class ThermionViewerFFI extends ThermionViewer {
       } else {
         transform = v64.Matrix4.translation(worldPosition);
       }
-      await FilamentApp.instance!.setTransform(
+      await _app.setTransform(
         _translationAxisAsset!.entity,
         transform,
       );
@@ -858,7 +863,7 @@ class ThermionViewerFFI extends ThermionViewer {
     if (_translationAxisAsset != null) {
       _assets.remove(_translationAxisAsset!);
       await scene.remove(_translationAxisAsset!);
-      await FilamentApp.instance!.destroyAsset(_translationAxisAsset!);
+      await _app.destroyAsset(_translationAxisAsset! as FFIAsset);
       _translationAxisAsset = null;
     }
     _translationAxisMaterial = null;
@@ -866,7 +871,7 @@ class ThermionViewerFFI extends ThermionViewer {
 
   //
   Future<Camera> createCamera() async {
-    var camera = await FilamentApp.instance!.createCamera();
+    var camera = await _app.createCamera();
 
     final viewport = await view.getViewport();
     var aspect = viewport.width / viewport.height;
@@ -913,7 +918,7 @@ class ThermionViewerFFI extends ThermionViewer {
     List<MaterialInstance>? materialInstances,
     bool addToScene = true,
   }) async {
-    final asset = await FilamentApp.instance!.createGeometry(
+    final asset = await _app.createGeometry(
       geometry,
       materialInstances: materialInstances,
     );
@@ -931,7 +936,7 @@ class ThermionViewerFFI extends ThermionViewer {
   @override
   Future<GizmoAsset> getGizmo(GizmoType gizmoType) async {
     if (_gizmos[gizmoType] == null) {
-      _gizmos[gizmoType] = await FilamentApp.instance!.createGizmo(
+      _gizmos[gizmoType] = await _app.createGizmo(
         view,
         gizmoType,
       );
@@ -1018,7 +1023,7 @@ class ThermionViewerFFI extends ThermionViewer {
       cb,
     ) {
       MaterialProvider_createMaterialInstanceRenderThread(
-        FilamentApp.instance!.ubershaderMaterialProvider,
+        _app.ubershaderMaterialProvider,
         false,
         true,
         false,
@@ -1061,7 +1066,7 @@ class ThermionViewerFFI extends ThermionViewer {
       );
     });
 
-    final material = FFIMaterialInstance(materialInstancePtr);
+    final material = FFIMaterialInstance(materialInstancePtr, _app);
     await material.setParameterFloat4(
       "baseColorFactor",
       1.0,
@@ -1077,7 +1082,7 @@ class ThermionViewerFFI extends ThermionViewer {
       primitiveType: PrimitiveType.LINES,
     );
 
-    final bbAsset = await FilamentApp.instance!.createGeometry(
+    final bbAsset = await _app.createGeometry(
       geometry,
       materialInstances: [material],
     );
@@ -1086,7 +1091,7 @@ class ThermionViewerFFI extends ThermionViewer {
     await bbAsset.setReceiveShadows(false);
 
     TransformManager_setParent(
-      Engine_getTransformManager(FilamentApp.instance!.engine),
+      Engine_getTransformManager(_app.engine),
       bbAsset.entity,
       asset.entity,
       false,
@@ -1108,7 +1113,7 @@ class ThermionViewerFFI extends ThermionViewer {
       await scene.remove(bbAsset);
       if (destroy) {
         _boundingBoxAssets.remove(asset);
-        await FilamentApp.instance!.destroyAsset(bbAsset);
+        await _app.destroyAsset(bbAsset as FFIAsset);
         _logger.info("Bounding box destroyed");
       } else {
         _logger.info("Bounding box hidden");

--- a/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
+++ b/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
@@ -130,11 +130,8 @@ class ThermionViewerFFI extends ThermionViewer {
         ),
       );
       await withVoidCallback(
-        (requestId, cb) => Renderer_endFrameRenderThread(
-          _app.renderer,
-          requestId,
-          cb,
-        ),
+        (requestId, cb) =>
+            Renderer_endFrameRenderThread(_app.renderer, requestId, cb),
       );
       await _app.flush();
     }
@@ -303,9 +300,7 @@ class ThermionViewerFFI extends ThermionViewer {
               )
               as FFITexture;
 
-      _skybox =
-          await _app.buildSkybox(texture: _skyboxTexture)
-              as FFISkybox;
+      _skybox = await _app.buildSkybox(texture: _skyboxTexture) as FFISkybox;
 
       await scene.setSkybox(_skybox!);
 
@@ -710,9 +705,7 @@ class ThermionViewerFFI extends ThermionViewer {
 
   //
   @override
-  @Deprecated(
-    "Call _app.renderableManager.getBoundingBox instead",
-  )
+  @Deprecated("Call _app.renderableManager.getBoundingBox instead")
   Future<v64.Aabb3> getRenderableBoundingBox(ThermionEntity entityId) async {
     return _app.renderableManager.getBoundingBox(entityId);
   }
@@ -736,7 +729,8 @@ class ThermionViewerFFI extends ThermionViewer {
     List<double> fadeOutStart = const [10.0, 500.0, 5000.0],
     List<double> fadeOutEnd = const [200.0, 2000.0, 20000.0],
   }) async {
-    _grid ??= await GridOverlay.create(_app,
+    _grid ??= await GridOverlay.create(
+      _app,
       axisColors: axisColors,
       gridColor: gridColor,
       spacing: spacing,
@@ -800,9 +794,7 @@ class ThermionViewerFFI extends ThermionViewer {
       if (origin != null) {
         worldPosition = origin;
       } else {
-        final worldTransform = await _app.getWorldTransform(
-          entity!,
-        );
+        final worldTransform = await _app.getWorldTransform(entity!);
         worldPosition = worldTransform.getTranslation();
         await _app.setPriority(entity, 0);
       }
@@ -850,10 +842,7 @@ class ThermionViewerFFI extends ThermionViewer {
       } else {
         transform = v64.Matrix4.translation(worldPosition);
       }
-      await _app.setTransform(
-        _translationAxisAsset!.entity,
-        transform,
-      );
+      await _app.setTransform(_translationAxisAsset!.entity, transform);
     } else {
       await _removeTranslationAxis();
     }
@@ -936,10 +925,7 @@ class ThermionViewerFFI extends ThermionViewer {
   @override
   Future<GizmoAsset> getGizmo(GizmoType gizmoType) async {
     if (_gizmos[gizmoType] == null) {
-      _gizmos[gizmoType] = await _app.createGizmo(
-        view,
-        gizmoType,
-      );
+      _gizmos[gizmoType] = await _app.createGizmo(view, gizmoType);
     }
     return _gizmos[gizmoType]!;
   }

--- a/thermion_dart/native/include/c_api/TRenderManager.h
+++ b/thermion_dart/native/include/c_api/TRenderManager.h
@@ -22,7 +22,7 @@ extern "C"
 	// and only calls these on the web build.
 	EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderer);
-	EMSCRIPTEN_KEEPALIVE void RenderManager_detachFromRenderThread();
+	EMSCRIPTEN_KEEPALIVE void RenderManager_detachFromRenderThread(TRenderManager *tRenderManager);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_setPaused(TRenderManager *tRenderer, bool paused);
 
 #ifdef __cplusplus

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -20,9 +20,6 @@ namespace thermion
         typedef void (*FilamentRenderCallback)(void *const owner);
 
         EMSCRIPTEN_KEEPALIVE void* RenderThread_create();
-        // Creates a RenderThread that transfers the given canvas element
-        // (CSS selector) to its worker — one thread per viewer on web.
-        EMSCRIPTEN_KEEPALIVE void* RenderThread_createForCanvas(const char *canvasSelector);
         EMSCRIPTEN_KEEPALIVE void RenderThread_destroy(void *renderThread);
         
         EMSCRIPTEN_KEEPALIVE void RenderThread_addTask(void (*task)());

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -20,7 +20,10 @@ namespace thermion
         typedef void (*FilamentRenderCallback)(void *const owner);
 
         EMSCRIPTEN_KEEPALIVE void* RenderThread_create();
-        EMSCRIPTEN_KEEPALIVE void RenderThread_destroy();
+        // Creates a RenderThread that transfers the given canvas element
+        // (CSS selector) to its worker — one thread per viewer on web.
+        EMSCRIPTEN_KEEPALIVE void* RenderThread_createForCanvas(const char *canvasSelector);
+        EMSCRIPTEN_KEEPALIVE void RenderThread_destroy(void *renderThread);
         
         EMSCRIPTEN_KEEPALIVE void RenderThread_addTask(void (*task)());
         EMSCRIPTEN_KEEPALIVE void RenderManager_setRenderableRenderThread(TRenderManager *tRenderer, TSwapChain *tSwapChain, TView **tViews, uint8_t numViews, uint32_t requestId, VoidCallback onComplete);

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <future>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <utility>
 
@@ -30,13 +31,24 @@ class RenderThread {
 public:
     /**
      * @brief Constructs a new RenderThread and starts the render thread.
+     *
+     * @param canvasSelector Web-only: the CSS selector of the canvas element
+     *        transferred to this thread's worker (default "#thermion_canvas").
+     *        Each engine-per-viewer thread owns its own canvas.
      */
-    explicit RenderThread();
+    explicit RenderThread(const char *canvasSelector = "#thermion_canvas");
 
     /**
      * @brief Destroys the RenderThread and stops the render thread.
      */
     ~RenderThread();
+
+    /**
+     * @brief The CSS selector of the canvas transferred to this thread's
+     *        worker (web only). Used by Engine_create to create the WebGL
+     *        context on the right canvas.
+     */
+    const char *canvasSelector() const { return _canvasSelector.c_str(); }
 
     /**
      * @brief Adds a task to the render thread's task queue.
@@ -66,24 +78,26 @@ public:
     #endif
 
     /**
-     * Signals worker shutdown. Native workers exit after draining queued
-     * tasks; web workers exit on their next browser-loop iteration. Written
-     * by the destructor (true) and constructor (false), read by the worker.
+     * Per-instance worker shutdown signal, heap-allocated and shared with the
+     * worker via a std::shared_ptr copy. Native workers exit after draining
+     * queued tasks; web workers exit on their next browser-loop iteration.
      *
-     * Static, not an instance member, because on web pthread_detach lets the
-     * destructor return and `*this` be freed before the worker observes the
-     * flag — a member would be UAF. Native could safely use a member (`t->join()`
-     * keeps `*this` alive across the worker's read) but the static works there
-     * too since RenderThread is a singleton, and one mechanism is simpler than
-     * two. RenderThread being a singleton is an existing invariant
-     * (`_renderThread` in ThermionDartRenderThreadApi.cpp); breaking it would
-     * require revisiting this design.
+     * The flag must outlive `this`: on web pthread_detach lets the destructor
+     * return and `*this` be freed before the worker observes the signal, so a
+     * plain member would be UAF. The worker only dereferences the RenderThread
+     * after observing the flag is false, which keeps the window closed (the
+     * destructor sets the flag before draining and detaching, so the worker
+     * never touches `this` after shutdown begins).
      *
-     * On web, create() after destroy() must wait for mLiveWorkerCount to hit 0
-     * before constructing the next RenderThread, otherwise the constructor's
-     * reset to false races the previous worker's read of true.
+     * Per-instance, not static: with one engine per thread, destroying one
+     * engine's RenderThread must not signal another engine's worker (a shared
+     * static flag would stop every worker in the module).
      */
-    static std::atomic<bool> mStop;
+    struct StopFlag {
+        std::atomic<bool> value{false};
+    };
+    std::shared_ptr<StopFlag> stopFlag() const { return _stop; }
+    std::shared_ptr<StopFlag> _stop = std::make_shared<StopFlag>();
 
     /**
      * Live worker count. Incremented on worker entry, decremented just before
@@ -115,6 +129,10 @@ private:
     int _frameCount = 0;
     float _accumulatedTime = 0.0f;
     float _fps = 0.0f;
+    // Owned copy: the Dart side frees its UTF8 buffer right after
+    // RenderThread_createForCanvas returns, and Engine_create reads the
+    // selector later (during the same serialized engine creation).
+    std::string _canvasSelector = "#thermion_canvas";
 
     
 #ifdef __EMSCRIPTEN__

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -7,7 +7,6 @@
 #include <functional>
 #include <future>
 #include <mutex>
-#include <string>
 #include <thread>
 #include <utility>
 
@@ -31,24 +30,13 @@ class RenderThread {
 public:
     /**
      * @brief Constructs a new RenderThread and starts the render thread.
-     *
-     * @param canvasSelector Web-only: the CSS selector of the canvas element
-     *        transferred to this thread's worker (default "#thermion_canvas").
-     *        Each engine-per-viewer thread owns its own canvas.
      */
-    explicit RenderThread(const char *canvasSelector = "#thermion_canvas");
+    explicit RenderThread();
 
     /**
      * @brief Destroys the RenderThread and stops the render thread.
      */
     ~RenderThread();
-
-    /**
-     * @brief The CSS selector of the canvas transferred to this thread's
-     *        worker (web only). Used by Engine_create to create the WebGL
-     *        context on the right canvas.
-     */
-    const char *canvasSelector() const { return _canvasSelector.c_str(); }
 
     /**
      * @brief Adds a task to the render thread's task queue.
@@ -129,12 +117,8 @@ private:
     int _frameCount = 0;
     float _accumulatedTime = 0.0f;
     float _fps = 0.0f;
-    // Owned copy: the Dart side frees its UTF8 buffer right after
-    // RenderThread_createForCanvas returns, and Engine_create reads the
-    // selector later (during the same serialized engine creation).
-    std::string _canvasSelector = "#thermion_canvas";
 
-    
+
 #ifdef __EMSCRIPTEN__
     pthread_t t;
 #else

--- a/thermion_dart/native/src/c_api/TEngine.cpp
+++ b/thermion_dart/native/src/c_api/TEngine.cpp
@@ -44,6 +44,12 @@ namespace thermion
     extern "C"
     {
         using namespace filament;
+
+        // Defined in ThermionDartRenderThreadApi.cpp. Direct-API getters use
+        // these to record which render thread owns an engine-scoped object
+        // (and which canvas the active thread's engine renders to).
+        void RenderThread_registerOwnerFromOwner(void *owner, void *knownOwner);
+        const char *RenderThread_getActiveCanvasSelector();
 #endif
 
         EMSCRIPTEN_KEEPALIVE uint64_t TSWAP_CHAIN_CONFIG_TRANSPARENT = filament::backend::SWAP_CHAIN_CONFIG_TRANSPARENT;
@@ -59,7 +65,10 @@ namespace thermion
             bool disableHandleUseAfterFreeCheck)
         {
             #ifdef __EMSCRIPTEN__
-            auto handle = Thermion_createGLContext();
+            // Engine_create runs inside the engine's RenderThread task, so the
+            // active thread IS this engine's thread — create the WebGL context
+            // on the canvas that was transferred to it.
+            auto handle = Thermion_createGLContext(RenderThread_getActiveCanvasSelector());
             tSharedContext = (void*)handle;
             tPlatform = (backend::Platform *)new filament::backend::PlatformWebGL();
             #endif
@@ -190,6 +199,9 @@ namespace thermion
         {
             auto *engine = reinterpret_cast<Engine *>(tEngine);
             auto &transformManager = engine->getTransformManager();
+            // Direct-API getters run on the main thread; record which render
+            // thread owns this manager so RenderThread dispatch can route to it.
+            RenderThread_registerOwnerFromOwner(&transformManager, tEngine);
             return reinterpret_cast<TTransformManager *>(&transformManager);
         }
 
@@ -197,6 +209,7 @@ namespace thermion
         {
             auto *engine = reinterpret_cast<Engine *>(tEngine);
             auto &renderableManager = engine->getRenderableManager();
+            RenderThread_registerOwnerFromOwner(&renderableManager, tEngine);
             return reinterpret_cast<TRenderableManager *>(&renderableManager);
         }
 
@@ -210,6 +223,7 @@ namespace thermion
         EMSCRIPTEN_KEEPALIVE TEntityManager *Engine_getEntityManager(TEngine *tEngine) {
             auto *engine = reinterpret_cast<Engine *>(tEngine);
             auto &entityManager = engine->getEntityManager();
+            RenderThread_registerOwnerFromOwner(&entityManager, tEngine);
             return reinterpret_cast<TEntityManager *>(&entityManager);
         }
 
@@ -338,6 +352,7 @@ namespace thermion
         {
             auto *engine = reinterpret_cast<Engine *>(tEngine);
             auto *scene = engine->createScene();
+            RenderThread_registerOwnerFromOwner(scene, tEngine);
             return reinterpret_cast<TScene *>(scene);
         }
 

--- a/thermion_dart/native/src/c_api/TEngine.cpp
+++ b/thermion_dart/native/src/c_api/TEngine.cpp
@@ -46,10 +46,8 @@ namespace thermion
         using namespace filament;
 
         // Defined in ThermionDartRenderThreadApi.cpp. Direct-API getters use
-        // these to record which render thread owns an engine-scoped object
-        // (and which canvas the active thread's engine renders to).
+        // this to record which render thread owns an engine-scoped object.
         void RenderThread_registerOwnerFromOwner(void *owner, void *knownOwner);
-        const char *RenderThread_getActiveCanvasSelector();
 #endif
 
         EMSCRIPTEN_KEEPALIVE uint64_t TSWAP_CHAIN_CONFIG_TRANSPARENT = filament::backend::SWAP_CHAIN_CONFIG_TRANSPARENT;
@@ -65,10 +63,7 @@ namespace thermion
             bool disableHandleUseAfterFreeCheck)
         {
             #ifdef __EMSCRIPTEN__
-            // Engine_create runs inside the engine's RenderThread task, so the
-            // active thread IS this engine's thread — create the WebGL context
-            // on the canvas that was transferred to it.
-            auto handle = Thermion_createGLContext(RenderThread_getActiveCanvasSelector());
+            auto handle = Thermion_createGLContext();
             tSharedContext = (void*)handle;
             tPlatform = (backend::Platform *)new filament::backend::PlatformWebGL();
             #endif

--- a/thermion_dart/native/src/c_api/TGltfAssetLoader.cpp
+++ b/thermion_dart/native/src/c_api/TGltfAssetLoader.cpp
@@ -32,7 +32,11 @@ namespace thermion
     extern "C"
     {
         using namespace filament;
-        
+
+        // Defined in ThermionDartRenderThreadApi.cpp; records which render
+        // thread owns an engine-scoped object.
+        void RenderThread_registerOwnerFromOwner(void *owner, void *knownOwner);
+
 #endif
 
 
@@ -127,6 +131,9 @@ EMSCRIPTEN_KEEPALIVE TMaterialInstance *GltfAssetLoader_getMaterialInstance(TRen
 EMSCRIPTEN_KEEPALIVE TMaterialProvider *GltfAssetLoader_getMaterialProvider(TGltfAssetLoader *tAssetLoader) {
     auto *assetLoader = reinterpret_cast<gltfio::AssetLoader *>(tAssetLoader);
     auto &materialProvider = assetLoader->getMaterialProvider();
+    // The provider is engine-scoped; record its render thread so
+    // MaterialProvider_createMaterialInstanceRenderThread can dispatch.
+    RenderThread_registerOwnerFromOwner(&materialProvider, tAssetLoader);
     return reinterpret_cast<TMaterialProvider *>(&materialProvider);
 }
 

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -50,14 +50,73 @@ using namespace std::chrono_literals;
 #define PROXY(call)                                           \
   auto startTime = std::chrono::high_resolution_clock::now(); \
   TRACE("PROXYING");                                          \
-  _renderThread->queue.proxySync(_renderThread->outer, [=]() { call; });
+  rt->queue.proxySync(rt->outer, [=]() { call; });
 #else
 #define PROXY(call) call
 #endif
 extern "C"
 {
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // Owner-keyed thread registry.
+  //
+  // Multi-engine web (one engine per viewer) runs each engine on its own
+  // RenderThread / pthread / canvas. Every `*RenderThread` function below
+  // dispatches to the thread that owns the object it operates on, resolved
+  // from g_threadByOwner. Entries are recorded at object-creation tasks
+  // (creation runs on the owning thread) and at the direct-API getters via
+  // RenderThread_registerOwnerFromOwner.
+  //
+  // Single-engine apps — and every native build — fall through to
+  // `_renderThread` (or the most recently created thread), preserving the
+  // historical singleton behavior exactly.
+  // ─────────────────────────────────────────────────────────────────────────
   std::unique_ptr<RenderThread> _renderThread;
+  std::unordered_map<void *, RenderThread *> g_threadByOwner;
+  std::unordered_map<void *, std::unique_ptr<RenderThread>> _renderThreads;
+  RenderThread *g_activeThread = nullptr;
+
+  // Resolve the thread for a dispatch. `owner` is the engine/manager/view/
+  // ... handle the operation targets; nullptr means "creation-time task" —
+  // the most recently created thread, which is the one the Dart side just
+  // built for this engine (Dart serialises engine creation).
+  RenderThread *RT(void *owner)
+  {
+    if (owner != nullptr)
+    {
+      auto it = g_threadByOwner.find(owner);
+      if (it != g_threadByOwner.end())
+      {
+        return it->second;
+      }
+    }
+    if (g_activeThread != nullptr)
+    {
+      return g_activeThread;
+    }
+    return _renderThread.get();
+  }
+
+  // Record that `owner` (created on the main thread via a direct-API getter,
+  // e.g. Engine_getTransformManager) belongs to the thread of `knownOwner`
+  // (an engine-scoped handle already in the registry).
+  EMSCRIPTEN_KEEPALIVE void RenderThread_registerOwnerFromOwner(void *owner, void *knownOwner)
+  {
+    if (owner == nullptr || knownOwner == nullptr)
+    {
+      return;
+    }
+    g_threadByOwner[owner] = RT(knownOwner);
+  }
+
+  // Web-only: the CSS selector of the canvas owned by the most recently
+  // created RenderThread, used by Engine_create to create the WebGL context
+  // on the right canvas.
+  EMSCRIPTEN_KEEPALIVE const char *RenderThread_getActiveCanvasSelector()
+  {
+    RenderThread *rt = g_activeThread != nullptr ? g_activeThread : _renderThread.get();
+    return rt != nullptr ? rt->canvasSelector() : "#thermion_canvas";
+  }
 
   EMSCRIPTEN_KEEPALIVE void* RenderThread_create()
   {
@@ -67,35 +126,69 @@ extern "C"
       Log("WARNING - you are attempting to create a RenderThread when the previous one has not been disposed.");
     }
     _renderThread = std::make_unique<RenderThread>();
+    g_activeThread = _renderThread.get();
     TRACE("RenderThread created");
     return _renderThread.get();
   }
 
-  EMSCRIPTEN_KEEPALIVE void RenderThread_destroy()
+  EMSCRIPTEN_KEEPALIVE void* RenderThread_createForCanvas(const char *canvasSelector)
+  {
+    TRACE("RenderThread_createForCanvas %s", canvasSelector);
+    auto thread = std::make_unique<RenderThread>(canvasSelector);
+    auto *raw = thread.get();
+    g_activeThread = raw;
+    _renderThreads[raw] = std::move(thread);
+    TRACE("RenderThread created for canvas %s", canvasSelector);
+    return raw;
+  }
+
+  EMSCRIPTEN_KEEPALIVE void RenderThread_destroy(void *renderThread)
   {
     TRACE("RenderThread_destroy");
-    _renderThread = nullptr;
+    if (renderThread == nullptr)
+    {
+      return;
+    }
+    if (renderThread == _renderThread.get())
+    {
+      _renderThread = nullptr;
+    }
+    else
+    {
+      auto it = _renderThreads.find(renderThread);
+      if (it != _renderThreads.end())
+      {
+        _renderThreads.erase(it);
+      }
+    }
+    if (g_activeThread == renderThread)
+    {
+      g_activeThread = nullptr;
+    }
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderThread_addTask(void (*task)())
   {
+    auto *rt = RT(nullptr);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           task();
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderManager)
   {
 #ifdef __EMSCRIPTEN__
-    if (!_renderThread) {
+    if (!_renderThread && g_threadByOwner.empty()) {
       Log("WARNING - RenderManager_attachToRenderThread called with no RenderThread active.");
       return;
     }
     auto *rm = reinterpret_cast<RenderManager *>(tRenderManager);
-    _renderThread->setRenderManager(rm);
+    auto *rt = RT(tRenderManager);
+    g_threadByOwner[tRenderManager] = rt;
+    rt->setRenderManager(rm);
 #else
     (void)tRenderManager; // no-op on native
 #endif
@@ -104,12 +197,16 @@ extern "C"
   // Inverse of RenderManager_attachToRenderThread. Call before deleting a
   // RenderManager so the worker's iter() doesn't dereference a freed pointer
   // on its next tick.
-  EMSCRIPTEN_KEEPALIVE void RenderManager_detachFromRenderThread()
+  EMSCRIPTEN_KEEPALIVE void RenderManager_detachFromRenderThread(TRenderManager *tRenderManager)
   {
 #ifdef __EMSCRIPTEN__
-    if (_renderThread) {
-      _renderThread->setRenderManager(nullptr);
+    auto *rt = RT(tRenderManager);
+    if (rt) {
+      rt->setRenderManager(nullptr);
     }
+    g_threadByOwner.erase(tRenderManager);
+#else
+    (void)tRenderManager; // no-op on native
 #endif
   }
 
@@ -119,6 +216,7 @@ extern "C"
     TView **tViews,
     uint8_t numViews,
     uint32_t requestId, VoidCallback onComplete) {
+    auto *rt = RT(tRenderer);
 
       std::packaged_task<void()> lambda(
         [=]() mutable
@@ -126,7 +224,7 @@ extern "C"
           RenderManager_setRenderable(tRenderer, tSwapChain, tViews, numViews);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
 
     }
 
@@ -136,8 +234,9 @@ extern "C"
     uint32_t requestId,
     VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderManager);
     auto queuedAt = std::chrono::steady_clock::now();
-    _renderThread->addDetachedTask([=]() mutable {
+    rt->addDetachedTask([=]() mutable {
       auto startedAt = std::chrono::steady_clock::now();
       float queueMs = std::chrono::duration_cast<std::chrono::nanoseconds>(startedAt - queuedAt).count() / 1e6f;
       RenderManager_render(tRenderManager, frameTimeInNanos);
@@ -159,13 +258,14 @@ extern "C"
     uint32_t requestId,
     VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           RenderManager_addAnimationManager(tRenderManager, tAnimationManager);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderManager_removeAnimationManagerRenderThread(
@@ -174,13 +274,14 @@ extern "C"
     uint32_t requestId,
     VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           RenderManager_removeAnimationManager(tRenderManager, tAnimationManager);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderManager_removeSwapChainRenderThread(
@@ -189,13 +290,14 @@ extern "C"
     uint32_t requestId,
     VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           RenderManager_removeSwapChain(tRenderManager, tSwapChain);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createRenderThread(
@@ -206,217 +308,243 @@ extern "C"
       bool disableHandleUseAfterFreeCheck,
       void (*onComplete)(TEngine *))
   {
+    auto *rt = RT(nullptr);
 
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *engine = Engine_create(backend, platform, sharedContext, stereoscopicEyeCount, disableHandleUseAfterFreeCheck);
-          PROXY(onComplete(engine));
+
+          g_threadByOwner[engine] = rt;          PROXY(onComplete(engine));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createRendererRenderThread(TEngine *tEngine, void (*onComplete)(TRenderer *))
   {
+    auto *rt = RT(tEngine);
 
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *renderer = Engine_createRenderer(tEngine);
-          PROXY(onComplete(renderer));
+
+          g_threadByOwner[renderer] = rt;          PROXY(onComplete(renderer));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createSwapChainRenderThread(TEngine *tEngine, void *window, uint64_t flags, void (*onComplete)(TSwapChain *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto swapChain = Engine_createSwapChain(tEngine, window, flags);
           PROXY(onComplete(swapChain));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createHeadlessSwapChainRenderThread(TEngine *tEngine, uint32_t width, uint32_t height, uint64_t flags, void (*onComplete)(TSwapChain *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto swapChain = Engine_createHeadlessSwapChain(tEngine, width, height, flags);
           PROXY(onComplete(swapChain));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroySwapChainRenderThread(TEngine *tEngine, TSwapChain *tSwapChain, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroySwapChain(tEngine, tSwapChain);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyRendererRenderThread(TEngine *tEngine, TRenderer *tRenderer, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyRenderer(tEngine, tRenderer);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyViewRenderThread(TEngine *tEngine, TView *tView, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyView(tEngine, tView);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroySceneRenderThread(TEngine *tEngine, TScene *tScene, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyScene(tEngine, tScene);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createCameraRenderThread(TEngine *tEngine, EntityId entityId, void (*onComplete)(TCamera *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto camera = Engine_createCamera(tEngine, entityId);
-          PROXY(onComplete(camera));
+
+          g_threadByOwner[camera] = rt;          PROXY(onComplete(camera));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyCameraRenderThread(TEngine *tEngine, TCamera *tCamera, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyCamera(tEngine, tCamera);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createViewRenderThread(TEngine *tEngine, void (*onComplete)(TView *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *view = Engine_createView(tEngine);
-          PROXY(onComplete(view));
+
+          g_threadByOwner[view] = rt;          PROXY(onComplete(view));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyRenderThread(TEngine *tEngine, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroy(tEngine);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyTextureRenderThread(TEngine *engine, TTexture *tTexture, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(engine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyTexture(engine, tTexture);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroySkyboxRenderThread(TEngine *tEngine, TSkybox *tSkybox, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroySkybox(tEngine, tSkybox);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyIndirectLightRenderThread(TEngine *tEngine, TIndirectLight *tIndirectLight, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyIndirectLight(tEngine, tIndirectLight);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_buildMaterialRenderThread(TEngine *tEngine, const uint8_t *materialData, size_t length, void (*onComplete)(TMaterial *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto material = Engine_buildMaterial(tEngine, materialData, length);
-          PROXY(onComplete(material));
+
+          g_threadByOwner[material] = rt;          PROXY(onComplete(material));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyMaterialRenderThread(TEngine *tEngine, TMaterial *tMaterial, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyMaterial(tEngine, tMaterial);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyMaterialInstanceRenderThread(TEngine *tEngine, TMaterialInstance *tMaterialInstance, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyMaterialInstance(tEngine, tMaterialInstance);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createFenceRenderThread(TEngine *tEngine, void (*onComplete)(TFence *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *fence = Engine_createFence(tEngine);
-          PROXY(onComplete(fence));
+
+          g_threadByOwner[fence] = rt;          PROXY(onComplete(fence));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Fence_waitAndDestroyRenderThread(TFence *tFence, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tFence);
     
     std::packaged_task<void()> lambda(
         [=]() mutable
@@ -424,33 +552,36 @@ extern "C"
           Fence_waitAndDestroy(tFence);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyFenceRenderThread(TEngine *tEngine, TFence *tFence, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_destroyFence(tEngine, tFence);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_flushAndWaitRenderThread(TEngine *tEngine, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Engine_flushAndWait(tEngine);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_executeRenderThread(TEngine *tEngine, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
@@ -460,38 +591,41 @@ extern "C"
           { 
             PROXY(onComplete(requestId));
           });
-          _renderThread->addTask(callback);
+          rt->addTask(callback);
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void execute_queue()
   {
+    auto *rt = RT(nullptr);
 #ifdef __EMSCRIPTEN__
-    _renderThread->queue.execute();
+    rt->queue.execute();
 #endif
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_buildSkyboxRenderThread(TEngine *tEngine, TTexture *tTexture, void (*onComplete)(TSkybox *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *skybox = Engine_buildSkybox(tEngine, tTexture);
           PROXY(onComplete(skybox));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_buildColoredSkyboxRenderThread(TEngine *tEngine, float r, float g, float b, float a, void (*onComplete)(TSkybox *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *skybox = Engine_buildColoredSkybox(tEngine, r, g, b, a);
           PROXY(onComplete(skybox));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
@@ -500,13 +634,14 @@ extern "C"
     TTexture* tIrradianceTexture,
     float intensity,
     void (*onComplete)(TIndirectLight *)) {
+    auto *rt = RT(tEngine);
       std::packaged_task<void()> lambda(
           [=]() mutable
           {
             auto *indirectLight = Engine_buildIndirectLightFromIrradianceTexture(tEngine, tReflectionsTexture, tIrradianceTexture, intensity);
             PROXY(onComplete(indirectLight));
           });
-      auto fut = _renderThread->addTask(lambda);
+      auto fut = rt->addTask(lambda);
   }
   
   EMSCRIPTEN_KEEPALIVE void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
@@ -515,57 +650,62 @@ extern "C"
     float *harmonics,
     float intensity,
     void (*onComplete)(TIndirectLight *)) {
+    auto *rt = RT(tEngine);
       std::packaged_task<void()> lambda(
           [=]() mutable
           {
             auto *indirectLight = Engine_buildIndirectLightFromIrradianceHarmonics(tEngine, tReflectionsTexture, harmonics, intensity);
             PROXY(onComplete(indirectLight));
           });
-      auto fut = _renderThread->addTask(lambda);
+      auto fut = rt->addTask(lambda);
   }
 
 
   EMSCRIPTEN_KEEPALIVE void Renderer_beginFrameRenderThread(TRenderer *tRenderer, TSwapChain *tSwapChain, uint64_t frameTimeInNanos, void (*onComplete)(bool))
   {
+    auto *rt = RT(tRenderer);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto result = Renderer_beginFrame(tRenderer, tSwapChain, frameTimeInNanos);
           PROXY(onComplete(result));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
   EMSCRIPTEN_KEEPALIVE void Renderer_endFrameRenderThread(TRenderer *tRenderer, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderer);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Renderer_endFrame(tRenderer);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Renderer_renderRenderThread(TRenderer *tRenderer, TView *tView, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderer);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Renderer_render(tRenderer, tView);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Renderer_renderStandaloneViewRenderThread(TRenderer *tRenderer, TView *tView, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderer);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Renderer_renderStandaloneView(tRenderer, tView);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Renderer_setClearOptionsRenderThread(
@@ -578,13 +718,14 @@ extern "C"
       bool clear,
       bool discard, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderer);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Renderer_setClearOptions(tRenderer, clearR, clearG, clearB, clearA, clearStencil, clear, discard);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Renderer_readPixelsRenderThread(
@@ -597,101 +738,118 @@ extern "C"
       size_t outLength,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderer);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Renderer_readPixels(tRenderer, width, height, xOffset, yOffset, tRenderTarget, tPixelBufferFormat, tPixelDataType, out, outLength);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createImageMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *instance = Material_createImageMaterial(tEngine);
-          PROXY(onComplete(instance));
+
+          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createGizmoMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *instance = Material_createGizmoMaterial(tEngine);
-          PROXY(onComplete(instance));
+
+          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createSilhouetteMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *instance = Material_createSilhouetteMaterial(tEngine);
-          PROXY(onComplete(instance));
+
+          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createEdgeOutlineMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *instance = Material_createEdgeOutlineMaterial(tEngine);
-          PROXY(onComplete(instance));
+
+          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createWireframeMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *instance = Material_createWireframeMaterial(tEngine);
-          PROXY(onComplete(instance));
+
+          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createTranslationAxisMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *instance = Material_createTranslationAxisMaterial(tEngine);
-          PROXY(onComplete(instance));
+
+          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createBoneOverlayMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *instance = Material_createBoneOverlayMaterial(tEngine);
-          PROXY(onComplete(instance));
+
+          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createInstanceRenderThread(TMaterial *tMaterial, void (*onComplete)(TMaterialInstance *))
   {
+    auto *rt = RT(tMaterial);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *instance = Material_createInstance(tMaterial);
-          PROXY(onComplete(instance));
+
+          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void MaterialInstance_setParameterTextureRenderThread(
@@ -702,24 +860,26 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tMaterialInstance);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           MaterialInstance_setParameterTexture(tMaterialInstance, propertyName, tTexture, tSampler);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_destroyRenderThread(TSceneAsset *tSceneAsset, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tSceneAsset);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           SceneAsset_destroy(tSceneAsset);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
 
@@ -731,13 +891,15 @@ extern "C"
       bool rebuildVertices,
       void (*onComplete)(TSceneAsset *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]
         {
           auto sceneAsset = SceneAsset_createFromFilamentAsset(tEngine, tAssetLoader, tNameComponentManager, tFilamentAsset, rebuildVertices);
-          PROXY(onComplete(sceneAsset));
+
+          g_threadByOwner[sceneAsset] = rt;          PROXY(onComplete(sceneAsset));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_createFromBuffersRenderThread(
@@ -750,13 +912,15 @@ extern "C"
       Aabb3 boundingBox,
       void (*callback)(TSceneAsset *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]
         {
           auto sceneAsset = SceneAsset_createFromBuffers(tEngine, tVertexBuffer, tIndexBuffer, materialInstances, materialInstanceCount, tPrimitiveType, boundingBox);
-          PROXY(callback(sceneAsset));
+
+          g_threadByOwner[sceneAsset] = rt;          PROXY(callback(sceneAsset));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_createInstanceRenderThread(
@@ -764,37 +928,41 @@ extern "C"
       int materialInstanceCount,
       void (*callback)(TSceneAsset *))
   {
+    auto *rt = RT(asset);
     std::packaged_task<void()> lambda(
         [=]
         {
           auto instanceAsset = SceneAsset_createInstance(asset, tMaterialInstances, materialInstanceCount);
-          PROXY(callback(instanceAsset));
+
+          g_threadByOwner[instanceAsset] = rt;          PROXY(callback(instanceAsset));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_releaseSourceDataRenderThread(
       TSceneAsset *tSceneAsset, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tSceneAsset);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           SceneAsset_releaseSourceData(tSceneAsset);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_setFlatShadingRenderThread(
       TSceneAsset *tSceneAsset, bool flatShading, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tSceneAsset);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           SceneAsset_setFlatShading(tSceneAsset, flatShading);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void MaterialProvider_createMaterialInstanceRenderThread(
@@ -839,6 +1007,7 @@ extern "C"
       bool hasVolume,
       void (*callback)(TMaterialInstance *))
   {
+    auto *rt = RT(tMaterialProvider);
     std::packaged_task<void()> lambda(
         [=]
         {
@@ -884,176 +1053,203 @@ extern "C"
               hasVolume);
           PROXY(callback(materialInstance));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ColorGrading_createRenderThread(TEngine *tEngine, TToneMapper *toneMapper, void (*callback)(TColorGrading *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]
         {
           auto cg = ColorGrading_create(tEngine, toneMapper);
-          PROXY(callback(cg));
+
+          g_threadByOwner[cg] = rt;          PROXY(callback(cg));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_createRenderThread(void (*onComplete)(TColorGradingBuilder *))
   {
+    auto *rt = RT(nullptr);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *builder = ColorGradingBuilder_create();
-          PROXY(onComplete(builder));
+
+          g_threadByOwner[builder] = rt;          PROXY(onComplete(builder));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_buildRenderThread(TColorGradingBuilder *tBuilder, TEngine *tEngine, void (*onComplete)(TColorGrading *))
   {
+    auto *rt = RT(tBuilder);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *colorGrading = ColorGradingBuilder_build(tBuilder, tEngine);
           PROXY(onComplete(colorGrading));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_destroyRenderThread(TColorGradingBuilder *tBuilder, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tBuilder);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           ColorGradingBuilder_destroy(tBuilder);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createLinearRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createLinear(tEngine);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createACESRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createACES(tEngine);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createACESLegacyRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createACESLegacy(tEngine);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createFilmicRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createFilmic(tEngine);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createPBRNeutralRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createPBRNeutral(tEngine);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createAGXRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createAGX(tEngine);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createAGXWithLookRenderThread(TEngine *tEngine, int look, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createAGXWithLook(tEngine, look);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createGenericRenderThread(TEngine *tEngine, float contrast, float midGrayIn, float midGrayOut, float hdrMax, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createGeneric(tEngine, contrast, midGrayIn, midGrayOut, hdrMax);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createDisplayRangeRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createDisplayRange(tEngine);
-          PROXY(onComplete(toneMapper));
+
+          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_destroyRenderThread(TToneMapper *tToneMapper, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tToneMapper);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           ToneMapper_destroy(tToneMapper);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyColorGradingRenderThread(TEngine *tEngine, TColorGrading *tColorGrading, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]
         {
           Engine_destroyColorGrading(tEngine, tColorGrading);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_pickRenderThread(TView *tView, uint32_t requestId, uint32_t x, uint32_t y, PickCallback callback)
   {
+    auto *rt = RT(tView);
     auto *view = reinterpret_cast<View *>(tView);
     view->pick(x, y, [=](filament::View::PickingQueryResult const &result)
                { PROXY(callback(requestId, utils::Entity::smuggle(result.renderable), result.depth, result.fragCoords.x, result.fragCoords.y, result.fragCoords.z)); });
@@ -1061,308 +1257,337 @@ extern "C"
 
   EMSCRIPTEN_KEEPALIVE void View_setColorGradingRenderThread(TView *tView, TColorGrading *tColorGrading, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setColorGrading(tView, tColorGrading);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setBloomRenderThread(TView *tView, bool enabled, double strength, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setBloom(tView, enabled, strength);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setCameraRenderThread(TView *tView, TCamera *tCamera, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setCamera(tView, tCamera);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_getNameRenderThread(TView *tView, void (*onComplete)(const char *))
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           auto name = View_getName(tView);
           PROXY(onComplete(name));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setNameRenderThread(TView *tView, const char *name, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setName(tView, name);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setViewportRenderThread(TView *tView, uint32_t width, uint32_t height, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setViewport(tView, width, height);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setRenderTargetRenderThread(TView *tView, TRenderTarget *tRenderTarget, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setRenderTarget(tView, tRenderTarget);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setAntiAliasingRenderThread(TView *tView, bool msaa, bool fxaa, bool taa, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setAntiAliasing(tView, msaa, fxaa, taa);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setPostProcessingRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setPostProcessing(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setFrustumCullingEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setFrustumCullingEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setStencilBufferEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setStencilBufferEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setDitheringEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setDitheringEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setRenderQualityRenderThread(TView *tView, int qualityLevel, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setRenderQuality(tView, static_cast<TQualityLevel>(qualityLevel));
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setSceneRenderThread(TView *tView, TScene *tScene, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setScene(tView, tScene);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setLayerEnabledRenderThread(TView *tView, int layer, bool visible, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setLayerEnabled(tView, layer, visible);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setBlendModeRenderThread(TView *tView, int blendMode, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setBlendMode(tView, static_cast<TBlendMode>(blendMode));
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setFogOptionsRenderThread(TView *tView, TFogOptions tFogOptions, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setFogOptions(tView, tFogOptions);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setAmbientOcclusionOptionsRenderThread(TView *tView, TAmbientOcclusionOptions options, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setAmbientOcclusionOptions(tView, options);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setFrontFaceWindingInvertedRenderThread(TView *tView, bool inverted, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setFrontFaceWindingInverted(tView, inverted);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setShadowsEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setShadowsEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setShadowTypeRenderThread(TView *tView, int shadowType, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setShadowType(tView, shadowType);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setSoftShadowOptionsRenderThread(TView *tView, TSoftShadowOptions options, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setSoftShadowOptions(tView, options);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setVsmShadowOptionsRenderThread(TView *tView, TVsmShadowOptions options, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setVsmShadowOptions(tView, options);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setTransparentPickingEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tView);
     std::packaged_task<void()> lambda(
         [=]
         {
           View_setTransparentPickingEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_resetToRestPoseRenderThread(TAnimationManager *tAnimationManager, TSceneAsset *tSceneAsset, uint32_t requestId, VoidCallback onComplete) {
+    auto *rt = RT(tAnimationManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           AnimationManager_resetToRestPose(tAnimationManager, tSceneAsset);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_createRenderThread(TEngine *tEngine, void (*onComplete)(TAnimationManager *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *animationManager = AnimationManager_create(tEngine);
-          PROXY(onComplete(animationManager));
+
+          g_threadByOwner[animationManager] = rt;          PROXY(onComplete(animationManager));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_destroyRenderThread(TAnimationManager *tAnimationManager, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tAnimationManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           AnimationManager_destroy(tAnimationManager);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_updateRenderThread(TAnimationManager *tAnimationManager, uint64_t frameTimeInNanos, uint32_t requestId, VoidCallback onComplete) {
+    auto *rt = RT(tAnimationManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           AnimationManager_update(tAnimationManager, frameTimeInNanos);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_updateBoneMatricesRenderThread(
@@ -1370,13 +1595,14 @@ extern "C"
       TSceneAsset *sceneAsset,
       void (*callback)(bool))
   {
+    auto *rt = RT(tAnimationManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           bool result = AnimationManager_updateBoneMatrices(tAnimationManager, sceneAsset);
           PROXY(callback(result));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_setMorphTargetWeightsRenderThread(
@@ -1386,90 +1612,100 @@ extern "C"
       int numWeights,
       void (*callback)(bool))
   {
+    auto *rt = RT(tAnimationManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           bool result = AnimationManager_setMorphTargetWeights(tAnimationManager, entityId, morphData, numWeights);
           PROXY(callback(result));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_createEmptyRenderThread(uint32_t width, uint32_t height, uint32_t channel, void (*onComplete)(TLinearImage *))
   {
+    auto *rt = RT(nullptr);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto image = Image_createEmpty(width, height, channel);
-          PROXY(onComplete(image));
+
+          g_threadByOwner[image] = rt;          PROXY(onComplete(image));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_decodeRenderThread(uint8_t *data, size_t length, const char *name, bool alpha, void (*onComplete)(TLinearImage *))
   {
+    auto *rt = RT(data);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto image = Image_decode(data, length, name, alpha);
-          PROXY(onComplete(image));
+
+          g_threadByOwner[image] = rt;          PROXY(onComplete(image));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_getBytesRenderThread(TLinearImage *tLinearImage, void (*onComplete)(float *))
   {
+    auto *rt = RT(tLinearImage);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto bytes = Image_getBytes(tLinearImage);
           PROXY(onComplete(bytes));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_destroyRenderThread(TLinearImage *tLinearImage, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tLinearImage);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Image_destroy(tLinearImage);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_getWidthRenderThread(TLinearImage *tLinearImage, void (*onComplete)(uint32_t))
   {
+    auto *rt = RT(tLinearImage);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto width = Image_getWidth(tLinearImage);
           PROXY(onComplete(width));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_getHeightRenderThread(TLinearImage *tLinearImage, void (*onComplete)(uint32_t))
   {
+    auto *rt = RT(tLinearImage);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto height = Image_getHeight(tLinearImage);
           PROXY(onComplete(height));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_getChannelsRenderThread(TLinearImage *tLinearImage, void (*onComplete)(uint32_t))
   {
+    auto *rt = RT(tLinearImage);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto channels = Image_getChannels(tLinearImage);
           PROXY(onComplete(channels));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Texture_buildRenderThread(
@@ -1483,33 +1719,37 @@ extern "C"
       TTextureSamplerType sampler,
       TTextureFormat format, void (*onComplete)(TTexture *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *texture = Texture_build(tEngine, width, height, depth, levels, tUsage, import, sampler, format);
-          PROXY(onComplete(texture));
+
+          g_threadByOwner[texture] = rt;          PROXY(onComplete(texture));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Texture_setExternalImageRenderThread(TEngine *tEngine, TTexture *tTexture, void *externalImage, uint32_t requestId, VoidCallback onComplete) {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Texture_setExternalImage(tEngine, tTexture, externalImage);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Texture_generateMipMapsRenderThread(TTexture *tTexture, TEngine *tEngine, uint32_t requestId, VoidCallback onComplete) {
+    auto *rt = RT(tTexture);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Texture_generateMipMaps(tTexture, tEngine);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   #ifdef EMSCRIPTEN
@@ -1537,18 +1777,21 @@ extern "C"
   // ffigen_js Uint8List.address path uses stackAlloc for buffers < 32KB).
   EMSCRIPTEN_KEEPALIVE void Ktx2Reader_createTextureRenderThread(
     TEngine *tEngine, uint8_t* data, size_t size, void (*onComplete)(TTexture *)) {
+    auto *rt = RT(tEngine);
     std::vector<uint8_t> bytes(data, data + size);
     std::packaged_task<void()> lambda(
-        [tEngine, bytes = std::move(bytes), onComplete]() mutable
+        [tEngine, bytes = std::move(bytes), onComplete, rt]() mutable
         {
           auto *texture = Ktx2Reader_createTexture(tEngine, bytes.data(), bytes.size());
+          g_threadByOwner[texture] = rt;
           PROXY(onComplete(texture));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Ktx1Reader_createTextureRenderThread(
     TEngine *tEngine, TKtx1Bundle *tBundle, uint32_t requestId, VoidCallback onTextureUploadComplete, void (*onComplete)(TTexture *)) {
+    auto *rt = RT(tEngine);
 
       #ifdef EMSCRIPTEN
         if(onTextureUploadComplete) {
@@ -1564,10 +1807,11 @@ extern "C"
             auto *texture = Ktx1Reader_createTexture(tEngine, tBundle, requestId, onTextureUploadComplete ? Emscripten_voidCallback : nullptr);
           #else
             auto *texture = Ktx1Reader_createTexture(tEngine, tBundle, requestId, onTextureUploadComplete);
-          #endif          
+          #endif
+          g_threadByOwner[texture] = rt;
           PROXY(onComplete(texture));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
 
@@ -1576,13 +1820,14 @@ extern "C"
                                                           int level,
                                                           void (*onComplete)(bool))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           bool result = Texture_loadImage(tEngine, tTexture, tImage, bufferFormat, pixelDataType, level);
           PROXY(onComplete(result));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Texture_setImageRenderThread(
@@ -1601,6 +1846,7 @@ extern "C"
       uint32_t pixelDataType,
       void (*onComplete)(bool))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
@@ -1620,18 +1866,19 @@ extern "C"
               pixelDataType);
           PROXY(onComplete(result));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderTarget_getColorTextureRenderThread(TRenderTarget *tRenderTarget, void (*onComplete)(TTexture *))
   {
+    auto *rt = RT(tRenderTarget);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto texture = RenderTarget_getColorTexture(tRenderTarget);
           PROXY(onComplete(texture));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderTarget_createRenderThread(
@@ -1640,6 +1887,7 @@ extern "C"
       TTexture *tDepth,
       void (*onComplete)(TRenderTarget *))
   {
+    auto *rt = RT(tEngine);
     auto color = reinterpret_cast<filament::Texture *>(tColor);
     auto depth = reinterpret_cast<filament::Texture *>(tDepth);
 
@@ -1647,9 +1895,10 @@ extern "C"
         [=]() mutable
         {
           auto texture = RenderTarget_create(tEngine, tColor, tDepth);
-          PROXY(onComplete(texture));
+
+          g_threadByOwner[texture] = rt;          PROXY(onComplete(texture));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderTarget_destroyRenderThread(
@@ -1657,24 +1906,27 @@ extern "C"
       TRenderTarget *tRenderTarget,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           RenderTarget_destroy(tEngine, tRenderTarget);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_createRenderThread(void (*onComplete)(TTextureSampler *))
   {
+    auto *rt = RT(nullptr);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto sampler = TextureSampler_create();
-          PROXY(onComplete(sampler));
+
+          g_threadByOwner[sampler] = rt;          PROXY(onComplete(sampler));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_createWithFilteringRenderThread(
@@ -1685,13 +1937,15 @@ extern "C"
       TSamplerWrapMode wrapR,
       void (*onComplete)(TTextureSampler *))
   {
+    auto *rt = RT(nullptr);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto sampler = TextureSampler_createWithFiltering(minFilter, magFilter, wrapS, wrapT, wrapR);
-          PROXY(onComplete(sampler));
+
+          g_threadByOwner[sampler] = rt;          PROXY(onComplete(sampler));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_createWithComparisonRenderThread(
@@ -1699,13 +1953,15 @@ extern "C"
       TSamplerCompareFunc compareFunc,
       void (*onComplete)(TTextureSampler *))
   {
+    auto *rt = RT(nullptr);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto sampler = TextureSampler_createWithComparison(compareMode, compareFunc);
-          PROXY(onComplete(sampler));
+
+          g_threadByOwner[sampler] = rt;          PROXY(onComplete(sampler));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setMinFilterRenderThread(
@@ -1713,13 +1969,14 @@ extern "C"
       TSamplerMinFilter filter,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(sampler);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TextureSampler_setMinFilter(sampler, filter);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setMagFilterRenderThread(
@@ -1727,13 +1984,14 @@ extern "C"
       TSamplerMagFilter filter,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(sampler);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TextureSampler_setMagFilter(sampler, filter);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setWrapModeSRenderThread(
@@ -1741,13 +1999,14 @@ extern "C"
       TSamplerWrapMode mode,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(sampler);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TextureSampler_setWrapModeS(sampler, mode);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setWrapModeTRenderThread(
@@ -1755,13 +2014,14 @@ extern "C"
       TSamplerWrapMode mode,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(sampler);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TextureSampler_setWrapModeT(sampler, mode);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setWrapModeRRenderThread(
@@ -1769,13 +2029,14 @@ extern "C"
       TSamplerWrapMode mode,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(sampler);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TextureSampler_setWrapModeR(sampler, mode);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setAnisotropyRenderThread(
@@ -1783,13 +2044,14 @@ extern "C"
       double anisotropy,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(sampler);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TextureSampler_setAnisotropy(sampler, anisotropy);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setCompareModeRenderThread(
@@ -1798,26 +2060,28 @@ extern "C"
       TTextureSamplerCompareFunc func,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(sampler);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TextureSampler_setCompareMode(sampler, mode, func);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_destroyRenderThread(
       TTextureSampler *sampler,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(sampler);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TextureSampler_destroy(sampler);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfAssetLoader_createRenderThread(
@@ -1826,13 +2090,15 @@ extern "C"
     TNameComponentManager *tNameComponentManager,
     void (*callback)(TGltfAssetLoader *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
       [=]() mutable
       {
         auto loader = GltfAssetLoader_create(tEngine, tMaterialProvider, tNameComponentManager);
-        PROXY(callback(loader));
+
+          g_threadByOwner[loader] = rt;        PROXY(callback(loader));
       });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfAssetLoader_destroyRenderThread(
@@ -1840,46 +2106,51 @@ extern "C"
     uint32_t requestId,
     VoidCallback onComplete)
   {
+    auto *rt = RT(tAssetLoader);
     std::packaged_task<void()> lambda(
       [=]() mutable
       {
         GltfAssetLoader_destroy(tAssetLoader);
         PROXY(onComplete(requestId));
       });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
   
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_createRenderThread(TEngine *tEngine, void (*callback)(TGltfResourceLoader *)) {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
       [=]() mutable
       {
         auto loader = GltfResourceLoader_create(tEngine);
-        PROXY(callback(loader));
+
+          g_threadByOwner[loader] = rt;        PROXY(callback(loader));
       });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_destroyRenderThread(TEngine *tEngine, TGltfResourceLoader *tResourceLoader, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           GltfResourceLoader_destroy(tEngine, tResourceLoader);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_loadResourcesRenderThread(TGltfResourceLoader *tGltfResourceLoader, TFilamentAsset *tFilamentAsset, void (*callback)(bool))
   {
+    auto *rt = RT(tGltfResourceLoader);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto result = GltfResourceLoader_loadResources(tGltfResourceLoader, tFilamentAsset);
           PROXY(callback(result));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_addResourceDataRenderThread(
@@ -1889,13 +2160,14 @@ extern "C"
       size_t length,
       uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tGltfResourceLoader);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           GltfResourceLoader_addResourceData(tGltfResourceLoader, uri, data, length);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_asyncBeginLoadRenderThread(
@@ -1903,37 +2175,40 @@ extern "C"
       TFilamentAsset *tFilamentAsset,
       void (*callback)(bool))
   {
+    auto *rt = RT(tGltfResourceLoader);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto result = GltfResourceLoader_asyncBeginLoad(tGltfResourceLoader, tFilamentAsset);
           PROXY(callback(result));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_asyncUpdateLoadRenderThread(
       TGltfResourceLoader *tGltfResourceLoader)
   {
+    auto *rt = RT(tGltfResourceLoader);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader);
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_asyncGetLoadProgressRenderThread(
       TGltfResourceLoader *tGltfResourceLoader,
       void (*callback)(float))
   {
+    auto *rt = RT(tGltfResourceLoader);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto result = GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader);
           PROXY(callback(result));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfAssetLoader_loadRenderThread(
@@ -1944,101 +2219,111 @@ extern "C"
       uint32_t numInstances,
       void (*callback)(TFilamentAsset *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto loader = GltfAssetLoader_load(tEngine, tAssetLoader, data, length, numInstances);
-          PROXY(callback(loader));
+
+          g_threadByOwner[loader] = rt;          PROXY(callback(loader));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_addFilamentAssetRenderThread(TScene *tScene, TFilamentAsset *tAsset, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tScene);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Scene_addFilamentAsset(tScene, tAsset);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void FilamentAsset_getWireframeRenderThread(TFilamentAsset *tFilamentAsset, void (*onComplete)(EntityId))
   {
+    auto *rt = RT(tFilamentAsset);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto entityId = FilamentAsset_getWireframe(tFilamentAsset);
           PROXY(onComplete(entityId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_addEntityRenderThread(TScene *tScene, EntityId entityId, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tScene);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Scene_addEntity(tScene, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_removeEntityRenderThread(TScene *tScene, EntityId entityId, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tScene);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Scene_removeEntity(tScene, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_addToSceneRenderThread(TSceneAsset *tSceneAsset, TScene *tScene, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tSceneAsset);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           SceneAsset_addToScene(tSceneAsset, tScene);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_removeFromSceneRenderThread(TSceneAsset *tSceneAsset, TScene *tScene, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tSceneAsset);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           SceneAsset_removeFromScene(tSceneAsset, tScene);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_setSkyboxRenderThread(TScene *tScene, TSkybox *tSkybox, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tScene);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Scene_setSkybox(tScene, tSkybox);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_setIndirectLightRenderThread(TScene *tScene, TIndirectLight *tIndirectLight, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tScene);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           Scene_setIndirectLight(tScene, tIndirectLight);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Gizmo_createRenderThread(
@@ -2051,13 +2336,15 @@ extern "C"
       TGizmoType tGizmoType,
       void (*callback)(TGizmo *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *gizmo = Gizmo_create(tEngine, tAssetLoader, tGltfResourceLoader, tNameComponentManager, tView, tMaterial, tGizmoType);
-          PROXY(callback(gizmo));
+
+          g_threadByOwner[gizmo] = rt;          PROXY(callback(gizmo));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void VertexBufferBuilder_buildRenderThread(
@@ -2065,13 +2352,15 @@ extern "C"
       TEngine *tEngine,
       void (*onComplete)(TVertexBuffer *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *vertexBuffer = VertexBufferBuilder_build(tBuilder, tEngine);
-          PROXY(onComplete(vertexBuffer));
+
+          g_threadByOwner[vertexBuffer] = rt;          PROXY(onComplete(vertexBuffer));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void VertexBuffer_destroyRenderThread(
@@ -2080,13 +2369,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           VertexBuffer_destroy(tEngine, tBuffer);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void VertexBuffer_setBufferAtRenderThread(
@@ -2099,6 +2389,7 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     // Copy data using std::vector to ensure it remains valid after the function returns
     auto *buffer = new std::vector<uint8_t>(sizeInBytes);
     std::copy(static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + sizeInBytes, buffer->begin());
@@ -2123,7 +2414,7 @@ extern "C"
 
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void IndexBufferBuilder_buildRenderThread(
@@ -2131,13 +2422,15 @@ extern "C"
       TEngine *tEngine,
       void (*onComplete)(TIndexBuffer *))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto *indexBuffer = IndexBufferBuilder_build(tBuilder, tEngine);
-          PROXY(onComplete(indexBuffer));
+
+          g_threadByOwner[indexBuffer] = rt;          PROXY(onComplete(indexBuffer));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void IndexBuffer_destroyRenderThread(
@@ -2146,13 +2439,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           IndexBuffer_destroy(tEngine, tBuffer);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void IndexBuffer_setBufferRenderThread(
@@ -2164,6 +2458,7 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tEngine);
     // Copy data using std::vector to ensure it remains valid after the function returns
     auto *buffer = new std::vector<uint8_t>(sizeInBytes);
     std::copy(static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + sizeInBytes, buffer->begin());
@@ -2188,7 +2483,7 @@ extern "C"
 
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableBuilder_buildRenderThread(
@@ -2197,6 +2492,7 @@ extern "C"
       EntityId entityId,
       void (*onComplete)(int))
   {
+    auto *rt = RT(tEngine);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
@@ -2207,29 +2503,31 @@ extern "C"
           auto result = builder->build(*engine, entity);
           PROXY(onComplete(static_cast<int>(result)));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void EntityManager_createEntityRenderThread(TEntityManager *tEntityManager, void (*onComplete)(EntityId))
   {
+    auto *rt = RT(tEntityManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           auto entityId = EntityManager_createEntity(tEntityManager);
           PROXY(onComplete(entityId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void EntityManager_destroyEntityRenderThread(TEntityManager *tEntityManager, EntityId entityId, uint32_t requestId, VoidCallback onComplete)
   {
+    auto *rt = RT(tEntityManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           EntityManager_destroyEntity(tEntityManager, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TransformManager_setTransformRenderThread(
@@ -2239,13 +2537,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tTransformManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TransformManager_setTransform(tTransformManager, entityId, transform);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TransformManager_setParentRenderThread(
@@ -2256,13 +2555,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tTransformManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TransformManager_setParent(tTransformManager, child, parent, preserveScaling);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TransformManager_createComponentRenderThread(
@@ -2271,13 +2571,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tTransformManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TransformManager_createComponent(tTransformManager, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TransformManager_removeComponentRenderThread(
@@ -2286,13 +2587,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tTransformManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           TransformManager_removeComponent(tTransformManager, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableManager_destroyEntityRenderThread(
@@ -2301,13 +2603,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderableManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           RenderableManager_destroyEntity(tRenderableManager, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableManager_setBonesFromMat4RenderThread(
@@ -2319,13 +2622,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderableManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           RenderableManager_setBonesFromMat4(tRenderableManager, entityId, transforms, boneCount, offset);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableManager_setBonesFromBoneRenderThread(
@@ -2337,13 +2641,14 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete)
   {
+    auto *rt = RT(tRenderableManager);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
           RenderableManager_setBonesFromBone(tRenderableManager, entityId, bones, boneCount, offset);
           PROXY(onComplete(requestId));
         });
-    auto fut = _renderThread->addTask(lambda);
+    auto fut = rt->addTask(lambda);
   }
 
 }

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <functional>
 #include <mutex>
+#include <shared_mutex>
 #include <thread>
 #include <stdlib.h>
 #include <vector>
@@ -76,6 +77,16 @@ extern "C"
   std::unordered_map<void *, std::unique_ptr<RenderThread>> _renderThreads;
   RenderThread *g_activeThread = nullptr;
 
+  // g_threadByOwner is written from RenderThread worker tasks (object
+  // creation registers the new handle on the thread that produced it — see
+  // the ~60 `setOwner(...)` sites below) and read from the Dart thread on
+  // every dispatch via RT(). std::unordered_map is not concurrency-safe: an
+  // unsynchronized find() racing an insert that triggers a rehash on the
+  // worker returns garbage, which surfaced as intermittent SEGVs inside
+  // addTask() (the dispatch dereferenced a wild pointer). Every access goes
+  // through g_ownerMutex.
+  std::shared_mutex g_ownerMutex;
+
   // Resolve the thread for a dispatch. `owner` is the engine/manager/view/
   // ... handle the operation targets; nullptr means "creation-time task" —
   // the most recently created thread, which is the one the Dart side just
@@ -84,6 +95,7 @@ extern "C"
   {
     if (owner != nullptr)
     {
+      std::shared_lock<std::shared_mutex> lock(g_ownerMutex);
       auto it = g_threadByOwner.find(owner);
       if (it != g_threadByOwner.end())
       {
@@ -97,6 +109,18 @@ extern "C"
     return _renderThread.get();
   }
 
+  // Record that `owner` belongs to `rt`. Called from worker-thread creation
+  // tasks and from the Dart thread; always under the exclusive lock.
+  static void setOwner(void *owner, RenderThread *rt)
+  {
+    if (owner == nullptr || rt == nullptr)
+    {
+      return;
+    }
+    std::lock_guard<std::shared_mutex> lock(g_ownerMutex);
+    g_threadByOwner[owner] = rt;
+  }
+
   // Record that `owner` (created on the main thread via a direct-API getter,
   // e.g. Engine_getTransformManager) belongs to the thread of `knownOwner`
   // (an engine-scoped handle already in the registry).
@@ -106,7 +130,22 @@ extern "C"
     {
       return;
     }
-    g_threadByOwner[owner] = RT(knownOwner);
+    RenderThread *rt;
+    {
+      std::shared_lock<std::shared_mutex> lock(g_ownerMutex);
+      auto it = g_threadByOwner.find(knownOwner);
+      rt = (it != g_threadByOwner.end()) ? it->second : nullptr;
+    }
+    // Preserve RT()'s fallback semantics for an unregistered knownOwner.
+    if (rt == nullptr)
+    {
+      rt = g_activeThread != nullptr ? g_activeThread : _renderThread.get();
+    }
+    if (rt == nullptr)
+    {
+      return;
+    }
+    setOwner(owner, rt);
   }
 
   EMSCRIPTEN_KEEPALIVE void* RenderThread_create()
@@ -145,6 +184,23 @@ extern "C"
     {
       g_activeThread = nullptr;
     }
+    // Drop owner registrations that still point at the destroyed thread. The
+    // handles themselves are tearing down, and leaving stale entries means a
+    // recycled handle address could later resolve to freed memory via RT().
+    {
+      std::lock_guard<std::shared_mutex> lock(g_ownerMutex);
+      for (auto it = g_threadByOwner.begin(); it != g_threadByOwner.end();)
+      {
+        if (it->second == renderThread)
+        {
+          it = g_threadByOwner.erase(it);
+        }
+        else
+        {
+          ++it;
+        }
+      }
+    }
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderThread_addTask(void (*task)())
@@ -161,13 +217,18 @@ extern "C"
   EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderManager)
   {
 #ifdef __EMSCRIPTEN__
-    if (!_renderThread && g_threadByOwner.empty()) {
+    bool ownersEmpty;
+    {
+      std::shared_lock<std::shared_mutex> lock(g_ownerMutex);
+      ownersEmpty = g_threadByOwner.empty();
+    }
+    if (!_renderThread && ownersEmpty) {
       Log("WARNING - RenderManager_attachToRenderThread called with no RenderThread active.");
       return;
     }
     auto *rm = reinterpret_cast<RenderManager *>(tRenderManager);
     auto *rt = RT(tRenderManager);
-    g_threadByOwner[tRenderManager] = rt;
+    setOwner(tRenderManager, rt);
     rt->setRenderManager(rm);
 #else
     (void)tRenderManager; // no-op on native
@@ -184,7 +245,10 @@ extern "C"
     if (rt) {
       rt->setRenderManager(nullptr);
     }
-    g_threadByOwner.erase(tRenderManager);
+    {
+      std::lock_guard<std::shared_mutex> lock(g_ownerMutex);
+      g_threadByOwner.erase(tRenderManager);
+    }
 #else
     (void)tRenderManager; // no-op on native
 #endif
@@ -295,7 +359,7 @@ extern "C"
         {
           auto *engine = Engine_create(backend, platform, sharedContext, stereoscopicEyeCount, disableHandleUseAfterFreeCheck);
 
-          g_threadByOwner[engine] = rt;          PROXY(onComplete(engine));
+          setOwner(engine, rt);          PROXY(onComplete(engine));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -309,7 +373,7 @@ extern "C"
         {
           auto *renderer = Engine_createRenderer(tEngine);
 
-          g_threadByOwner[renderer] = rt;          PROXY(onComplete(renderer));
+          setOwner(renderer, rt);          PROXY(onComplete(renderer));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -394,7 +458,7 @@ extern "C"
         {
           auto camera = Engine_createCamera(tEngine, entityId);
 
-          g_threadByOwner[camera] = rt;          PROXY(onComplete(camera));
+          setOwner(camera, rt);          PROXY(onComplete(camera));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -419,7 +483,7 @@ extern "C"
         {
           auto *view = Engine_createView(tEngine);
 
-          g_threadByOwner[view] = rt;          PROXY(onComplete(view));
+          setOwner(view, rt);          PROXY(onComplete(view));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -480,7 +544,7 @@ extern "C"
         {
           auto material = Engine_buildMaterial(tEngine, materialData, length);
 
-          g_threadByOwner[material] = rt;          PROXY(onComplete(material));
+          setOwner(material, rt);          PROXY(onComplete(material));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -517,7 +581,7 @@ extern "C"
         {
           auto *fence = Engine_createFence(tEngine);
 
-          g_threadByOwner[fence] = rt;          PROXY(onComplete(fence));
+          setOwner(fence, rt);          PROXY(onComplete(fence));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -736,7 +800,7 @@ extern "C"
         {
           auto *instance = Material_createImageMaterial(tEngine);
 
-          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
+          setOwner(instance, rt);          PROXY(onComplete(instance));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -749,7 +813,7 @@ extern "C"
         {
           auto *instance = Material_createGizmoMaterial(tEngine);
 
-          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
+          setOwner(instance, rt);          PROXY(onComplete(instance));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -762,7 +826,7 @@ extern "C"
         {
           auto *instance = Material_createSilhouetteMaterial(tEngine);
 
-          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
+          setOwner(instance, rt);          PROXY(onComplete(instance));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -775,7 +839,7 @@ extern "C"
         {
           auto *instance = Material_createEdgeOutlineMaterial(tEngine);
 
-          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
+          setOwner(instance, rt);          PROXY(onComplete(instance));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -788,7 +852,7 @@ extern "C"
         {
           auto *instance = Material_createWireframeMaterial(tEngine);
 
-          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
+          setOwner(instance, rt);          PROXY(onComplete(instance));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -801,7 +865,7 @@ extern "C"
         {
           auto *instance = Material_createTranslationAxisMaterial(tEngine);
 
-          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
+          setOwner(instance, rt);          PROXY(onComplete(instance));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -814,7 +878,7 @@ extern "C"
         {
           auto *instance = Material_createBoneOverlayMaterial(tEngine);
 
-          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
+          setOwner(instance, rt);          PROXY(onComplete(instance));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -827,7 +891,7 @@ extern "C"
         {
           auto *instance = Material_createInstance(tMaterial);
 
-          g_threadByOwner[instance] = rt;          PROXY(onComplete(instance));
+          setOwner(instance, rt);          PROXY(onComplete(instance));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -877,7 +941,7 @@ extern "C"
         {
           auto sceneAsset = SceneAsset_createFromFilamentAsset(tEngine, tAssetLoader, tNameComponentManager, tFilamentAsset, rebuildVertices);
 
-          g_threadByOwner[sceneAsset] = rt;          PROXY(onComplete(sceneAsset));
+          setOwner(sceneAsset, rt);          PROXY(onComplete(sceneAsset));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -898,7 +962,7 @@ extern "C"
         {
           auto sceneAsset = SceneAsset_createFromBuffers(tEngine, tVertexBuffer, tIndexBuffer, materialInstances, materialInstanceCount, tPrimitiveType, boundingBox);
 
-          g_threadByOwner[sceneAsset] = rt;          PROXY(callback(sceneAsset));
+          setOwner(sceneAsset, rt);          PROXY(callback(sceneAsset));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -914,7 +978,7 @@ extern "C"
         {
           auto instanceAsset = SceneAsset_createInstance(asset, tMaterialInstances, materialInstanceCount);
 
-          g_threadByOwner[instanceAsset] = rt;          PROXY(callback(instanceAsset));
+          setOwner(instanceAsset, rt);          PROXY(callback(instanceAsset));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1044,7 +1108,7 @@ extern "C"
         {
           auto cg = ColorGrading_create(tEngine, toneMapper);
 
-          g_threadByOwner[cg] = rt;          PROXY(callback(cg));
+          setOwner(cg, rt);          PROXY(callback(cg));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1057,7 +1121,7 @@ extern "C"
         {
           auto *builder = ColorGradingBuilder_create();
 
-          g_threadByOwner[builder] = rt;          PROXY(onComplete(builder));
+          setOwner(builder, rt);          PROXY(onComplete(builder));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1094,7 +1158,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createLinear(tEngine);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1107,7 +1171,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createACES(tEngine);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1120,7 +1184,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createACESLegacy(tEngine);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1133,7 +1197,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createFilmic(tEngine);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1146,7 +1210,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createPBRNeutral(tEngine);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1159,7 +1223,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createAGX(tEngine);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1172,7 +1236,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createAGXWithLook(tEngine, look);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1185,7 +1249,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createGeneric(tEngine, contrast, midGrayIn, midGrayOut, hdrMax);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1198,7 +1262,7 @@ extern "C"
         {
           auto *toneMapper = ToneMapper_createDisplayRange(tEngine);
 
-          g_threadByOwner[toneMapper] = rt;          PROXY(onComplete(toneMapper));
+          setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1542,7 +1606,7 @@ extern "C"
         {
           auto *animationManager = AnimationManager_create(tEngine);
 
-          g_threadByOwner[animationManager] = rt;          PROXY(onComplete(animationManager));
+          setOwner(animationManager, rt);          PROXY(onComplete(animationManager));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1610,7 +1674,7 @@ extern "C"
         {
           auto image = Image_createEmpty(width, height, channel);
 
-          g_threadByOwner[image] = rt;          PROXY(onComplete(image));
+          setOwner(image, rt);          PROXY(onComplete(image));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1623,7 +1687,7 @@ extern "C"
         {
           auto image = Image_decode(data, length, name, alpha);
 
-          g_threadByOwner[image] = rt;          PROXY(onComplete(image));
+          setOwner(image, rt);          PROXY(onComplete(image));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1705,7 +1769,7 @@ extern "C"
         {
           auto *texture = Texture_build(tEngine, width, height, depth, levels, tUsage, import, sampler, format);
 
-          g_threadByOwner[texture] = rt;          PROXY(onComplete(texture));
+          setOwner(texture, rt);          PROXY(onComplete(texture));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1763,7 +1827,7 @@ extern "C"
         [tEngine, bytes = std::move(bytes), onComplete, rt]() mutable
         {
           auto *texture = Ktx2Reader_createTexture(tEngine, bytes.data(), bytes.size());
-          g_threadByOwner[texture] = rt;
+          setOwner(texture, rt);
           PROXY(onComplete(texture));
         });
     auto fut = rt->addTask(lambda);
@@ -1788,7 +1852,7 @@ extern "C"
           #else
             auto *texture = Ktx1Reader_createTexture(tEngine, tBundle, requestId, onTextureUploadComplete);
           #endif
-          g_threadByOwner[texture] = rt;
+          setOwner(texture, rt);
           PROXY(onComplete(texture));
         });
     auto fut = rt->addTask(lambda);
@@ -1876,7 +1940,7 @@ extern "C"
         {
           auto texture = RenderTarget_create(tEngine, tColor, tDepth);
 
-          g_threadByOwner[texture] = rt;          PROXY(onComplete(texture));
+          setOwner(texture, rt);          PROXY(onComplete(texture));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1904,7 +1968,7 @@ extern "C"
         {
           auto sampler = TextureSampler_create();
 
-          g_threadByOwner[sampler] = rt;          PROXY(onComplete(sampler));
+          setOwner(sampler, rt);          PROXY(onComplete(sampler));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1923,7 +1987,7 @@ extern "C"
         {
           auto sampler = TextureSampler_createWithFiltering(minFilter, magFilter, wrapS, wrapT, wrapR);
 
-          g_threadByOwner[sampler] = rt;          PROXY(onComplete(sampler));
+          setOwner(sampler, rt);          PROXY(onComplete(sampler));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -1939,7 +2003,7 @@ extern "C"
         {
           auto sampler = TextureSampler_createWithComparison(compareMode, compareFunc);
 
-          g_threadByOwner[sampler] = rt;          PROXY(onComplete(sampler));
+          setOwner(sampler, rt);          PROXY(onComplete(sampler));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -2076,7 +2140,7 @@ extern "C"
       {
         auto loader = GltfAssetLoader_create(tEngine, tMaterialProvider, tNameComponentManager);
 
-          g_threadByOwner[loader] = rt;        PROXY(callback(loader));
+          setOwner(loader, rt);        PROXY(callback(loader));
       });
     auto fut = rt->addTask(lambda);
   }
@@ -2103,7 +2167,7 @@ extern "C"
       {
         auto loader = GltfResourceLoader_create(tEngine);
 
-          g_threadByOwner[loader] = rt;        PROXY(callback(loader));
+          setOwner(loader, rt);        PROXY(callback(loader));
       });
     auto fut = rt->addTask(lambda);
   }
@@ -2205,7 +2269,7 @@ extern "C"
         {
           auto loader = GltfAssetLoader_load(tEngine, tAssetLoader, data, length, numInstances);
 
-          g_threadByOwner[loader] = rt;          PROXY(callback(loader));
+          setOwner(loader, rt);          PROXY(callback(loader));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -2322,7 +2386,7 @@ extern "C"
         {
           auto *gizmo = Gizmo_create(tEngine, tAssetLoader, tGltfResourceLoader, tNameComponentManager, tView, tMaterial, tGizmoType);
 
-          g_threadByOwner[gizmo] = rt;          PROXY(callback(gizmo));
+          setOwner(gizmo, rt);          PROXY(callback(gizmo));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -2338,7 +2402,7 @@ extern "C"
         {
           auto *vertexBuffer = VertexBufferBuilder_build(tBuilder, tEngine);
 
-          g_threadByOwner[vertexBuffer] = rt;          PROXY(onComplete(vertexBuffer));
+          setOwner(vertexBuffer, rt);          PROXY(onComplete(vertexBuffer));
         });
     auto fut = rt->addTask(lambda);
   }
@@ -2408,7 +2472,7 @@ extern "C"
         {
           auto *indexBuffer = IndexBufferBuilder_build(tBuilder, tEngine);
 
-          g_threadByOwner[indexBuffer] = rt;          PROXY(onComplete(indexBuffer));
+          setOwner(indexBuffer, rt);          PROXY(onComplete(indexBuffer));
         });
     auto fut = rt->addTask(lambda);
   }

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -121,6 +121,30 @@ extern "C"
     g_threadByOwner[owner] = rt;
   }
 
+  // Remove every owner registration that maps to `rt`. Call AFTER the thread's
+  // worker has been joined (otherwise an in-flight creation task on that worker
+  // could re-add an entry pointing at the about-to-be-freed RenderThread, and a
+  // recycled handle address would later resolve to freed memory via RT()).
+  static void unregisterOwnersOf(void *rt)
+  {
+    if (rt == nullptr)
+    {
+      return;
+    }
+    std::lock_guard<std::shared_mutex> lock(g_ownerMutex);
+    for (auto it = g_threadByOwner.begin(); it != g_threadByOwner.end();)
+    {
+      if (it->second == rt)
+      {
+        it = g_threadByOwner.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+  }
+
   // Record that `owner` (created on the main thread via a direct-API getter,
   // e.g. Engine_getTransformManager) belongs to the thread of `knownOwner`
   // (an engine-scoped handle already in the registry).
@@ -151,11 +175,20 @@ extern "C"
   EMSCRIPTEN_KEEPALIVE void* RenderThread_create()
   {
     TRACE("RenderThread_create");
-    if (_renderThread)
+    RenderThread *stale = _renderThread ? _renderThread.get() : nullptr;
+    if (stale != nullptr)
     {
       Log("WARNING - you are attempting to create a RenderThread when the previous one has not been disposed.");
     }
     _renderThread = std::make_unique<RenderThread>();
+    // The assignment above destroyed the previous RenderThread (and joined its
+    // worker). Sweep stale owner registrations AFTER the join — the dying
+    // worker's last creation task can't then re-add an entry pointing at freed
+    // memory, and a recycled handle address can't resolve to it via RT().
+    if (stale != nullptr)
+    {
+      unregisterOwnersOf(stale);
+    }
     g_activeThread = _renderThread.get();
     TRACE("RenderThread created");
     return _renderThread.get();
@@ -184,23 +217,10 @@ extern "C"
     {
       g_activeThread = nullptr;
     }
-    // Drop owner registrations that still point at the destroyed thread. The
-    // handles themselves are tearing down, and leaving stale entries means a
-    // recycled handle address could later resolve to freed memory via RT().
-    {
-      std::lock_guard<std::shared_mutex> lock(g_ownerMutex);
-      for (auto it = g_threadByOwner.begin(); it != g_threadByOwner.end();)
-      {
-        if (it->second == renderThread)
-        {
-          it = g_threadByOwner.erase(it);
-        }
-        else
-        {
-          ++it;
-        }
-      }
-    }
+    // _renderThread = nullptr / _renderThreads.erase above already destroyed
+    // the RenderThread (and joined its worker), so it's safe to drop any owner
+    // registrations that still point at it.
+    unregisterOwnersOf(renderThread);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderThread_addTask(void (*task)())

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -109,15 +109,6 @@ extern "C"
     g_threadByOwner[owner] = RT(knownOwner);
   }
 
-  // Web-only: the CSS selector of the canvas owned by the most recently
-  // created RenderThread, used by Engine_create to create the WebGL context
-  // on the right canvas.
-  EMSCRIPTEN_KEEPALIVE const char *RenderThread_getActiveCanvasSelector()
-  {
-    RenderThread *rt = g_activeThread != nullptr ? g_activeThread : _renderThread.get();
-    return rt != nullptr ? rt->canvasSelector() : "#thermion_canvas";
-  }
-
   EMSCRIPTEN_KEEPALIVE void* RenderThread_create()
   {
     TRACE("RenderThread_create");
@@ -129,17 +120,6 @@ extern "C"
     g_activeThread = _renderThread.get();
     TRACE("RenderThread created");
     return _renderThread.get();
-  }
-
-  EMSCRIPTEN_KEEPALIVE void* RenderThread_createForCanvas(const char *canvasSelector)
-  {
-    TRACE("RenderThread_createForCanvas %s", canvasSelector);
-    auto thread = std::make_unique<RenderThread>(canvasSelector);
-    auto *raw = thread.get();
-    g_activeThread = raw;
-    _renderThreads[raw] = std::move(thread);
-    TRACE("RenderThread created for canvas %s", canvasSelector);
-    return raw;
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderThread_destroy(void *renderThread)

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -73,8 +73,7 @@ static void *startHelper(void * parm) {
 
 #endif
 
-RenderThread::RenderThread(const char *canvasSelector)
-    : _canvasSelector(canvasSelector != nullptr ? canvasSelector : "#thermion_canvas")
+RenderThread::RenderThread()
 {
     srand(time(NULL));
     _lastFrameTime = std::chrono::high_resolution_clock::now();
@@ -83,7 +82,7 @@ RenderThread::RenderThread(const char *canvasSelector)
     outer = pthread_self();
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    emscripten_pthread_attr_settransferredcanvases(&attr, canvasSelector);
+    emscripten_pthread_attr_settransferredcanvases(&attr, "#thermion_canvas");
     auto *workerArg = new WorkerArg{this, _stop};
     pthread_create(&t, &attr, startHelper, workerArg);
     #else

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -10,7 +10,6 @@
 
 namespace thermion {
 
-std::atomic<bool> RenderThread::mStop{false};
 std::atomic<int32_t> RenderThread::mLiveWorkerCount{0};
 
 #ifdef __EMSCRIPTEN__
@@ -28,11 +27,22 @@ std::chrono::high_resolution_clock::time_point loopStart;
 std::chrono::high_resolution_clock::time_point loopExitTime;
 bool loopExitTimeValid = false;
 
+// Heap arg for the worker: owns a shared_ptr copy of the stop flag so the
+// flag outlives the RenderThread (web detach lets the destructor return
+// before the worker's next iteration). The worker frees this struct itself
+// on exit — the destructor never touches it.
+struct WorkerArg {
+    RenderThread *rt;
+    std::shared_ptr<RenderThread::StopFlag> stop;
+};
+
 static void mainLoop(void* arg) {
-    // Check the stop flag BEFORE touching `arg` — the destructor may have
-    // returned (via pthread_detach) and `*this` may already be freed. mStop
-    // is a static, so the read is safe regardless.
-    if (RenderThread::mStop.load()) {
+    // Check the stop flag BEFORE touching `rt` — the destructor may have
+    // returned (via pthread_detach) and `*this` may already be freed. The
+    // flag is heap-shared, so the read is safe; the worker never dereferences
+    // the RenderThread after observing stop.
+    auto *workerArg = static_cast<WorkerArg *>(arg);
+    if (workerArg->stop->value.load()) {
         emscripten_cancel_main_loop();
         loopExitTime = std::chrono::high_resolution_clock::now();
         loopExitTimeValid = true;
@@ -44,10 +54,11 @@ static void mainLoop(void* arg) {
         // to unwind startHelper, so the pthread function never returned. The
         // JS-side worker would otherwise stay alive in the event loop after
         // emscripten_cancel_main_loop; explicit pthread_exit terminates it.
+        delete workerArg;
         pthread_exit(nullptr);
     }
 
-    auto *rt = static_cast<RenderThread *>(arg);
+    auto *rt = workerArg->rt;
     rt->iter();
     loopExitTime = std::chrono::high_resolution_clock::now();
     loopExitTimeValid = true;
@@ -62,22 +73,19 @@ static void *startHelper(void * parm) {
 
 #endif
 
-RenderThread::RenderThread()
+RenderThread::RenderThread(const char *canvasSelector)
+    : _canvasSelector(canvasSelector != nullptr ? canvasSelector : "#thermion_canvas")
 {
     srand(time(NULL));
     _lastFrameTime = std::chrono::high_resolution_clock::now();
-    // Reset the static stop flag so the new worker doesn't immediately exit
-    // if the previous cycle left it true. On web the caller must have waited
-    // for mLiveWorkerCount to hit 0 before getting here, otherwise the previous
-    // worker can observe this reset and miss its stop signal.
-    mStop.store(false);
     #ifdef __EMSCRIPTEN__
     Log("Starting RenderThread")
     outer = pthread_self();
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    emscripten_pthread_attr_settransferredcanvases(&attr, "#thermion_canvas");
-    pthread_create(&t, &attr, startHelper, this);
+    emscripten_pthread_attr_settransferredcanvases(&attr, canvasSelector);
+    auto *workerArg = new WorkerArg{this, _stop};
+    pthread_create(&t, &attr, startHelper, workerArg);
     #else
     t = new std::thread([this]() { runNativeLoop(); });
     #endif
@@ -93,7 +101,7 @@ RenderThread::~RenderThread()
         pendingTaskCount = _tasks.size();
     }
     TRACE("Destroying RenderThread (%zu tasks remaining)", pendingTaskCount);
-    mStop.store(true, std::memory_order_release);
+    _stop->value.store(true, std::memory_order_release);
 
     #ifdef __EMSCRIPTEN__
     // The web worker cannot be synchronously joined from the browser main
@@ -173,13 +181,13 @@ void RenderThread::runNativeLoop() {
     while (true) {
         _cv.wait(taskLock, [this] {
             return !_tasks.empty() ||
-                   mStop.load(std::memory_order_acquire);
+                   _stop->value.load(std::memory_order_acquire);
         });
 
         if (_tasks.empty()) {
             // A stop request only terminates the worker after it has executed
             // every task that was already queued.
-            if (mStop.load(std::memory_order_acquire)) {
+            if (_stop->value.load(std::memory_order_acquire)) {
                 break;
             }
             continue;

--- a/thermion_dart/native/web/include/ThermionWebApi.h
+++ b/thermion_dart/native/web/include/ThermionWebApi.h
@@ -8,10 +8,7 @@ extern "C" {
 
 void Thermion_setCanvasElementSize(const char *name, int width, int height);
 void Thermion_destroyCanvas();
-// Creates a WebGL2 context on the given canvas element (e.g.
-// "#thermion_canvas_0"). Called from Engine_create on the engine's render
-// thread; the canvas must have been transferred to that thread.
-EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_createGLContext(const char *canvasSelector);
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_createGLContext();
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_getGLContext();
 
 

--- a/thermion_dart/native/web/include/ThermionWebApi.h
+++ b/thermion_dart/native/web/include/ThermionWebApi.h
@@ -8,7 +8,10 @@ extern "C" {
 
 void Thermion_setCanvasElementSize(const char *name, int width, int height);
 void Thermion_destroyCanvas();
-EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_createGLContext();
+// Creates a WebGL2 context on the given canvas element (e.g.
+// "#thermion_canvas_0"). Called from Engine_create on the engine's render
+// thread; the canvas must have been transferred to that thread.
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_createGLContext(const char *canvasSelector);
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE Thermion_getGLContext();
 
 

--- a/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
+++ b/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
@@ -50,25 +50,25 @@ extern "C"
     return _context;
   }
 
-  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE EMSCRIPTEN_KEEPALIVE Thermion_createGLContext() {
-    
-    std::cout << "Creating WebGL context." << std::endl;
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE EMSCRIPTEN_KEEPALIVE Thermion_createGLContext(const char *canvasSelector) {
+
+    std::cout << "Creating WebGL context for " << canvasSelector << std::endl;
 
     EmscriptenWebGLContextAttributes attr;
-    
+
     emscripten_webgl_init_context_attributes(&attr);
-    attr.alpha = EM_TRUE; 
-    attr.depth = EM_TRUE;  
-    attr.stencil = EM_TRUE; 
-    attr.antialias = EM_FALSE; 
-    attr.explicitSwapControl = EM_TRUE; 
-    attr.preserveDrawingBuffer = EM_FALSE; 
-    attr.proxyContextToMainThread = EMSCRIPTEN_WEBGL_CONTEXT_PROXY_DISALLOW; 
+    attr.alpha = EM_TRUE;
+    attr.depth = EM_TRUE;
+    attr.stencil = EM_TRUE;
+    attr.antialias = EM_FALSE;
+    attr.explicitSwapControl = EM_TRUE;
+    attr.preserveDrawingBuffer = EM_FALSE;
+    attr.proxyContextToMainThread = EMSCRIPTEN_WEBGL_CONTEXT_PROXY_DISALLOW;
     attr.enableExtensionsByDefault = EM_TRUE;
     attr.renderViaOffscreenBackBuffer = EM_FALSE;
     attr.majorVersion = 2;
-    
-    _context = emscripten_webgl_create_context("#thermion_canvas", &attr);
+
+    _context = emscripten_webgl_create_context(canvasSelector, &attr);
 
     if(!_context) {
       std::cout << "Failed to create WebGL context" << std::endl;  

--- a/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
+++ b/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
@@ -50,9 +50,9 @@ extern "C"
     return _context;
   }
 
-  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE EMSCRIPTEN_KEEPALIVE Thermion_createGLContext(const char *canvasSelector) {
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE EMSCRIPTEN_KEEPALIVE Thermion_createGLContext() {
 
-    std::cout << "Creating WebGL context for " << canvasSelector << std::endl;
+    std::cout << "Creating WebGL context." << std::endl;
 
     EmscriptenWebGLContextAttributes attr;
 
@@ -68,7 +68,7 @@ extern "C"
     attr.renderViaOffscreenBackBuffer = EM_FALSE;
     attr.majorVersion = 2;
 
-    _context = emscripten_webgl_create_context(canvasSelector, &attr);
+    _context = emscripten_webgl_create_context("#thermion_canvas", &attr);
 
     if(!_context) {
       std::cout << "Failed to create WebGL context" << std::endl;  

--- a/thermion_dart/test/color_grading_tests.dart
+++ b/thermion_dart/test/color_grading_tests.dart
@@ -2,6 +2,7 @@
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'helpers.dart';
 
 void main() async {
@@ -15,27 +16,27 @@ void main() async {
   test('all available ToneMappers', () async {
     // Test all available ToneMapper factory methods using ViewerBuilder
     final toneMappers = [
-      () => ToneMapper.linear(),
+      () => ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp),
       'linear',
-      () => ToneMapper.aces(),
+      () => ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp),
       'aces',
-      () => ToneMapper.acesLegacy(),
+      () => ToneMapper.acesLegacy(FilamentApp.instance! as FFIFilamentApp),
       'aces_legacy',
-      () => ToneMapper.filmic(),
+      () => ToneMapper.filmic(FilamentApp.instance! as FFIFilamentApp),
       'filmic',
-      () => ToneMapper.pbrNeutral(),
+      () => ToneMapper.pbrNeutral(FilamentApp.instance! as FFIFilamentApp),
       'pbr_neutral',
-      () => ToneMapper.agx(),
+      () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp),
       'agx_none',
-      () => ToneMapper.agx(look: AgxLook.punchy),
+      () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp, look: AgxLook.punchy),
       'agx_punchy',
-      () => ToneMapper.agx(look: AgxLook.golden),
+      () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp, look: AgxLook.golden),
       'agx_golden',
-      () => ToneMapper.generic(),
+      () => ToneMapper.generic(FilamentApp.instance! as FFIFilamentApp),
       'generic_default',
-      () => ToneMapper.generic(contrast: 2.0),
+      () => ToneMapper.generic(FilamentApp.instance! as FFIFilamentApp, contrast: 2.0),
       'generic_contrast_2_0',
-      () => ToneMapper.displayRange(),
+      () => ToneMapper.displayRange(FilamentApp.instance! as FFIFilamentApp),
       'display_range',
     ];
 
@@ -96,7 +97,7 @@ void main() async {
               .saturation(0.95) // Slight desaturation
               .luminanceScaling(true) // Better HDR handling
               .gamutMapping(true) // Prevent hue shifts
-              .toneMapper(await ToneMapper.aces()) // Add a tone mapper
+              .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp)) // Add a tone mapper
               .shadowsMidtonesHighlights(
                 Vector4(0.8, 0.9, 1.0, 0.5), // Slightly cool shadows
                 Vector4(1.0, 1.0, 1.0, 1.0), // Neutral midtones
@@ -149,7 +150,7 @@ void main() async {
             final colorGrading = await builder
                 .format(format)
                 .dimensions(dim)
-                .toneMapper(await ToneMapper.aces())
+                .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp))
                 .saturation(1.3)
                 .contrast(1.2)
                 .build();
@@ -199,7 +200,7 @@ void main() async {
             final builder = await result.viewer.view
                 .createColorGradingBuilder();
             final colorGrading = await builder
-                .toneMapper(await ToneMapper.linear())
+                .toneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp))
                 .channelMixer(outRed, outGreen, outBlue)
                 .build();
 
@@ -240,7 +241,7 @@ void main() async {
               .exposure(0.5)
               .contrast(1.2)
               .saturation(1.1)
-              .toneMapper(await ToneMapper.aces())
+              .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp))
               .build();
 
           // Apply the color grading to the view

--- a/thermion_dart/test/color_grading_tests.dart
+++ b/thermion_dart/test/color_grading_tests.dart
@@ -28,13 +28,22 @@ void main() async {
       'pbr_neutral',
       () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp),
       'agx_none',
-      () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp, look: AgxLook.punchy),
+      () => ToneMapper.agx(
+        FilamentApp.instance! as FFIFilamentApp,
+        look: AgxLook.punchy,
+      ),
       'agx_punchy',
-      () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp, look: AgxLook.golden),
+      () => ToneMapper.agx(
+        FilamentApp.instance! as FFIFilamentApp,
+        look: AgxLook.golden,
+      ),
       'agx_golden',
       () => ToneMapper.generic(FilamentApp.instance! as FFIFilamentApp),
       'generic_default',
-      () => ToneMapper.generic(FilamentApp.instance! as FFIFilamentApp, contrast: 2.0),
+      () => ToneMapper.generic(
+        FilamentApp.instance! as FFIFilamentApp,
+        contrast: 2.0,
+      ),
       'generic_contrast_2_0',
       () => ToneMapper.displayRange(FilamentApp.instance! as FFIFilamentApp),
       'display_range',
@@ -97,7 +106,9 @@ void main() async {
               .saturation(0.95) // Slight desaturation
               .luminanceScaling(true) // Better HDR handling
               .gamutMapping(true) // Prevent hue shifts
-              .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp)) // Add a tone mapper
+              .toneMapper(
+                await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp),
+              ) // Add a tone mapper
               .shadowsMidtonesHighlights(
                 Vector4(0.8, 0.9, 1.0, 0.5), // Slightly cool shadows
                 Vector4(1.0, 1.0, 1.0, 1.0), // Neutral midtones
@@ -150,7 +161,11 @@ void main() async {
             final colorGrading = await builder
                 .format(format)
                 .dimensions(dim)
-                .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp))
+                .toneMapper(
+                  await ToneMapper.aces(
+                    FilamentApp.instance! as FFIFilamentApp,
+                  ),
+                )
                 .saturation(1.3)
                 .contrast(1.2)
                 .build();
@@ -200,7 +215,11 @@ void main() async {
             final builder = await result.viewer.view
                 .createColorGradingBuilder();
             final colorGrading = await builder
-                .toneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp))
+                .toneMapper(
+                  await ToneMapper.linear(
+                    FilamentApp.instance! as FFIFilamentApp,
+                  ),
+                )
                 .channelMixer(outRed, outGreen, outBlue)
                 .build();
 
@@ -241,7 +260,9 @@ void main() async {
               .exposure(0.5)
               .contrast(1.2)
               .saturation(1.1)
-              .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp))
+              .toneMapper(
+                await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp),
+              )
               .build();
 
           // Apply the color grading to the view

--- a/thermion_dart/test/engine_tests.html
+++ b/thermion_dart/test/engine_tests.html
@@ -2,15 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>engine_tests</title>
+    <title>engine_tests.dart</title>
 
-    <!-- emscripten Filament module factory (built by `make wasm`, copied here). -->
+    <!-- emscripten Filament module factory (built by `make wasm`, copied to test/). -->
     <script src="thermion_dart.js"></script>
 
     <!-- Standard package:test bootstrap. These must be STATIC scripts: dart.js
-         locates itself via document.currentScript to find the compiled test, so
-         it cannot be injected dynamically. Ordering with the WASM module is
-         handled on the Dart side: initTestBindings() awaits globalThis.__thermionReady. -->
+         locates itself via document.currentScript to find the compiled test. -->
     <link rel="x-dart-test" href="engine_tests.dart" />
     <script src="packages/test/dart.js"></script>
 
@@ -20,23 +18,15 @@
   </head>
   <body>
     <!-- The pthreads build transfers this canvas as an OffscreenCanvas to the
-         render-thread worker; emscripten's OFFSCREENCANVASES_TO_PTHREAD targets
-         the id "thermion_canvas", so it must match exactly. -->
+         render-thread worker; the id must match exactly. -->
     <canvas id="thermion_canvas" width="512" height="512"></canvas>
 
     <script>
       // Kick off module init now that the canvas exists, and publish a readiness
-      // promise the Dart side awaits before touching the bindings.
+      // promise the Dart side awaits (initTestBindings) before touching bindings.
       globalThis.__thermionReady = thermion_dart()
-        .then(function (module) {
-          globalThis.thermion_dart = module;
-          console.log(
-            "[coi-diag] module ready; crossOriginIsolated=" +
-              self.crossOriginIsolated);
-        })
-        .catch(function (err) {
-          console.error("[coi-diag] module init failed:", err);
-        });
+        .then(function (module) { globalThis.thermion_dart = module; })
+        .catch(function (err) { console.error("[coi-diag] module init failed:", err); });
     </script>
   </body>
 </html>

--- a/thermion_dart/test/helpers.dart
+++ b/thermion_dart/test/helpers.dart
@@ -357,7 +357,9 @@ class TestHelper {
 
     await viewer.setPostProcessing(postProcessing);
 
-    await viewer.setToneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp));
+    await viewer.setToneMapper(
+      await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp),
+    );
     return (viewer, swapChain);
   }
 

--- a/thermion_dart/test/helpers.dart
+++ b/thermion_dart/test/helpers.dart
@@ -302,7 +302,7 @@ class TestHelper {
               as FFIRenderTarget;
     }
 
-    var viewer = ThermionViewerFFI();
+    var viewer = ThermionViewerFFI(app: FilamentApp.instance as FFIFilamentApp);
     await viewer.initialized;
     await FilamentApp.instance!.renderManager.attach(viewer.view, swapChain);
 
@@ -357,7 +357,7 @@ class TestHelper {
 
     await viewer.setPostProcessing(postProcessing);
 
-    await viewer.setToneMapper(await ToneMapper.aces());
+    await viewer.setToneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp));
     return (viewer, swapChain);
   }
 

--- a/thermion_dart/test/image_tests.dart
+++ b/thermion_dart/test/image_tests.dart
@@ -15,7 +15,10 @@ void main() async {
       final ktx1Data = File(
         "${testHelper.assetsDir}/default_env_skybox.ktx",
       ).readAsBytesSync();
-      final bundle = await FFIKtx1Bundle.create(FilamentApp.instance! as FFIFilamentApp, ktx1Data);
+      final bundle = await FFIKtx1Bundle.create(
+        FilamentApp.instance! as FFIFilamentApp,
+        ktx1Data,
+      );
     });
   });
 

--- a/thermion_dart/test/image_tests.dart
+++ b/thermion_dart/test/image_tests.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:test/test.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_ktx1_bundle.dart';
 import 'package:thermion_dart/src/utils/src/geometry/utils.dart';
 import 'package:thermion_dart/src/viewer/viewer.dart';
@@ -14,7 +15,7 @@ void main() async {
       final ktx1Data = File(
         "${testHelper.assetsDir}/default_env_skybox.ktx",
       ).readAsBytesSync();
-      final bundle = await FFIKtx1Bundle.create(ktx1Data);
+      final bundle = await FFIKtx1Bundle.create(FilamentApp.instance! as FFIFilamentApp, ktx1Data);
     });
   });
 

--- a/thermion_dart/test/light_tests.dart
+++ b/thermion_dart/test/light_tests.dart
@@ -65,7 +65,8 @@ void main() async {
             PixelDataType.FLOAT,
           );
 
-          var indirectLight = await FFIIndirectLight.fromIrradianceTexture(FilamentApp.instance! as FFIFilamentApp, 
+          var indirectLight = await FFIIndirectLight.fromIrradianceTexture(
+            FilamentApp.instance! as FFIFilamentApp,
             texture,
             reflectionsTexture: texture,
             intensity: 30000.0,

--- a/thermion_dart/test/light_tests.dart
+++ b/thermion_dart/test/light_tests.dart
@@ -1,6 +1,7 @@
 import 'package:thermion_dart/src/filament/src/implementation/ffi_indirect_light.dart';
 import 'package:test/test.dart';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'helpers.dart';
 
 void main() async {
@@ -64,7 +65,7 @@ void main() async {
             PixelDataType.FLOAT,
           );
 
-          var indirectLight = await FFIIndirectLight.fromIrradianceTexture(
+          var indirectLight = await FFIIndirectLight.fromIrradianceTexture(FilamentApp.instance! as FFIFilamentApp, 
             texture,
             reflectionsTexture: texture,
             intensity: 30000.0,

--- a/thermion_dart/test/unlit_material_tests.dart
+++ b/thermion_dart/test/unlit_material_tests.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:test/test.dart';
 import 'helpers.dart';
 
@@ -59,7 +60,7 @@ void main() async {
   test('unlit + baseColorFactor', () async {
     await testHelper.withViewer((viewer) async {
       await viewer.setPostProcessing(true);
-      await viewer.setToneMapper(await ToneMapper.linear());
+      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp));
 
       var materialInstance = await FilamentApp.instance!
           .createUnlitMaterialInstance();
@@ -302,7 +303,7 @@ void main() async {
   test('unlit material with color + alpha', () async {
     await testHelper.withViewer((viewer) async {
       await viewer.setPostProcessing(true);
-      await viewer.setToneMapper(await ToneMapper.linear());
+      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp));
 
       var materialInstance = await FilamentApp.instance!
           .createUnlitMaterialInstance();
@@ -334,7 +335,7 @@ void main() async {
     await viewer.setCameraPosition(0, 0, 6);
     await viewer.setBackgroundColor(1.0, 0.0, 0.0, 1.0);
     await viewer.setPostProcessing(true);
-    await viewer.setToneMapper(await ToneMapper.linear());
+    await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp));
 
     var materialInstance = await viewer.createUnlitFixedSizeMaterialInstance();
     var cube = await viewer.createGeometry(

--- a/thermion_dart/test/unlit_material_tests.dart
+++ b/thermion_dart/test/unlit_material_tests.dart
@@ -60,7 +60,9 @@ void main() async {
   test('unlit + baseColorFactor', () async {
     await testHelper.withViewer((viewer) async {
       await viewer.setPostProcessing(true);
-      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp));
+      await viewer.setToneMapper(
+        await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp),
+      );
 
       var materialInstance = await FilamentApp.instance!
           .createUnlitMaterialInstance();
@@ -303,7 +305,9 @@ void main() async {
   test('unlit material with color + alpha', () async {
     await testHelper.withViewer((viewer) async {
       await viewer.setPostProcessing(true);
-      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp));
+      await viewer.setToneMapper(
+        await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp),
+      );
 
       var materialInstance = await FilamentApp.instance!
           .createUnlitMaterialInstance();

--- a/thermion_flutter/thermion_flutter/lib/src/swift/swift_bindings.g.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/swift/swift_bindings.g.dart
@@ -7,40 +7,56 @@ import 'dart:ffi' as ffi;
 import 'package:objective_c/objective_c.dart' as objc;
 
 @ffi.Native<
-    ffi.Pointer<objc.ObjCObject> Function(
-        ffi.Pointer<objc.ObjCObject>, ffi.Pointer<ffi.Void>)>()
+  ffi.Pointer<objc.ObjCObject> Function(
+    ffi.Pointer<objc.ObjCObject>,
+    ffi.Pointer<ffi.Void>,
+  )
+>()
 external ffi.Pointer<objc.ObjCObject>
-    _SwiftThermionFlutterPluginObjCAPI_protocolTrampoline_1mbt9g9(
+_SwiftThermionFlutterPluginObjCAPI_protocolTrampoline_1mbt9g9(
   ffi.Pointer<objc.ObjCObject> target,
   ffi.Pointer<ffi.Void> arg0,
 );
 
-late final _class_FlutterMetalTextureWrapper =
-    objc.getClass("thermion_flutter.FlutterMetalTextureWrapper");
+late final _class_FlutterMetalTextureWrapper = objc.getClass(
+  "thermion_flutter.FlutterMetalTextureWrapper",
+);
 late final _sel_isKindOfClass_ = objc.registerName("isKindOfClass:");
 final _objc_msgSend_19nvye5 = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Bool Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject>)>>()
+      ffi.NativeFunction<
+        ffi.Bool Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+          ffi.Pointer<objc.ObjCObject>,
+        )
+      >
+    >()
     .asFunction<
-        bool Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
+      bool Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+        ffi.Pointer<objc.ObjCObject>,
+      )
+    >();
 typedef instancetype = ffi.Pointer<objc.ObjCObject>;
 typedef Dartinstancetype = objc.ObjCObjectBase;
-late final _class_MetalTextureWrapper =
-    objc.getClass("thermion_flutter.MetalTextureWrapper");
+late final _class_MetalTextureWrapper = objc.getClass(
+  "thermion_flutter.MetalTextureWrapper",
+);
 late final _sel_pixelBuffer = objc.registerName("pixelBuffer");
 final _objc_msgSend_13yqbb6 = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Int Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
+      ffi.NativeFunction<
+        ffi.Int Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+        )
+      >
+    >()
     .asFunction<
-        int Function(
-            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
+      int Function(ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)
+    >();
 late final _sel_cvMetalTextureCache = objc.registerName("cvMetalTextureCache");
 
 /// WARNING: MTLDevice is a stub. To generate bindings for this class, include
@@ -48,29 +64,40 @@ late final _sel_cvMetalTextureCache = objc.registerName("cvMetalTextureCache");
 ///
 /// MTLDevice
 interface class MTLDevice extends objc.ObjCProtocolBase {
-  MTLDevice._(ffi.Pointer<objc.ObjCObject> pointer,
-      {bool retain = false, bool release = false})
-      : super(pointer, retain: retain, release: release);
+  MTLDevice._(
+    ffi.Pointer<objc.ObjCObject> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) : super(pointer, retain: retain, release: release);
 
   /// Constructs a [MTLDevice] that points to the same underlying object as [other].
   MTLDevice.castFrom(objc.ObjCObjectBase other)
-      : this._(other.ref.pointer, retain: true, release: true);
+    : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [MTLDevice] that wraps the given raw object pointer.
-  MTLDevice.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
-      {bool retain = false, bool release = false})
-      : this._(other, retain: retain, release: release);
+  MTLDevice.castFromPointer(
+    ffi.Pointer<objc.ObjCObject> other, {
+    bool retain = false,
+    bool release = false,
+  }) : this._(other, retain: retain, release: release);
 }
 
 late final _sel_metalDevice = objc.registerName("metalDevice");
 final _objc_msgSend_151sglz = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
-    .asFunction<
+      ffi.NativeFunction<
         ffi.Pointer<objc.ObjCObject> Function(
-            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+        )
+      >
+    >()
+    .asFunction<
+      ffi.Pointer<objc.ObjCObject> Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+      )
+    >();
 late final _sel_cvMetalTexture = objc.registerName("cvMetalTexture");
 
 /// WARNING: MTLTexture is a stub. To generate bindings for this class, include
@@ -78,145 +105,211 @@ late final _sel_cvMetalTexture = objc.registerName("cvMetalTexture");
 ///
 /// MTLTexture
 interface class MTLTexture extends objc.ObjCProtocolBase {
-  MTLTexture._(ffi.Pointer<objc.ObjCObject> pointer,
-      {bool retain = false, bool release = false})
-      : super(pointer, retain: retain, release: release);
+  MTLTexture._(
+    ffi.Pointer<objc.ObjCObject> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) : super(pointer, retain: retain, release: release);
 
   /// Constructs a [MTLTexture] that points to the same underlying object as [other].
   MTLTexture.castFrom(objc.ObjCObjectBase other)
-      : this._(other.ref.pointer, retain: true, release: true);
+    : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [MTLTexture] that wraps the given raw object pointer.
-  MTLTexture.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
-      {bool retain = false, bool release = false})
-      : this._(other, retain: retain, release: release);
+  MTLTexture.castFromPointer(
+    ffi.Pointer<objc.ObjCObject> other, {
+    bool retain = false,
+    bool release = false,
+  }) : this._(other, retain: retain, release: release);
 }
 
 late final _sel_metalTexture = objc.registerName("metalTexture");
 late final _sel_metalTextureAddress = objc.registerName("metalTextureAddress");
 final _objc_msgSend_1hz7y9r = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Long Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
+      ffi.NativeFunction<
+        ffi.Long Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+        )
+      >
+    >()
     .asFunction<
-        int Function(
-            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
+      int Function(ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)
+    >();
 late final _sel_width = objc.registerName("width");
 final _objc_msgSend_pysgoz = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Int64 Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
+      ffi.NativeFunction<
+        ffi.Int64 Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+        )
+      >
+    >()
     .asFunction<
-        int Function(
-            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
+      int Function(ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)
+    >();
 late final _sel_height = objc.registerName("height");
-late final _sel_allocateWithWidth_height_isDepth_isStencil_ =
-    objc.registerName("allocateWithWidth:height:isDepth:isStencil:");
+late final _sel_allocateWithWidth_height_isDepth_isStencil_ = objc.registerName(
+  "allocateWithWidth:height:isDepth:isStencil:",
+);
 final _objc_msgSend_1v8gk45 = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Int64,
-                ffi.Int64,
-                ffi.Bool,
-                ffi.Bool)>>()
+      ffi.NativeFunction<
+        ffi.Pointer<objc.ObjCObject> Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+          ffi.Int64,
+          ffi.Int64,
+          ffi.Bool,
+          ffi.Bool,
+        )
+      >
+    >()
     .asFunction<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, int, int, bool, bool)>();
-late final _sel_supportsRenderTarget =
-    objc.registerName("supportsRenderTarget");
+      ffi.Pointer<objc.ObjCObject> Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+        int,
+        int,
+        bool,
+        bool,
+      )
+    >();
+late final _sel_supportsRenderTarget = objc.registerName(
+  "supportsRenderTarget",
+);
 final _objc_msgSend_91o635 = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Bool Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
+      ffi.NativeFunction<
+        ffi.Bool Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+        )
+      >
+    >()
     .asFunction<
-        bool Function(
-            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
+      bool Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+      )
+    >();
 late final _sel_flushCache = objc.registerName("flushCache");
 final _objc_msgSend_1pl9qdv = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Void Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
+      ffi.NativeFunction<
+        ffi.Void Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+        )
+      >
+    >()
     .asFunction<
-        void Function(
-            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
+      void Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+      )
+    >();
 late final _sel_init = objc.registerName("init");
 late final _sel_new = objc.registerName("new");
 late final _sel_allocWithZone_ = objc.registerName("allocWithZone:");
 final _objc_msgSend_1cwp428 = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.NSZone>)>>()
+      ffi.NativeFunction<
+        ffi.Pointer<objc.ObjCObject> Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+          ffi.Pointer<objc.NSZone>,
+        )
+      >
+    >()
     .asFunction<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.NSZone>)>();
+      ffi.Pointer<objc.ObjCObject> Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+        ffi.Pointer<objc.NSZone>,
+      )
+    >();
 late final _sel_alloc = objc.registerName("alloc");
 late final _sel_self = objc.registerName("self");
 ffi.Pointer<objc.ObjCObject> _ObjCBlock_objcObjCObject_ffiVoid_fnPtrTrampoline(
-        ffi.Pointer<objc.ObjCBlockImpl> block, ffi.Pointer<ffi.Void> arg0) =>
-    block.ref.target
-        .cast<
-            ffi.NativeFunction<
-                ffi.Pointer<objc.ObjCObject> Function(
-                    ffi.Pointer<ffi.Void> arg0)>>()
-        .asFunction<
-            ffi.Pointer<objc.ObjCObject> Function(
-                ffi.Pointer<ffi.Void>)>()(arg0);
+  ffi.Pointer<objc.ObjCBlockImpl> block,
+  ffi.Pointer<ffi.Void> arg0,
+) => block.ref.target
+    .cast<
+      ffi.NativeFunction<
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void> arg0)
+      >
+    >()
+    .asFunction<
+      ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
+    >()(arg0);
 ffi.Pointer<ffi.Void> _ObjCBlock_objcObjCObject_ffiVoid_fnPtrCallable =
     ffi.Pointer.fromFunction<
-                ffi.Pointer<objc.ObjCObject> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)>(
-            _ObjCBlock_objcObjCObject_ffiVoid_fnPtrTrampoline)
+          ffi.Pointer<objc.ObjCObject> Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+          )
+        >(_ObjCBlock_objcObjCObject_ffiVoid_fnPtrTrampoline)
         .cast();
 ffi.Pointer<objc.ObjCObject>
-    _ObjCBlock_objcObjCObject_ffiVoid_closureTrampoline(
-            ffi.Pointer<objc.ObjCBlockImpl> block,
-            ffi.Pointer<ffi.Void> arg0) =>
-        (objc.getBlockClosure(block) as ffi.Pointer<objc.ObjCObject> Function(
-            ffi.Pointer<ffi.Void>))(arg0);
+_ObjCBlock_objcObjCObject_ffiVoid_closureTrampoline(
+  ffi.Pointer<objc.ObjCBlockImpl> block,
+  ffi.Pointer<ffi.Void> arg0,
+) =>
+    (objc.getBlockClosure(block)
+        as ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>))(arg0);
 ffi.Pointer<ffi.Void> _ObjCBlock_objcObjCObject_ffiVoid_closureCallable =
     ffi.Pointer.fromFunction<
-                ffi.Pointer<objc.ObjCObject> Function(
-                    ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)>(
-            _ObjCBlock_objcObjCObject_ffiVoid_closureTrampoline)
+          ffi.Pointer<objc.ObjCObject> Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+          )
+        >(_ObjCBlock_objcObjCObject_ffiVoid_closureTrampoline)
         .cast();
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>`.
 abstract final class ObjCBlock_objcObjCObject_ffiVoid {
   /// Returns a block that wraps the given raw block pointer.
-  static objc
-      .ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>
-      castFromPointer(ffi.Pointer<objc.ObjCBlockImpl> pointer,
-              {bool retain = false, bool release = false}) =>
-          objc.ObjCBlock<
-                  ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>(
-              pointer,
-              retain: retain,
-              release: release);
+  static objc.ObjCBlock<
+    ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
+  >
+  castFromPointer(
+    ffi.Pointer<objc.ObjCBlockImpl> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) =>
+      objc.ObjCBlock<
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
+      >(pointer, retain: retain, release: release);
 
   /// Creates a block from a C function pointer.
   ///
   /// This block must be invoked by native code running on the same thread as
   /// the isolate that registered it. Invoking the block on the wrong thread
   /// will result in a crash.
-  static objc.ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>
-      fromFunctionPointer(
-              ffi.Pointer<
-                      ffi.NativeFunction<
-                          ffi.Pointer<objc.ObjCObject> Function(
-                              ffi.Pointer<ffi.Void> arg0)>>
-                  ptr) =>
-          objc.ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>(
-              objc.newPointerBlock(_ObjCBlock_objcObjCObject_ffiVoid_fnPtrCallable, ptr.cast()),
-              retain: false,
-              release: true);
+  static objc.ObjCBlock<
+    ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
+  >
+  fromFunctionPointer(
+    ffi.Pointer<
+      ffi.NativeFunction<
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void> arg0)
+      >
+    >
+    ptr,
+  ) =>
+      objc.ObjCBlock<
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
+      >(
+        objc.newPointerBlock(
+          _ObjCBlock_objcObjCObject_ffiVoid_fnPtrCallable,
+          ptr.cast(),
+        ),
+        retain: false,
+        release: true,
+      );
 
   /// Creates a block from a Dart function.
   ///
@@ -226,37 +319,51 @@ abstract final class ObjCBlock_objcObjCObject_ffiVoid {
   ///
   /// If `keepIsolateAlive` is true, this block will keep this isolate alive
   /// until it is garbage collected by both Dart and ObjC.
-  static objc
-      .ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>
-      fromFunction(objc.ObjCObjectBase Function(ffi.Pointer<ffi.Void>) fn,
-              {bool keepIsolateAlive = true}) =>
-          objc.ObjCBlock<
-                  ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>(
-              objc.newClosureBlock(
-                  _ObjCBlock_objcObjCObject_ffiVoid_closureCallable,
-                  (ffi.Pointer<ffi.Void> arg0) =>
-                      fn(arg0).ref.retainAndAutorelease(),
-                  keepIsolateAlive),
-              retain: false,
-              release: true);
+  static objc.ObjCBlock<
+    ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
+  >
+  fromFunction(
+    objc.ObjCObjectBase Function(ffi.Pointer<ffi.Void>) fn, {
+    bool keepIsolateAlive = true,
+  }) =>
+      objc.ObjCBlock<
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
+      >(
+        objc.newClosureBlock(
+          _ObjCBlock_objcObjCObject_ffiVoid_closureCallable,
+          (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
+          keepIsolateAlive,
+        ),
+        retain: false,
+        release: true,
+      );
 }
 
 /// Call operator for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>`.
-extension ObjCBlock_objcObjCObject_ffiVoid_CallExtension on objc
-    .ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)> {
+extension ObjCBlock_objcObjCObject_ffiVoid_CallExtension
+    on
+        objc.ObjCBlock<
+          ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
+        > {
   objc.ObjCObjectBase call(ffi.Pointer<ffi.Void> arg0) => objc.ObjCObjectBase(
-      ref.pointer.ref.invoke
-          .cast<
-              ffi.NativeFunction<
-                  ffi.Pointer<objc.ObjCObject> Function(
-                      ffi.Pointer<objc.ObjCBlockImpl> block,
-                      ffi.Pointer<ffi.Void> arg0)>>()
-          .asFunction<
-              ffi.Pointer<objc.ObjCObject> Function(
-                  ffi.Pointer<objc.ObjCBlockImpl>,
-                  ffi.Pointer<ffi.Void>)>()(ref.pointer, arg0),
-      retain: true,
-      release: true);
+    ref.pointer.ref.invoke
+        .cast<
+          ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(
+              ffi.Pointer<objc.ObjCBlockImpl> block,
+              ffi.Pointer<ffi.Void> arg0,
+            )
+          >
+        >()
+        .asFunction<
+          ffi.Pointer<objc.ObjCObject> Function(
+            ffi.Pointer<objc.ObjCBlockImpl>,
+            ffi.Pointer<ffi.Void>,
+          )
+        >()(ref.pointer, arg0),
+    retain: true,
+    release: true,
+  );
 }
 
 late final _sel_retain = objc.registerName("retain");
@@ -264,23 +371,30 @@ late final _sel_autorelease = objc.registerName("autorelease");
 
 /// MetalTextureWrapper
 class MetalTextureWrapper extends objc.NSObject {
-  MetalTextureWrapper._(ffi.Pointer<objc.ObjCObject> pointer,
-      {bool retain = false, bool release = false})
-      : super.castFromPointer(pointer, retain: retain, release: release);
+  MetalTextureWrapper._(
+    ffi.Pointer<objc.ObjCObject> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) : super.castFromPointer(pointer, retain: retain, release: release);
 
   /// Constructs a [MetalTextureWrapper] that points to the same underlying object as [other].
   MetalTextureWrapper.castFrom(objc.ObjCObjectBase other)
-      : this._(other.ref.pointer, retain: true, release: true);
+    : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [MetalTextureWrapper] that wraps the given raw object pointer.
-  MetalTextureWrapper.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
-      {bool retain = false, bool release = false})
-      : this._(other, retain: retain, release: release);
+  MetalTextureWrapper.castFromPointer(
+    ffi.Pointer<objc.ObjCObject> other, {
+    bool retain = false,
+    bool release = false,
+  }) : this._(other, retain: retain, release: release);
 
   /// Returns whether [obj] is an instance of [MetalTextureWrapper].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_19nvye5(
-        obj.ref.pointer, _sel_isKindOfClass_, _class_MetalTextureWrapper);
+      obj.ref.pointer,
+      _sel_isKindOfClass_,
+      _class_MetalTextureWrapper,
+    );
   }
 
   /// pixelBuffer
@@ -331,16 +445,24 @@ class MetalTextureWrapper extends objc.NSObject {
 
   /// allocateWithWidth:height:isDepth:isStencil:
   static MetalTextureWrapper allocateWithWidth_height_isDepth_isStencil_(
-      int width, int height, bool isDepth, bool isStencil) {
+    int width,
+    int height,
+    bool isDepth,
+    bool isStencil,
+  ) {
     final _ret = _objc_msgSend_1v8gk45(
-        _class_MetalTextureWrapper,
-        _sel_allocateWithWidth_height_isDepth_isStencil_,
-        width,
-        height,
-        isDepth,
-        isStencil);
-    return MetalTextureWrapper.castFromPointer(_ret,
-        retain: true, release: true);
+      _class_MetalTextureWrapper,
+      _sel_allocateWithWidth_height_isDepth_isStencil_,
+      width,
+      height,
+      isDepth,
+      isStencil,
+    );
+    return MetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// supportsRenderTarget
@@ -355,55 +477,84 @@ class MetalTextureWrapper extends objc.NSObject {
 
   /// init
   MetalTextureWrapper init() {
-    objc.checkOsVersionInternal('MetalTextureWrapper.init',
-        iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
-    final _ret =
-        _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
-    return MetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+    objc.checkOsVersionInternal(
+      'MetalTextureWrapper.init',
+      iOS: (false, (2, 0, 0)),
+      macOS: (false, (10, 0, 0)),
+    );
+    final _ret = _objc_msgSend_151sglz(
+      this.ref.retainAndReturnPointer(),
+      _sel_init,
+    );
+    return MetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// new
   static MetalTextureWrapper new$() {
     final _ret = _objc_msgSend_151sglz(_class_MetalTextureWrapper, _sel_new);
-    return MetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+    return MetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// allocWithZone:
   static MetalTextureWrapper allocWithZone_(ffi.Pointer<objc.NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
-        _class_MetalTextureWrapper, _sel_allocWithZone_, zone);
-    return MetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+      _class_MetalTextureWrapper,
+      _sel_allocWithZone_,
+      zone,
+    );
+    return MetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// alloc
   static MetalTextureWrapper alloc() {
     final _ret = _objc_msgSend_151sglz(_class_MetalTextureWrapper, _sel_alloc);
-    return MetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+    return MetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// self
   MetalTextureWrapper self$1() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_self);
-    return MetalTextureWrapper.castFromPointer(_ret,
-        retain: true, release: true);
+    return MetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// retain
   MetalTextureWrapper retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
-    return MetalTextureWrapper.castFromPointer(_ret,
-        retain: true, release: true);
+    return MetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// autorelease
   MetalTextureWrapper autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
-    return MetalTextureWrapper.castFromPointer(_ret,
-        retain: true, release: true);
+    return MetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// Returns a new instance of MetalTextureWrapper constructed with the default `new` method.
@@ -413,296 +564,447 @@ class MetalTextureWrapper extends objc.NSObject {
 late final _sel_initWithTexture_ = objc.registerName("initWithTexture:");
 final _objc_msgSend_1sotr3r = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject>)>>()
+      ffi.NativeFunction<
+        ffi.Pointer<objc.ObjCObject> Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+          ffi.Pointer<objc.ObjCObject>,
+        )
+      >
+    >()
     .asFunction<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
+      ffi.Pointer<objc.ObjCObject> Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+        ffi.Pointer<objc.ObjCObject>,
+      )
+    >();
 
 /// FlutterMetalTextureWrapper
 class FlutterMetalTextureWrapper extends objc.NSObject {
-  FlutterMetalTextureWrapper._(ffi.Pointer<objc.ObjCObject> pointer,
-      {bool retain = false, bool release = false})
-      : super.castFromPointer(pointer, retain: retain, release: release);
+  FlutterMetalTextureWrapper._(
+    ffi.Pointer<objc.ObjCObject> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) : super.castFromPointer(pointer, retain: retain, release: release);
 
   /// Constructs a [FlutterMetalTextureWrapper] that points to the same underlying object as [other].
   FlutterMetalTextureWrapper.castFrom(objc.ObjCObjectBase other)
-      : this._(other.ref.pointer, retain: true, release: true);
+    : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [FlutterMetalTextureWrapper] that wraps the given raw object pointer.
-  FlutterMetalTextureWrapper.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
-      {bool retain = false, bool release = false})
-      : this._(other, retain: retain, release: release);
+  FlutterMetalTextureWrapper.castFromPointer(
+    ffi.Pointer<objc.ObjCObject> other, {
+    bool retain = false,
+    bool release = false,
+  }) : this._(other, retain: retain, release: release);
 
   /// Returns whether [obj] is an instance of [FlutterMetalTextureWrapper].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_19nvye5(obj.ref.pointer, _sel_isKindOfClass_,
-        _class_FlutterMetalTextureWrapper);
+    return _objc_msgSend_19nvye5(
+      obj.ref.pointer,
+      _sel_isKindOfClass_,
+      _class_FlutterMetalTextureWrapper,
+    );
   }
 
   /// initWithTexture:
   FlutterMetalTextureWrapper initWithTexture_(MetalTextureWrapper texture) {
-    final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithTexture_, texture.ref.pointer);
-    return FlutterMetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+    final _ret = _objc_msgSend_1sotr3r(
+      this.ref.retainAndReturnPointer(),
+      _sel_initWithTexture_,
+      texture.ref.pointer,
+    );
+    return FlutterMetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// init
   FlutterMetalTextureWrapper init() {
-    objc.checkOsVersionInternal('FlutterMetalTextureWrapper.init',
-        iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
-    final _ret =
-        _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
-    return FlutterMetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+    objc.checkOsVersionInternal(
+      'FlutterMetalTextureWrapper.init',
+      iOS: (false, (2, 0, 0)),
+      macOS: (false, (10, 0, 0)),
+    );
+    final _ret = _objc_msgSend_151sglz(
+      this.ref.retainAndReturnPointer(),
+      _sel_init,
+    );
+    return FlutterMetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// new
   static FlutterMetalTextureWrapper new$() {
-    final _ret =
-        _objc_msgSend_151sglz(_class_FlutterMetalTextureWrapper, _sel_new);
-    return FlutterMetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+    final _ret = _objc_msgSend_151sglz(
+      _class_FlutterMetalTextureWrapper,
+      _sel_new,
+    );
+    return FlutterMetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// allocWithZone:
   static FlutterMetalTextureWrapper allocWithZone_(
-      ffi.Pointer<objc.NSZone> zone) {
+    ffi.Pointer<objc.NSZone> zone,
+  ) {
     final _ret = _objc_msgSend_1cwp428(
-        _class_FlutterMetalTextureWrapper, _sel_allocWithZone_, zone);
-    return FlutterMetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+      _class_FlutterMetalTextureWrapper,
+      _sel_allocWithZone_,
+      zone,
+    );
+    return FlutterMetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// alloc
   static FlutterMetalTextureWrapper alloc() {
-    final _ret =
-        _objc_msgSend_151sglz(_class_FlutterMetalTextureWrapper, _sel_alloc);
-    return FlutterMetalTextureWrapper.castFromPointer(_ret,
-        retain: false, release: true);
+    final _ret = _objc_msgSend_151sglz(
+      _class_FlutterMetalTextureWrapper,
+      _sel_alloc,
+    );
+    return FlutterMetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// self
   FlutterMetalTextureWrapper self$1() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_self);
-    return FlutterMetalTextureWrapper.castFromPointer(_ret,
-        retain: true, release: true);
+    return FlutterMetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// retain
   FlutterMetalTextureWrapper retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
-    return FlutterMetalTextureWrapper.castFromPointer(_ret,
-        retain: true, release: true);
+    return FlutterMetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// autorelease
   FlutterMetalTextureWrapper autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
-    return FlutterMetalTextureWrapper.castFromPointer(_ret,
-        retain: true, release: true);
+    return FlutterMetalTextureWrapper.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// Returns a new instance of FlutterMetalTextureWrapper constructed with the default `new` method.
   factory FlutterMetalTextureWrapper() => new$();
 }
 
-late final _class_SwiftThermionFlutterPluginObjCAPI =
-    objc.getClass("thermion_flutter.SwiftThermionFlutterPluginObjCAPI");
+late final _class_SwiftThermionFlutterPluginObjCAPI = objc.getClass(
+  "thermion_flutter.SwiftThermionFlutterPluginObjCAPI",
+);
 late final _sel_textureRegistry = objc.registerName("textureRegistry");
-late final _sel_startFrameSchedulerWithCallbackAddress_targetFps_ =
-    objc.registerName("startFrameSchedulerWithCallbackAddress:targetFps:");
+late final _sel_startFrameSchedulerWithCallbackAddress_targetFps_ = objc
+    .registerName("startFrameSchedulerWithCallbackAddress:targetFps:");
 final _objc_msgSend_12xnd2d = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Void Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>, ffi.Int64, ffi.Long)>>()
+      ffi.NativeFunction<
+        ffi.Void Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+          ffi.Int64,
+          ffi.Long,
+        )
+      >
+    >()
     .asFunction<
-        void Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, int, int)>();
+      void Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+        int,
+        int,
+      )
+    >();
 late final _sel_stopFrameScheduler = objc.registerName("stopFrameScheduler");
 late final _sel_initializeDartApi_ = objc.registerName("initializeDartApi:");
 final _objc_msgSend_17gvxvj = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Void Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>, ffi.Int64)>>()
+      ffi.NativeFunction<
+        ffi.Void Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+          ffi.Int64,
+        )
+      >
+    >()
     .asFunction<
-        void Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, int)>();
-late final _sel_startFrameSchedulerWithPort_targetFps_ =
-    objc.registerName("startFrameSchedulerWithPort:targetFps:");
+      void Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+        int,
+      )
+    >();
+late final _sel_startFrameSchedulerWithPort_targetFps_ = objc.registerName(
+  "startFrameSchedulerWithPort:targetFps:",
+);
 
 /// SwiftThermionFlutterPluginObjCAPI
 class SwiftThermionFlutterPluginObjCAPI extends objc.NSObject {
-  SwiftThermionFlutterPluginObjCAPI._(ffi.Pointer<objc.ObjCObject> pointer,
-      {bool retain = false, bool release = false})
-      : super.castFromPointer(pointer, retain: retain, release: release);
+  SwiftThermionFlutterPluginObjCAPI._(
+    ffi.Pointer<objc.ObjCObject> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) : super.castFromPointer(pointer, retain: retain, release: release);
 
   /// Constructs a [SwiftThermionFlutterPluginObjCAPI] that points to the same underlying object as [other].
   SwiftThermionFlutterPluginObjCAPI.castFrom(objc.ObjCObjectBase other)
-      : this._(other.ref.pointer, retain: true, release: true);
+    : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [SwiftThermionFlutterPluginObjCAPI] that wraps the given raw object pointer.
   SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-      ffi.Pointer<objc.ObjCObject> other,
-      {bool retain = false,
-      bool release = false})
-      : this._(other, retain: retain, release: release);
+    ffi.Pointer<objc.ObjCObject> other, {
+    bool retain = false,
+    bool release = false,
+  }) : this._(other, retain: retain, release: release);
 
   /// Returns whether [obj] is an instance of [SwiftThermionFlutterPluginObjCAPI].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_19nvye5(obj.ref.pointer, _sel_isKindOfClass_,
-        _class_SwiftThermionFlutterPluginObjCAPI);
+    return _objc_msgSend_19nvye5(
+      obj.ref.pointer,
+      _sel_isKindOfClass_,
+      _class_SwiftThermionFlutterPluginObjCAPI,
+    );
   }
 
   /// textureRegistry
   static objc.NSObject textureRegistry() {
     final _ret = _objc_msgSend_151sglz(
-        _class_SwiftThermionFlutterPluginObjCAPI, _sel_textureRegistry);
+      _class_SwiftThermionFlutterPluginObjCAPI,
+      _sel_textureRegistry,
+    );
     return objc.NSObject.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// startFrameSchedulerWithCallbackAddress:targetFps:
   static void startFrameSchedulerWithCallbackAddress_targetFps_(
-      int callbackAddress, int targetFps) {
+    int callbackAddress,
+    int targetFps,
+  ) {
     _objc_msgSend_12xnd2d(
-        _class_SwiftThermionFlutterPluginObjCAPI,
-        _sel_startFrameSchedulerWithCallbackAddress_targetFps_,
-        callbackAddress,
-        targetFps);
+      _class_SwiftThermionFlutterPluginObjCAPI,
+      _sel_startFrameSchedulerWithCallbackAddress_targetFps_,
+      callbackAddress,
+      targetFps,
+    );
   }
 
   /// stopFrameScheduler
   static void stopFrameScheduler() {
     _objc_msgSend_1pl9qdv(
-        _class_SwiftThermionFlutterPluginObjCAPI, _sel_stopFrameScheduler);
+      _class_SwiftThermionFlutterPluginObjCAPI,
+      _sel_stopFrameScheduler,
+    );
   }
 
   /// initializeDartApi:
   static void initializeDartApi_(int dataAddress) {
-    _objc_msgSend_17gvxvj(_class_SwiftThermionFlutterPluginObjCAPI,
-        _sel_initializeDartApi_, dataAddress);
+    _objc_msgSend_17gvxvj(
+      _class_SwiftThermionFlutterPluginObjCAPI,
+      _sel_initializeDartApi_,
+      dataAddress,
+    );
   }
 
   /// startFrameSchedulerWithPort:targetFps:
   static void startFrameSchedulerWithPort_targetFps_(int port, int targetFps) {
-    _objc_msgSend_12xnd2d(_class_SwiftThermionFlutterPluginObjCAPI,
-        _sel_startFrameSchedulerWithPort_targetFps_, port, targetFps);
+    _objc_msgSend_12xnd2d(
+      _class_SwiftThermionFlutterPluginObjCAPI,
+      _sel_startFrameSchedulerWithPort_targetFps_,
+      port,
+      targetFps,
+    );
   }
 
   /// init
   SwiftThermionFlutterPluginObjCAPI init() {
-    objc.checkOsVersionInternal('SwiftThermionFlutterPluginObjCAPI.init',
-        iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
-    final _ret =
-        _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
-        retain: false, release: true);
+    objc.checkOsVersionInternal(
+      'SwiftThermionFlutterPluginObjCAPI.init',
+      iOS: (false, (2, 0, 0)),
+      macOS: (false, (10, 0, 0)),
+    );
+    final _ret = _objc_msgSend_151sglz(
+      this.ref.retainAndReturnPointer(),
+      _sel_init,
+    );
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// new
   static SwiftThermionFlutterPluginObjCAPI new$() {
     final _ret = _objc_msgSend_151sglz(
-        _class_SwiftThermionFlutterPluginObjCAPI, _sel_new);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
-        retain: false, release: true);
+      _class_SwiftThermionFlutterPluginObjCAPI,
+      _sel_new,
+    );
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// allocWithZone:
   static SwiftThermionFlutterPluginObjCAPI allocWithZone_(
-      ffi.Pointer<objc.NSZone> zone) {
+    ffi.Pointer<objc.NSZone> zone,
+  ) {
     final _ret = _objc_msgSend_1cwp428(
-        _class_SwiftThermionFlutterPluginObjCAPI, _sel_allocWithZone_, zone);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
-        retain: false, release: true);
+      _class_SwiftThermionFlutterPluginObjCAPI,
+      _sel_allocWithZone_,
+      zone,
+    );
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// alloc
   static SwiftThermionFlutterPluginObjCAPI alloc() {
     final _ret = _objc_msgSend_151sglz(
-        _class_SwiftThermionFlutterPluginObjCAPI, _sel_alloc);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
-        retain: false, release: true);
+      _class_SwiftThermionFlutterPluginObjCAPI,
+      _sel_alloc,
+    );
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// self
   SwiftThermionFlutterPluginObjCAPI self$1() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_self);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
-        retain: true, release: true);
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// retain
   SwiftThermionFlutterPluginObjCAPI retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
-        retain: true, release: true);
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// autorelease
   SwiftThermionFlutterPluginObjCAPI autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
-        retain: true, release: true);
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// Returns a new instance of SwiftThermionFlutterPluginObjCAPI constructed with the default `new` method.
   factory SwiftThermionFlutterPluginObjCAPI() => new$();
 }
 
-late final _class_ThermionTextureRegistry =
-    objc.getClass("thermion_flutter.ThermionTextureRegistry");
+late final _class_ThermionTextureRegistry = objc.getClass(
+  "thermion_flutter.ThermionTextureRegistry",
+);
 late final _sel_registerTexture_ = objc.registerName("registerTexture:");
 final _objc_msgSend_1oj5o8z = objc.msgSendPointer
     .cast<
-        ffi.NativeFunction<
-            ffi.Int64 Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject>)>>()
+      ffi.NativeFunction<
+        ffi.Int64 Function(
+          ffi.Pointer<objc.ObjCObject>,
+          ffi.Pointer<objc.ObjCSelector>,
+          ffi.Pointer<objc.ObjCObject>,
+        )
+      >
+    >()
     .asFunction<
-        int Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
-late final _sel_textureFrameAvailable_ =
-    objc.registerName("textureFrameAvailable:");
+      int Function(
+        ffi.Pointer<objc.ObjCObject>,
+        ffi.Pointer<objc.ObjCSelector>,
+        ffi.Pointer<objc.ObjCObject>,
+      )
+    >();
+late final _sel_textureFrameAvailable_ = objc.registerName(
+  "textureFrameAvailable:",
+);
 late final _sel_unregisterTexture_ = objc.registerName("unregisterTexture:");
 
 /// ThermionTextureRegistry
 class ThermionTextureRegistry extends objc.NSObject {
-  ThermionTextureRegistry._(ffi.Pointer<objc.ObjCObject> pointer,
-      {bool retain = false, bool release = false})
-      : super.castFromPointer(pointer, retain: retain, release: release);
+  ThermionTextureRegistry._(
+    ffi.Pointer<objc.ObjCObject> pointer, {
+    bool retain = false,
+    bool release = false,
+  }) : super.castFromPointer(pointer, retain: retain, release: release);
 
   /// Constructs a [ThermionTextureRegistry] that points to the same underlying object as [other].
   ThermionTextureRegistry.castFrom(objc.ObjCObjectBase other)
-      : this._(other.ref.pointer, retain: true, release: true);
+    : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [ThermionTextureRegistry] that wraps the given raw object pointer.
-  ThermionTextureRegistry.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
-      {bool retain = false, bool release = false})
-      : this._(other, retain: retain, release: release);
+  ThermionTextureRegistry.castFromPointer(
+    ffi.Pointer<objc.ObjCObject> other, {
+    bool retain = false,
+    bool release = false,
+  }) : this._(other, retain: retain, release: release);
 
   /// Returns whether [obj] is an instance of [ThermionTextureRegistry].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_19nvye5(
-        obj.ref.pointer, _sel_isKindOfClass_, _class_ThermionTextureRegistry);
+      obj.ref.pointer,
+      _sel_isKindOfClass_,
+      _class_ThermionTextureRegistry,
+    );
   }
 
   /// registerTexture:
   int registerTexture_(objc.NSObject texture) {
     return _objc_msgSend_1oj5o8z(
-        this.ref.pointer, _sel_registerTexture_, texture.ref.pointer);
+      this.ref.pointer,
+      _sel_registerTexture_,
+      texture.ref.pointer,
+    );
   }
 
   /// textureFrameAvailable:
   void textureFrameAvailable_(int textureId) {
     _objc_msgSend_17gvxvj(
-        this.ref.pointer, _sel_textureFrameAvailable_, textureId);
+      this.ref.pointer,
+      _sel_textureFrameAvailable_,
+      textureId,
+    );
   }
 
   /// unregisterTexture:
@@ -712,57 +1014,90 @@ class ThermionTextureRegistry extends objc.NSObject {
 
   /// init
   ThermionTextureRegistry init() {
-    objc.checkOsVersionInternal('ThermionTextureRegistry.init',
-        iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
-    final _ret =
-        _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
-    return ThermionTextureRegistry.castFromPointer(_ret,
-        retain: false, release: true);
+    objc.checkOsVersionInternal(
+      'ThermionTextureRegistry.init',
+      iOS: (false, (2, 0, 0)),
+      macOS: (false, (10, 0, 0)),
+    );
+    final _ret = _objc_msgSend_151sglz(
+      this.ref.retainAndReturnPointer(),
+      _sel_init,
+    );
+    return ThermionTextureRegistry.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// new
   static ThermionTextureRegistry new$() {
-    final _ret =
-        _objc_msgSend_151sglz(_class_ThermionTextureRegistry, _sel_new);
-    return ThermionTextureRegistry.castFromPointer(_ret,
-        retain: false, release: true);
+    final _ret = _objc_msgSend_151sglz(
+      _class_ThermionTextureRegistry,
+      _sel_new,
+    );
+    return ThermionTextureRegistry.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// allocWithZone:
   static ThermionTextureRegistry allocWithZone_(ffi.Pointer<objc.NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
-        _class_ThermionTextureRegistry, _sel_allocWithZone_, zone);
-    return ThermionTextureRegistry.castFromPointer(_ret,
-        retain: false, release: true);
+      _class_ThermionTextureRegistry,
+      _sel_allocWithZone_,
+      zone,
+    );
+    return ThermionTextureRegistry.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// alloc
   static ThermionTextureRegistry alloc() {
-    final _ret =
-        _objc_msgSend_151sglz(_class_ThermionTextureRegistry, _sel_alloc);
-    return ThermionTextureRegistry.castFromPointer(_ret,
-        retain: false, release: true);
+    final _ret = _objc_msgSend_151sglz(
+      _class_ThermionTextureRegistry,
+      _sel_alloc,
+    );
+    return ThermionTextureRegistry.castFromPointer(
+      _ret,
+      retain: false,
+      release: true,
+    );
   }
 
   /// self
   ThermionTextureRegistry self$1() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_self);
-    return ThermionTextureRegistry.castFromPointer(_ret,
-        retain: true, release: true);
+    return ThermionTextureRegistry.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// retain
   ThermionTextureRegistry retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
-    return ThermionTextureRegistry.castFromPointer(_ret,
-        retain: true, release: true);
+    return ThermionTextureRegistry.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// autorelease
   ThermionTextureRegistry autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
-    return ThermionTextureRegistry.castFromPointer(_ret,
-        retain: true, release: true);
+    return ThermionTextureRegistry.castFromPointer(
+      _ret,
+      retain: true,
+      release: true,
+    );
   }
 
   /// Returns a new instance of ThermionTextureRegistry constructed with the default `new` method.

--- a/thermion_flutter/thermion_flutter/lib/src/swift/swift_bindings.g.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/swift/swift_bindings.g.dart
@@ -7,56 +7,40 @@ import 'dart:ffi' as ffi;
 import 'package:objective_c/objective_c.dart' as objc;
 
 @ffi.Native<
-  ffi.Pointer<objc.ObjCObject> Function(
-    ffi.Pointer<objc.ObjCObject>,
-    ffi.Pointer<ffi.Void>,
-  )
->()
+    ffi.Pointer<objc.ObjCObject> Function(
+        ffi.Pointer<objc.ObjCObject>, ffi.Pointer<ffi.Void>)>()
 external ffi.Pointer<objc.ObjCObject>
-_SwiftThermionFlutterPluginObjCAPI_protocolTrampoline_1mbt9g9(
+    _SwiftThermionFlutterPluginObjCAPI_protocolTrampoline_1mbt9g9(
   ffi.Pointer<objc.ObjCObject> target,
   ffi.Pointer<ffi.Void> arg0,
 );
 
-late final _class_FlutterMetalTextureWrapper = objc.getClass(
-  "thermion_flutter.FlutterMetalTextureWrapper",
-);
+late final _class_FlutterMetalTextureWrapper =
+    objc.getClass("thermion_flutter.FlutterMetalTextureWrapper");
 late final _sel_isKindOfClass_ = objc.registerName("isKindOfClass:");
 final _objc_msgSend_19nvye5 = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Bool Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-          ffi.Pointer<objc.ObjCObject>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Bool Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject>)>>()
     .asFunction<
-      bool Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-        ffi.Pointer<objc.ObjCObject>,
-      )
-    >();
+        bool Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
 typedef instancetype = ffi.Pointer<objc.ObjCObject>;
 typedef Dartinstancetype = objc.ObjCObjectBase;
-late final _class_MetalTextureWrapper = objc.getClass(
-  "thermion_flutter.MetalTextureWrapper",
-);
+late final _class_MetalTextureWrapper =
+    objc.getClass("thermion_flutter.MetalTextureWrapper");
 late final _sel_pixelBuffer = objc.registerName("pixelBuffer");
 final _objc_msgSend_13yqbb6 = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Int Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Int Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
     .asFunction<
-      int Function(ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)
-    >();
+        int Function(
+            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
 late final _sel_cvMetalTextureCache = objc.registerName("cvMetalTextureCache");
 
 /// WARNING: MTLDevice is a stub. To generate bindings for this class, include
@@ -64,40 +48,29 @@ late final _sel_cvMetalTextureCache = objc.registerName("cvMetalTextureCache");
 ///
 /// MTLDevice
 interface class MTLDevice extends objc.ObjCProtocolBase {
-  MTLDevice._(
-    ffi.Pointer<objc.ObjCObject> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) : super(pointer, retain: retain, release: release);
+  MTLDevice._(ffi.Pointer<objc.ObjCObject> pointer,
+      {bool retain = false, bool release = false})
+      : super(pointer, retain: retain, release: release);
 
   /// Constructs a [MTLDevice] that points to the same underlying object as [other].
   MTLDevice.castFrom(objc.ObjCObjectBase other)
-    : this._(other.ref.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [MTLDevice] that wraps the given raw object pointer.
-  MTLDevice.castFromPointer(
-    ffi.Pointer<objc.ObjCObject> other, {
-    bool retain = false,
-    bool release = false,
-  }) : this._(other, retain: retain, release: release);
+  MTLDevice.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
+      {bool retain = false, bool release = false})
+      : this._(other, retain: retain, release: release);
 }
 
 late final _sel_metalDevice = objc.registerName("metalDevice");
 final _objc_msgSend_151sglz = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Pointer<objc.ObjCObject> Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
     .asFunction<
-      ffi.Pointer<objc.ObjCObject> Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-      )
-    >();
+        ffi.Pointer<objc.ObjCObject> Function(
+            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
 late final _sel_cvMetalTexture = objc.registerName("cvMetalTexture");
 
 /// WARNING: MTLTexture is a stub. To generate bindings for this class, include
@@ -105,211 +78,145 @@ late final _sel_cvMetalTexture = objc.registerName("cvMetalTexture");
 ///
 /// MTLTexture
 interface class MTLTexture extends objc.ObjCProtocolBase {
-  MTLTexture._(
-    ffi.Pointer<objc.ObjCObject> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) : super(pointer, retain: retain, release: release);
+  MTLTexture._(ffi.Pointer<objc.ObjCObject> pointer,
+      {bool retain = false, bool release = false})
+      : super(pointer, retain: retain, release: release);
 
   /// Constructs a [MTLTexture] that points to the same underlying object as [other].
   MTLTexture.castFrom(objc.ObjCObjectBase other)
-    : this._(other.ref.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [MTLTexture] that wraps the given raw object pointer.
-  MTLTexture.castFromPointer(
-    ffi.Pointer<objc.ObjCObject> other, {
-    bool retain = false,
-    bool release = false,
-  }) : this._(other, retain: retain, release: release);
+  MTLTexture.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
+      {bool retain = false, bool release = false})
+      : this._(other, retain: retain, release: release);
 }
 
 late final _sel_metalTexture = objc.registerName("metalTexture");
 late final _sel_metalTextureAddress = objc.registerName("metalTextureAddress");
 final _objc_msgSend_1hz7y9r = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Long Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Long Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
     .asFunction<
-      int Function(ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)
-    >();
+        int Function(
+            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
 late final _sel_width = objc.registerName("width");
 final _objc_msgSend_pysgoz = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Int64 Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Int64 Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
     .asFunction<
-      int Function(ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)
-    >();
+        int Function(
+            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
 late final _sel_height = objc.registerName("height");
-late final _sel_allocateWithWidth_height_isDepth_isStencil_ = objc.registerName(
-  "allocateWithWidth:height:isDepth:isStencil:",
-);
+late final _sel_allocateWithWidth_height_isDepth_isStencil_ =
+    objc.registerName("allocateWithWidth:height:isDepth:isStencil:");
 final _objc_msgSend_1v8gk45 = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Pointer<objc.ObjCObject> Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-          ffi.Int64,
-          ffi.Int64,
-          ffi.Bool,
-          ffi.Bool,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Int64,
+                ffi.Int64,
+                ffi.Bool,
+                ffi.Bool)>>()
     .asFunction<
-      ffi.Pointer<objc.ObjCObject> Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-        int,
-        int,
-        bool,
-        bool,
-      )
-    >();
-late final _sel_supportsRenderTarget = objc.registerName(
-  "supportsRenderTarget",
-);
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, int, int, bool, bool)>();
+late final _sel_supportsRenderTarget =
+    objc.registerName("supportsRenderTarget");
 final _objc_msgSend_91o635 = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Bool Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Bool Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
     .asFunction<
-      bool Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-      )
-    >();
+        bool Function(
+            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
 late final _sel_flushCache = objc.registerName("flushCache");
 final _objc_msgSend_1pl9qdv = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Void Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Void Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
     .asFunction<
-      void Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-      )
-    >();
+        void Function(
+            ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
 late final _sel_init = objc.registerName("init");
 late final _sel_new = objc.registerName("new");
 late final _sel_allocWithZone_ = objc.registerName("allocWithZone:");
 final _objc_msgSend_1cwp428 = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Pointer<objc.ObjCObject> Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-          ffi.Pointer<objc.NSZone>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.NSZone>)>>()
     .asFunction<
-      ffi.Pointer<objc.ObjCObject> Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-        ffi.Pointer<objc.NSZone>,
-      )
-    >();
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.NSZone>)>();
 late final _sel_alloc = objc.registerName("alloc");
 late final _sel_self = objc.registerName("self");
 ffi.Pointer<objc.ObjCObject> _ObjCBlock_objcObjCObject_ffiVoid_fnPtrTrampoline(
-  ffi.Pointer<objc.ObjCBlockImpl> block,
-  ffi.Pointer<ffi.Void> arg0,
-) => block.ref.target
-    .cast<
-      ffi.NativeFunction<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void> arg0)
-      >
-    >()
-    .asFunction<
-      ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
-    >()(arg0);
+        ffi.Pointer<objc.ObjCBlockImpl> block, ffi.Pointer<ffi.Void> arg0) =>
+    block.ref.target
+        .cast<
+            ffi.NativeFunction<
+                ffi.Pointer<objc.ObjCObject> Function(
+                    ffi.Pointer<ffi.Void> arg0)>>()
+        .asFunction<
+            ffi.Pointer<objc.ObjCObject> Function(
+                ffi.Pointer<ffi.Void>)>()(arg0);
 ffi.Pointer<ffi.Void> _ObjCBlock_objcObjCObject_ffiVoid_fnPtrCallable =
     ffi.Pointer.fromFunction<
-          ffi.Pointer<objc.ObjCObject> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >(_ObjCBlock_objcObjCObject_ffiVoid_fnPtrTrampoline)
+                ffi.Pointer<objc.ObjCObject> Function(
+                    ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)>(
+            _ObjCBlock_objcObjCObject_ffiVoid_fnPtrTrampoline)
         .cast();
 ffi.Pointer<objc.ObjCObject>
-_ObjCBlock_objcObjCObject_ffiVoid_closureTrampoline(
-  ffi.Pointer<objc.ObjCBlockImpl> block,
-  ffi.Pointer<ffi.Void> arg0,
-) =>
-    (objc.getBlockClosure(block)
-        as ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>))(arg0);
+    _ObjCBlock_objcObjCObject_ffiVoid_closureTrampoline(
+            ffi.Pointer<objc.ObjCBlockImpl> block,
+            ffi.Pointer<ffi.Void> arg0) =>
+        (objc.getBlockClosure(block) as ffi.Pointer<objc.ObjCObject> Function(
+            ffi.Pointer<ffi.Void>))(arg0);
 ffi.Pointer<ffi.Void> _ObjCBlock_objcObjCObject_ffiVoid_closureCallable =
     ffi.Pointer.fromFunction<
-          ffi.Pointer<objc.ObjCObject> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >(_ObjCBlock_objcObjCObject_ffiVoid_closureTrampoline)
+                ffi.Pointer<objc.ObjCObject> Function(
+                    ffi.Pointer<objc.ObjCBlockImpl>, ffi.Pointer<ffi.Void>)>(
+            _ObjCBlock_objcObjCObject_ffiVoid_closureTrampoline)
         .cast();
 
 /// Construction methods for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>`.
 abstract final class ObjCBlock_objcObjCObject_ffiVoid {
   /// Returns a block that wraps the given raw block pointer.
-  static objc.ObjCBlock<
-    ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
-  >
-  castFromPointer(
-    ffi.Pointer<objc.ObjCBlockImpl> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) =>
-      objc.ObjCBlock<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
-      >(pointer, retain: retain, release: release);
+  static objc
+      .ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>
+      castFromPointer(ffi.Pointer<objc.ObjCBlockImpl> pointer,
+              {bool retain = false, bool release = false}) =>
+          objc.ObjCBlock<
+                  ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>(
+              pointer,
+              retain: retain,
+              release: release);
 
   /// Creates a block from a C function pointer.
   ///
   /// This block must be invoked by native code running on the same thread as
   /// the isolate that registered it. Invoking the block on the wrong thread
   /// will result in a crash.
-  static objc.ObjCBlock<
-    ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
-  >
-  fromFunctionPointer(
-    ffi.Pointer<
-      ffi.NativeFunction<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void> arg0)
-      >
-    >
-    ptr,
-  ) =>
-      objc.ObjCBlock<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
-      >(
-        objc.newPointerBlock(
-          _ObjCBlock_objcObjCObject_ffiVoid_fnPtrCallable,
-          ptr.cast(),
-        ),
-        retain: false,
-        release: true,
-      );
+  static objc.ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>
+      fromFunctionPointer(
+              ffi.Pointer<
+                      ffi.NativeFunction<
+                          ffi.Pointer<objc.ObjCObject> Function(
+                              ffi.Pointer<ffi.Void> arg0)>>
+                  ptr) =>
+          objc.ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>(
+              objc.newPointerBlock(_ObjCBlock_objcObjCObject_ffiVoid_fnPtrCallable, ptr.cast()),
+              retain: false,
+              release: true);
 
   /// Creates a block from a Dart function.
   ///
@@ -319,51 +226,37 @@ abstract final class ObjCBlock_objcObjCObject_ffiVoid {
   ///
   /// If `keepIsolateAlive` is true, this block will keep this isolate alive
   /// until it is garbage collected by both Dart and ObjC.
-  static objc.ObjCBlock<
-    ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
-  >
-  fromFunction(
-    objc.ObjCObjectBase Function(ffi.Pointer<ffi.Void>) fn, {
-    bool keepIsolateAlive = true,
-  }) =>
-      objc.ObjCBlock<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
-      >(
-        objc.newClosureBlock(
-          _ObjCBlock_objcObjCObject_ffiVoid_closureCallable,
-          (ffi.Pointer<ffi.Void> arg0) => fn(arg0).ref.retainAndAutorelease(),
-          keepIsolateAlive,
-        ),
-        retain: false,
-        release: true,
-      );
+  static objc
+      .ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>
+      fromFunction(objc.ObjCObjectBase Function(ffi.Pointer<ffi.Void>) fn,
+              {bool keepIsolateAlive = true}) =>
+          objc.ObjCBlock<
+                  ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>(
+              objc.newClosureBlock(
+                  _ObjCBlock_objcObjCObject_ffiVoid_closureCallable,
+                  (ffi.Pointer<ffi.Void> arg0) =>
+                      fn(arg0).ref.retainAndAutorelease(),
+                  keepIsolateAlive),
+              retain: false,
+              release: true);
 }
 
 /// Call operator for `objc.ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)>`.
-extension ObjCBlock_objcObjCObject_ffiVoid_CallExtension
-    on
-        objc.ObjCBlock<
-          ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)
-        > {
+extension ObjCBlock_objcObjCObject_ffiVoid_CallExtension on objc
+    .ObjCBlock<ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<ffi.Void>)> {
   objc.ObjCObjectBase call(ffi.Pointer<ffi.Void> arg0) => objc.ObjCObjectBase(
-    ref.pointer.ref.invoke
-        .cast<
-          ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(
-              ffi.Pointer<objc.ObjCBlockImpl> block,
-              ffi.Pointer<ffi.Void> arg0,
-            )
-          >
-        >()
-        .asFunction<
-          ffi.Pointer<objc.ObjCObject> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.Void>,
-          )
-        >()(ref.pointer, arg0),
-    retain: true,
-    release: true,
-  );
+      ref.pointer.ref.invoke
+          .cast<
+              ffi.NativeFunction<
+                  ffi.Pointer<objc.ObjCObject> Function(
+                      ffi.Pointer<objc.ObjCBlockImpl> block,
+                      ffi.Pointer<ffi.Void> arg0)>>()
+          .asFunction<
+              ffi.Pointer<objc.ObjCObject> Function(
+                  ffi.Pointer<objc.ObjCBlockImpl>,
+                  ffi.Pointer<ffi.Void>)>()(ref.pointer, arg0),
+      retain: true,
+      release: true);
 }
 
 late final _sel_retain = objc.registerName("retain");
@@ -371,30 +264,23 @@ late final _sel_autorelease = objc.registerName("autorelease");
 
 /// MetalTextureWrapper
 class MetalTextureWrapper extends objc.NSObject {
-  MetalTextureWrapper._(
-    ffi.Pointer<objc.ObjCObject> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) : super.castFromPointer(pointer, retain: retain, release: release);
+  MetalTextureWrapper._(ffi.Pointer<objc.ObjCObject> pointer,
+      {bool retain = false, bool release = false})
+      : super.castFromPointer(pointer, retain: retain, release: release);
 
   /// Constructs a [MetalTextureWrapper] that points to the same underlying object as [other].
   MetalTextureWrapper.castFrom(objc.ObjCObjectBase other)
-    : this._(other.ref.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [MetalTextureWrapper] that wraps the given raw object pointer.
-  MetalTextureWrapper.castFromPointer(
-    ffi.Pointer<objc.ObjCObject> other, {
-    bool retain = false,
-    bool release = false,
-  }) : this._(other, retain: retain, release: release);
+  MetalTextureWrapper.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
+      {bool retain = false, bool release = false})
+      : this._(other, retain: retain, release: release);
 
   /// Returns whether [obj] is an instance of [MetalTextureWrapper].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_19nvye5(
-      obj.ref.pointer,
-      _sel_isKindOfClass_,
-      _class_MetalTextureWrapper,
-    );
+        obj.ref.pointer, _sel_isKindOfClass_, _class_MetalTextureWrapper);
   }
 
   /// pixelBuffer
@@ -445,24 +331,16 @@ class MetalTextureWrapper extends objc.NSObject {
 
   /// allocateWithWidth:height:isDepth:isStencil:
   static MetalTextureWrapper allocateWithWidth_height_isDepth_isStencil_(
-    int width,
-    int height,
-    bool isDepth,
-    bool isStencil,
-  ) {
+      int width, int height, bool isDepth, bool isStencil) {
     final _ret = _objc_msgSend_1v8gk45(
-      _class_MetalTextureWrapper,
-      _sel_allocateWithWidth_height_isDepth_isStencil_,
-      width,
-      height,
-      isDepth,
-      isStencil,
-    );
-    return MetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+        _class_MetalTextureWrapper,
+        _sel_allocateWithWidth_height_isDepth_isStencil_,
+        width,
+        height,
+        isDepth,
+        isStencil);
+    return MetalTextureWrapper.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// supportsRenderTarget
@@ -477,84 +355,55 @@ class MetalTextureWrapper extends objc.NSObject {
 
   /// init
   MetalTextureWrapper init() {
-    objc.checkOsVersionInternal(
-      'MetalTextureWrapper.init',
-      iOS: (false, (2, 0, 0)),
-      macOS: (false, (10, 0, 0)),
-    );
-    final _ret = _objc_msgSend_151sglz(
-      this.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
-    return MetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    objc.checkOsVersionInternal('MetalTextureWrapper.init',
+        iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
+    final _ret =
+        _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
+    return MetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// new
   static MetalTextureWrapper new$() {
     final _ret = _objc_msgSend_151sglz(_class_MetalTextureWrapper, _sel_new);
-    return MetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    return MetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// allocWithZone:
   static MetalTextureWrapper allocWithZone_(ffi.Pointer<objc.NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
-      _class_MetalTextureWrapper,
-      _sel_allocWithZone_,
-      zone,
-    );
-    return MetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+        _class_MetalTextureWrapper, _sel_allocWithZone_, zone);
+    return MetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// alloc
   static MetalTextureWrapper alloc() {
     final _ret = _objc_msgSend_151sglz(_class_MetalTextureWrapper, _sel_alloc);
-    return MetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    return MetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// self
   MetalTextureWrapper self$1() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_self);
-    return MetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return MetalTextureWrapper.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// retain
   MetalTextureWrapper retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
-    return MetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return MetalTextureWrapper.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// autorelease
   MetalTextureWrapper autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
-    return MetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return MetalTextureWrapper.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// Returns a new instance of MetalTextureWrapper constructed with the default `new` method.
@@ -564,447 +413,296 @@ class MetalTextureWrapper extends objc.NSObject {
 late final _sel_initWithTexture_ = objc.registerName("initWithTexture:");
 final _objc_msgSend_1sotr3r = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Pointer<objc.ObjCObject> Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-          ffi.Pointer<objc.ObjCObject>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject>)>>()
     .asFunction<
-      ffi.Pointer<objc.ObjCObject> Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-        ffi.Pointer<objc.ObjCObject>,
-      )
-    >();
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
 
 /// FlutterMetalTextureWrapper
 class FlutterMetalTextureWrapper extends objc.NSObject {
-  FlutterMetalTextureWrapper._(
-    ffi.Pointer<objc.ObjCObject> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) : super.castFromPointer(pointer, retain: retain, release: release);
+  FlutterMetalTextureWrapper._(ffi.Pointer<objc.ObjCObject> pointer,
+      {bool retain = false, bool release = false})
+      : super.castFromPointer(pointer, retain: retain, release: release);
 
   /// Constructs a [FlutterMetalTextureWrapper] that points to the same underlying object as [other].
   FlutterMetalTextureWrapper.castFrom(objc.ObjCObjectBase other)
-    : this._(other.ref.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [FlutterMetalTextureWrapper] that wraps the given raw object pointer.
-  FlutterMetalTextureWrapper.castFromPointer(
-    ffi.Pointer<objc.ObjCObject> other, {
-    bool retain = false,
-    bool release = false,
-  }) : this._(other, retain: retain, release: release);
+  FlutterMetalTextureWrapper.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
+      {bool retain = false, bool release = false})
+      : this._(other, retain: retain, release: release);
 
   /// Returns whether [obj] is an instance of [FlutterMetalTextureWrapper].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_19nvye5(
-      obj.ref.pointer,
-      _sel_isKindOfClass_,
-      _class_FlutterMetalTextureWrapper,
-    );
+    return _objc_msgSend_19nvye5(obj.ref.pointer, _sel_isKindOfClass_,
+        _class_FlutterMetalTextureWrapper);
   }
 
   /// initWithTexture:
   FlutterMetalTextureWrapper initWithTexture_(MetalTextureWrapper texture) {
-    final _ret = _objc_msgSend_1sotr3r(
-      this.ref.retainAndReturnPointer(),
-      _sel_initWithTexture_,
-      texture.ref.pointer,
-    );
-    return FlutterMetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
+        _sel_initWithTexture_, texture.ref.pointer);
+    return FlutterMetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// init
   FlutterMetalTextureWrapper init() {
-    objc.checkOsVersionInternal(
-      'FlutterMetalTextureWrapper.init',
-      iOS: (false, (2, 0, 0)),
-      macOS: (false, (10, 0, 0)),
-    );
-    final _ret = _objc_msgSend_151sglz(
-      this.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
-    return FlutterMetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    objc.checkOsVersionInternal('FlutterMetalTextureWrapper.init',
+        iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
+    final _ret =
+        _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
+    return FlutterMetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// new
   static FlutterMetalTextureWrapper new$() {
-    final _ret = _objc_msgSend_151sglz(
-      _class_FlutterMetalTextureWrapper,
-      _sel_new,
-    );
-    return FlutterMetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    final _ret =
+        _objc_msgSend_151sglz(_class_FlutterMetalTextureWrapper, _sel_new);
+    return FlutterMetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// allocWithZone:
   static FlutterMetalTextureWrapper allocWithZone_(
-    ffi.Pointer<objc.NSZone> zone,
-  ) {
+      ffi.Pointer<objc.NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
-      _class_FlutterMetalTextureWrapper,
-      _sel_allocWithZone_,
-      zone,
-    );
-    return FlutterMetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+        _class_FlutterMetalTextureWrapper, _sel_allocWithZone_, zone);
+    return FlutterMetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// alloc
   static FlutterMetalTextureWrapper alloc() {
-    final _ret = _objc_msgSend_151sglz(
-      _class_FlutterMetalTextureWrapper,
-      _sel_alloc,
-    );
-    return FlutterMetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    final _ret =
+        _objc_msgSend_151sglz(_class_FlutterMetalTextureWrapper, _sel_alloc);
+    return FlutterMetalTextureWrapper.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// self
   FlutterMetalTextureWrapper self$1() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_self);
-    return FlutterMetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return FlutterMetalTextureWrapper.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// retain
   FlutterMetalTextureWrapper retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
-    return FlutterMetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return FlutterMetalTextureWrapper.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// autorelease
   FlutterMetalTextureWrapper autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
-    return FlutterMetalTextureWrapper.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return FlutterMetalTextureWrapper.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// Returns a new instance of FlutterMetalTextureWrapper constructed with the default `new` method.
   factory FlutterMetalTextureWrapper() => new$();
 }
 
-late final _class_SwiftThermionFlutterPluginObjCAPI = objc.getClass(
-  "thermion_flutter.SwiftThermionFlutterPluginObjCAPI",
-);
+late final _class_SwiftThermionFlutterPluginObjCAPI =
+    objc.getClass("thermion_flutter.SwiftThermionFlutterPluginObjCAPI");
 late final _sel_textureRegistry = objc.registerName("textureRegistry");
-late final _sel_startFrameSchedulerWithCallbackAddress_targetFps_ = objc
-    .registerName("startFrameSchedulerWithCallbackAddress:targetFps:");
+late final _sel_startFrameSchedulerWithCallbackAddress_targetFps_ =
+    objc.registerName("startFrameSchedulerWithCallbackAddress:targetFps:");
 final _objc_msgSend_12xnd2d = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Void Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-          ffi.Int64,
-          ffi.Long,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Void Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>, ffi.Int64, ffi.Long)>>()
     .asFunction<
-      void Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-        int,
-        int,
-      )
-    >();
+        void Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, int, int)>();
 late final _sel_stopFrameScheduler = objc.registerName("stopFrameScheduler");
 late final _sel_initializeDartApi_ = objc.registerName("initializeDartApi:");
 final _objc_msgSend_17gvxvj = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Void Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-          ffi.Int64,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Void Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>, ffi.Int64)>>()
     .asFunction<
-      void Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-        int,
-      )
-    >();
-late final _sel_startFrameSchedulerWithPort_targetFps_ = objc.registerName(
-  "startFrameSchedulerWithPort:targetFps:",
-);
+        void Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, int)>();
+late final _sel_startFrameSchedulerWithPort_targetFps_ =
+    objc.registerName("startFrameSchedulerWithPort:targetFps:");
 
 /// SwiftThermionFlutterPluginObjCAPI
 class SwiftThermionFlutterPluginObjCAPI extends objc.NSObject {
-  SwiftThermionFlutterPluginObjCAPI._(
-    ffi.Pointer<objc.ObjCObject> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) : super.castFromPointer(pointer, retain: retain, release: release);
+  SwiftThermionFlutterPluginObjCAPI._(ffi.Pointer<objc.ObjCObject> pointer,
+      {bool retain = false, bool release = false})
+      : super.castFromPointer(pointer, retain: retain, release: release);
 
   /// Constructs a [SwiftThermionFlutterPluginObjCAPI] that points to the same underlying object as [other].
   SwiftThermionFlutterPluginObjCAPI.castFrom(objc.ObjCObjectBase other)
-    : this._(other.ref.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [SwiftThermionFlutterPluginObjCAPI] that wraps the given raw object pointer.
   SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-    ffi.Pointer<objc.ObjCObject> other, {
-    bool retain = false,
-    bool release = false,
-  }) : this._(other, retain: retain, release: release);
+      ffi.Pointer<objc.ObjCObject> other,
+      {bool retain = false,
+      bool release = false})
+      : this._(other, retain: retain, release: release);
 
   /// Returns whether [obj] is an instance of [SwiftThermionFlutterPluginObjCAPI].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_19nvye5(
-      obj.ref.pointer,
-      _sel_isKindOfClass_,
-      _class_SwiftThermionFlutterPluginObjCAPI,
-    );
+    return _objc_msgSend_19nvye5(obj.ref.pointer, _sel_isKindOfClass_,
+        _class_SwiftThermionFlutterPluginObjCAPI);
   }
 
   /// textureRegistry
   static objc.NSObject textureRegistry() {
     final _ret = _objc_msgSend_151sglz(
-      _class_SwiftThermionFlutterPluginObjCAPI,
-      _sel_textureRegistry,
-    );
+        _class_SwiftThermionFlutterPluginObjCAPI, _sel_textureRegistry);
     return objc.NSObject.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// startFrameSchedulerWithCallbackAddress:targetFps:
   static void startFrameSchedulerWithCallbackAddress_targetFps_(
-    int callbackAddress,
-    int targetFps,
-  ) {
+      int callbackAddress, int targetFps) {
     _objc_msgSend_12xnd2d(
-      _class_SwiftThermionFlutterPluginObjCAPI,
-      _sel_startFrameSchedulerWithCallbackAddress_targetFps_,
-      callbackAddress,
-      targetFps,
-    );
+        _class_SwiftThermionFlutterPluginObjCAPI,
+        _sel_startFrameSchedulerWithCallbackAddress_targetFps_,
+        callbackAddress,
+        targetFps);
   }
 
   /// stopFrameScheduler
   static void stopFrameScheduler() {
     _objc_msgSend_1pl9qdv(
-      _class_SwiftThermionFlutterPluginObjCAPI,
-      _sel_stopFrameScheduler,
-    );
+        _class_SwiftThermionFlutterPluginObjCAPI, _sel_stopFrameScheduler);
   }
 
   /// initializeDartApi:
   static void initializeDartApi_(int dataAddress) {
-    _objc_msgSend_17gvxvj(
-      _class_SwiftThermionFlutterPluginObjCAPI,
-      _sel_initializeDartApi_,
-      dataAddress,
-    );
+    _objc_msgSend_17gvxvj(_class_SwiftThermionFlutterPluginObjCAPI,
+        _sel_initializeDartApi_, dataAddress);
   }
 
   /// startFrameSchedulerWithPort:targetFps:
   static void startFrameSchedulerWithPort_targetFps_(int port, int targetFps) {
-    _objc_msgSend_12xnd2d(
-      _class_SwiftThermionFlutterPluginObjCAPI,
-      _sel_startFrameSchedulerWithPort_targetFps_,
-      port,
-      targetFps,
-    );
+    _objc_msgSend_12xnd2d(_class_SwiftThermionFlutterPluginObjCAPI,
+        _sel_startFrameSchedulerWithPort_targetFps_, port, targetFps);
   }
 
   /// init
   SwiftThermionFlutterPluginObjCAPI init() {
-    objc.checkOsVersionInternal(
-      'SwiftThermionFlutterPluginObjCAPI.init',
-      iOS: (false, (2, 0, 0)),
-      macOS: (false, (10, 0, 0)),
-    );
-    final _ret = _objc_msgSend_151sglz(
-      this.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    objc.checkOsVersionInternal('SwiftThermionFlutterPluginObjCAPI.init',
+        iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
+    final _ret =
+        _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// new
   static SwiftThermionFlutterPluginObjCAPI new$() {
     final _ret = _objc_msgSend_151sglz(
-      _class_SwiftThermionFlutterPluginObjCAPI,
-      _sel_new,
-    );
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+        _class_SwiftThermionFlutterPluginObjCAPI, _sel_new);
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// allocWithZone:
   static SwiftThermionFlutterPluginObjCAPI allocWithZone_(
-    ffi.Pointer<objc.NSZone> zone,
-  ) {
+      ffi.Pointer<objc.NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
-      _class_SwiftThermionFlutterPluginObjCAPI,
-      _sel_allocWithZone_,
-      zone,
-    );
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+        _class_SwiftThermionFlutterPluginObjCAPI, _sel_allocWithZone_, zone);
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// alloc
   static SwiftThermionFlutterPluginObjCAPI alloc() {
     final _ret = _objc_msgSend_151sglz(
-      _class_SwiftThermionFlutterPluginObjCAPI,
-      _sel_alloc,
-    );
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+        _class_SwiftThermionFlutterPluginObjCAPI, _sel_alloc);
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// self
   SwiftThermionFlutterPluginObjCAPI self$1() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_self);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// retain
   SwiftThermionFlutterPluginObjCAPI retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// autorelease
   SwiftThermionFlutterPluginObjCAPI autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
-    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return SwiftThermionFlutterPluginObjCAPI.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// Returns a new instance of SwiftThermionFlutterPluginObjCAPI constructed with the default `new` method.
   factory SwiftThermionFlutterPluginObjCAPI() => new$();
 }
 
-late final _class_ThermionTextureRegistry = objc.getClass(
-  "thermion_flutter.ThermionTextureRegistry",
-);
+late final _class_ThermionTextureRegistry =
+    objc.getClass("thermion_flutter.ThermionTextureRegistry");
 late final _sel_registerTexture_ = objc.registerName("registerTexture:");
 final _objc_msgSend_1oj5o8z = objc.msgSendPointer
     .cast<
-      ffi.NativeFunction<
-        ffi.Int64 Function(
-          ffi.Pointer<objc.ObjCObject>,
-          ffi.Pointer<objc.ObjCSelector>,
-          ffi.Pointer<objc.ObjCObject>,
-        )
-      >
-    >()
+        ffi.NativeFunction<
+            ffi.Int64 Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject>)>>()
     .asFunction<
-      int Function(
-        ffi.Pointer<objc.ObjCObject>,
-        ffi.Pointer<objc.ObjCSelector>,
-        ffi.Pointer<objc.ObjCObject>,
-      )
-    >();
-late final _sel_textureFrameAvailable_ = objc.registerName(
-  "textureFrameAvailable:",
-);
+        int Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
+late final _sel_textureFrameAvailable_ =
+    objc.registerName("textureFrameAvailable:");
 late final _sel_unregisterTexture_ = objc.registerName("unregisterTexture:");
 
 /// ThermionTextureRegistry
 class ThermionTextureRegistry extends objc.NSObject {
-  ThermionTextureRegistry._(
-    ffi.Pointer<objc.ObjCObject> pointer, {
-    bool retain = false,
-    bool release = false,
-  }) : super.castFromPointer(pointer, retain: retain, release: release);
+  ThermionTextureRegistry._(ffi.Pointer<objc.ObjCObject> pointer,
+      {bool retain = false, bool release = false})
+      : super.castFromPointer(pointer, retain: retain, release: release);
 
   /// Constructs a [ThermionTextureRegistry] that points to the same underlying object as [other].
   ThermionTextureRegistry.castFrom(objc.ObjCObjectBase other)
-    : this._(other.ref.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [ThermionTextureRegistry] that wraps the given raw object pointer.
-  ThermionTextureRegistry.castFromPointer(
-    ffi.Pointer<objc.ObjCObject> other, {
-    bool retain = false,
-    bool release = false,
-  }) : this._(other, retain: retain, release: release);
+  ThermionTextureRegistry.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
+      {bool retain = false, bool release = false})
+      : this._(other, retain: retain, release: release);
 
   /// Returns whether [obj] is an instance of [ThermionTextureRegistry].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_19nvye5(
-      obj.ref.pointer,
-      _sel_isKindOfClass_,
-      _class_ThermionTextureRegistry,
-    );
+        obj.ref.pointer, _sel_isKindOfClass_, _class_ThermionTextureRegistry);
   }
 
   /// registerTexture:
   int registerTexture_(objc.NSObject texture) {
     return _objc_msgSend_1oj5o8z(
-      this.ref.pointer,
-      _sel_registerTexture_,
-      texture.ref.pointer,
-    );
+        this.ref.pointer, _sel_registerTexture_, texture.ref.pointer);
   }
 
   /// textureFrameAvailable:
   void textureFrameAvailable_(int textureId) {
     _objc_msgSend_17gvxvj(
-      this.ref.pointer,
-      _sel_textureFrameAvailable_,
-      textureId,
-    );
+        this.ref.pointer, _sel_textureFrameAvailable_, textureId);
   }
 
   /// unregisterTexture:
@@ -1014,90 +712,57 @@ class ThermionTextureRegistry extends objc.NSObject {
 
   /// init
   ThermionTextureRegistry init() {
-    objc.checkOsVersionInternal(
-      'ThermionTextureRegistry.init',
-      iOS: (false, (2, 0, 0)),
-      macOS: (false, (10, 0, 0)),
-    );
-    final _ret = _objc_msgSend_151sglz(
-      this.ref.retainAndReturnPointer(),
-      _sel_init,
-    );
-    return ThermionTextureRegistry.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    objc.checkOsVersionInternal('ThermionTextureRegistry.init',
+        iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
+    final _ret =
+        _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
+    return ThermionTextureRegistry.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// new
   static ThermionTextureRegistry new$() {
-    final _ret = _objc_msgSend_151sglz(
-      _class_ThermionTextureRegistry,
-      _sel_new,
-    );
-    return ThermionTextureRegistry.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    final _ret =
+        _objc_msgSend_151sglz(_class_ThermionTextureRegistry, _sel_new);
+    return ThermionTextureRegistry.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// allocWithZone:
   static ThermionTextureRegistry allocWithZone_(ffi.Pointer<objc.NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
-      _class_ThermionTextureRegistry,
-      _sel_allocWithZone_,
-      zone,
-    );
-    return ThermionTextureRegistry.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+        _class_ThermionTextureRegistry, _sel_allocWithZone_, zone);
+    return ThermionTextureRegistry.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// alloc
   static ThermionTextureRegistry alloc() {
-    final _ret = _objc_msgSend_151sglz(
-      _class_ThermionTextureRegistry,
-      _sel_alloc,
-    );
-    return ThermionTextureRegistry.castFromPointer(
-      _ret,
-      retain: false,
-      release: true,
-    );
+    final _ret =
+        _objc_msgSend_151sglz(_class_ThermionTextureRegistry, _sel_alloc);
+    return ThermionTextureRegistry.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// self
   ThermionTextureRegistry self$1() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_self);
-    return ThermionTextureRegistry.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return ThermionTextureRegistry.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// retain
   ThermionTextureRegistry retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
-    return ThermionTextureRegistry.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return ThermionTextureRegistry.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// autorelease
   ThermionTextureRegistry autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
-    return ThermionTextureRegistry.castFromPointer(
-      _ret,
-      retain: true,
-      release: true,
-    );
+    return ThermionTextureRegistry.castFromPointer(_ret,
+        retain: true, release: true);
   }
 
   /// Returns a new instance of ThermionTextureRegistry constructed with the default `new` method.

--- a/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'package:thermion_dart/thermion_dart.dart';
+// ignore: implementation_imports
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_flutter/src/options.dart';
 import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
 import 'platform/platform.dart';
@@ -78,6 +80,7 @@ abstract class ThermionFlutterPlugin {
     _logger.finest("Plugin initialized");
     final viewer = ThermionViewerFFI(
       createOverlay: instance.options.nativeOptions.createOverlay,
+      app: result.app as FFIFilamentApp,
     );
     await viewer.initialized;
     _logger.finest("Viewer initialized");

--- a/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
@@ -80,7 +80,9 @@ abstract class ThermionFlutterPlugin {
     _logger.finest("Plugin initialized");
     final viewer = ThermionViewerFFI(
       createOverlay: instance.options.nativeOptions.createOverlay,
-      app: result.app as FFIFilamentApp,
+      // The foundation still has the native single-app initialize contract.
+      // The web feature layer replaces this with its per-initialization app.
+      app: FilamentApp.instance as FFIFilamentApp,
     );
     await viewer.initialized;
     _logger.finest("Viewer initialized");


### PR DESCRIPTION
On native platforms,  we historically assumed that there will only ever be a single Filament `Engine` and `FilamentApp` instance per-process. 

This assumption doesn't hold on the WebGL2 backend, where one context per canvas is needed (and thus one engine/FilamentApp per canvas/context).

We therefore need to revert to our earlier implementation where all FFI* classes are associated with the FilamentApp instance that created them.   

This PR:
- routes render-thread work through owner-keyed `RenderThread` instances.
- makes each render thread own its canvas selector and stop state.
- Allow explicitly owned concurrent apps via `destroyExisting: false`.
- Scope render-attachment bookkeeping per engine.

We preserve the current single-app Flutter initialization API. 