### PR TITLE
fix: serialize VkQueue calls on single-queue hardware (#180)

### DIFF
--- a/thermion_dart/native/include/vulkan/VulkanUtils.h
+++ b/thermion_dart/native/include/vulkan/VulkanUtils.h
@@ -43,6 +43,7 @@ struct CommandResources {
     VkCommandPool commandPool;
     VkQueue queue;
     uint32_t queueFamilyIndex;
+    bool queueSharedWithFilament = false;  // true when the blit had to reuse Filament's queue 0 (single-queue HW)
 };
 
 CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physicalDevice);

--- a/thermion_dart/native/include/vulkan/linux/LinuxVulkanUtils.h
+++ b/thermion_dart/native/include/vulkan/linux/LinuxVulkanUtils.h
@@ -24,6 +24,7 @@ struct CommandResources {
     VkCommandPool commandPool;
     VkQueue queue;
     uint32_t queueFamilyIndex;
+    bool queueSharedWithFilament = false;  // true when the blit had to reuse Filament's queue 0 (single-queue HW)
 };
 
 CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physicalDevice);

--- a/thermion_dart/native/src/vulkan/VulkanUtils.cpp
+++ b/thermion_dart/native/src/vulkan/VulkanUtils.cpp
@@ -285,6 +285,9 @@ CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physic
     bluevk::vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, families.data());
     const uint32_t queueIndex =
         families[resources.queueFamilyIndex].queueCount >= 2 ? 1u : 0u;
+    // Signal single-queue HW: the blit reuses Filament's queue 0 and so
+    // needs queue-level call serialization (see WindowsVulkanContext shim).
+    resources.queueSharedWithFilament = (queueIndex == 0);
     Log("[INFO] Blit/command queue: family %d, queue index %d",
         (int)resources.queueFamilyIndex, (int)queueIndex);
 

--- a/thermion_dart/native/src/vulkan/linux/LinuxVulkanContext.cpp
+++ b/thermion_dart/native/src/vulkan/linux/LinuxVulkanContext.cpp
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <memory>
+#include <mutex>
 #include <iostream>
 #include <unordered_map>
 
