### PR TITLE
apply glTF animation on first update() instead of rest pose

### DIFF
--- a/examples/dart/cli_headless/bin/render_demo.dart
+++ b/examples/dart/cli_headless/bin/render_demo.dart
@@ -255,14 +255,9 @@ Future<void> main(List<String> argv) async {
   print('Rendering $frameCount frames at ${width}x$height (${fps}fps, '
       '${durationSeconds}s)...');
 
-  // Prime the animation start time. GltfAnimationComponentManager::update()
-  // stamps startTime and SKIPS applying the animation on its very first call,
-  // so without this the first captured frame would be the drone's rest/export
-  // pose instead of animation-frame-0. Consuming the stamping call here means
-  // the loop's first update() applies at elapsed 0 (the true first frame).
-  // Frames 1..N are unaffected, so only frame 0 differs from an unprimed render.
-  await app.animationManager.update(animDtNanos);
-
+  // The engine now applies animation-frame-0 on the first update() call (it
+  // no longer stamps-and-skips), so no priming is needed: frame 0 of the loop
+  // is the true first animation frame.
   for (var i = 0; i < frameCount; i++) {
     final t = i / frameCount; // [0, 1)
 

--- a/thermion_dart/native/src/components/GltfAnimationComponentManager.cpp
+++ b/thermion_dart/native/src/components/GltfAnimationComponentManager.cpp
@@ -106,10 +106,13 @@ namespace thermion
             {
                 auto &animationStatus = gltfAnimations[i];
 
-                // Initialize start time on first use
+                // Initialize start time on first use, then fall through so the
+                // animation is also applied on this first call (at elapsed 0).
+                // Previously this `continue`d, skipping applyAnimation and
+                // leaving the first rendered frame at the asset's rest/export
+                // pose instead of animation-frame-0.
                 if (animationStatus.startTimeInNanos == 0) {
                     animationStatus.startTimeInNanos = frameTimeInNanos;
-                    continue;
                 }
 
                 uint64_t elapsedInNanos = frameTimeInNanos - animationStatus.startTimeInNanos;


### PR DESCRIPTION
The first frame rendered after `playGltfAnimation` is called should immediately show the first frame of the animation. There's no need to wait for a second frame to update.