### PR TITLE
ci: skip the native build when downloading web artifacts (supersedes #220)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,14 +30,11 @@ concurrency:
 jobs:
   deploy:
     name: Build & deploy site
-    # ubuntu-22.04 (not -24.04): the "Download thermion web artifacts" step runs
-    # `dart run bin/download_web.dart`, which resolves thermion_dart's native
-    # assets and fires hook/build.dart for the HOST target — compiling the C++
-    # glue. On ubuntu-24.04 clang can't find the C++ stdlib headers
-    # (fatal error: 'cstdint' file not found); 22.04's toolchain resolves them.
-    # Same image run-web-builds.yml uses for the identical command. Keep this as
-    # the single download pathway — do not duplicate it with curl/unzip.
-    runs-on: ubuntu-22.04
+    # Any standard runner works: the web-artifact download step runs
+    # `dart run thermion_dart:download_web` with `skip_native_build` set (see
+    # examples/dart/web_gallery/pubspec.yaml + thermion_dart/hook/build.dart), so
+    # it does no host C++ compile and needs no C++ toolchain.
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -64,8 +61,15 @@ jobs:
           (cd examples/dart/examples_lib && dart pub get)
           (cd examples/dart/web_gallery && dart pub get)
       - name: Download thermion web artifacts (thermion_dart.js/wasm)
-        working-directory: thermion_dart
-        run: dart run bin/download_web.dart -o ../examples/dart/web_gallery/web
+        # Run from the gallery so thermion_dart's build hook picks up the
+        # `skip_native_build` userDefine (declared under hooks.user_defines in
+        # examples/dart/web_gallery/pubspec.yaml). That makes the hook no-op its
+        # host C++ build: download_web.dart only fetches prebuilt artifacts over
+        # HTTP, so no native compile — and no C++ toolchain on the runner — is
+        # needed. (The later `dart compile wasm` step is unaffected: the hook's
+        # buildCodeAssets branch runs before the skip and still downloads for web.)
+        working-directory: examples/dart/web_gallery
+        run: dart run thermion_dart:download_web -o web
       - name: Copy shared assets
         run: cp -r examples/assets examples/dart/web_gallery/web/assets
       - name: Compile gallery to WASM

--- a/examples/dart/web_gallery/pubspec.yaml
+++ b/examples/dart/web_gallery/pubspec.yaml
@@ -13,3 +13,15 @@ dependencies:
     path: ../examples_lib
   logging: ^1.3.0
   web: ^1.0.0
+
+# This package only ever builds for the web (compiled to WASM), so it never
+# needs a host native build. Setting skip_native_build lets us run Thermion's
+# pure-Dart tooling here — notably `dart run thermion_dart:download_web`, which
+# only fetches prebuilt web artifacts over HTTP — without the build hook firing
+# a host C++ compile (and without needing a C++ toolchain on the runner). The
+# web build itself is unaffected: the hook's buildCodeAssets branch still
+# downloads artifacts before this skip takes effect.
+hooks:
+  user_defines:
+    thermion_dart:
+      skip_native_build: true

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -21,6 +21,22 @@ void main(List<String> args) async {
       return;
     }
 
+    // Escape hatch for running pure-Dart tooling in this package — e.g.
+    // `bin/download_web.dart`, which only fetches prebuilt artifacts over HTTP
+    // and uses no native code — without paying for a host C++ build (and without
+    // needing a C++ toolchain on the runner at all). `dart run` always resolves
+    // this package's native assets and would otherwise fire the CBuilder below.
+    // Set `skip_native_build: true` under `hooks.user_defines.thermion_dart` in
+    // the *consuming* package's pubspec.yaml: CLI defines aren't supported, and
+    // env vars aren't forwarded into the hook subprocess (it gets a curated
+    // PATH/HOME-only environment). Placed after the web branch above so a web
+    // build still downloads its artifacts. Produces no code assets, so only safe
+    // for invocations that need no native library.
+    if (input.userDefines["skip_native_build"] == true) {
+      logger.info("skip_native_build userDefine is set; skipping host native build");
+      return;
+    }
+
     logger.info(input.assets.encodedAssets.keys.toList());
 
     final config = input.config;


### PR DESCRIPTION
Adds THERMION_SKIP_NATIVE_BUILD env var so we can skip an actual build in build.dart and just download web artifacts.
