### PR TITLE
Refactor FrameScheduler callback dispatch

### DIFF
--- a/thermion_dart/native/include/c_api/FrameSchedulerApi.h
+++ b/thermion_dart/native/include/c_api/FrameSchedulerApi.h
@@ -15,27 +15,17 @@ namespace thermion
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_start(FrameCallback callback, int targetFps);
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_stop();
 
-        // Native render loop
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_setRenderThread(void* renderThread);
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_setRenderManager(TRenderManager* rm);
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_setPostRenderCallback(PostRenderCallback callback, void* userData);
-        // Request a single render frame (non-blocking, queues to render thread).
-        // Returns true only when a render was actually queued.
         EMSCRIPTEN_KEEPALIVE bool FrameScheduler_requestRender(uint64_t frameTimeNanos);
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_startNativeRenderLoop(int targetFps);
 
-        // Port-based frame scheduler (hot restart safe)
-        // Initialize Dart API DL - must be called once before using port mode
         EMSCRIPTEN_KEEPALIVE int FrameScheduler_initDartApi(void* data);
-        // Start frame scheduler in port mode - posts frame timestamps to Dart port
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_startWithPort(int64_t port, int targetFps);
 
-        // Cap the dispatch rate to [fps] by skipping frames at the source.
-        // fps <= 0 means unlimited (dispatch every vsync). The value is retained
-        // and applied to schedulers created after this call as well.
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_setTargetFps(int fps);
 
-        // Returns steady_clock microseconds
         EMSCRIPTEN_KEEPALIVE int64_t FrameScheduler_steadyClockUs();
 
 #ifdef __cplusplus

