### PR TITLE
fix(flutter): prevent desktop resize flash

### DIFF
--- a/examples/flutter/quickstart/integration_test/texture_resize_test.dart
+++ b/examples/flutter/quickstart/integration_test/texture_resize_test.dart
@@ -10,6 +10,7 @@
 // Windows updates its descriptor in place while other platforms replace it;
 // teardown must serialize correctly with either resize strategy.
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart' hide View;
 import 'package:flutter_test/flutter_test.dart';
@@ -17,6 +18,8 @@ import 'package:integration_test/integration_test.dart';
 import 'package:thermion_flutter/thermion_flutter.dart' hide Texture;
 // ignore: implementation_imports
 import 'package:thermion_flutter/src/platform/src/frame_scheduler.dart';
+// ignore: implementation_imports
+import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -27,6 +30,10 @@ void main() {
       final viewer = await ThermionFlutterPlugin.createViewer();
       final size = ValueNotifier<Size>(const Size(160, 120));
       var textureUpdateCount = 0;
+      var texturePreparationCount = 0;
+      final publishedDescriptors = <PlatformTextureDescriptor>[];
+      final stagedPreparationGate = Completer<void>();
+      final usesStagedResize = Platform.isMacOS || Platform.isLinux;
 
       await tester.pumpWidget(
         MaterialApp(
@@ -51,6 +58,13 @@ void main() {
                     onTextureUpdated: (descriptor) {
                       if (descriptor != null) {
                         textureUpdateCount++;
+                        publishedDescriptors.add(descriptor);
+                      }
+                    },
+                    onTexturePreparing: (descriptor) async {
+                      texturePreparationCount++;
+                      if (usesStagedResize && texturePreparationCount == 2) {
+                        await stagedPreparationGate.future;
                       }
                     },
                   ),
@@ -69,11 +83,36 @@ void main() {
 
       size.value = const Size(240, 180);
       await tester.pump();
+
+      if (usesStagedResize) {
+        await _pumpUntil(
+          tester,
+          () => texturePreparationCount == 2,
+          'the staged replacement to enter the widget tree',
+        );
+        expect(
+          find.byType(Texture),
+          findsNWidgets(2),
+          reason: 'the old texture must cover the mounted replacement',
+        );
+        expect(publishedDescriptors.single.destroyed, isFalse);
+        stagedPreparationGate.complete();
+      }
+
       await _pumpUntil(
         tester,
         () => textureUpdateCount == 2,
         'the resized texture allocation',
       );
+
+      if (usesStagedResize) {
+        await _pumpUntil(
+          tester,
+          () => publishedDescriptors.first.destroyed,
+          'the superseded descriptor to retire after presentation',
+        );
+        expect(find.byType(Texture), findsOneWidget);
+      }
 
       // Let errors from unawaited descriptor cleanup reach the test binding.
       // Before the fix, Darwin throws here because resizeTexture() has already

--- a/examples/flutter/quickstart/integration_test/texture_resize_test.dart
+++ b/examples/flutter/quickstart/integration_test/texture_resize_test.dart
@@ -29,9 +29,8 @@ void main() {
     (tester) async {
       final viewer = await ThermionFlutterPlugin.createViewer();
       final size = ValueNotifier<Size>(const Size(160, 120));
-      var textureUpdateCount = 0;
       var texturePreparationCount = 0;
-      final publishedDescriptors = <PlatformTextureDescriptor>[];
+      final preparedDescriptors = <PlatformTextureDescriptor>[];
       final stagedPreparationGate = Completer<void>();
       final usesStagedResize = Platform.isMacOS || Platform.isLinux;
 
@@ -55,14 +54,9 @@ void main() {
                         textureId: descriptor.flutterTextureId,
                       );
                     },
-                    onTextureUpdated: (descriptor) {
-                      if (descriptor != null) {
-                        textureUpdateCount++;
-                        publishedDescriptors.add(descriptor);
-                      }
-                    },
                     onTexturePreparing: (descriptor) async {
                       texturePreparationCount++;
+                      preparedDescriptors.add(descriptor);
                       if (usesStagedResize && texturePreparationCount == 2) {
                         await stagedPreparationGate.future;
                       }
@@ -77,7 +71,9 @@ void main() {
 
       await _pumpUntil(
         tester,
-        () => textureUpdateCount == 1,
+        () =>
+            texturePreparationCount == 1 &&
+            _showsOnlyTexture(tester, preparedDescriptors.single),
         'the initial texture allocation',
       );
 
@@ -95,20 +91,22 @@ void main() {
           findsNWidgets(2),
           reason: 'the old texture must cover the mounted replacement',
         );
-        expect(publishedDescriptors.single.destroyed, isFalse);
+        expect(preparedDescriptors.first.destroyed, isFalse);
         stagedPreparationGate.complete();
       }
 
       await _pumpUntil(
         tester,
-        () => textureUpdateCount == 2,
+        () =>
+            texturePreparationCount == 2 &&
+            _showsOnlyTexture(tester, preparedDescriptors.last),
         'the resized texture allocation',
       );
 
       if (usesStagedResize) {
         await _pumpUntil(
           tester,
-          () => publishedDescriptors.first.destroyed,
+          () => preparedDescriptors.first.destroyed,
           'the superseded descriptor to retire after presentation',
         );
         expect(find.byType(Texture), findsOneWidget);
@@ -152,9 +150,9 @@ void main() {
         () => scheduler.isPaused,
         'resizeTexture to pause behind the controlled frame',
       );
-      final updatesAtUnmount = textureUpdateCount;
+      final preparationsAtUnmount = texturePreparationCount;
       expect(
-        updatesAtUnmount,
+        preparationsAtUnmount,
         2,
         reason: 'the native resize must still be in flight at unmount',
       );
@@ -171,9 +169,9 @@ void main() {
       await tester.pump();
 
       expect(
-        textureUpdateCount,
-        updatesAtUnmount,
-        reason: 'an allocation completing after dispose must not notify',
+        texturePreparationCount,
+        preparationsAtUnmount,
+        reason: 'an allocation completing after dispose must not prepare',
       );
       expect(tester.takeException(), isNull);
 
@@ -182,6 +180,16 @@ void main() {
       size.dispose();
     },
   );
+}
+
+bool _showsOnlyTexture(
+  WidgetTester tester,
+  PlatformTextureDescriptor descriptor,
+) {
+  final textures = find.byType(Texture);
+  if (textures.evaluate().length != 1) return false;
+  return tester.widget<Texture>(textures).textureId ==
+      descriptor.flutterTextureId;
 }
 
 Future<void> _pumpUntil(

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -117,6 +117,21 @@ The Flutter side is a standard `Texture(textureId: descriptor.flutterTextureId, 
 
 Compositing itself is Flutter's responsibility — the Texture widget participates in the normal widget tree, so transforms/opacity/clipping all work. The trade-off is one extra texture sample per frame versus drawing directly into the Flutter surface (which Thermion does not do).
 
+### Desktop resize handoff
+
+macOS and Linux resize with a staged texture handoff. The replacement texture
+is first mounted underneath the previous texture (Linux may need this mount for
+its deferred `populate()` callback), then the camera/viewport state is updated
+and one frame is rendered into the replacement while the scheduler is paused.
+Only after platform publication work completes does the widget reveal the new
+texture. The previous descriptor remains registered until Flutter's post-frame
+callback confirms that the replacement has entered the composited widget tree.
+
+Windows keeps its existing native in-place descriptor swap: Flutter continues
+to reference the same texture ID while the plugin blits the old surface, primes
+the replacement, and swaps the underlying D3D handle. Android and web retain
+their platform-specific resize behavior.
+
 ### Pause/resume
 
 **The invariant (both platforms): pause stops rendering only. The task queue keeps draining.**

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
@@ -34,7 +34,7 @@ class AndroidPlatformTextureDescriptor
   /// texture ID, adding one platform message per frame without changing
   /// presentation state.
   @override
-  void markTextureFrameAvailable() {}
+  Future<void> markTextureFrameAvailable() => Future<void>.value();
 
   static Future<AndroidPlatformTextureDescriptor> allocate(
     MethodChannel channel,

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/darwin_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/darwin_platform_texture_descriptor.dart
@@ -84,7 +84,7 @@ class DarwinPlatformTextureDescriptorImpl extends PlatformTextureDescriptor {
   }
 
   @override
-  void markTextureFrameAvailable() {
+  Future<void> markTextureFrameAvailable() {
     if (_destroyed) {
       throw Exception(
         "markTextureFrameAvailable cannot be called on a "
@@ -92,6 +92,7 @@ class DarwinPlatformTextureDescriptorImpl extends PlatformTextureDescriptor {
       );
     }
     _textureRegistry.textureFrameAvailable_(flutterTextureId);
+    return Future<void>.value();
   }
 
   static DarwinPlatformTextureDescriptorImpl allocate(int width, int height) {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
@@ -33,6 +33,17 @@ class MethodChannelPlatformTextureDescriptor extends PlatformTextureDescriptor {
     await channel.invokeMethod("markTextureFrameAvailable", flutterTextureId);
   }
 
+  @override
+  Future<void> markTextureFrameAvailableAndWait() async {
+    if (destroyed) {
+      throw Exception(
+        "markTextureFrameAvailable cannot be called on a "
+        "destroyed texture descriptor.",
+      );
+    }
+    await channel.invokeMethod("markTextureFrameAvailable", flutterTextureId);
+  }
+
   static Future<MethodChannelPlatformTextureDescriptor> allocate(
     MethodChannel channel,
     int width,

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
@@ -23,18 +23,7 @@ class MethodChannelPlatformTextureDescriptor extends PlatformTextureDescriptor {
   }
 
   @override
-  void markTextureFrameAvailable() async {
-    if (destroyed) {
-      throw Exception(
-        "markTextureFrameAvailable cannot be called on a "
-        "destroyed texture descriptor.",
-      );
-    }
-    await channel.invokeMethod("markTextureFrameAvailable", flutterTextureId);
-  }
-
-  @override
-  Future<void> markTextureFrameAvailableAndWait() async {
+  Future<void> markTextureFrameAvailable() async {
     if (destroyed) {
       throw Exception(
         "markTextureFrameAvailable cannot be called on a "

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
@@ -85,6 +85,11 @@ class NativeTextureSurfaceManager {
   // blits into a pending replacement image.
   final _deferredRenderTargets = <(RenderTarget, int)>[];
 
+  // A Linux descriptor may need to enter the widget tree before populate()
+  // can publish its hardware texture. Staged resize waits on this future
+  // before rendering the replacement's first visible frame.
+  final _replacementBindings = <PlatformTextureDescriptor, Future<void>>{};
+
   bool get hasUnavailableSurfaces => registry.hasUnavailableSurfaces;
 
   Future<FilamentRenderingContext> getFilamentRenderingContext(
@@ -102,6 +107,7 @@ class NativeTextureSurfaceManager {
     registry.clear();
     _viewRenderTargets.clear();
     _deferredRenderTargets.clear();
+    _replacementBindings.clear();
   }
 
   /// Notifies live descriptors and reaps render targets deferred by Windows
@@ -167,6 +173,8 @@ class NativeTextureSurfaceManager {
     int width,
     int height, {
     PlatformTextureDescriptor? destroyAfterDeferredBinding,
+    bool preserveExistingBindings = false,
+    Completer<void>? bindingReady,
   }) async {
     if (width == 0 || height == 0) {
       throw ArgumentError(
@@ -191,7 +199,8 @@ class NativeTextureSurfaceManager {
         // Keep the previous descriptor associated with this view until the
         // deferred replacement has a Filament target. Teardown can then find
         // and destroy both descriptors if the widget unmounts while waiting.
-        releaseExistingBindings: !mayRequireDeferredBinding,
+        releaseExistingBindings:
+            !mayRequireDeferredBinding && !preserveExistingBindings,
       );
 
       // Prefer a hardware handle returned by native allocation. In particular,
@@ -199,6 +208,7 @@ class NativeTextureSurfaceManager {
       // with awaitTextureReady's Flutter-side GL texture ID is invalid.
       if (!managesFilamentSurface && descriptor.hardwareId != 0) {
         await _createFilamentResources(descriptor, view, width, height);
+        if (!(bindingReady?.isCompleted ?? true)) bindingReady!.complete();
       } else if (shouldDeferNativeTextureBinding(
         managesFilamentSurface: managesFilamentSurface,
         hardwareId: descriptor.hardwareId,
@@ -213,6 +223,7 @@ class NativeTextureSurfaceManager {
             width,
             height,
             destroyAfterBinding: destroyAfterDeferredBinding,
+            bindingReady: bindingReady,
           ),
         );
       } else if (!managesFilamentSurface) {
@@ -222,8 +233,15 @@ class NativeTextureSurfaceManager {
         );
       }
 
+      if (managesFilamentSurface && !(bindingReady?.isCompleted ?? true)) {
+        bindingReady!.complete();
+      }
+
       return descriptor;
     } catch (error, stackTrace) {
+      if (!(bindingReady?.isCompleted ?? true)) {
+        bindingReady!.completeError(error, stackTrace);
+      }
       if (error is _FilamentResourceRollbackFailure) {
         // The descriptor's platform memory must outlive the Filament objects
         // that could not be destroyed. Detach it from the view but deliberately
@@ -244,6 +262,7 @@ class NativeTextureSurfaceManager {
     int width,
     int height, {
     PlatformTextureDescriptor? destroyAfterBinding,
+    Completer<void>? bindingReady,
   }) async {
     try {
       final hardwareId = await descriptor.awaitTextureReady();
@@ -261,9 +280,13 @@ class NativeTextureSurfaceManager {
               registry.contains(destroyAfterBinding)) {
             await registry.destroy(destroyAfterBinding);
           }
+          if (!(bindingReady?.isCompleted ?? true)) bindingReady!.complete();
         });
       });
     } catch (error, stackTrace) {
+      if (!(bindingReady?.isCompleted ?? true)) {
+        bindingReady!.completeError(error, stackTrace);
+      }
       _logger.warning('Deferred texture binding failed', error, stackTrace);
       if (error is _FilamentResourceRollbackFailure) {
         // Keep the platform allocation alive for any Filament object whose
@@ -427,20 +450,91 @@ class NativeTextureSurfaceManager {
       return _resizeWindows(texture, view, width, height);
     }
 
+    if (!Platform.isMacOS && !Platform.isLinux) {
+      final newTexture = await _createAndBind(
+        view,
+        width,
+        height,
+        destroyAfterDeferredBinding: texture,
+      );
+      if (!shouldDeferNativeTextureBinding(
+        managesFilamentSurface: false,
+        hardwareId: newTexture.hardwareId,
+        supportsDeferredBinding: newTexture.deferred,
+      )) {
+        await registry.destroy(texture);
+      }
+      return newTexture;
+    }
+
+    final bindingReady = Completer<void>();
     final newTexture = await _createAndBind(
       view,
       width,
       height,
-      destroyAfterDeferredBinding: texture,
+      preserveExistingBindings: true,
+      bindingReady: bindingReady,
     );
-    if (!shouldDeferNativeTextureBinding(
-      managesFilamentSurface: false,
-      hardwareId: newTexture.hardwareId,
-      supportsDeferredBinding: newTexture.deferred,
-    )) {
-      await registry.destroy(texture);
-    }
+    _replacementBindings[newTexture] = bindingReady.future;
     return newTexture;
+  }
+
+  /// Waits for deferred platform binding, then renders the replacement once
+  /// while the scheduler is paused. The widget continues to cover this
+  /// texture with the previous descriptor until this future completes.
+  Future<void> prepareForPresentation(PlatformTextureDescriptor texture) async {
+    final binding = _replacementBindings[texture];
+    if (binding == null) return;
+    await binding;
+
+    await registry.serialized(
+      () => _lifecycle.duringTextureMutation(() async {
+        if (!registry.contains(texture) || texture.destroyed) return;
+        final app = FilamentApp.instance;
+        if (app == null) {
+          throw StateError('Cannot prime a texture after Filament shutdown');
+        }
+        await app.render();
+        await texture.markTextureFrameAvailableAndWait();
+      }),
+    );
+  }
+
+  /// The old descriptor remains registered until the first Flutter frame
+  /// containing its replacement has completed.
+  Future<void> retireAfterResize(PlatformTextureDescriptor texture) {
+    return registry.serialized(() async {
+      _replacementBindings.remove(texture);
+      if (registry.contains(texture)) {
+        await registry.destroy(texture);
+      }
+    });
+  }
+
+  /// Rebinds the last visible descriptor if preparing its replacement fails.
+  Future<void> cancelStagedResize(
+    PlatformTextureDescriptor replacement,
+    PlatformTextureDescriptor previous,
+    View view,
+  ) {
+    return registry.serialized(
+      () => _lifecycle.duringTextureMutation(() async {
+        _replacementBindings.remove(replacement);
+        if (!registry.contains(previous) || previous.destroyed) return;
+
+        await registry.bindToView(previous, view);
+        await view.setViewport(previous.width, previous.height);
+        await _createFilamentResources(
+          previous,
+          view,
+          previous.width,
+          previous.height,
+        );
+        if (registry.contains(replacement)) {
+          await registry.destroy(replacement);
+        }
+      }),
+    );
   }
 
   Future<PlatformTextureDescriptor> _resizeWindows(
@@ -538,6 +632,10 @@ class NativeTextureSurfaceManager {
         await registry.destroyBindingsForView(
           view,
           beforeDescriptorDestroy: () => _destroyRenderTargetForView(view),
+        );
+        _replacementBindings.removeWhere(
+          (descriptor, _) =>
+              descriptor.boundView == view || descriptor.destroyed,
         );
       }),
     );

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
@@ -495,7 +495,7 @@ class NativeTextureSurfaceManager {
           throw StateError('Cannot prime a texture after Filament shutdown');
         }
         await app.render();
-        await texture.markTextureFrameAvailableAndWait();
+        await texture.markTextureFrameAvailable();
       }),
     );
   }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
@@ -40,16 +40,11 @@ abstract class PlatformTextureDescriptor {
   @override
   int get hashCode => flutterTextureId.hashCode;
 
-  /// Instruct the Flutter framework that the content of the texture has been
-  /// updated.
-  void markTextureFrameAvailable();
-
-  /// Awaitable form used when presentation must not race platform work such
-  /// as Linux's Vulkan export blit. Synchronous implementations can use this
-  /// default wrapper.
-  Future<void> markTextureFrameAvailableAndWait() async {
-    markTextureFrameAvailable();
-  }
+  /// Instructs Flutter that the texture content has been updated.
+  ///
+  /// The returned future completes after any platform-side publication work,
+  /// such as Linux's Vulkan export blit, has finished.
+  Future<void> markTextureFrameAvailable();
 
   /// Schedules this texture for destruction.
   ///

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
@@ -44,6 +44,13 @@ abstract class PlatformTextureDescriptor {
   /// updated.
   void markTextureFrameAvailable();
 
+  /// Awaitable form used when presentation must not race platform work such
+  /// as Linux's Vulkan export blit. Synchronous implementations can use this
+  /// default wrapper.
+  Future<void> markTextureFrameAvailableAndWait() async {
+    markTextureFrameAvailable();
+  }
+
   /// Schedules this texture for destruction.
   ///
   /// Package code should normally call

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry.dart
@@ -158,7 +158,7 @@ class PlatformTextureDescriptorRegistry {
     }
 
     for (final descriptor in List<PlatformTextureDescriptor>.of(_descriptors)) {
-      descriptor.markTextureFrameAvailable();
+      unawaited(descriptor.markTextureFrameAvailable());
     }
   }
 

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/thermion_flutter_plugin_native.dart
@@ -220,6 +220,30 @@ class ThermionFlutterPluginImpl extends ThermionFlutterPlugin {
   }
 
   @override
+  bool get supportsStagedTextureResize => Platform.isMacOS || Platform.isLinux;
+
+  @override
+  Future<void> prepareTextureForPresentation(
+    PlatformTextureDescriptor texture,
+  ) {
+    return _textureSurfaces.prepareForPresentation(texture);
+  }
+
+  @override
+  Future<void> retireTextureAfterResize(PlatformTextureDescriptor texture) {
+    return _textureSurfaces.retireAfterResize(texture);
+  }
+
+  @override
+  Future<void> cancelStagedTextureResize(
+    PlatformTextureDescriptor replacement,
+    PlatformTextureDescriptor previous,
+    View view,
+  ) {
+    return _textureSurfaces.cancelStagedResize(replacement, previous, view);
+  }
+
+  @override
   Future<void> destroyTextureForView(View view) {
     return _textureSurfaces.destroyForView(view);
   }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/web_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/web_platform_texture_descriptor.dart
@@ -20,7 +20,8 @@ class WebPlatformTextureDescriptor extends PlatformTextureDescriptor {
   }
 
   @override
-  void markTextureFrameAvailable() {
+  Future<void> markTextureFrameAvailable() {
     // No-op on web - canvas updates handled by _ImageCopyingWidget
+    return Future<void>.value();
   }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/thermion_flutter_plugin.dart
@@ -131,6 +131,28 @@ abstract class ThermionFlutterPlugin {
     int height,
   );
 
+  /// Whether resize can keep the previous Flutter texture visible while a
+  /// replacement is mounted and primed.
+  bool get supportsStagedTextureResize => false;
+
+  /// Renders a frame into a staged replacement before it is made visible.
+  Future<void> prepareTextureForPresentation(
+    PlatformTextureDescriptor texture,
+  ) async {}
+
+  /// Releases a superseded descriptor after Flutter has composited its
+  /// replacement.
+  Future<void> retireTextureAfterResize(
+    PlatformTextureDescriptor texture,
+  ) async {}
+
+  /// Restores [previous] if preparing [replacement] fails.
+  Future<void> cancelStagedTextureResize(
+    PlatformTextureDescriptor replacement,
+    PlatformTextureDescriptor previous,
+    View view,
+  ) async {}
+
   /// Releases every texture resource bound to [view].
   ///
   /// Implementations must detach descriptor-managed surfaces, destroy

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -23,10 +23,7 @@ class _ThermionWidgetState extends State<ThermionWidget> {
     return ThermionWidgetInternal(
       view: widget.viewer.view,
       surfaceWidgetBuilder: surfaceWidgetBuilder,
-      onTextureUpdated: (descriptor) async {
-        if (descriptor == null) {
-          return;
-        }
+      onTexturePreparing: (descriptor) async {
         final view = widget.viewer.view;
         var camera = await view.getCamera();
         var near = await camera.getNear();
@@ -54,22 +51,40 @@ class ThermionWidgetInternal extends StatefulWidget {
   final View view;
   final void Function(PlatformTextureDescriptor? descriptor)? onTextureUpdated;
   final Widget Function(PlatformTextureDescriptor?, View) surfaceWidgetBuilder;
+  final Future<void> Function(PlatformTextureDescriptor descriptor)?
+  onTexturePreparing;
 
   const ThermionWidgetInternal({
     super.key,
     required this.view,
     required this.surfaceWidgetBuilder,
     this.onTextureUpdated,
+    this.onTexturePreparing,
   });
 
   @override
   State<ThermionWidgetInternal> createState() => _ThermionWidgetInternalState();
 }
 
+@visibleForTesting
+Widget buildStagedTextureSurface({
+  required Widget current,
+  Widget? replacement,
+}) {
+  if (replacement == null) return current;
+  return Stack(
+    fit: StackFit.expand,
+    // The replacement must be mounted so deferred Linux textures receive a
+    // populate callback, but the last valid frame stays painted above it.
+    children: [replacement, current],
+  );
+}
+
 class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
   static const _debounceDuration = Duration(milliseconds: 100);
 
   PlatformTextureDescriptor? _texture;
+  PlatformTextureDescriptor? _pendingTexture;
   Timer? _debounceTimer;
   Future<void> _textureOperations = Future<void>.value();
   bool _disposing = false;
@@ -94,6 +109,7 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
       // also guarantees the final descriptor is destroyed exactly once.
       await ThermionFlutterPlugin.instance.destroyTextureForView(view);
       _texture = null;
+      _pendingTexture = null;
     }, 'disposing a Thermion widget texture');
     super.dispose();
   }
@@ -117,15 +133,27 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
             // Initial case - no texture yet
             _scheduleTextureAllocation(width, height);
           }
-          return widget.surfaceWidgetBuilder(_texture, widget.view);
+          return _buildSurface();
         }
 
         // Size changed - schedule a debounced allocation
         _scheduleTextureAllocation(width, height);
 
         // Keep showing the old texture during debounce
-        return widget.surfaceWidgetBuilder(_texture, widget.view);
+        return _buildSurface();
       },
+    );
+  }
+
+  Widget _buildSurface() {
+    final pending = _pendingTexture;
+    final current = _texture;
+    if (pending == null || current == null) {
+      return widget.surfaceWidgetBuilder(current ?? pending, widget.view);
+    }
+    return buildStagedTextureSurface(
+      current: widget.surfaceWidgetBuilder(current, widget.view),
+      replacement: widget.surfaceWidgetBuilder(pending, widget.view),
     );
   }
 
@@ -155,11 +183,16 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
 
     PlatformTextureDescriptor? texture;
 
-    if (_texture != null) {
+    final previousTexture = _texture;
+    final plugin = ThermionFlutterPlugin.instance;
+    final staged =
+        previousTexture != null && plugin.supportsStagedTextureResize;
+
+    if (previousTexture != null) {
       // Resize existing texture (on Windows this reuses the Flutter
       // texture ID to avoid a black frame flash).
       texture = await ThermionFlutterPlugin.instance.resizeTexture(
-        _texture!,
+        previousTexture,
         widget.view,
         width,
         height,
@@ -174,25 +207,64 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
 
     if (texture == null) return;
 
+    if (staged && !identical(texture, previousTexture)) {
+      if (_disposing || !mounted) return;
+      setState(() => _pendingTexture = texture);
+
+      // Linux can only create its GL texture from populate(), so ensure the
+      // hidden replacement has entered the tree before awaiting native bind.
+      await WidgetsBinding.instance.endOfFrame;
+      if (_disposing || !mounted) return;
+
+      try {
+        await widget.onTexturePreparing?.call(texture);
+        await plugin.prepareTextureForPresentation(texture);
+      } catch (error, stackTrace) {
+        await plugin.cancelStagedTextureResize(
+          texture,
+          previousTexture,
+          widget.view,
+        );
+        if (!_disposing && mounted) {
+          setState(() => _pendingTexture = null);
+        }
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+      if (_disposing || !mounted) return;
+    } else {
+      await widget.onTexturePreparing?.call(texture);
+    }
+
     if (_disposing || !mounted) {
       // Publish the result even if dispose() ran while the platform operation
       // was awaiting. The queued teardown operation owns releasing this final
       // descriptor and its per-view binding.
       _texture = texture;
+      _pendingTexture = null;
       _currentWidth = width;
       _currentHeight = height;
       return;
     }
 
     setState(() {
-      // resizeTexture owns disposal of the superseded descriptor. On Windows
-      // it returns the existing descriptor after updating it in place.
+      // Windows updates the descriptor in place. Staged desktop resize swaps
+      // to an already-primed descriptor and retires the old one below.
       _texture = texture;
+      _pendingTexture = null;
       _currentWidth = width;
       _currentHeight = height;
     });
 
     widget.onTextureUpdated?.call(texture);
+
+    if (staged && !identical(previousTexture, texture)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _enqueueTextureOperation(
+          () => plugin.retireTextureAfterResize(previousTexture),
+          'retiring a resized Thermion widget texture',
+        );
+      });
+    }
   }
 
   void _enqueueTextureOperation(

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget.dart
@@ -49,7 +49,6 @@ class _ThermionWidgetState extends State<ThermionWidget> {
 // the actual platform; see [ThermionFlutterPluginImpl] for details.
 class ThermionWidgetInternal extends StatefulWidget {
   final View view;
-  final void Function(PlatformTextureDescriptor? descriptor)? onTextureUpdated;
   final Widget Function(PlatformTextureDescriptor?, View) surfaceWidgetBuilder;
   final Future<void> Function(PlatformTextureDescriptor descriptor)?
   onTexturePreparing;
@@ -58,7 +57,6 @@ class ThermionWidgetInternal extends StatefulWidget {
     super.key,
     required this.view,
     required this.surfaceWidgetBuilder,
-    this.onTextureUpdated,
     this.onTexturePreparing,
   });
 
@@ -254,8 +252,6 @@ class _ThermionWidgetInternalState extends State<ThermionWidgetInternal> {
       _currentWidth = width;
       _currentHeight = height;
     });
-
-    widget.onTextureUpdated?.call(texture);
 
     if (staged && !identical(previousTexture, texture)) {
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_web.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/widgets/src/thermion_widget_internal/thermion_widget_internal_web.dart
@@ -16,7 +16,6 @@
 //             .instance.options.webOptions.importCanvasAsWidget
 //         ? _ImageCopyingWidget(
 //             view: widget.view,
-//             onTextureUpdated: widget.onTextureUpdated,
 //           )
 //         : SizedBox.expand(child: CustomPaint(painter: TransparencyPainter()));
 //   }
@@ -72,12 +71,10 @@
 
 // class _ImageCopyingWidget extends StatefulWidget {
 //   final View view;
-//   final void Function(PlatformTextureDescriptor? descriptor)? onTextureUpdated;
 
 //   const _ImageCopyingWidget({
 //     super.key,
 //     required this.view,
-//     this.onTextureUpdated,
 //   });
 //   @override
 //   State<StatefulWidget> createState() {
@@ -191,14 +188,6 @@
 //       _currentWidth = width;
 //       _currentHeight = height;
 
-//       // Invoke callback with dimensions
-//       if (widget.onTextureUpdated != null) {
-//         final descriptor = WebPlatformTextureDescriptor(
-//           width: width,
-//           height: height,
-//         );
-//         widget.onTextureUpdated!(descriptor);
-//       }
 //     } catch (err) {
 //       _logger.severe("Failed to resize: $err");
 //     }

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_registry_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_registry_test.dart
@@ -286,7 +286,7 @@ class _TestDescriptor extends PlatformTextureDescriptor {
   bool get isSurfaceAvailable => _surfaceAvailable;
 
   @override
-  void markTextureFrameAvailable() {
+  Future<void> markTextureFrameAvailable() async {
     markFrameAvailableCount++;
   }
 

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thermion_flutter/src/platform/src/android_platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/platform/src/darwin_platform_texture_descriptor.dart';
+import 'package:thermion_flutter/src/platform/src/method_channel_platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/options.dart';
 
@@ -105,6 +108,40 @@ void main() {
     expect(methodCallCount, 0);
   });
 
+  test('awaitable frame publication waits for platform work', () async {
+    const channel = MethodChannel('thermion.test.texture.presentation');
+    final platformGate = Completer<void>();
+    var completed = false;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          expect(call.method, 'markTextureFrameAvailable');
+          await platformGate.future;
+          return null;
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    final descriptor = MethodChannelPlatformTextureDescriptor(
+      channel,
+      flutterTextureId: 1,
+      hardwareId: 2,
+      windowHandle: 3,
+      width: 4,
+      height: 5,
+    );
+    final publication = descriptor.markTextureFrameAvailableAndWait().then(
+      (_) => completed = true,
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(completed, isFalse);
+    platformGate.complete();
+    await publication;
+    expect(completed, isTrue);
+  });
+
   for (final (textureSource, expectedSurfaceProducer) in [
     (AndroidTextureSource.surfaceTexture, false),
     (AndroidTextureSource.surfaceProducer, true),
@@ -144,15 +181,13 @@ void main() {
 }
 
 class _TestDescriptor extends PlatformTextureDescriptor {
-  _TestDescriptor({
-    required int flutterTextureId,
-    int hardwareId = 0,
-  }) : super(
-          flutterTextureId: flutterTextureId,
-          hardwareId: hardwareId,
-          width: 1,
-          height: 1,
-        );
+  _TestDescriptor({required int flutterTextureId, int hardwareId = 0})
+    : super(
+        flutterTextureId: flutterTextureId,
+        hardwareId: hardwareId,
+        width: 1,
+        height: 1,
+      );
 
   @override
   void markTextureFrameAvailable() {}

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
@@ -102,8 +102,7 @@ void main() {
       height: 5,
     );
 
-    descriptor.markTextureFrameAvailable();
-    await Future<void>.delayed(Duration.zero);
+    await descriptor.markTextureFrameAvailable();
 
     expect(methodCallCount, 0);
   });
@@ -131,7 +130,7 @@ void main() {
       width: 4,
       height: 5,
     );
-    final publication = descriptor.markTextureFrameAvailableAndWait().then(
+    final publication = descriptor.markTextureFrameAvailable().then(
       (_) => completed = true,
     );
 
@@ -190,7 +189,7 @@ class _TestDescriptor extends PlatformTextureDescriptor {
       );
 
   @override
-  void markTextureFrameAvailable() {}
+  Future<void> markTextureFrameAvailable() async {}
 
   @override
   Future destroy() async {}

--- a/thermion_flutter/thermion_flutter/test/thermion_widget_resize_transition_test.dart
+++ b/thermion_flutter/thermion_flutter/test/thermion_widget_resize_transition_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thermion_flutter/src/widgets/src/thermion_widget.dart';
+
+void main() {
+  testWidgets('staged replacement is mounted below the last valid frame', (
+    tester,
+  ) async {
+    const currentKey = ValueKey('current');
+    const replacementKey = ValueKey('replacement');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 100,
+          height: 100,
+          child: buildStagedTextureSurface(
+            current: const ColoredBox(key: currentKey, color: Colors.green),
+            replacement: const ColoredBox(
+              key: replacementKey,
+              color: Colors.black,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final stack = tester.widget<Stack>(find.byType(Stack).last);
+    expect(stack.children.map((child) => child.key), [
+      replacementKey,
+      currentKey,
+    ]);
+    expect(find.byKey(replacementKey), findsOneWidget);
+    expect(find.byKey(currentKey), findsOneWidget);
+  });
+
+  testWidgets('unstaged surface paints only the current frame', (tester) async {
+    const currentKey = ValueKey('current');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: buildStagedTextureSurface(
+          current: const ColoredBox(key: currentKey, color: Colors.green),
+        ),
+      ),
+    );
+
+    expect(find.byKey(currentKey), findsOneWidget);
+    expect(find.byType(Stack), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Prevents desktop resize flashes by staging replacement textures underneath the last valid frame, now rebased onto the scheduler/render separation from #278.

- stages macOS and Linux texture replacements beneath the current texture
- waits for deferred Linux binding before rendering the replacement's first frame
- primes and publishes the replacement before revealing it
- makes `markTextureFrameAvailable()` uniformly awaitable instead of adding a
  separate `markTextureFrameAvailableAndWait()` variant
- removes the obsolete `onTextureUpdated` hook; integration coverage observes
  the committed texture in the widget tree instead
- retires the superseded descriptor only after Flutter composites the replacement
- restores the previous descriptor if replacement preparation fails
- preserves the existing Windows in-place descriptor handoff
- leaves Android and web resize behavior unchanged

## Integration with #278

Resize preparation uses the common Dart rendering pipeline while frame scheduling is paused. It calls `FilamentApp.render()` for the replacement and awaits platform texture publication without introducing a separate scheduler or render loop.

The unified `Future<void> markTextureFrameAvailable()` API lets staged resize wait for Linux platform work, including a Vulkan export blit, before revealing the replacement. Ordinary frame notification remains explicitly fire-and-forget, preserving its existing timing on every platform.

The rebased integration uses `FrameScheduler.setFrameHandler` and composes cleanly with `NativeTextureSurfaceManager`'s Linux direct post-render notification and the shared in-flight guard.

## Validation

- rebased onto current `develop`
- full `thermion_flutter` test suite: 32 tests passed
- `flutter analyze` in `thermion_flutter`: clean
- `flutter analyze` in `examples/flutter/quickstart`: clean
- macOS `texture_resize_test.dart` integration test: passed
- focused resize tests cover staged layering, awaitable publication, rollback, and serialized teardown
- `git diff --check`: clean
- GitHub Actions rerun pending on the updated head
