### PR TITLE
ci: fix inputs.verify boolean comparisons in generate-swift-bindings

### DIFF
--- a/.github/workflows/generate-swift-bindings.yml
+++ b/.github/workflows/generate-swift-bindings.yml
@@ -65,14 +65,14 @@ jobs:
       # Release gate (called with verify: true): the tag must already contain
       # committed Swift bindings. A diff means they are stale — abort release.
       - name: Fail if swift bindings are stale (verify)
-        if: ${{ inputs.verify == 'true' && steps.git-check.outputs.changed == 'true' }}
+        if: ${{ inputs.verify && steps.git-check.outputs.changed == 'true' }}
         run: |
           echo "::error::Generated swift bindings differ from the committed tag. Run 'make flutter-bindings', commit on develop, then re-tag."
           git --no-pager diff --stat
           exit 1
 
       - name: Commit and push if changed
-        if: inputs.verify != 'true' && steps.git-check.outputs.changed == 'true'
+        if: ${{ !inputs.verify && steps.git-check.outputs.changed == 'true' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## What

Follow-up to #232 — the same `inputs.verify` boolean-vs-string trap exists in `generate-swift-bindings.yml` (flagged in #232's PR body). This fixes its two occurrences.

## Root cause

`verify` is `type: boolean`. GitHub Actions does not coerce a boolean to the string `'true'` in `==`/`!=`:

- L68 `inputs.verify == 'true'` with `verify=true` → **FALSE** → the stale-swift-binding gate never fired in verify mode.
- L75 `inputs.verify != 'true'` with `verify=true` → **TRUE** → the commit-and-push step ran even in verify mode (would push from a tag-path run).

## Fix

Truthiness, matching #232:

- L68: `inputs.verify == 'true'` → `inputs.verify`
- L75: `inputs.verify != 'true'` → `!inputs.verify` (wrapped in `${{ }}` so YAML doesn't read the `!` as an anchor)

One file, two lines. `actionlint` parses clean (the two remaining notes — SC2086 shellcheck info at L63 and the pre-existing `github.head_ref` inline-script note at L76 — are unrelated to this change; the head_ref injection hardening is a separate concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)