### PR TITLE
ci: fix inputs.verify boolean comparisons (string-coercion trap)

### DIFF
--- a/.github/workflows/generate-artifacts.yml
+++ b/.github/workflows/generate-artifacts.yml
@@ -163,14 +163,14 @@ jobs:
       # committed bindings. A diff here means bindings are stale — abort the
       # release rather than shipping or auto-committing.
       - name: Fail if generated artifacts are stale (verify)
-        if: ${{ inputs.verify == 'true' && steps.git-check.outputs.changed == 'true' }}
+        if: ${{ inputs.verify && steps.git-check.outputs.changed == 'true' }}
         run: |
           echo "::error::Generated bindings/materials differ from the committed tag. Run 'make bindings' / 'make materials', commit on develop, then re-tag."
           git --no-pager diff --stat
           exit 1
 
       - name: Commit and push if changed
-        if: inputs.verify != 'true' && steps.git-check.outputs.changed == 'true'
+        if: ${{ !inputs.verify && steps.git-check.outputs.changed == 'true' }}
         env:
           # Pass via env (not inline) to avoid script injection from PR head refs.
           PUSH_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -209,7 +209,7 @@ jobs:
         run: make wasm
 
       - name: Package and upload web artifacts to R2
-        if: inputs.verify != 'true' && steps.changes.outputs.native-changed == 'true' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/'))
+        if: ${{ !inputs.verify && steps.changes.outputs.native-changed == 'true' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')) }}
         # R2 is a cache, not a release gate: an R2 outage must not block a
         # release (deploy.yml failing later is the softer signal).
         continue-on-error: true
@@ -229,7 +229,7 @@ jobs:
           echo "$SHORT_SHA" > "${{ github.workspace }}/thermion_dart/native/web/web.version"
 
       - name: Commit web.version
-        if: inputs.verify != 'true' && steps.changes.outputs.native-changed == 'true' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/'))
+        if: ${{ !inputs.verify && steps.changes.outputs.native-changed == 'true' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')) }}
         env:
           PUSH_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
@@ -248,7 +248,7 @@ jobs:
           path: thermion_dart/native/web/build/build/out/
 
       - name: Resolve post-push SHA
-        if: inputs.verify != 'true'
+        if: ${{ !inputs.verify }}
         id: resolve-sha
         env:
           PUSH_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -261,7 +261,7 @@ jobs:
     name: Run Tests
     # Skipped when called as the release verify gate — the release orchestrator
     # (publish-pub-dev.yml) runs its own tests at the tag SHA.
-    if: inputs.verify != 'true'
+    if: ${{ !inputs.verify }}
     needs: generate-artifacts
     uses: ./.github/workflows/run-tests.yml
     with:

--- a/.tickets/the-f3wv.md
+++ b/.tickets/the-f3wv.md
@@ -1,0 +1,72 @@
+---
+id: the-f3wv
+status: in_progress
+deps: [the-k5p9]
+links: []
+created: 2026-08-10T05:10:00Z
+type: bug
+priority: 0
+assignee: Nick Fisher
+tags: [ci, release]
+---
+# Fix inputs.verify comparisons: boolean vs string type trap in generate-artifacts.yml
+
+## Symptom
+Release cycle for v0.5.0-pre.5 (Create Release run 31357040677 -> publish run
+31357070941, head_sha 4fe518a3 which ALREADY contained the the-k5p9 guard).
+"Verify generated artifacts / Generate Artifacts" STILL failed at
+"Resolve post-push SHA" with the SAME error:
+
+```
+* tag v0.5.0-pre.5 -> FETCH_HEAD
+fatal: ambiguous argument 'origin/v0.5.0-pre.5': unknown revision
+exit code 128
+```
+
+The step RAN despite `if: inputs.verify != 'true'` being present.
+
+## Root cause (verified)
+The `verify` input is declared `type: boolean` and the caller passes
+`with: verify: true` (a YAML boolean). GitHub Actions expressions do NOT
+coerce booleans to strings in == / != comparisons (the falsy/truthy coercion
+documented for expressions applies only to conditionals' truthiness, not to
+equality between a boolean and the STRING 'true'). So:
+
+- `inputs.verify != 'true'` with verify=true evaluates to TRUE -> steps that
+  should be SKIPPED in verify mode actually RUN (this failure).
+- `inputs.verify == 'true'` with verify=true evaluates to FALSE -> the
+  "Fail if generated artifacts are stale (verify)" gate would NEVER fire on
+  stale artifacts (silent gate bypass, not yet observed because artifacts
+  were fresh, but equally broken).
+
+ALL SIX occurrences in .github/workflows/generate-artifacts.yml are affected:
+- L166  `if: inputs.verify == 'true' && steps.git-check.outputs.changed == 'true'`
+- L173  `if: inputs.verify != 'true' && steps.git-check.outputs.changed == 'true'`
+- L212  `if: inputs.verify != 'true' && steps.changes.outputs.native-changed == 'true' && (...)`
+- L232  `if: inputs.verify != 'true' && steps.changes.outputs.native-changed == 'true' && (...)`
+- L251  `if: inputs.verify != 'true'`  (Resolve post-push SHA)
+- L264  `if: inputs.verify != 'true'`  (run-tests job)
+
+## Fix
+Replace ALL occurrences with truthiness comparisons (documented: falsy
+false/0/""/null and truthy values coerce correctly in conditionals):
+
+- `inputs.verify == 'true'` -> `inputs.verify`
+- `inputs.verify != 'true'` -> `!inputs.verify`
+
+Keep everything else byte-identical (same operators, same && chains, same
+indentation). Verify with actionlint. Also grep to confirm ZERO remaining
+`inputs.verify == 'true'` / `inputs.verify != 'true'` in the repo's workflows
+(any other workflow with the same pattern needs the same fix).
+
+## Rules
+- ONLY .github/workflows/generate-artifacts.yml (plus the ticket file). If
+  grep finds the broken pattern in OTHER workflows, mention it in the PR
+  body but do NOT change them unless Nick approves.
+- Raise a PR to develop. Set ticket status to closed.
+
+## Context
+Tag v0.5.0-pre.5 exists at 4fe518a3. After this PR merges, Nick deletes the
+tag and re-creates it at the new tip, then re-dispatches. Expected next
+obstacle (if any): the Test suite gate, which now runs against the
+libc++-fixed R2 zips (PR #224) — hopefully green.

--- a/.tickets/the-f3wv.md
+++ b/.tickets/the-f3wv.md
@@ -1,6 +1,6 @@
 ---
 id: the-f3wv
-status: in_progress
+status: closed
 deps: [the-k5p9]
 links: []
 created: 2026-08-10T05:10:00Z


### PR DESCRIPTION
## Bug

The `the-k5p9` guard (`if: inputs.verify != 'true'`) did **not** help — "Resolve post-push SHA" still ran on the tag push and crashed with the same `origin/v0.5.0-pre.5: unknown revision` error.

## Root cause

`verify` is declared `type: boolean` and the caller passes `verify: true` (a YAML boolean). GitHub Actions expressions do **not** coerce a boolean to the string `'true'` in `==` / `!=` comparisons. So with `verify=true`:

- `inputs.verify != 'true'` → **TRUE** → steps that should *skip* in verify mode actually **ran** (this failure).
- `inputs.verify == 'true'` → **FALSE** → the stale-artifact gate would *never* fire (silent bypass — not yet observed only because artifacts were fresh).

(The falsy/truthy coercion GitHub documents applies to a conditional's overall truthiness, not to equality against a literal string.)

## Fix

All six occurrences in `generate-artifacts.yml` switched to truthiness:

- `inputs.verify == 'true'` → `inputs.verify`
- `inputs.verify != 'true'` → `!inputs.verify`

The negated forms are wrapped in `${{ }}` so YAML doesn't read the leading `!` as an anchor (a bare `!inputs.verify` breaks the YAML parse). Operators, `&&` chains, and indentation are unchanged. `actionlint` parses clean (only pre-existing shellcheck SC2086 info-notes at lines 94/159 remain, unrelated to this change).

## ⚠️ Same bug exists elsewhere — NOT fixed here (needs your call)

`generate-swift-bindings.yml` has the **same two broken patterns** and is equally affected:

- L68: `if: ${{ inputs.verify == 'true' && steps.git-check.outputs.changed == 'true' }}` — stale-swift-binding gate never fires in verify mode.
- L75: `if: inputs.verify != 'true' && steps.git-check.outputs.changed == 'true'` — the commit-and-push step runs even in verify mode (would push from a tag path).

Per the ticket rules I did **not** touch that file. Want me to open a follow-up PR for it?

## After merge

Tag `v0.5.0-pre.5` is at `4fe518a3`. Nick deletes + re-creates it at the new tip and re-dispatches. Next likely obstacle: the Test suite gate (now on libc++-fixed R2 zips).

Fixes the-f3wv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)