### PR TITLE
fix!: dispatch light/renderable shadow setters on the render thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 > Shared changelog for `thermion_dart` and `thermion_flutter` (released in lockstep).
 
+## 0.6.0
+
+### Fixes
+- dispatch light and renderable shadow setters on the render thread;
+  `LightManager.setShadowCaster`/`setShadowOptions` and
+  `RenderableManager.setCastShadows`/`setReceiveShadows` previously ran on the
+  caller's thread, racing Filament's renderer so the shadow flags never
+  reliably took effect — realtime shadows did not render even with view
+  shadowing enabled.
+
 ## 0.5.0-pre.5
 
 - Rework the CI release pipeline: releases are cut from `develop` via a manual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 ## 0.6.0
 
-### Fixes
-- dispatch light and renderable shadow setters on the render thread;
-  `LightManager.setShadowCaster`/`setShadowOptions` and
-  `RenderableManager.setCastShadows`/`setReceiveShadows` previously ran on the
-  caller's thread, racing Filament's renderer so the shadow flags never
-  reliably took effect — realtime shadows did not render even with view
-  shadowing enabled.
+### Breaking changes
+- `LightManager.setShadowCaster`/`setShadowOptions` and
+  `RenderableManager.setCastShadows`/`setReceiveShadows` now return `Future`
+  instead of `void` (internally, these now correctly run on the
+  main Filament thread).
 
 ## 0.5.0-pre.5
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -1648,6 +1648,177 @@ external void TransformManager_openLocalTransformTransaction(ffi.Pointer<TTransf
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
 external void TransformManager_commitLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
 
+@ffi.Native<ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>, ffi.UnsignedInt)>(isLeaf: true)
+external int LightManager_createLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external void LightManager_destroyLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_hasComponent(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external int LightManager_getType(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isDirectional(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isPointLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isSpotLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getPosition(ffi.Pointer<TLightManager> tLightManager, int light);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getDirection(ffi.Pointer<TLightManager> tLightManager, int light);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setColor(ffi.Pointer<TLightManager> tLightManager, int entity, double r, double g, double b);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getColor(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensity(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityCandela(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getIntensity(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double falloff);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSpotLightOuterCone(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSpotLightInnerCone(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunAngularRadius(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity, double haloSize);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double haloFalloff);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void LightManager_setShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity, bool enabled);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external TShadowOptions LightManager_getShadowOptions(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool LightManager_getLightChannel(ffi.Pointer<TLightManager> tLightManager, int entity, int channel);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(ffi.Pointer<ffi.Float> splitPositions, int cascades);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external double LightManager_rgbToColorTemperature(double r, double g, double b);
+
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
 external ffi.Pointer<ffi.Void> RenderThread_create();
 
@@ -3516,7 +3687,9 @@ external void RenderableManager_setBonesFromBoneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void RenderableManager_setCastShadowsRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -3525,11 +3698,33 @@ external void RenderableManager_setCastShadowsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void RenderableManager_setReceiveShadowsRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
   bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void LightManager_setShadowCasterRenderThread(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entityId,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void LightManager_setShadowOptionsRenderThread(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entityId,
+  TShadowOptions options,
   int requestId,
   VoidCallback onComplete,
 );
@@ -3549,195 +3744,6 @@ external int GltfParser_parseBuffer(
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGltfMeshData>)>(isLeaf: true)
 external void GltfParser_freeMeshData(ffi.Pointer<TGltfMeshData> meshData);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>, ffi.UnsignedInt)>(isLeaf: true)
-external int LightManager_createLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external void LightManager_destroyLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_hasComponent(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external int LightManager_getType(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isDirectional(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isPointLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isSpotLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getPosition(ffi.Pointer<TLightManager> tLightManager, int light);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getDirection(ffi.Pointer<TLightManager> tLightManager, int light);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setColor(ffi.Pointer<TLightManager> tLightManager, int entity, double r, double g, double b);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getColor(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensity(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityCandela(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getIntensity(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double falloff);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSpotLightOuterCone(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSpotLightInnerCone(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunAngularRadius(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity, double haloSize);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double haloFalloff);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void LightManager_setShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void LightManager_setShadowCasterRenderThread(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void LightManager_setShadowOptionsRenderThread(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external TShadowOptions LightManager_getShadowOptions(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
-external bool LightManager_getLightChannel(ffi.Pointer<TLightManager> tLightManager, int entity, int channel);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(ffi.Pointer<ffi.Float> splitPositions, int cascades);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external double LightManager_rgbToColorTemperature(double r, double g, double b);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
 external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
@@ -5450,25 +5456,6 @@ sealed class TBackend {
   static const BACKEND_NOOP = 4;
 }
 
-typedef FilamentRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> owner);
-typedef DartFilamentRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> owner);
-typedef FilamentRenderCallback = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
-
-final class TGltfMeshData extends ffi.Struct {
-  external ffi.Pointer<ffi.Float> vertices;
-
-  @ffi.Uint32()
-  external int vertexCount;
-
-  external ffi.Pointer<ffi.Uint32> indices;
-
-  @ffi.Uint32()
-  external int indexCount;
-
-  @ffi.UnsignedInt()
-  external int primitiveType;
-}
-
 sealed class TLightType {
   static const LIGHT_TYPE_SUN = 0;
   static const LIGHT_TYPE_DIRECTIONAL = 1;
@@ -5543,6 +5530,25 @@ final class TShadowOptions extends ffi.Struct {
 
   @ffi.Float()
   external double transformW;
+}
+
+typedef FilamentRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> owner);
+typedef DartFilamentRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> owner);
+typedef FilamentRenderCallback = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+
+final class TGltfMeshData extends ffi.Struct {
+  external ffi.Pointer<ffi.Float> vertices;
+
+  @ffi.Uint32()
+  external int vertexCount;
+
+  external ffi.Pointer<ffi.Uint32> indices;
+
+  @ffi.Uint32()
+  external int indexCount;
+
+  @ffi.UnsignedInt()
+  external int primitiveType;
 }
 
 sealed class TGizmoAxis {

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -3516,6 +3516,24 @@ external void RenderableManager_setBonesFromBoneRenderThread(
   VoidCallback onComplete,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void RenderableManager_setCastShadowsRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void RenderableManager_setReceiveShadowsRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
 @ffi.Native<ffi.Void Function(TGltfMeshData)>(isLeaf: true)
 external void dummy(TGltfMeshData dummy);
 
@@ -3664,6 +3682,24 @@ external void LightManager_setShadowOptions(
   ffi.Pointer<TLightManager> tLightManager,
   int entity,
   TShadowOptions options,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void LightManager_setShadowCasterRenderThread(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void LightManager_setShadowOptionsRenderThread(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+  int requestId,
+  VoidCallback onComplete,
 );
 
 @ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -755,6 +755,124 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
   external void _TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
+  external int _LightManager_createLight(
+    Pointer<TEngine> tEngine,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
+  );
+  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double r,
+    double g,
+    double b,
+  );
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
+  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
+  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
+  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
+  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
+  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
   external Pointer<Void> _RenderThread_create();
   external Pointer<Void> _RenderThread_createForCanvas(Pointer<Char> canvasSelector);
   external void _RenderThread_destroy(Pointer<Void> renderThread);
@@ -1761,6 +1879,20 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
+  external void _LightManager_setShadowCasterRenderThread(
+    Pointer<TLightManager> tLightManager,
+    EntityId entityId,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _LightManager_setShadowOptionsRenderThread(
+    Pointer<TLightManager> tLightManager,
+    EntityId entityId,
+    Pointer<TShadowOptions> optionsPtr,
+    int requestId,
+    VoidCallback onComplete,
+  );
   external void _dummy(Pointer<TGltfMeshData> dummyPtr);
   external int _GltfParser_parseBuffer(
     Pointer<Uint8> data,
@@ -1769,138 +1901,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TGltfMeshData> outMeshData,
   );
   external void _GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData);
-  external int _LightManager_createLight(
-    Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
-  );
-  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double r,
-    double g,
-    double b,
-  );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
-  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
-  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
-  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_setShadowCasterRenderThread(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _LightManager_setShadowOptionsRenderThread(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
-  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
-  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
   external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
   external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
   external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
@@ -4660,6 +4660,262 @@ void TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager>
   return result;
 }
 
+int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
+    tEngine.cast(),
+    tLightManager.cast(),
+    tLightTtype,
+  );
+  return result;
+}
+
+void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
+  return result;
+}
+
+double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+  return result;
+}
+
+double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+  return result;
+}
+
+bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
+  return result;
+}
+
+void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+    lambda,
+  );
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
+  return result;
+}
+
 Pointer<Void> RenderThread_create() {
   final result = GeneratedBindings.instance._RenderThread_create();
   return Pointer<Void>(result);
@@ -7120,6 +7376,41 @@ void RenderableManager_setReceiveShadowsRenderThread(
   return result;
 }
 
+void LightManager_setShadowCasterRenderThread(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entityId,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCasterRenderThread(
+    tLightManager.cast(),
+    entityId,
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void LightManager_setShadowOptionsRenderThread(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entityId,
+  TShadowOptions options,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptionsRenderThread(
+    tLightManager.cast(),
+    entityId,
+    optionsPtr.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
 void dummy(TGltfMeshData dummy) {
   final dummyPtr = dummy.address;
   final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
@@ -7138,297 +7429,6 @@ int GltfParser_parseBuffer(
 
 void GltfParser_freeMeshData(Pointer<TGltfMeshData> meshData) {
   final result = GeneratedBindings.instance._GltfParser_freeMeshData(meshData.cast());
-  return result;
-}
-
-int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-    tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
-  );
-  return result;
-}
-
-void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
-  );
-  return result;
-}
-
-double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
-  );
-  return result;
-}
-
-double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
-  return result;
-}
-
-double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
-  );
-  return result;
-}
-
-double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
-  return result;
-}
-
-double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
-  return result;
-}
-
-double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
-  return result;
-}
-
-bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-void LightManager_setShadowCasterRenderThread(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCasterRenderThread(
-    tLightManager.cast(),
-    entity,
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void LightManager_setShadowOptionsRenderThread(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  TShadowOptions options,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptionsRenderThread(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
-  return result;
-}
-
-void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
-  return result;
-}
-
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-) {
-  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
-    splitPositions,
-    cascades,
-    near,
-    far,
-    lambda,
-  );
-  return result;
-}
-
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
   return result;
 }
 
@@ -10602,151 +10602,6 @@ sealed class TVertexAttributeType {
   static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
-  }
-}
-
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
-
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
-  }
-}
-
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
-  }
-}
-
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
-
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
-  }
-}
-
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
-  }
-}
-
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
-
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
-  }
-}
-
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
-  }
-}
-
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
-
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
-  }
-}
-
-extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
-  TRenderableBuilder toDart() {
-    return TRenderableBuilder(this);
-  }
-}
-
-final class TRenderableBuilder extends Struct {
-  Pointer<TRenderableBuilder> get address => super.address.cast();
-  TRenderableBuilder(super.address);
-
-  static Pointer<TRenderableBuilder> stackAlloc() {
-    return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
-  }
-}
-
-extension TGltfMeshDataExt on Pointer<TGltfMeshData> {
-  TGltfMeshData toDart() {
-    return TGltfMeshData(this);
-  }
-}
-
-final class TGltfMeshData extends Struct {
-  Pointer<TGltfMeshData> get address => super.address.cast();
-  Pointer<Float32> get vertices {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Pointer<Float32>(value.toDartInt);
-  }
-
-  set vertices(Pointer<Float32> val) {
-    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 0), val.toJS, '*');
-  }
-
-  int get vertexCount {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set vertexCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 4), val.toJS, 'i32');
-  }
-
-  Pointer<Uint32> get indices {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Pointer<Uint32>(value.toDartInt);
-  }
-
-  set indices(Pointer<Uint32> val) {
-    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 8), val.toJS, '*');
-  }
-
-  int get indexCount {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set indexCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 12), val.toJS, 'i32');
-  }
-
-  int get primitiveType {
-    final addr = Pointer<TGltfMeshData>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set primitiveType(int val) {
-    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 16), val.toJS, 'i32');
-  }
-
-  TGltfMeshData(super.address);
-
-  static Pointer<TGltfMeshData> stackAlloc() {
-    return Pointer<TGltfMeshData>(NativeLibrary.instance.stackAlloc<TGltfMeshData>(20));
-  }
-}
-
 sealed class TLightType {
   static const LIGHT_TYPE_SUN = 0;
   static const LIGHT_TYPE_DIRECTIONAL = 1;
@@ -10990,6 +10845,151 @@ final class TShadowOptions extends Struct {
   }
 }
 
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
+  }
+}
+
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
+
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
+  }
+}
+
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
+  }
+}
+
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
+
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+  }
+}
+
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
+  }
+}
+
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
+
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
+  }
+}
+
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
+  }
+}
+
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
+
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  }
+}
+
+extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
+  TRenderableBuilder toDart() {
+    return TRenderableBuilder(this);
+  }
+}
+
+final class TRenderableBuilder extends Struct {
+  Pointer<TRenderableBuilder> get address => super.address.cast();
+  TRenderableBuilder(super.address);
+
+  static Pointer<TRenderableBuilder> stackAlloc() {
+    return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
+  }
+}
+
+extension TGltfMeshDataExt on Pointer<TGltfMeshData> {
+  TGltfMeshData toDart() {
+    return TGltfMeshData(this);
+  }
+}
+
+final class TGltfMeshData extends Struct {
+  Pointer<TGltfMeshData> get address => super.address.cast();
+  Pointer<Float32> get vertices {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Pointer<Float32>(value.toDartInt);
+  }
+
+  set vertices(Pointer<Float32> val) {
+    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 0), val.toJS, '*');
+  }
+
+  int get vertexCount {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set vertexCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 4), val.toJS, 'i32');
+  }
+
+  Pointer<Uint32> get indices {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Pointer<Uint32>(value.toDartInt);
+  }
+
+  set indices(Pointer<Uint32> val) {
+    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 8), val.toJS, '*');
+  }
+
+  int get indexCount {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set indexCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 12), val.toJS, 'i32');
+  }
+
+  int get primitiveType {
+    final addr = Pointer<TGltfMeshData>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set primitiveType(int val) {
+    NativeLibrary.instance.setValue(Pointer<TGltfMeshData>(this.address.addr + 16), val.toJS, 'i32');
+  }
+
+  TGltfMeshData(super.address);
+
+  static Pointer<TGltfMeshData> stackAlloc() {
+    return Pointer<TGltfMeshData>(NativeLibrary.instance.stackAlloc<TGltfMeshData>(20));
+  }
+}
+
 sealed class TGizmoPickResultType {
   static const AxisX = 0;
   static const AxisY = 1;
@@ -11195,6 +11195,9 @@ extension StructAllocator on Struct {
       case TVertexBufferBuilder:
         final ptr = TVertexBufferBuilder.stackAlloc();
         return ptr.toDart() as T;
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
       case TRenderManager:
         final ptr = TRenderManager.stackAlloc();
         return ptr.toDart() as T;
@@ -11212,9 +11215,6 @@ extension StructAllocator on Struct {
         return ptr.toDart() as T;
       case TGltfMeshData:
         final ptr = TGltfMeshData.stackAlloc();
-        return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1747,6 +1747,20 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
+  external void _RenderableManager_setCastShadowsRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderableManager_setReceiveShadowsRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
   external void _dummy(Pointer<TGltfMeshData> dummyPtr);
   external int _GltfParser_parseBuffer(
     Pointer<Uint8> data,
@@ -1850,6 +1864,20 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TLightManager> tLightManager,
     EntityId entity,
     Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_setShadowCasterRenderThread(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _LightManager_setShadowOptionsRenderThread(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+    int requestId,
+    VoidCallback onComplete,
   );
   external void _LightManager_getShadowOptions(
     Pointer<TShadowOptions> TShadowOptions_out,
@@ -7058,6 +7086,40 @@ void RenderableManager_setBonesFromBoneRenderThread(
   return result;
 }
 
+void RenderableManager_setCastShadowsRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setCastShadowsRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderableManager_setReceiveShadowsRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadowsRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
 void dummy(TGltfMeshData dummy) {
   final dummyPtr = dummy.address;
   final result = GeneratedBindings.instance._dummy(dummyPtr.cast());
@@ -7274,6 +7336,41 @@ void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEnt
     tLightManager.cast(),
     entity,
     optionsPtr.cast(),
+  );
+  return result;
+}
+
+void LightManager_setShadowCasterRenderThread(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCasterRenderThread(
+    tLightManager.cast(),
+    entity,
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void LightManager_setShadowOptionsRenderThread(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  TShadowOptions options,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptionsRenderThread(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
   return result;
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -1509,7 +1509,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
     // Note: Sun-specific properties (angular radius, halo size, halo falloff)
     // are not currently exposed in the Dart LightManager interface
-    lightManager.setShadowCaster(entity, directLight.castShadows);
+    await lightManager.setShadowCaster(entity, directLight.castShadows);
 
     return entity;
   }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_light_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_light_manager.dart
@@ -68,8 +68,16 @@ class FFILightManager extends LightManager<Pointer<TLightManager>> {
   }
 
   @override
-  void setShadowCaster(ThermionEntity light, bool enabled) {
-    LightManager_setShadowCaster(lightManager, light, enabled);
+  Future<void> setShadowCaster(ThermionEntity light, bool enabled) async {
+    await withVoidCallback(
+      (requestId, cb) => LightManager_setShadowCasterRenderThread(
+        lightManager,
+        light,
+        enabled,
+        requestId,
+        cb,
+      ),
+    );
   }
 
   @override
@@ -182,7 +190,7 @@ class FFILightManager extends LightManager<Pointer<TLightManager>> {
   }
 
   @override
-  void setShadowOptions(ThermionEntity light, ShadowOptions options) {
+  Future<void> setShadowOptions(ThermionEntity light, ShadowOptions options) async {
     final tShadowOptions = StructAllocator.create<TShadowOptions>();
     tShadowOptions.mapSize = options.mapSize;
     tShadowOptions.shadowCascades = options.shadowCascades;
@@ -220,7 +228,15 @@ class FFILightManager extends LightManager<Pointer<TLightManager>> {
     tShadowOptions.transformY = options.transform.y;
     tShadowOptions.transformZ = options.transform.z;
 
-    LightManager_setShadowOptions(lightManager, light, tShadowOptions);
+    await withVoidCallback(
+      (requestId, cb) => LightManager_setShadowOptionsRenderThread(
+        lightManager,
+        light,
+        tShadowOptions,
+        requestId,
+        cb,
+      ),
+    );
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_light_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_light_manager.dart
@@ -70,13 +70,7 @@ class FFILightManager extends LightManager<Pointer<TLightManager>> {
   @override
   Future<void> setShadowCaster(ThermionEntity light, bool enabled) async {
     await withVoidCallback(
-      (requestId, cb) => LightManager_setShadowCasterRenderThread(
-        lightManager,
-        light,
-        enabled,
-        requestId,
-        cb,
-      ),
+      (requestId, cb) => LightManager_setShadowCasterRenderThread(lightManager, light, enabled, requestId, cb),
     );
   }
 
@@ -229,13 +223,7 @@ class FFILightManager extends LightManager<Pointer<TLightManager>> {
     tShadowOptions.transformZ = options.transform.z;
 
     await withVoidCallback(
-      (requestId, cb) => LightManager_setShadowOptionsRenderThread(
-        lightManager,
-        light,
-        tShadowOptions,
-        requestId,
-        cb,
-      ),
+      (requestId, cb) => LightManager_setShadowOptionsRenderThread(lightManager, light, tShadowOptions, requestId, cb),
     );
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
@@ -194,13 +194,8 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
   @override
   Future setCastShadows(ThermionEntity entity, bool enabled) async {
     await withVoidCallback(
-      (requestId, cb) => RenderableManager_setCastShadowsRenderThread(
-        renderableManager,
-        entity,
-        enabled,
-        requestId,
-        cb,
-      ),
+      (requestId, cb) =>
+          RenderableManager_setCastShadowsRenderThread(renderableManager, entity, enabled, requestId, cb),
     );
   }
 
@@ -212,13 +207,8 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
   @override
   Future setReceiveShadows(ThermionEntity entity, bool enabled) async {
     await withVoidCallback(
-      (requestId, cb) => RenderableManager_setReceiveShadowsRenderThread(
-        renderableManager,
-        entity,
-        enabled,
-        requestId,
-        cb,
-      ),
+      (requestId, cb) =>
+          RenderableManager_setReceiveShadowsRenderThread(renderableManager, entity, enabled, requestId, cb),
     );
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
@@ -193,7 +193,15 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
 
   @override
   Future setCastShadows(ThermionEntity entity, bool enabled) async {
-    RenderableManager_setCastShadows(renderableManager, entity, enabled);
+    await withVoidCallback(
+      (requestId, cb) => RenderableManager_setCastShadowsRenderThread(
+        renderableManager,
+        entity,
+        enabled,
+        requestId,
+        cb,
+      ),
+    );
   }
 
   @override
@@ -203,7 +211,15 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
 
   @override
   Future setReceiveShadows(ThermionEntity entity, bool enabled) async {
-    RenderableManager_setReceiveShadows(renderableManager, entity, enabled);
+    await withVoidCallback(
+      (requestId, cb) => RenderableManager_setReceiveShadowsRenderThread(
+        renderableManager,
+        entity,
+        enabled,
+        requestId,
+        cb,
+      ),
+    );
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/interface/light_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/light_manager.dart
@@ -122,16 +122,12 @@ abstract class LightManager<T> extends NativeHandle<T> {
   // ============================================================================
 
   /// Enables or disables shadow casting for the specified light.
-  ///
-  /// Dispatched on the render thread (Filament requires light mutation there).
   Future<void> setShadowCaster(ThermionEntity light, bool enabled);
 
   /// Returns whether the light casts shadows.
   bool isShadowCaster(ThermionEntity light);
 
   /// Sets the shadow options for the light.
-  ///
-  /// Dispatched on the render thread (Filament requires light mutation there).
   Future<void> setShadowOptions(ThermionEntity light, ShadowOptions options);
 
   /// Returns the shadow options for the light.

--- a/thermion_dart/lib/src/filament/src/interface/light_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/light_manager.dart
@@ -122,13 +122,17 @@ abstract class LightManager<T> extends NativeHandle<T> {
   // ============================================================================
 
   /// Enables or disables shadow casting for the specified light.
-  void setShadowCaster(ThermionEntity light, bool enabled);
+  ///
+  /// Dispatched on the render thread (Filament requires light mutation there).
+  Future<void> setShadowCaster(ThermionEntity light, bool enabled);
 
   /// Returns whether the light casts shadows.
   bool isShadowCaster(ThermionEntity light);
 
   /// Sets the shadow options for the light.
-  void setShadowOptions(ThermionEntity light, ShadowOptions options);
+  ///
+  /// Dispatched on the render thread (Filament requires light mutation there).
+  Future<void> setShadowOptions(ThermionEntity light, ShadowOptions options);
 
   /// Returns the shadow options for the light.
   ShadowOptions getShadowOptions(ThermionEntity light);

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -9,6 +9,7 @@
 #include "TVertexBuffer.h"
 #include "TIndexBuffer.h"
 #include "TTransformManager.h"
+#include "TLightManager.h"
 
 #ifdef __cplusplus
 namespace thermion
@@ -497,6 +498,40 @@ namespace thermion
             const float *bones,
             size_t boneCount,
             size_t offset,
+            uint32_t requestId,
+            VoidCallback onComplete
+        );
+
+        // Shadow flags MUST be applied on the render thread — Filament's
+        // RenderableManager/LightManager are not concurrency-safe, so the
+        // non-render-thread setters race the renderer and the flags don't take
+        // (realtime shadows never appear). These mirror the existing render-
+        // thread dispatch pattern.
+        EMSCRIPTEN_KEEPALIVE void RenderableManager_setCastShadowsRenderThread(
+            TRenderableManager *tRenderableManager,
+            EntityId entityId,
+            bool enabled,
+            uint32_t requestId,
+            VoidCallback onComplete
+        );
+        EMSCRIPTEN_KEEPALIVE void RenderableManager_setReceiveShadowsRenderThread(
+            TRenderableManager *tRenderableManager,
+            EntityId entityId,
+            bool enabled,
+            uint32_t requestId,
+            VoidCallback onComplete
+        );
+        EMSCRIPTEN_KEEPALIVE void LightManager_setShadowCasterRenderThread(
+            TLightManager *tLightManager,
+            EntityId entityId,
+            bool enabled,
+            uint32_t requestId,
+            VoidCallback onComplete
+        );
+        EMSCRIPTEN_KEEPALIVE void LightManager_setShadowOptionsRenderThread(
+            TLightManager *tLightManager,
+            EntityId entityId,
+            TShadowOptions options,
             uint32_t requestId,
             VoidCallback onComplete
         );

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -2770,4 +2770,76 @@ extern "C"
     auto fut = rt->addTask(lambda);
   }
 
+  // Shadow flags MUST be applied on the render thread — Filament's
+  // RenderableManager/LightManager are not concurrency-safe, so the
+  // non-render-thread setters race the renderer and the flags don't take
+  // (realtime shadows never appear).
+  EMSCRIPTEN_KEEPALIVE void RenderableManager_setCastShadowsRenderThread(
+      TRenderableManager *tRenderableManager,
+      EntityId entityId,
+      bool enabled,
+      uint32_t requestId,
+      VoidCallback onComplete)
+  {
+    auto *rt = RT(tRenderableManager);
+    std::packaged_task<void()> lambda(
+        [=]() mutable
+        {
+          RenderableManager_setCastShadows(tRenderableManager, entityId, enabled);
+          PROXY(onComplete(requestId));
+        });
+    auto fut = rt->addTask(lambda);
+  }
+
+  EMSCRIPTEN_KEEPALIVE void RenderableManager_setReceiveShadowsRenderThread(
+      TRenderableManager *tRenderableManager,
+      EntityId entityId,
+      bool enabled,
+      uint32_t requestId,
+      VoidCallback onComplete)
+  {
+    auto *rt = RT(tRenderableManager);
+    std::packaged_task<void()> lambda(
+        [=]() mutable
+        {
+          RenderableManager_setReceiveShadows(tRenderableManager, entityId, enabled);
+          PROXY(onComplete(requestId));
+        });
+    auto fut = rt->addTask(lambda);
+  }
+
+  EMSCRIPTEN_KEEPALIVE void LightManager_setShadowCasterRenderThread(
+      TLightManager *tLightManager,
+      EntityId entityId,
+      bool enabled,
+      uint32_t requestId,
+      VoidCallback onComplete)
+  {
+    auto *rt = RT(tLightManager);
+    std::packaged_task<void()> lambda(
+        [=]() mutable
+        {
+          LightManager_setShadowCaster(tLightManager, entityId, enabled);
+          PROXY(onComplete(requestId));
+        });
+    auto fut = rt->addTask(lambda);
+  }
+
+  EMSCRIPTEN_KEEPALIVE void LightManager_setShadowOptionsRenderThread(
+      TLightManager *tLightManager,
+      EntityId entityId,
+      TShadowOptions options,
+      uint32_t requestId,
+      VoidCallback onComplete)
+  {
+    auto *rt = RT(tLightManager);
+    std::packaged_task<void()> lambda(
+        [=]() mutable
+        {
+          LightManager_setShadowOptions(tLightManager, entityId, options);
+          PROXY(onComplete(requestId));
+        });
+    auto fut = rt->addTask(lambda);
+  }
+
 }

--- a/thermion_dart/pubspec.yaml
+++ b/thermion_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: thermion_dart
 description: 3D rendering toolkit for Dart.
-version: 0.5.0-pre.5
+version: 0.6.0
 homepage: https://thermion.dev
 repository: https://github.com/nmfisher/thermion
 

--- a/thermion_dart/pubspec.yaml
+++ b/thermion_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: thermion_dart
 description: 3D rendering toolkit for Dart.
-version: 0.6.0
+version: 0.6.0-pre.0
 homepage: https://thermion.dev
 repository: https://github.com/nmfisher/thermion
 

--- a/thermion_dart/test/light_tests.dart
+++ b/thermion_dart/test/light_tests.dart
@@ -228,7 +228,7 @@ void main() async {
       await testHelper.capture(result.viewer.view, "sun_light_created_no_shadows");
 
       // Test shadow caster
-      lightManager.setShadowCaster(sunLight, true);
+      await lightManager.setShadowCaster(sunLight, true);
       await testHelper.capture(result.viewer.view, "shadow_caster_enabled");
 
       expect(lightManager.isShadowCaster(sunLight), isTrue);
@@ -242,7 +242,7 @@ void main() async {
         normalBias: 2.0,
         stable: true,
       );
-      lightManager.setShadowOptions(sunLight, shadowOptions);
+      await lightManager.setShadowOptions(sunLight, shadowOptions);
       await testHelper.capture(result.viewer.view, "shadow_options_configured");
 
       final retrievedOptions = lightManager.getShadowOptions(sunLight);

--- a/thermion_flutter/thermion_flutter/pubspec.yaml
+++ b/thermion_flutter/thermion_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: thermion_flutter
 description: Flutter plugin for 3D rendering with the Thermion toolkit.
-version: 0.5.0-pre.5
+version: 0.6.0
 homepage: https://thermion.dev
 repository: https://github.com/nmfisher/thermion
 

--- a/thermion_flutter/thermion_flutter/pubspec.yaml
+++ b/thermion_flutter/thermion_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   vector_math: ^2.1.2
   plugin_platform_interface: ^2.0.0
   ffi: ^2.1.2
-  thermion_dart: ^0.5.0-pre
+  thermion_dart: ^0.6.0
   hooks: ^1.0.0
   logging: ^1.2.0
   web: ^1.0.0

--- a/thermion_flutter/thermion_flutter/pubspec.yaml
+++ b/thermion_flutter/thermion_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: thermion_flutter
 description: Flutter plugin for 3D rendering with the Thermion toolkit.
-version: 0.6.0
+version: 0.6.0-pre.0
 homepage: https://thermion.dev
 repository: https://github.com/nmfisher/thermion
 


### PR DESCRIPTION
This PR ensures the following methods are called on the main Filament thread:

- `LightManager_setShadowCaster`
- `LightManager_setShadowOptions`
- `RenderableManager_setCastShadows`
- `RenderableManager_setReceiveShadows`

Breaking change as the Dart methods now return a `Future` rather than `void`.