@@ -15,6 +16,97 @@
 namespace thermion::vulkan::linux_platform {
 
 using namespace bluevk;
+
+namespace {
+
+// Single-queue-hardware fallback. When the graphics family exposes only one
+// queue, the blit worker and Filament's render thread both submit to queue 0.
+// Vulkan requires external synchronization of every queue-level call, so we
+// interpose the process-wide bluevk function-pointer globals with wrappers
+// that serialize on this mutex. Filament's Vulkan backend (backend) and this
+// blit worker are statically linked into the same thermion_dart.so and
+// therefore dereference the SAME bluevk globals (declared extern in
+// BlueVK.h), so interposing them here funnels both threads' submissions
+// through one lock. On multi-queue HW this shim is never installed.
+std::mutex sQueueMutex;
+
+PFN_vkQueueSubmit     sRealQueueSubmit     = nullptr;
+PFN_vkQueueSubmit2    sRealQueueSubmit2    = nullptr;
+PFN_vkQueueWaitIdle   sRealQueueWaitIdle   = nullptr;
+PFN_vkQueuePresentKHR sRealQueuePresentKHR = nullptr;
+PFN_vkQueueBindSparse sRealQueueBindSparse = nullptr;
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueueSubmit(VkQueue queue, uint32_t submitCount,
+                                                     const VkSubmitInfo* pSubmits, VkFence fence) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueueSubmit(queue, submitCount, pSubmits, fence);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueueSubmit2(VkQueue queue, uint32_t submitCount,
+                                                      const VkSubmitInfo2* pSubmits, VkFence fence) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueueSubmit2(queue, submitCount, pSubmits, fence);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueueWaitIdle(VkQueue queue) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueueWaitIdle(queue);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueuePresentKHR(VkQueue queue,
+                                                         const VkPresentInfoKHR* pPresentInfo) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueuePresentKHR(queue, pPresentInfo);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueueBindSparse(VkQueue queue, uint32_t bindInfoCount,
+                                                         const VkBindSparseInfo* pBindInfo, VkFence fence) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
+}
+
+// Idempotent: safe to call every frame. For each global, capture the current
+// (real) pointer and reassign the global to our wrapper — but only when it is
+// not already pointing at the wrapper, which prevents infinite recursion on
+// re-install (Filament re-binds these globals on Engine (re)creation, dropping
+// our shim, so BlitToExport re-calls this).
+void InstallQueueSerializationShim() {
+    static bool sLogged = false;
+    bool swapped = false;
+
+    if (bluevk::vkQueueSubmit && bluevk::vkQueueSubmit != &SerializedQueueSubmit) {
+        sRealQueueSubmit = bluevk::vkQueueSubmit;
+        bluevk::vkQueueSubmit = &SerializedQueueSubmit;
+        swapped = true;
+    }
+    if (bluevk::vkQueueSubmit2 && bluevk::vkQueueSubmit2 != &SerializedQueueSubmit2) {
+        sRealQueueSubmit2 = bluevk::vkQueueSubmit2;
+        bluevk::vkQueueSubmit2 = &SerializedQueueSubmit2;
+        swapped = true;
+    }
+    if (bluevk::vkQueueWaitIdle && bluevk::vkQueueWaitIdle != &SerializedQueueWaitIdle) {
+        sRealQueueWaitIdle = bluevk::vkQueueWaitIdle;
+        bluevk::vkQueueWaitIdle = &SerializedQueueWaitIdle;
+        swapped = true;
+    }
+    if (bluevk::vkQueuePresentKHR && bluevk::vkQueuePresentKHR != &SerializedQueuePresentKHR) {
+        sRealQueuePresentKHR = bluevk::vkQueuePresentKHR;
+        bluevk::vkQueuePresentKHR = &SerializedQueuePresentKHR;
+        swapped = true;
+    }
+    if (bluevk::vkQueueBindSparse && bluevk::vkQueueBindSparse != &SerializedQueueBindSparse) {
+        sRealQueueBindSparse = bluevk::vkQueueBindSparse;
+        bluevk::vkQueueBindSparse = &SerializedQueueBindSparse;
+        swapped = true;
+    }
+
+    if (swapped && !sLogged) {
+        sLogged = true;
+        std::cerr << "[ThermionVk] Queue-submission serialization shim installed" << std::endl;
+    }
+}
+
+} // namespace
 
 class LinuxVulkanContext::Impl {
     public:
@@ -170,7 +262,14 @@ class LinuxVulkanContext::Impl {
                 };
                 vkAllocateCommandBuffers(device, &cmdAllocInfo, &_blitCmdBuffer);
 
-                std::cerr << "[ThermionVk:Context] Blit resources initialized (queue index 1)" << std::endl;
+                std::cerr << "[ThermionVk:Context] Blit resources initialized" << std::endl;
+            }
+
+            // Single-queue HW: the blit shares Filament's queue 0, so serialize
+            // queue calls. Re-installed per frame (idempotent) to survive
+            // Filament re-binding the bluevk globals on Engine (re)creation.
+            if (_blitResources.queueSharedWithFilament) {
+                InstallQueueSerializationShim();
             }
 
             // Wait for Filament's GPU work to finish

--- a/thermion_dart/native/src/vulkan/linux/LinuxVulkanUtils.cpp
+++ b/thermion_dart/native/src/vulkan/linux/LinuxVulkanUtils.cpp
@@ -212,10 +212,26 @@ CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physic
     // 1. Find a suitable queue family
     resources.queueFamilyIndex = findGraphicsQueueFamily(physicalDevice);
 
