### PR TITLE
Authenticate SwiftShader download in Windows CI

### DIFF
--- a/.github/actions/setup-windows-env/action.yml
+++ b/.github/actions/setup-windows-env/action.yml
@@ -22,6 +22,7 @@ runs:
         install_runtime: true
         cache: true
         install_swiftshader: true
+        github_token: ${{ github.token }}
 
     - name: Verify SwiftShader installation
       shell: pwsh


### PR DESCRIPTION
Pass the automatic GitHub Actions token to the Vulkan SDK installer & authenticate the SwiftShader release lookup to avoid anonymous GitHub API rate limits.