### PR TITLE
CI: fix first-build header ordering and stage libzstd.a for Android

### DIFF
--- a/.github/workflows/run-flutter-builds.yml
+++ b/.github/workflows/run-flutter-builds.yml
@@ -49,8 +49,23 @@ jobs:
           channel: ${{ matrix.flutter-channel }}
           architecture: ${{ matrix.flutter-arch }}
 
+      # The plugin's CMake configure runs BEFORE the in-build hook step that
+      # extracts the Filament headers from the R2 artifact and writes
+      # .dart_tool/generated_headers.cmake (DART_PKG_HEADERS). On a fresh
+      # checkout the first `flutter build windows/linux` therefore configures
+      # with an empty DART_PKG_HEADERS and the plugin compile fails on
+      # bluevk/BlueVK.h. Running the plugin unit tests first fires the build
+      # hooks out of band, so the header dir and generated_headers.cmake
+      # already exist when cmake configures.
       - name: Run thermion_flutter unit tests (macOS)
         if: matrix.name == 'macOS'
+        working-directory: thermion_flutter/thermion_flutter
+        run: |
+          flutter pub get
+          flutter test
+
+      - name: Run thermion_flutter unit tests (Windows)
+        if: matrix.name == 'Windows'
         working-directory: thermion_flutter/thermion_flutter
         run: |
           flutter pub get
@@ -126,7 +141,19 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libdrm-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libdrm-dev libegl1 libegl1-mesa-dev libc++-dev libc++abi-dev
+
+      # Same priming as the Windows/macOS unit test steps above: fires the
+      # build hooks so the Filament headers are extracted and
+      # generated_headers.cmake exists before cmake configures. Must run
+      # after the toolchain deps above are installed.
+      - name: Run thermion_flutter unit tests (Linux)
+        if: matrix.name == 'Linux'
+        working-directory: thermion_flutter/thermion_flutter
+        shell: bash
+        run: |
+          flutter pub get
+          flutter test
 
       - name: Build quickstart (Linux)
         if: matrix.name == 'Linux'

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -284,13 +284,13 @@ if [ "$BUILD_RELEASE" = true ]; then
     CMAKE_ARCH=$(abi_to_cmake_arch "$ARCH")
     mkdir -p "$TARGET_RELEASE_DIR/$ARCH"
 