--- a/thermion_dart/native/include/rendering/CADisplayLinkWrapper.h
+++ b/thermion_dart/native/include/rendering/CADisplayLinkWrapper.h
@@ -8,6 +8,7 @@ extern "C" {
 
 typedef void (*CADisplayLinkFrameCallback)(uint64_t frameTimeNanos, void* context);
 void* CADisplayLinkWrapper_create(CADisplayLinkFrameCallback callback, void* context);
+void CADisplayLinkWrapper_setTargetFps(void* wrapper, int fps);
 void CADisplayLinkWrapper_start(void* wrapper);
 void CADisplayLinkWrapper_stop(void* wrapper);
 void CADisplayLinkWrapper_destroy(void* wrapper);

--- a/thermion_dart/native/include/rendering/FrameScheduler.hpp
+++ b/thermion_dart/native/include/rendering/FrameScheduler.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <atomic>
-#include <thread>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
+#include <mutex>
+#include <thread>
 
 #if __APPLE__
 #include <TargetConditionals.h>
@@ -15,79 +17,127 @@
 
 namespace thermion {
 
+/// Produces rate-limited callbacks from platform frame-timing sources.
+///
+/// A frame source is the platform mechanism that supplies timing events. The
+/// source is CVDisplayLink on macOS, CADisplayLink on iOS, AChoreographer on
+/// Android, DXGI vertical blanking on Windows, or an interruptible timer when
+/// no platform source is available. One timing event is a source tick.
+///
+/// The scheduler applies the rate limit to each source tick. A tick that passes
+/// the rate limit causes one callback. A rejected tick does not reach the
+/// callback.
+///
+/// The callback runs on the source callback context. The timer, Android, and
+/// Windows implementations use a scheduler-owned thread. CADisplayLink uses
+/// the iOS main run loop. CVDisplayLink uses its system callback thread. The
+/// callback must return quickly because it blocks that context. A slow callback
+/// can delay or drop later callback delivery.
+///
+/// FrameScheduler only supplies timing callbacks. It does not prescribe what a
+/// callback does. Callers generally use each callback to request a rendered
+/// frame, but they can use it for any work that needs frame-based timing.
+///
+/// setTargetFps() asks supported platform sources to use the target rate. This
+/// reduces wakeups. The scheduler also checks each source tick against the
+/// target rate. This final check handles approximate source rates and changes
+/// to the display rate. It also handles a target rate that does not divide the
+/// display rate evenly.
+///
+/// The final check uses absolute deadlines. It skips missed deadlines and does
+/// not send a burst of late callbacks. It can accept a tick up to 1 ms before a
+/// deadline. This tolerance accounts for timestamp variation.
+///
+/// Each frame timestamp is a monotonic value in nanoseconds. The active platform
+/// source selects the clock domain. Do not use the timestamp as wall-clock time.
 class FrameScheduler {
 public:
-    using Callback = void (*)(uint64_t frameTimeNanos);
+    /// Receives a monotonic frame timestamp and the pointer supplied to start().
+    using Callback = void (*)(uint64_t frameTimeNanos, void* userData);
 
     virtual ~FrameScheduler() = default;
-    virtual void start(Callback callback) = 0;
-    virtual void startWithPort(int64_t port) {}
+
+    /// Starts the frame source. Each source tick that passes rate gating invokes
+    /// `callback` with its timestamp and `userData`.
+    ///
+    /// The scheduler does not own `userData`. The callback and `userData` must
+    /// remain valid until stop() returns. Call stop() before a second start().
+    virtual void start(Callback callback, void* userData = nullptr) = 0;
+
+    /// Stops the frame source and waits for its callback context to stop.
+    /// Work that the callback already posted can continue after this returns.
     virtual void stop() = 0;
 
-    void setRenderThread(void* renderThread) { _renderThread = renderThread; }
-    void* renderThread() const { return _renderThread; }
-
+    /// Creates a scheduler for the current platform.
+    ///
+    /// `targetFps` sets the fallback timer rate. It does not set the dispatch
+    /// rate limit. Call setTargetFps() to set or change that limit. The caller
+    /// owns the returned scheduler and must stop and delete it.
     static FrameScheduler* create(int targetFps);
 
-    /// Cap the dispatch rate to [fps] by skipping frames at the source (in
-    /// dispatchFrame). fps <= 0 means unlimited (dispatch every vsync).
-    /// Honored by every scheduler that routes through dispatchFrame
-    /// (CVDisplayLink / CADisplayLink / AChoreographer / timer / DXGI).
+    /// Sets the maximum callback rate. A value of zero or less removes the
+    /// limit. Without a limit, each source tick causes one callback.
+    ///
+    /// A caller can use this method while the scheduler runs. Supported platform
+    /// sources change their rate when they next schedule a tick. The scheduler
+    /// enforces the limit on all platforms.
     void setTargetFps(int fps);
 
 protected:
     Callback _callback = nullptr;
-    int64_t _dartPort = 0;
-    bool _usePortMode = false;
-    void* _renderThread = nullptr;
+    void* _callbackUserData = nullptr;
 
-    // Framerate-limiting state. _fpsLimit is set from another thread (Dart),
-    // so it is atomic; the timing fields are only touched from the scheduler's
-    // own callback thread (or after that thread has stopped).
+    // setTargetFps() can change _fpsLimit from another thread. The source
+    // callback owns the other timing fields while the scheduler runs.
     std::atomic<int> _fpsLimit{0};
     int _appliedFpsLimit = 0;
+    uint64_t _dispatchIntervalNs = 0;
     uint64_t _nextDispatchNs = 0;
 
-    void dispatchFrame(uint64_t nanos);
+    void handleSourceTick(uint64_t timestampNanos);
     void resetState();
+    virtual void onTargetFpsChanged(int) {}
 };
 
-/// Timer-based fallback (Windows, Linux, Android, etc.).
+/// Uses an interruptible timer as the frame source.
 class TimerFrameScheduler : public FrameScheduler {
     std::thread* _thread = nullptr;
     std::atomic<bool> _running{false};
     int _targetFps;
+    std::mutex _wakeMutex;
+    std::condition_variable _wakeCondition;
 public:
     explicit TimerFrameScheduler(int targetFps) : _targetFps(targetFps) {}
     ~TimerFrameScheduler() override { stop(); }
-    void start(Callback callback) override;
-    void startWithPort(int64_t port) override;
+    void start(Callback callback, void* userData = nullptr) override;
     void stop() override;
+private:
+    void run();
+    void onTargetFpsChanged(int) override;
 };
 
 #if __APPLE__ && TARGET_OS_IOS
-/// iOS CADisplayLink-based scheduler for proper vsync timing.
+/// Uses CADisplayLink as the iOS frame source.
 class CADisplayLinkScheduler : public FrameScheduler {
     void* _wrapper = nullptr;
 public:
     ~CADisplayLinkScheduler() override { stop(); }
-    void start(Callback callback) override;
-    void startWithPort(int64_t port) override;
+    void start(Callback callback, void* userData = nullptr) override;
     void stop() override;
 private:
     static void displayLinkCallback(uint64_t frameTimeNanos, void* context);
+    void onTargetFpsChanged(int fps) override;
 };
 #endif // __APPLE__ && TARGET_OS_IOS
 
 #if __APPLE__ && TARGET_OS_OSX
-/// macOS CVDisplayLink-based scheduler for proper vsync timing.
+/// Uses CVDisplayLink as the macOS frame source.
 class CVDisplayLinkScheduler : public FrameScheduler {
     CVDisplayLinkRef _displayLink = nullptr;
     mach_timebase_info_data_t _timebase{};
 public:
     ~CVDisplayLinkScheduler() override { stop(); }
-    void start(Callback callback) override;
-    void startWithPort(int64_t port) override;
+    void start(Callback callback, void* userData = nullptr) override;
     void stop() override;
 private:
     static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
@@ -97,7 +147,7 @@ private:
 #endif // __APPLE__ && TARGET_OS_OSX
 
 #ifdef _WIN32
-/// Windows DXGI-based scheduler for proper vsync timing.
+/// Uses DXGI as the Windows frame source.
 class DXGIFrameScheduler : public FrameScheduler {
     std::thread* _thread = nullptr;
     std::atomic<bool> _running{false};
@@ -105,27 +155,27 @@ class DXGIFrameScheduler : public FrameScheduler {
 public:
     explicit DXGIFrameScheduler(int targetFps) : _targetFps(targetFps) {}
     ~DXGIFrameScheduler() override { stop(); }
-    void start(Callback callback) override;
-    void startWithPort(int64_t port) override;
+    void start(Callback callback, void* userData = nullptr) override;
     void stop() override;
 };
 #endif
 
 #ifdef __ANDROID__
-/// Android Choreographer-based scheduler for proper vsync timing.
-/// Uses AChoreographer API (NDK API level 24+) to synchronize with display refresh.
+/// Uses AChoreographer as the Android frame source.
+/// Requires Android NDK API level 24 or later.
 class AChoreographerFrameScheduler : public FrameScheduler {
     std::thread* _thread = nullptr;
     std::atomic<bool> _running{false};
-    void* _looper = nullptr;  // ALooper*
-    void* _choreographer = nullptr;  // AChoreographer*
+    std::atomic<void*> _looper{nullptr};
+    void* _choreographer = nullptr;
+    int _sourceFps = 0;
+    uint64_t _nextSourceFrameNs = 0;
 public:
     ~AChoreographerFrameScheduler() override { stop(); }
-    void start(Callback callback) override;
-    void startWithPort(int64_t port) override;
+    void start(Callback callback, void* userData = nullptr) override;
     void stop() override;
 private:
-    void scheduleNextFrame();
+    void scheduleNextFrame(uint64_t lastFrameTimeNanos = 0);
     static void frameCallback(long frameTimeNanos, void* data);
 };
 #endif

--- a/thermion_dart/native/src/c_api/FrameSchedulerApi.cpp
+++ b/thermion_dart/native/src/c_api/FrameSchedulerApi.cpp
@@ -10,9 +10,8 @@
 #include "rendering/RenderManager.hpp"
 #include "rendering/FrameScheduler.hpp"
 
-// Dart API for port-based frame scheduling (hot restart safe)
 #ifndef __EMSCRIPTEN__
-#include "dart/dart_api_dl.h" // needed for FrameScheduler_initDartApi
+#include "dart/dart_api_dl.h"
 #endif
 
 using namespace thermion;
@@ -21,27 +20,44 @@ extern "C"
 {
 
   static thermion::FrameScheduler* _frameScheduler = nullptr;
+  static FrameCallback _scheduledCallback = nullptr;
+  static int64_t _dartPort = 0;
 
-  // Native render loop state
   static TRenderManager* _nativeRenderManager = nullptr;
-  static RenderThread* _renderThread = nullptr;  // non-owning; owned by ThermionDartRenderThreadApi
+  static RenderThread* _renderThread = nullptr;
   static std::atomic<bool> _nativeRenderInProgress{false};
   static PostRenderCallback _postRenderCallback = nullptr;
   static void* _postRenderUserData = nullptr;
 
-  // Process-wide desired cap. It survives scheduler stop/start so lifecycle
-  // transitions do not silently discard the user's setting. 0 = unlimited.
   static std::atomic<int> _targetFpsLimit{0};
 
-  // Pacing state for the Linux Flutter-synced request-render path, which
-  // bypasses FrameScheduler::dispatchFrame. These fields are only touched on
-  // Flutter's UI thread.
   static int _requestAppliedFpsLimit = 0;
   static uint64_t _nextRequestRenderNs = 0;
 
   static void applyTargetFps(FrameScheduler* scheduler) {
     scheduler->setTargetFps(_targetFpsLimit.load(std::memory_order_relaxed));
   }
+
+  static void forwardScheduledFrame(
+      uint64_t frameTimeNanos, void* userData) {
+    auto callback = *static_cast<FrameCallback*>(userData);
+    if (callback) {
+      callback(frameTimeNanos);
+    }
+  }
+
+#ifndef __EMSCRIPTEN__
+  static void postScheduledFrameToDart(
+      uint64_t frameTimeNanos, void* userData) {
+    const int64_t port = *static_cast<int64_t*>(userData);
+    if (port == 0) return;
+
+    Dart_CObject message;
+    message.type = Dart_CObject_kInt64;
+    message.value.as_int64 = static_cast<int64_t>(frameTimeNanos);
+    Dart_PostCObject_DL(port, &message);
+  }
+#endif
 
   EMSCRIPTEN_KEEPALIVE void FrameScheduler_start(FrameCallback callback, int targetFps) {
 #ifndef __EMSCRIPTEN__
@@ -52,7 +68,8 @@ extern "C"
     }
     _frameScheduler = thermion::FrameScheduler::create(targetFps);
     applyTargetFps(_frameScheduler);
-    _frameScheduler->start(callback);
+    _scheduledCallback = callback;
+    _frameScheduler->start(forwardScheduledFrame, &_scheduledCallback);
 #endif
   }
 
@@ -63,9 +80,9 @@ extern "C"
       delete _frameScheduler;
       _frameScheduler = nullptr;
     }
+    _scheduledCallback = nullptr;
+    _dartPort = 0;
 
-    // No scheduler callback can be admitted after stop() returns. Wait for
-    // the final accepted render before invalidating any pointer it captured.
     while (_nativeRenderInProgress.load(std::memory_order_acquire)) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
@@ -76,15 +93,10 @@ extern "C"
 #endif
   }
 
-  // Port-based frame scheduler (hot restart safe)
-  // When the Dart isolate dies (hot restart), Dart_PostCObject_DL silently
-  // drops messages instead of crashing.
-
 #ifndef __EMSCRIPTEN__
   static bool _dartApiInitialized = false;
 #endif
 
-  // Returns steady_clock microseconds — call from Dart to measure port transit time
   EMSCRIPTEN_KEEPALIVE int64_t FrameScheduler_steadyClockUs() {
     return std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -112,7 +124,8 @@ extern "C"
     }
     _frameScheduler = thermion::FrameScheduler::create(targetFps);
     applyTargetFps(_frameScheduler);
-    _frameScheduler->startWithPort(port);
+    _dartPort = port;
+    _frameScheduler->start(postScheduledFrameToDart, &_dartPort);
 #endif
   }
 
@@ -125,8 +138,6 @@ extern "C"
     }
 #endif
   }