-    // 2. Get the queue handle (index 1 = blit queue, index 0 is reserved for Filament)
+    // 2. Get the queue handle. Use the SECOND queue in the family when the
+    //    hardware has one (the device requests two — see createLogicalDevice):
+    //    queue 0 belongs to Filament; submitting to it concurrently from the
+    //    blit thread is a data race. Fall back to queue 0 only on single-queue
+    //    hardware, where the LinuxVulkanContext shim serializes queue calls.
+    uint32_t familyCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, nullptr);
+    std::vector<VkQueueFamilyProperties> families(familyCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &familyCount, families.data());
+    const uint32_t queueIndex =
+        families[resources.queueFamilyIndex].queueCount >= 2 ? 1u : 0u;
+    resources.queueSharedWithFilament = (queueIndex == 0);
+    std::cerr << "[ThermionVk] Blit/command queue: family "
+              << resources.queueFamilyIndex << ", queue index " << queueIndex
+              << (resources.queueSharedWithFilament ? " (shared with Filament)" : "")
+              << std::endl;
+
     vkGetDeviceQueue(device,
         resources.queueFamilyIndex,
-        1,
+        queueIndex,
         &resources.queue);
 
     // 3. Create command pool
@@ -342,14 +358,20 @@ VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevi
                   << ": flags=0x" << std::hex << qfProps[i].queueFlags << std::dec
                   << " count=" << qfProps[i].queueCount << std::endl;
     }
+    // Request a second queue in the family when the hardware exposes one.
+    // Queue 0 is handed to Filament; the blit submits from a separate thread.
+    // VkQueue access is externally synchronized, so sharing one queue across
+    // those threads is a data race. With two queues the blit gets its own
+    // (see createCommandResources); with one queue they share queue 0 and the
+    // blit's queue calls are serialized via the LinuxVulkanContext shim.
+    const uint32_t queueCount = qfProps[*queueFamilyIndex].queueCount >= 2 ? 2u : 1u;
     std::cerr << "[ThermionVk] Using graphics queue family " << *queueFamilyIndex
-              << " (supports " << qfProps[*queueFamilyIndex].queueCount << " queues, requesting 2)" << std::endl;
+              << " (supports " << qfProps[*queueFamilyIndex].queueCount
+              << " queues, requesting " << queueCount << ")" << std::endl;
 
