### PR TITLE
CI: bump macOS runner to macos-15 / Xcode 16

### DIFF
--- a/.github/workflows/build-filament.yml
+++ b/.github/workflows/build-filament.yml
@@ -84,7 +84,10 @@ jobs:
 
   build-macos:
     name: Build macOS
-    runs-on: macos-14
+    # Xcode 16 (Clang 16+) is required for Dawn's use of C++20 parenthesized
+    # aggregate initialization (P0960). macos-14 ships Xcode 15.4 / Clang 15,
+    # which lacks P0960 and fails compiling third_party/dawn/src/dawn/platform.
+    runs-on: macos-15
     needs: setup
     if: contains(needs.setup.outputs.matrix, 'macos')
     env:


### PR DESCRIPTION
Bumps shared macOS CI runner to macos-15 with Xcode 16. Dawn's macOS CI build needs the newer runner (but this will affect all macOS builds, not just webgpu). 