-
-  // === Native render loop (bypasses Dart event loop) ===
 
   EMSCRIPTEN_KEEPALIVE void FrameScheduler_setRenderThread(void* renderThread) {
 #ifndef __EMSCRIPTEN__
@@ -143,7 +154,6 @@ extern "C"
     _postRenderUserData = userData;
   }
 
-  // Frame callback for native render loop — runs on scheduler thread
   static bool _nativeFrameCallback(uint64_t frameTimeNanos) {
     auto* renderManager = _nativeRenderManager;
     auto* renderThread = _renderThread;
@@ -151,7 +161,7 @@ extern "C"
     auto* postRenderUserData = _postRenderUserData;
     if (!renderManager || !renderThread) return false;
     if (_nativeRenderInProgress.exchange(true, std::memory_order_acq_rel)) {
-      return false; // skip if still rendering
+      return false;
     }
 
     renderThread->addDetachedTask([
@@ -171,23 +181,17 @@ extern "C"
     return true;
   }
 
-  // Adapter for FrameScheduler::Callback, whose return type is void.
-  static void _nativeScheduledFrameCallback(uint64_t frameTimeNanos) {
+  static void _nativeScheduledFrameCallback(
+      uint64_t frameTimeNanos, void*) {
     _nativeFrameCallback(frameTimeNanos);
   }
 
-  // Request a single render frame (called from Dart's frame callback).
-  // Non-blocking: queues the render to the render thread and returns.
-  // Throttled here (not in _nativeFrameCallback) so the Linux Flutter-synced
-  // path — which bypasses the FrameScheduler/dispatchFrame throttle — still
-  // honors the target fps. display-link/timer/DXGI paths pace themselves in
-  // dispatchFrame and don't go through requestRender.
   EMSCRIPTEN_KEEPALIVE bool FrameScheduler_requestRender(uint64_t frameTimeNanos) {
     int fps = _targetFpsLimit.load(std::memory_order_relaxed);
     if (fps > 0) {
       const uint64_t interval = std::max<uint64_t>(
           1, 1000000000ULL / static_cast<uint64_t>(fps));
-      const uint64_t tolerance = 1000000ULL; // 1 ms
+      const uint64_t tolerance = 1000000ULL;
 
       if (_requestAppliedFpsLimit != fps || _nextRequestRenderNs == 0) {
         _requestAppliedFpsLimit = fps;

--- a/thermion_dart/native/src/rendering/CADisplayLinkWrapper.m
+++ b/thermion_dart/native/src/rendering/CADisplayLinkWrapper.m
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/CADisplayLink.h>
+#import <dispatch/dispatch.h>
 #include "rendering/CADisplayLinkWrapper.h"
 
 @interface ThermionDisplayLinkHelper : NSObject {
@@ -8,6 +9,7 @@
     void* _context;
 }
 - (instancetype)initWithCallback:(CADisplayLinkFrameCallback)callback context:(void*)context;
+- (void)setTargetFps:(int)fps;
 - (void)start;
 - (void)stop;
 - (void)displayLinkFired:(CADisplayLink*)link;
@@ -23,6 +25,19 @@
         _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(displayLinkFired:)];
     }
     return self;
+}
+
+- (void)setTargetFps:(int)fps {
+    if (@available(iOS 15.0, *)) {
+        if (fps > 0) {
+            const float rate = (float)fps;
+            _displayLink.preferredFrameRateRange = CAFrameRateRangeMake(rate, rate, rate);
+        } else {
+            _displayLink.preferredFrameRateRange = CAFrameRateRangeDefault;
+        }
+    } else {
+        _displayLink.preferredFramesPerSecond = fps > 0 ? fps : 0;
+    }
 }
 
 - (void)start {
@@ -45,6 +60,20 @@
 void* CADisplayLinkWrapper_create(CADisplayLinkFrameCallback callback, void* context) {
     ThermionDisplayLinkHelper* helper = [[ThermionDisplayLinkHelper alloc] initWithCallback:callback context:context];
     return (__bridge_retained void*)helper;
+}
+
+void CADisplayLinkWrapper_setTargetFps(void* wrapper, int fps) {
+    if (!wrapper) return;
+    ThermionDisplayLinkHelper* helper = (__bridge ThermionDisplayLinkHelper*)wrapper;
+    if ([NSThread isMainThread]) {
+        [helper setTargetFps:fps];
+    } else {
+        // CADisplayLink is attached to the main run loop. The block retains the
+        // helper, so a concurrent stop can safely invalidate it before this runs.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [helper setTargetFps:fps];
+        });
+    }
 }
 
 void CADisplayLinkWrapper_start(void* wrapper) {

--- a/thermion_dart/native/src/rendering/FrameScheduler.cpp
+++ b/thermion_dart/native/src/rendering/FrameScheduler.cpp
@@ -1,6 +1,5 @@
 #include "rendering/FrameScheduler.hpp"
 #include "Log.hpp"
-#include "dart/dart_api_dl.h"
 #include <algorithm>
 #include <iostream>
 
@@ -25,10 +24,15 @@ namespace thermion {
 // ---------------------------------------------------------------------------
 
 void FrameScheduler::setTargetFps(int fps) {
-    _fpsLimit.store(fps > 0 ? fps : 0, std::memory_order_relaxed);
+    const int normalizedFps = fps > 0 ? fps : 0;
+    const int previousFps = _fpsLimit.exchange(
+        normalizedFps, std::memory_order_relaxed);
+    if (previousFps != normalizedFps) {
+        onTargetFpsChanged(normalizedFps);
+    }
 }
 
-void FrameScheduler::dispatchFrame(uint64_t nanos) {
+void FrameScheduler::handleSourceTick(uint64_t nanos) {
     // Framerate limiting: use an absolute deadline rather than measuring from
     // the last dispatched vsync. This preserves the requested average on
     // refresh rates that are not integer multiples of the target (for example,
@@ -36,12 +40,12 @@ void FrameScheduler::dispatchFrame(uint64_t nanos) {
     // of collapsing to 45 fps).
     int fps = _fpsLimit.load(std::memory_order_relaxed);
     if (fps > 0) {
-        const uint64_t interval = std::max<uint64_t>(
-            1, 1000000000ULL / static_cast<uint64_t>(fps));
         const uint64_t tolerance = 1000000ULL; // 1 ms
 
         if (_appliedFpsLimit != fps || _nextDispatchNs == 0) {
             _appliedFpsLimit = fps;
+            _dispatchIntervalNs = std::max<uint64_t>(
+                1, 1000000000ULL / static_cast<uint64_t>(fps));
             _nextDispatchNs = nanos;
         }
 
@@ -55,34 +59,28 @@ void FrameScheduler::dispatchFrame(uint64_t nanos) {
         // catch up.
         if (_nextDispatchNs <= nanos) {
             const uint64_t missedIntervals =
-                (nanos - _nextDispatchNs) / interval + 1;
-            _nextDispatchNs += missedIntervals * interval;
+                (nanos - _nextDispatchNs) / _dispatchIntervalNs + 1;
+            _nextDispatchNs += missedIntervals * _dispatchIntervalNs;
         } else {
             // Accepted up to [tolerance] before the deadline.
-            _nextDispatchNs += interval;
+            _nextDispatchNs += _dispatchIntervalNs;
         }
     } else {
         _appliedFpsLimit = 0;
+        _dispatchIntervalNs = 0;
         _nextDispatchNs = 0;
     }
 
-    if (_usePortMode) {
-        if (_dartPort != 0) {
-            Dart_CObject msg;
-            msg.type = Dart_CObject_kInt64;
-            msg.value.as_int64 = static_cast<int64_t>(nanos);
-            Dart_PostCObject_DL(_dartPort, &msg);
-        }
-    } else if (_callback) {
-        _callback(nanos);
+    if (_callback) {
+        _callback(nanos, _callbackUserData);
     }
 }
 
 void FrameScheduler::resetState() {
     _callback = nullptr;
-    _dartPort = 0;
-    _usePortMode = false;
+    _callbackUserData = nullptr;
     _appliedFpsLimit = 0;
+    _dispatchIntervalNs = 0;
     _nextDispatchNs = 0;
 }
 
@@ -105,67 +103,93 @@ FrameScheduler* FrameScheduler::create(int targetFps) {
 // TimerFrameScheduler
 // ---------------------------------------------------------------------------
 
-void TimerFrameScheduler::start(Callback callback) {
-    if (_running) return;
-    _callback = callback;
-    _usePortMode = false;
-    _running = true;
-    auto interval = std::chrono::nanoseconds(1000000000 / _targetFps);
-    _thread = new std::thread([this, interval]() {
-        uint64_t frameCount = 0;
-        auto lastActual = std::chrono::steady_clock::now();
-        while (_running) {
-            auto start = std::chrono::steady_clock::now();
-            uint64_t nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                start.time_since_epoch()).count();
-
-            auto actualIntervalUs = std::chrono::duration_cast<std::chrono::microseconds>(
-                start - lastActual).count();
-            lastActual = start;
-
-            dispatchFrame(nanos);
-
-            auto elapsed = std::chrono::steady_clock::now() - start;
-            auto callbackUs = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-
-            if (elapsed < interval) {
-                std::this_thread::sleep_for(interval - elapsed);
-            }
-
-            frameCount++;
-            if (frameCount % 300 == 0) {
-                auto targetUs = std::chrono::duration_cast<std::chrono::microseconds>(interval).count();
-                std::cerr << "[ThermionVk:Sched] interval=" << actualIntervalUs
-                          << "us callback=" << callbackUs
-                          << "us target=" << targetUs << "us" << std::endl;
-            }
-        }
-    });
+void TimerFrameScheduler::onTargetFpsChanged(int) {
+    // Synchronize with condition_variable::wait_until so a rate change cannot
+    // land between its predicate check and the thread actually blocking.
+    std::lock_guard<std::mutex> lock(_wakeMutex);
+    _wakeCondition.notify_all();
 }
 
-void TimerFrameScheduler::startWithPort(int64_t port) {
-    if (_running) return;
-    _dartPort = port;
-    _usePortMode = true;
-    _callback = nullptr;
-    _running = true;
-    auto interval = std::chrono::nanoseconds(1000000000 / _targetFps);
-    _thread = new std::thread([this, interval]() {
-        while (_running) {
-            auto start = std::chrono::steady_clock::now();
-            uint64_t nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                start.time_since_epoch()).count();
-            dispatchFrame(nanos);
-            auto elapsed = std::chrono::steady_clock::now() - start;
-            if (elapsed < interval) {
-                std::this_thread::sleep_for(interval - elapsed);
-            }
+void TimerFrameScheduler::run() {
+    using Clock = std::chrono::steady_clock;
+
+    int appliedSourceFps = 0;
+    std::chrono::nanoseconds sourceInterval{0};
+    auto nextWake = Clock::now();
+    auto lastActual = nextWake;
+    uint64_t frameCount = 0;
+
+    while (_running.load(std::memory_order_relaxed)) {
+        const int requestedFps = _fpsLimit.load(std::memory_order_relaxed);
+        const int sourceFps = requestedFps > 0
+            ? requestedFps
+            : std::max(1, _targetFps);
+        if (sourceFps != appliedSourceFps) {
+            appliedSourceFps = sourceFps;
+            sourceInterval = std::chrono::nanoseconds(
+                std::max<uint64_t>(
+                    1, 1000000000ULL / static_cast<uint64_t>(sourceFps)));
+            // Apply both increases and decreases immediately. handleSourceTick()
+            // resets its deadline on the same target-FPS change.
+            nextWake = Clock::now();
         }
-    });
+
+        const auto start = Clock::now();
+        const uint64_t nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            start.time_since_epoch()).count();
+        const auto actualIntervalUs = std::chrono::duration_cast<std::chrono::microseconds>(
+            start - lastActual).count();
+        lastActual = start;
+
+        handleSourceTick(nanos);
+
+        const auto callbackElapsed = Clock::now() - start;
+        const auto callbackUs = std::chrono::duration_cast<std::chrono::microseconds>(
+            callbackElapsed).count();
+
+        ++frameCount;
+        if (frameCount % 300 == 0) {
+            const auto targetUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                sourceInterval).count();
+            std::cerr << "[ThermionVk:Sched] interval=" << actualIntervalUs
+                      << "us callback=" << callbackUs
+                      << "us target=" << targetUs << "us" << std::endl;
+        }
+
+        nextWake += sourceInterval;
+        const auto now = Clock::now();
+        if (nextWake <= now) {
+            const auto missedIntervals =
+                (now - nextWake) / sourceInterval + 1;
+            nextWake += sourceInterval * missedIntervals;
+        }
+
+        std::unique_lock<std::mutex> lock(_wakeMutex);
+        _wakeCondition.wait_until(lock, nextWake, [this, appliedSourceFps]() {
+            const int requestedFps = _fpsLimit.load(std::memory_order_relaxed);
+            const int sourceFps = requestedFps > 0
+                ? requestedFps
+                : std::max(1, _targetFps);
+            return !_running.load(std::memory_order_relaxed) ||
+                sourceFps != appliedSourceFps;
+        });
+    }
+}
+
+void TimerFrameScheduler::start(Callback callback, void* userData) {
+    if (_running) return;
+    _callback = callback;
+    _callbackUserData = userData;
+    _running = true;
+    _thread = new std::thread([this]() { run(); });
 }
 
 void TimerFrameScheduler::stop() {
-    _running = false;
+    {
+        std::lock_guard<std::mutex> lock(_wakeMutex);
+        _running = false;
+    }
+    _wakeCondition.notify_all();
     if (_thread) {
         _thread->join();
         delete _thread;
@@ -182,24 +206,23 @@ void TimerFrameScheduler::stop() {
 
 void CADisplayLinkScheduler::displayLinkCallback(uint64_t frameTimeNanos, void* context) {
     auto* self = static_cast<CADisplayLinkScheduler*>(context);
-    self->dispatchFrame(frameTimeNanos);
+    self->handleSourceTick(frameTimeNanos);
 }
 
-void CADisplayLinkScheduler::start(Callback callback) {
+void CADisplayLinkScheduler::start(Callback callback, void* userData) {
     stop();
     _callback = callback;
-    _usePortMode = false;
+    _callbackUserData = userData;
     _wrapper = CADisplayLinkWrapper_create(displayLinkCallback, this);
+    CADisplayLinkWrapper_setTargetFps(
+        _wrapper, _fpsLimit.load(std::memory_order_relaxed));
     CADisplayLinkWrapper_start(_wrapper);
 }
 
-void CADisplayLinkScheduler::startWithPort(int64_t port) {
-    stop();
-    _dartPort = port;
-    _usePortMode = true;
-    _callback = nullptr;
-    _wrapper = CADisplayLinkWrapper_create(displayLinkCallback, this);
-    CADisplayLinkWrapper_start(_wrapper);
+void CADisplayLinkScheduler::onTargetFpsChanged(int fps) {
+    if (_wrapper) {
+        CADisplayLinkWrapper_setTargetFps(_wrapper, fps);
+    }
 }
 
 void CADisplayLinkScheduler::stop() {
@@ -218,22 +241,10 @@ void CADisplayLinkScheduler::stop() {
 
 #if __APPLE__ && TARGET_OS_OSX
 
-void CVDisplayLinkScheduler::start(Callback callback) {
+void CVDisplayLinkScheduler::start(Callback callback, void* userData) {
     stop();
     _callback = callback;
-    _usePortMode = false;
-    mach_timebase_info(&_timebase);
-
-    CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
-    CVDisplayLinkSetOutputCallback(_displayLink, displayLinkCallback, this);
-    CVDisplayLinkStart(_displayLink);
-}
-
-void CVDisplayLinkScheduler::startWithPort(int64_t port) {
-    stop();
-    _dartPort = port;
-    _usePortMode = true;
-    _callback = nullptr;
+    _callbackUserData = userData;
     mach_timebase_info(&_timebase);
 
     CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
@@ -255,12 +266,12 @@ CVReturn CVDisplayLinkScheduler::displayLinkCallback(CVDisplayLinkRef displayLin
     CVOptionFlags flagsIn, CVOptionFlags* flagsOut, void* context) {
 
     auto* self = static_cast<CVDisplayLinkScheduler*>(context);
-    // hostTime is Mach absolute time; convert to nanoseconds so dispatchFrame's
+    // hostTime is Mach absolute time; convert to nanoseconds so the rate gate's
     // interval math is unit-correct on every Mac (Apple Silicon is 1:1, but
     // don't assume it).
     uint64_t hostTime = inOutputTime->hostTime;
     uint64_t nanos = hostTime * self->_timebase.numer / self->_timebase.denom;
-    self->dispatchFrame(nanos);
+    self->handleSourceTick(nanos);
     return kCVReturnSuccess;
 }
 
@@ -272,10 +283,10 @@ CVReturn CVDisplayLinkScheduler::displayLinkCallback(CVDisplayLinkRef displayLin
 
 #ifdef _WIN32
 
-void DXGIFrameScheduler::start(Callback callback) {
+void DXGIFrameScheduler::start(Callback callback, void* userData) {
     stop();
     _callback = callback;
-    _usePortMode = false;
+    _callbackUserData = userData;
     _running = true;
 
     _thread = new std::thread([this]() {
@@ -306,52 +317,7 @@ void DXGIFrameScheduler::start(Callback callback) {
                 auto now = std::chrono::steady_clock::now();
                 uint64_t nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
                     now.time_since_epoch()).count();
-                dispatchFrame(nanos);
-            }
-        }
-
-        if (output) output->Release();
-        if (adapter) adapter->Release();
-        if (factory) factory->Release();
-    });
-}
-
-void DXGIFrameScheduler::startWithPort(int64_t port) {
-    stop();
-    _dartPort = port;
-    _usePortMode = true;
-    _callback = nullptr;
-    _running = true;
-
-    _thread = new std::thread([this]() {
-        IDXGIFactory1* factory = nullptr;
-        IDXGIAdapter* adapter = nullptr;
-        IDXGIOutput* output = nullptr;
-
-        HRESULT hr = CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&factory);
-        if (SUCCEEDED(hr) && factory) {
-            hr = factory->EnumAdapters(0, &adapter);
-            if (SUCCEEDED(hr) && adapter) {
-                hr = adapter->EnumOutputs(0, &output);
-                if (FAILED(hr)) {
-                    output = nullptr;
-                    Log("DXGIFrameScheduler: Failed to get DXGI output for WaitForVBlank, falling back to timer");
-                }
-            }
-        }
-
-        auto interval = std::chrono::nanoseconds(1000000000 / _targetFps);
-        while (_running) {
-            if (output) {
-                output->WaitForVBlank();
-            } else {
-                std::this_thread::sleep_for(interval);
-            }
-            if (_running) {
-                auto now = std::chrono::steady_clock::now();
-                uint64_t nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    now.time_since_epoch()).count();
-                dispatchFrame(nanos);
+                handleSourceTick(nanos);
             }
         }
 
@@ -384,32 +350,67 @@ void AChoreographerFrameScheduler::frameCallback(long frameTimeNanos, void* data
     if (!self->_running) return;
 
     uint64_t nanos = static_cast<uint64_t>(frameTimeNanos);
-    self->dispatchFrame(nanos);
+    self->handleSourceTick(nanos);
 
     // Re-schedule for next frame (Choreographer callbacks are one-shot)
-    self->scheduleNextFrame();
+    self->scheduleNextFrame(nanos);
 }
 
-void AChoreographerFrameScheduler::scheduleNextFrame() {
+void AChoreographerFrameScheduler::scheduleNextFrame(uint64_t lastFrameTimeNanos) {
     if (!_running || !_choreographer) return;
-    // AChoreographer_postFrameCallback is available from API 24 (deprecated in 29 but still works)
-    AChoreographer_postFrameCallback(
-        static_cast<AChoreographer*>(_choreographer),
-        frameCallback,
-        this
-    );
+
+    long delayMillis = 0;
+    const int fps = _fpsLimit.load(std::memory_order_relaxed);
+    if (fps > 0 && lastFrameTimeNanos != 0) {
+        const uint64_t interval = std::max<uint64_t>(
+            1, 1000000000ULL / static_cast<uint64_t>(fps));
+        if (_sourceFps != fps || _nextSourceFrameNs == 0) {
+            _sourceFps = fps;
+            _nextSourceFrameNs = lastFrameTimeNanos + interval;
+        } else if (_nextSourceFrameNs <= lastFrameTimeNanos) {
+            const uint64_t missedIntervals =
+                (lastFrameTimeNanos - _nextSourceFrameNs) / interval + 1;
+            _nextSourceFrameNs += missedIntervals * interval;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        const uint64_t nowNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            now.time_since_epoch()).count();
+        if (_nextSourceFrameNs > nowNanos) {
+            // Round down so the callback is eligible for the first vsync at
+            // the target deadline rather than accidentally slipping one.
+            delayMillis = static_cast<long>(
+                (_nextSourceFrameNs - nowNanos) / 1000000ULL);
+        }
+    } else {
+        _sourceFps = 0;
+        _nextSourceFrameNs = 0;
+    }
+
+    if (delayMillis > 0) {
+        AChoreographer_postFrameCallbackDelayed(
+            static_cast<AChoreographer*>(_choreographer),
+            frameCallback,
+            this,
+            delayMillis);
+    } else {
+        AChoreographer_postFrameCallback(
+            static_cast<AChoreographer*>(_choreographer),
+            frameCallback,
+            this);
+    }
 }
 
-void AChoreographerFrameScheduler::start(Callback callback) {
+void AChoreographerFrameScheduler::start(Callback callback, void* userData) {
     stop();
     _callback = callback;
-    _usePortMode = false;
+    _callbackUserData = userData;
     _running = true;
 
     _thread = new std::thread([this]() {
         // Prepare looper for this thread
         ALooper* looper = ALooper_prepare(ALOOPER_PREPARE_ALLOW_NON_CALLBACKS);
-        _looper = looper;
+        _looper.store(looper, std::memory_order_release);
 
         // Get choreographer instance for this thread
         AChoreographer* choreographer = AChoreographer_getInstance();
@@ -433,45 +434,7 @@ void AChoreographerFrameScheduler::start(Callback callback) {
         }
 
         _choreographer = nullptr;
-        _looper = nullptr;
-    });
-}
-
-void AChoreographerFrameScheduler::startWithPort(int64_t port) {
-    stop();
-    _dartPort = port;
-    _usePortMode = true;
-    _callback = nullptr;
-    _running = true;
-
-    _thread = new std::thread([this]() {
-        // Prepare looper for this thread
-        ALooper* looper = ALooper_prepare(ALOOPER_PREPARE_ALLOW_NON_CALLBACKS);
-        _looper = looper;
-
-        // Get choreographer instance for this thread
-        AChoreographer* choreographer = AChoreographer_getInstance();
-        if (!choreographer) {
-            Log("AChoreographerFrameScheduler: Failed to get AChoreographer instance");
-            _running = false;
-            return;
-        }
-        _choreographer = choreographer;
-
-        // Post first frame callback
-        scheduleNextFrame();
-
-        // Run the looper - this blocks and processes choreographer callbacks
-        while (_running) {
-            int result = ALooper_pollOnce(-1, nullptr, nullptr, nullptr);
-            if (result == ALOOPER_POLL_ERROR) {
-                Log("AChoreographerFrameScheduler: Looper error");
-                break;
-            }
-        }
-
-        _choreographer = nullptr;
-        _looper = nullptr;
+        _looper.store(nullptr, std::memory_order_release);
     });
 }
 
@@ -479,8 +442,8 @@ void AChoreographerFrameScheduler::stop() {
     _running = false;
 
     // Wake up the looper so it can exit
-    if (_looper) {
-        ALooper_wake(static_cast<ALooper*>(_looper));
+    if (void* looper = _looper.load(std::memory_order_acquire)) {
+        ALooper_wake(static_cast<ALooper*>(looper));
     }
 
     if (_thread) {
@@ -489,8 +452,10 @@ void AChoreographerFrameScheduler::stop() {
         _thread = nullptr;
     }
     resetState();
+    _sourceFps = 0;
+    _nextSourceFrameNs = 0;
     _choreographer = nullptr;
-    _looper = nullptr;
+    _looper.store(nullptr, std::memory_order_release);
 }
 
 #endif // __ANDROID__


### PR DESCRIPTION
This PR refactors FrameScheduler to make it more generic, since there's no requirement that this be used for rendering. 
- replace the internal start/startWithPort split with one callback-plus-context interface
- move Dart port delivery into the C API adapter while preserving the public C ABI
- improve timer, CADisplayLink, and AChoreographer source cadence handling
- retain absolute-deadline dispatch gating and remove duplicated platform scheduler paths
- document frame sources, callback threading, rate gating, ownership, and render-thread dispatch
