### PR TITLE
refactor: allocate() takes byteCount instead of ambiguous count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 Update to Filament v1.75.0!
 
 ### Changes
-- `allocate` FFI shim now takes a byte count instead of a count of
-  pointer-sized slots
+- `allocate` FFI shim now takes `byteCount` instead of `count`
 
 ### Breaking changes
 - `LightManager.setShadowCaster`/`setShadowOptions` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@
 Update to Filament v1.75.0!
 
 ### Changes
-- The internal `allocate` FFI shim now takes a byte count (matching
-  `package:ffi`'s `Allocator.allocate`) instead of a count of
-  pointer-sized slots, fixing platform-dependent buffer sizes for
-  `Char` allocations.
+- `allocate` FFI shim now takes a byte count instead of a count of
+  pointer-sized slots
 
 ### Breaking changes
 - `LightManager.setShadowCaster`/`setShadowOptions` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Update to Filament v1.75.0!
 
+### Changes
+- The internal `allocate` FFI shim now takes a byte count (matching
+  `package:ffi`'s `Allocator.allocate`) instead of a count of
+  pointer-sized slots, fixing platform-dependent buffer sizes for
+  `Char` allocations.
+
 ### Breaking changes
 - `LightManager.setShadowCaster`/`setShadowOptions` and
   `RenderableManager.setCastShadows`/`setReceiveShadows` now return `Future`

--- a/thermion_dart/lib/src/bindings/src/ffi.dart
+++ b/thermion_dart/lib/src/bindings/src/ffi.dart
@@ -64,8 +64,8 @@ class CallbackHolder<T extends Function> {
   }
 }
 
-Pointer<T> allocate<T extends NativeType>(int count) {
-  return calloc.allocate<T>(count * sizeOf<Pointer>());
+Pointer<T> allocate<T extends NativeType>(int byteCount) {
+  return calloc.allocate<T>(byteCount);
 }
 
 void free(Pointer ptr) {

--- a/thermion_dart/lib/src/bindings/src/js_interop.dart
+++ b/thermion_dart/lib/src/bindings/src/js_interop.dart
@@ -162,12 +162,11 @@ Future<int> withIntCallback(Function(Pointer<NativeFunction<void Function(int)>>
   return completer.future;
 }
 
-Pointer<T> allocate<T extends NativeType>(int count) {
+Pointer<T> allocate<T extends NativeType>(int byteCount) {
   switch (T) {
     case PointerClass:
-      return malloc(count * 4);
     case Char:
-      return malloc(count);
+      return malloc(byteCount);
     default:
       throw Exception(T.toString());
   }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
@@ -178,7 +178,7 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
     for (final swapChainHandle in snapshot.keys) {
       final views = snapshot[swapChainHandle];
       if (views == null) continue;
-      final pointers = allocate<PointerClass>(views.length);
+      final pointers = allocate<PointerClass>(views.length * sizeOf<PointerClass>());
       for (int i = 0; i < views.length; i++) {
         pointers[i] = views[i].$2.getNativeHandle();
       }


### PR DESCRIPTION
`allocate` previously accepted a `count` argument (consistent with the use of `calloc` internally) but this was restricted to Pointer/Char types because we can't call sizeOf<T> to determine the size of an arbitrary generic type at runtime. This meant the caller had to calculate the size-in-bytes anyway, so the argument was confusing.  

This PR renames the argument to `byteCount` to make it clear the caller has to make the correct size calculation. This also updates the calculation at a handful of internal call sites to ensure the allocation is correct.