-    # Copy main Filament libraries
-    for lib in out/android-release/filament/lib/$ARCH/*.a; do
-      case "$(basename "$lib")" in
-        *zstd*) echo "Skipping $lib (bundled in Filament already)" ;;
-        *) cp "$lib" "$TARGET_RELEASE_DIR/$ARCH/" ;;
-      esac
-    done
+    # Copy main Filament libraries.
+    # libzstd.a MUST be staged: as of Filament 1.75.0 libfilamat.a has
+    # undefined zstd symbols and thermion_dart links -lzstd explicitly
+    # (see zip_android.sh). Skipping it here leaves the R2 artifact
+    # without libzstd.a and the Android link fails with
+    # "unable to find library -lzstd".
+    cp out/android-release/filament/lib/$ARCH/*.a "$TARGET_RELEASE_DIR/$ARCH/"
 
     # Copy imageio (built per-arch by build_third_party_for_arch)
     IMAGEIO_SRC="out/cmake-android-release-${CMAKE_ARCH}/third_party/imageio/libimageio.a"
@@ -332,13 +332,8 @@ if [ "$BUILD_DEBUG" = true ]; then
     CMAKE_ARCH=$(abi_to_cmake_arch "$ARCH")
     mkdir -p "$TARGET_DEBUG_DIR/$ARCH"
 
-    # Copy main Filament libraries
-    for lib in out/android-debug/filament/lib/$ARCH/*.a; do
-      case "$(basename "$lib")" in
-        *zstd*) echo "Skipping $lib (bundled in Filament already)" ;;
-        *) cp "$lib" "$TARGET_DEBUG_DIR/$ARCH/" ;;
-      esac
-    done
+    # Copy main Filament libraries (libzstd.a included; see release note above)
+    cp out/android-debug/filament/lib/$ARCH/*.a "$TARGET_DEBUG_DIR/$ARCH/"
 
     # Copy imageio (built per-arch by build_third_party_for_arch)
     IMAGEIO_SRC="out/cmake-android-debug-${CMAKE_ARCH}/third_party/imageio/libimageio.a"

--- a/thermion_flutter/thermion_flutter/linux/CMakeLists.txt
+++ b/thermion_flutter/thermion_flutter/linux/CMakeLists.txt
@@ -34,8 +34,6 @@ else()
     "next build will pick it up automatically.")
   set(DART_PKG_HEADERS "")
 endif()
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
-  "${GENERATED_HEADERS_CMAKE}")
 
 # thermion_dart native-assets output
 # Flutter places native-assets at: <project>/build/native_assets/linux/

--- a/thermion_flutter/thermion_flutter/linux/CMakeLists.txt
+++ b/thermion_flutter/thermion_flutter/linux/CMakeLists.txt
@@ -34,6 +34,8 @@ else()
     "next build will pick it up automatically.")
   set(DART_PKG_HEADERS "")
 endif()
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+  "${GENERATED_HEADERS_CMAKE}")
 
 # thermion_dart native-assets output
 # Flutter places native-assets at: <project>/build/native_assets/linux/


### PR DESCRIPTION
Fixes two CI failures on `filament-v1.75.0`.

## Failure 1 — flutter-builds Linux/Windows: `bluevk/BlueVK.h` not found

The plugin CMake configure runs before the in-build hook step that extracts the Filament headers from the R2 artifact and writes `.dart_tool/generated_headers.cmake`. On a fresh checkout the first `flutter build windows`/`flutter build linux` therefore configures with an empty `DART_PKG_HEADERS` and the plugin compile fails on `bluevk/BlueVK.h` (ninja even reports "File modified during build" because the hook writes the file mid-build).

Fix: fire the build hooks out of band first by running the `thermion_flutter` unit tests before the Windows/Linux example builds — the macOS job already did this. The artifact header dir and `generated_headers.cmake` then exist before configure. Also:

- register `generated_headers.cmake` as a configure dependency in the Linux plugin CMakeLists (Windows already had it), so cmake auto-reconfigures once the hook writes it
- add `libegl1`/`libegl1-mesa-dev`/`libc++-dev`/`libc++abi-dev` to the Linux deps (same set `run-dart-tests.yml` installs) for the hook link and the previously unreached plugin link stage (`-l:libc++.a`, `-lEGL`)

## Failure 2 — Android link: `unable to find library -lzstd`

`scripts/build_android.sh` skipped `*zstd*` archives when copying Filament libs, so the R2 android artifact ships without `libzstd.a`, while `thermion_dart` links `-lzstd` explicitly (`libfilamat.a` has undefined zstd symbols as of Filament 1.75.0 — see the note in `zip_android.sh`). Removed the skip in both the release and debug copy blocks so `libzstd.a` is staged.

The **Build Filament** workflow is triggered on this branch (android only, upload to R2) to rebuild the R2 android artifact with `libzstd.a` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verified status (run 31863717801)

| Job | Result |
|---|---|
| flutter-builds Linux | ✅ pass |
| flutter-builds Windows | ✅ pass |
| dart-tests Windows | ✅ pass |
| flutter-builds macOS | ❌ fail — expected |
| dart-tests Linux (golden) | ❌ fail — expected |

Both remaining failures are unrelated to this PR's code changes:

- **macOS**: the job builds the Android example, and the Android link still fails with `unable to find library -lzstd`. This uses the old R2 android artifact, which predates the `libzstd.a` staging fix here. The "Build Filament" rebuild (run 31860021416) is currently running and will publish a new R2 android artifact that includes `libzstd.a`; macOS should pass once it completes and is re-run.
- **dart-tests Linux golden**: golden comparison fails because this branch predates the golden pin commit `df0389d4` on `filament-v1.75.0` — output/golden sets don't match. Will be resolved by rebasing on `filament-v1.75.0`, not by changes in this PR.