-    if (qfProps[*queueFamilyIndex].queueCount < 2) {
-        std::cerr << "[ThermionVk] WARNING: Queue family only supports "
-                  << qfProps[*queueFamilyIndex].queueCount
-                  << " queues, but we need 2 (Filament + blit). "
-                  << "Filament and blit will share a queue." << std::endl;
+    if (queueCount < 2) {
+        std::cerr << "[ThermionVk] Single graphics queue: Filament and blit share queue 0; "
+                  << "queue calls will be serialized (see LinuxVulkanContext shim)." << std::endl;
     }
 
     // Check which device extensions are available
@@ -436,7 +458,7 @@ VkResult createLogicalDevice(VkInstance instance, VkPhysicalDevice *physicalDevi
     VkDeviceQueueCreateInfo queueCreateInfo = {};
     queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
     queueCreateInfo.queueFamilyIndex = *queueFamilyIndex;
-    queueCreateInfo.queueCount = 2;
+    queueCreateInfo.queueCount = queueCount;
     queueCreateInfo.pQueuePriorities = queuePriorities;
 
     VkDeviceCreateInfo deviceCreateInfo = {};

--- a/thermion_dart/native/src/vulkan/windows/WindowsVulkanContext.cpp
+++ b/thermion_dart/native/src/vulkan/windows/WindowsVulkanContext.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <thread>
 
 #include "filament/backend/platforms/VulkanPlatform.h"
@@ -32,6 +33,97 @@
 namespace thermion::vulkan::windows {
 
 using namespace bluevk;
+
+namespace {
+
+// Single-queue-hardware fallback. When the graphics family exposes only one
+// queue, the blit worker and Filament's render thread both submit to queue 0.
+// Vulkan requires external synchronization of every queue-level call, so we
+// interpose the process-wide bluevk function-pointer globals with wrappers
+// that serialize on this mutex. Both Filament's Vulkan backend (backend.lib)
+// and this blit worker are statically linked into the same thermion_dart.dll
+// and therefore dereference the SAME bluevk globals (declared extern in
+// BlueVK.h), so interposing them here funnels both threads' submissions
+// through one lock. On multi-queue HW this shim is never installed.
+std::mutex sQueueMutex;
+
+PFN_vkQueueSubmit     sRealQueueSubmit     = nullptr;
+PFN_vkQueueSubmit2    sRealQueueSubmit2    = nullptr;
+PFN_vkQueueWaitIdle   sRealQueueWaitIdle   = nullptr;
+PFN_vkQueuePresentKHR sRealQueuePresentKHR = nullptr;
+PFN_vkQueueBindSparse sRealQueueBindSparse = nullptr;
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueueSubmit(VkQueue queue, uint32_t submitCount,
+                                                     const VkSubmitInfo* pSubmits, VkFence fence) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueueSubmit(queue, submitCount, pSubmits, fence);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueueSubmit2(VkQueue queue, uint32_t submitCount,
+                                                      const VkSubmitInfo2* pSubmits, VkFence fence) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueueSubmit2(queue, submitCount, pSubmits, fence);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueueWaitIdle(VkQueue queue) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueueWaitIdle(queue);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueuePresentKHR(VkQueue queue,
+                                                         const VkPresentInfoKHR* pPresentInfo) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueuePresentKHR(queue, pPresentInfo);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL SerializedQueueBindSparse(VkQueue queue, uint32_t bindInfoCount,
+                                                         const VkBindSparseInfo* pBindInfo, VkFence fence) {
+    std::lock_guard<std::mutex> lock(sQueueMutex);
+    return sRealQueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
+}
+
+// Idempotent: safe to call every frame. For each global, capture the current
+// (real) pointer and reassign the global to our wrapper — but only when it is
+// not already pointing at the wrapper, which prevents infinite recursion on
+// re-install (Filament's bindInstance() re-binds these globals on Engine
+// (re)creation, dropping our shim, so CreateRenderingSurface/Blit re-call this).
+void InstallQueueSerializationShim() {
+    static bool sLogged = false;
+    bool swapped = false;
+
+    if (bluevk::vkQueueSubmit && bluevk::vkQueueSubmit != &SerializedQueueSubmit) {
+        sRealQueueSubmit = bluevk::vkQueueSubmit;
+        bluevk::vkQueueSubmit = &SerializedQueueSubmit;
+        swapped = true;
+    }
+    if (bluevk::vkQueueSubmit2 && bluevk::vkQueueSubmit2 != &SerializedQueueSubmit2) {
+        sRealQueueSubmit2 = bluevk::vkQueueSubmit2;
+        bluevk::vkQueueSubmit2 = &SerializedQueueSubmit2;
+        swapped = true;
+    }
+    if (bluevk::vkQueueWaitIdle && bluevk::vkQueueWaitIdle != &SerializedQueueWaitIdle) {
+        sRealQueueWaitIdle = bluevk::vkQueueWaitIdle;
+        bluevk::vkQueueWaitIdle = &SerializedQueueWaitIdle;
+        swapped = true;
+    }
+    if (bluevk::vkQueuePresentKHR && bluevk::vkQueuePresentKHR != &SerializedQueuePresentKHR) {
+        sRealQueuePresentKHR = bluevk::vkQueuePresentKHR;
+        bluevk::vkQueuePresentKHR = &SerializedQueuePresentKHR;
+        swapped = true;
+    }
+    if (bluevk::vkQueueBindSparse && bluevk::vkQueueBindSparse != &SerializedQueueBindSparse) {
+        sRealQueueBindSparse = bluevk::vkQueueBindSparse;
+        bluevk::vkQueueBindSparse = &SerializedQueueBindSparse;
+        swapped = true;
+    }
+
+    if (swapped && !sLogged) {
+        sLogged = true;
+        std::cerr << "[ThermionVk] Queue-submission serialization shim installed" << std::endl;
+    }
+}
+
+} // namespace
 
 class WindowsVulkanContext::Impl {
     public:
@@ -85,6 +177,7 @@ class WindowsVulkanContext::Impl {
 
             commandPool = cmdResources.commandPool;
             queue = cmdResources.queue;
+            queueSharedWithFilament = cmdResources.queueSharedWithFilament;
             Log("[INFO] Vulkan command resources using queue family index %d",
                 (int)cmdResources.queueFamilyIndex);
 
@@ -169,6 +262,14 @@ class WindowsVulkanContext::Impl {
         }
 
         HANDLE CreateRenderingSurface(uint32_t width, uint32_t height, uint32_t left, uint32_t top) {
+            // CreateRenderingSurface runs after Filament Engine creation, which
+            // re-binds the bluevk globals and would drop any previously
+            // installed shim. Re-install (idempotent) here, before the first
+            // blit, when the blit shares Filament's queue.
+            if (queueSharedWithFilament) {
+                InstallQueueSerializationShim();
+            }
+
             Log("Creating Vulkan texture %dx%d", width, height);
 
             // 1. Create pure Vulkan texture for render target (returned to Flutter as hardware texture ID)
@@ -269,6 +370,12 @@ class WindowsVulkanContext::Impl {
         }
 
         void Blit(HANDLE d3dTextureHandle) {
+            // Per-frame re-check: a later Filament Engine re-creation re-binds
+            // the bluevk globals and would silently drop the shim. Idempotent.
+            if (queueSharedWithFilament) {
+                InstallQueueSerializationShim();
+            }
+
             // Skip the first Blit after texture creation.  The render
             // target has uninitialized contents until Filament renders
             // into it; blitting garbage produces visible jank.
@@ -714,6 +821,7 @@ class WindowsVulkanContext::Impl {
         VkCommandBuffer blitCommandBuffer = VK_NULL_HANDLE;
         VkFence blitFence = VK_NULL_HANDLE;
         VkQueue queue = VK_NULL_HANDLE;
+        bool queueSharedWithFilament = false;  // set from CommandResources; gates the serialization shim
 
         std::unique_ptr<thermion::windows::d3d::D3DContext> _d3dContext;
 


### PR DESCRIPTION
Closes #180 (VkQueue submission race on single-queue-hardware) on both Windows and Linux.

PR #174 eliminated the race on multi-queue hardware by giving Filament queue 0 and the blit queue 1. But when a graphics family exposes only one queue (some Intel iGPUs, some VMs), both the blit worker and Filament's render thread submit to `VkQueue` 0 with no external synchronization — Vulkan UB that surfaces as `VK_ERROR_DEVICE_LOST` under sustained rendering on newer drivers. You can't request a second queue that doesn't exist, so the fix is to serialize the shared queue's calls.

On Linux, we previously hardcoded `queueCount = 2`, so `vkCreateDevice` **failed outright** on single-queue HW — Linux couldn't initialize there at all. This PR also makes Linux request `min(2, available)` so it both runs and stays race-free.

## Change

Gates the issue's verified bluevk interposition shim on the single-queue fallback, mirrored across both backends:

- **`VulkanUtils.{h,cpp}`** (Windows) and **`LinuxVulkanUtils.{h,cpp}`** (Linux) — device creation requests `min(2, available)` queues; `createCommandResources` sets a `CommandResources::queueSharedWithFilament` flag (`true` exactly when the blit had to reuse queue 0).
- **`WindowsVulkanContext.cpp`** and **`LinuxVulkanContext.cpp`** — when the flag is set, install idempotent `std::mutex`-serializing wrappers over the five process-wide bluevk queue globals (`vkQueueSubmit`, `vkQueueSubmit2`, `vkQueueWaitIdle`, `vkQueuePresentKHR`, `vkQueueBindSparse`). The shim is re-installed per frame (Windows: `CreateRenderingSurface` + `Blit`; Linux: `BlitToExport`) to survive Filament's `bindInstance()` re-bind on Engine (re)creation.
- **Linux keeps `vkDeviceWaitIdle`** before each blit — it still guarantees the render→blit data dependency; the shim adds the fine-grained queue serialization on top.

Zero cost on multi-queue HW, the flag is false and the shim is never installed, so Filament's queue-0 submissions stay unserialized.


