### PR TITLE
chore: fix picking tests & clean up web quickstart

### DIFF
--- a/examples/flutter/quickstart/README.md
+++ b/examples/flutter/quickstart/README.md
@@ -11,10 +11,6 @@ the concurrent mount/dispose stress path. Use the **×** on a cell to remove
 it individually. On web, each viewer runs its own engine and canvas, and the
 batch is capped by `WebOptions.maxViewers`.
 
-> On web builds the batch stepper is capped at 1: every view renders into a
-> single shared DOM canvas, so more than one viewer cannot be displayed.
-> Multi-viewer is a native (desktop/mobile) capability for now.
-
 > Note: the grid is rebuilt from a fresh list on every add/remove (see
 > `_MyHomePageState`). Mutating the list in place will leave new cells latent
 > until a layout pass (e.g. a window resize) forces the `GridView` to

--- a/examples/flutter/quickstart/lib/main.dart
+++ b/examples/flutter/quickstart/lib/main.dart
@@ -97,9 +97,9 @@ class _MyHomePageState extends State<MyHomePage> {
   /// Batch size for the footer's add/remove control.
   int _batch = 1;
 
-  /// Web builds render every view into a single shared DOM canvas, so only
-  /// one viewer can be displayed at a time — cap the batch accordingly.
-  final int _maxBatch = kIsWeb ? 1 : 64;
+  /// Web runs one engine/canvas/worker per viewer; WebOptions.maxViewers
+  /// (default 8) caps concurrent viewers there. Native has no such cap.
+  final int _maxBatch = kIsWeb ? 8 : 64;
 
   late DirectLight _sun;
 
@@ -154,11 +154,11 @@ class _MyHomePageState extends State<MyHomePage> {
       child: SafeArea(
         child: Column(
           children: [
-            _Header(count: _tiles.length, multiViewer: !kIsWeb),
+            _Header(count: _tiles.length, multiViewer: true),
             const _Divider(),
             Expanded(
               child: _tiles.isEmpty
-                  ? const _EmptyState(singleViewerOnly: kIsWeb)
+                  ? const _EmptyState()
                   : GridView.count(
                       crossAxisCount: 2,
                       childAspectRatio: 1,
@@ -266,8 +266,7 @@ class _Divider extends StatelessWidget {
 }
 
 class _EmptyState extends StatefulWidget {
-  const _EmptyState({required this.singleViewerOnly});
-  final bool singleViewerOnly;
+  const _EmptyState();
 
   @override
   State<_EmptyState> createState() => _EmptyStateState();
@@ -323,11 +322,9 @@ class _EmptyStateState extends State<_EmptyState>
                     letterSpacing: 0.2,
                   )),
               const SizedBox(height: 6),
-              Text(
-                widget.singleViewerOnly
-                    ? 'Web builds support a single viewer at a time.'
-                    : 'Set a batch with the stepper, then hit “Add”.',
-                style: const TextStyle(color: _textDim, fontSize: 12.5),
+              const Text(
+                'Set a batch with the stepper, then hit “Add”.',
+                style: TextStyle(color: _textDim, fontSize: 12.5),
               ),
             ],
           );

--- a/examples/flutter/quickstart/pubspec.yaml
+++ b/examples/flutter/quickstart/pubspec.yaml
@@ -23,14 +23,6 @@ dependency_overrides:
   thermion_flutter:
     path: ../../../thermion_flutter/thermion_flutter
 
-# Iterating on thermion_dart's native C++ against web: copy the locally
-# built emscripten artifacts (native/web/build/build/out) instead of
-# downloading the R2 release build. Remove before shipping.
-hooks:
-  user_defines:
-    thermion_dart:
-      web_local: true
-  
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/thermion_dart/test/bone_picking_tests.dart
+++ b/thermion_dart/test/bone_picking_tests.dart
@@ -4,8 +4,6 @@ import 'package:thermion_dart/thermion_dart.dart';
 import 'package:test/test.dart';
 import 'helpers.dart';
 
-import 'package:thermion_dart/thermion_dart.dart';
-
 /// Visualizes bones with Blender-style head/tail shapes.
 ///
 /// Each bone is rendered as:
@@ -603,6 +601,11 @@ void main() async {
       final viewport = await viewer.view.getViewport();
       final centerX = viewport.width ~/ 2;
       final centerY = viewport.height ~/ 2;
+
+      // The bone overlay material is blended (transparent), and View::pick
+      // only considers opaque renderables unless transparent picking is
+      // enabled (it is disabled by default in Filament).
+      await viewer.view.setTransparentPickingEnabled(true);
 
       print('Picking at center: ($centerX, $centerY)');
 

--- a/thermion_dart/test/picking_tests.dart
+++ b/thermion_dart/test/picking_tests.dart
@@ -40,49 +40,51 @@ void main() async {
         });
   });
 
-  // test('pick transparent cube with transparent picking disabled ', () async {
-  //   await ViewerBuilder(testHelper)
-  //       .setRenderTargetEnabled(false)
-  //       .setCameraLookAt(Vector3(10, 10, 10), focus: Vector3(0, 0, 0))
-  //       .execute((result) async {
-  //     await FilamentApp.instance!.setClearOptions(0, 1, 0, 1);
+  // Reinstated 2026-08-18: disabled in 1750c1a5 pending a Filament build with
+  // the upstream transparent-picking fix; #241 bumped to v1.75.0 which has it.
+  test('pick transparent cube with transparent picking disabled ', () async {
+    await ViewerBuilder(testHelper)
+        .setRenderTargetEnabled(false)
+        .setCameraLookAt(Vector3(10, 10, 10), focus: Vector3(0, 0, 0))
+        .execute((result) async {
+          await FilamentApp.instance!.setClearOptions(0, 1, 0, 1);
 
-  //     final viewer = result.viewer;
+          final viewer = result.viewer;
 
-  //     final mi = await FilamentApp.instance!.createUbershaderMaterialInstance(
-  //         alphaMode: AlphaMode.BLEND,
-  //         unlit: true,
-  //         hasVertexColors: false,
-  //         hasNormalTexture: false,
-  //         hasBaseColorTexture: false,
-  //         hasClearCoat: false,
-  //         hasIOR: false);
-  //     await mi.setParameterFloat4("baseColorFactor", 1, 0, 0, 0.5);
-  //     final cubeGeometry = GeometryUtils.cube();
-  //     final cube =
-  //         await viewer.createGeometry(cubeGeometry, materialInstances: [mi]);
-  //     final view = await viewer.view;
-  //     final viewport = await view.getViewport();
-  //     await view.setTransparentPickingEnabled(false);
+          final mi = await FilamentApp.instance!.createUbershaderMaterialInstance(
+            alphaMode: AlphaMode.BLEND,
+            unlit: true,
+            hasVertexColors: false,
+            hasNormalTexture: false,
+            hasBaseColorTexture: false,
+            hasClearCoat: false,
+            hasIOR: false,
+          );
+          await mi.setParameterFloat4("baseColorFactor", 1, 0, 0, 0.5);
+          final cubeGeometry = GeometryUtils.cube();
+          final cube = await viewer.createGeometry(cubeGeometry, materialInstances: [mi]);
+          final view = await viewer.view;
+          final viewport = await view.getViewport();
+          await view.setTransparentPickingEnabled(false);
 
-  //     final completer = Completer<PickResult>();
+          final completer = Completer<PickResult>();
 
-  //     await view.pick(viewport.width ~/ 2, viewport.height ~/ 2, (result) {
-  //       completer.complete(result);
-  //     });
+          await view.pick(viewport.width ~/ 2, viewport.height ~/ 2, (result) {
+            completer.complete(result);
+          });
 
-  //     for (int i = 0; i < 10; i++) {
-  //       await testHelper.capture(viewer.view, "transparent_pick_enabled");
-  //       if (completer.isCompleted) {
-  //         break;
-  //       }
-  //     }
+          for (int i = 0; i < 10; i++) {
+            await testHelper.capture(viewer.view, "transparent_pick_enabled");
+            if (completer.isCompleted) {
+              break;
+            }
+          }
 
-  //     expect(completer.isCompleted, true); // callback is always called
-  //     var pickResult = await completer.future;
-  //     print("pickResult.entity ${pickResult.entity}");
-  //     // With transparent picking disabled, the transparent cube should NOT be picked
-  //     expect(pickResult.entity, isNot(equals(cube.entity)));
-  //   });
-  // });
+          expect(completer.isCompleted, true); // callback is always called
+          var pickResult = await completer.future;
+          print("pickResult.entity ${pickResult.entity}");
+          // With transparent picking disabled, the transparent cube should NOT be picked
+          expect(pickResult.entity, isNot(equals(cube.entity)));
+        });
+  });
 }


### PR DESCRIPTION
- reinstate some tests (which were disabled because they failed on earlier versions of Filament where transparent picking was buggy)
- fix quickstart on web by removing `web_local` dependency and  disabling the 1-viewer cap 