### PR TITLE
feat: add GTAO ambient occlusion options

### DIFF
--- a/.github/workflows/run-dart-tests.yml
+++ b/.github/workflows/run-dart-tests.yml
@@ -150,8 +150,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh run download 31859320186 \
-            --name golden-images-bf88d58c9fd228bfd35d7d52bf88bceb8b3984e8  \
+          gh run download 32349488816 \
+            --name golden-images-b69b6d54fac83278f34e905aaede8ceffa060ae5  \
             --dir ./thermion_dart/test/golden-downloads
       - name: Unzip golden images
         if: matrix.name == 'Linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Update to Filament v1.75.0!
 
 ### Changes
 - `allocate` FFI shim now takes `byteCount` instead of `count`
+- Add SAO/GTAO algorithm selection and GTAO sampling, thickness, and
+  visibility-bitmask controls to `AmbientOcclusionOptions`.
 
 ### Breaking changes
 - `LightManager.setShadowCaster`/`setShadowOptions` and

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -5034,7 +5034,39 @@ final class TSsct extends ffi.Struct {
   external bool enabled;
 }
 
-/// Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+sealed class TAmbientOcclusionType {
+  static const SAO = 0;
+  static const GTAO = 1;
+}
+
+/// Ground Truth-based Ambient Occlusion (GTAO) options
+final class TGtao extends ffi.Struct {
+  /// !< number of slices; higher values reduce noise
+  @ffi.Uint8()
+  external int sampleSliceCount;
+
+  /// !< integration steps per slice; higher values reduce bias
+  @ffi.Uint8()
+  external int sampleStepsPerSlice;
+
+  /// !< ignored when visibility bitmasks are enabled
+  @ffi.Float()
+  external double thicknessHeuristic;
+
+  /// !< enables visibility bitmasks mode
+  @ffi.Bool()
+  external bool useVisibilityBitmasks;
+
+  /// !< world-space thickness used by visibility bitmasks
+  @ffi.Float()
+  external double constThickness;
+
+  /// !< increases thickness with distance
+  @ffi.Bool()
+  external bool linearThickness;
+}
+
+/// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
 final class TAmbientOcclusionOptions extends ffi.Struct {
   /// !< Ambient Occlusion radius in meters, between 0 and ~10
   @ffi.Float()
@@ -5085,6 +5117,12 @@ final class TAmbientOcclusionOptions extends ffi.Struct {
   external double minHorizonAngleRad;
 
   external TSsct ssct;
+
+  external TGtao gtao;
+
+  /// !< ambient occlusion algorithm
+  @ffi.UnsignedInt()
+  external int aoType;
 }
 
 typedef PickCallbackFunction =

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -9082,7 +9082,7 @@ final class TScene extends Struct {
   }
 }
 
-/// Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+/// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
 
 extension TAmbientOcclusionOptionsExt on Pointer<TAmbientOcclusionOptions> {
   TAmbientOcclusionOptions toDart() {
@@ -9243,11 +9243,37 @@ final class TAmbientOcclusionOptions extends Struct {
     NativeLibrary.instance.setValue(Pointer<TAmbientOcclusionOptions>(this.address.addr + 42), val.address.toJS, '*');
   }
 
+  TGtao get gtao {
+    final addr = Pointer<TAmbientOcclusionOptions>(this.address.addr + 81);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return TGtao(Pointer<TGtao>(addr));
+  }
+
+  set gtao(TGtao val) {
+    NativeLibrary.instance.setValue(Pointer<TAmbientOcclusionOptions>(this.address.addr + 81), val.address.toJS, '*');
+  }
+
+  /// !< ambient occlusion algorithm
+  int get aoType {
+    final addr = Pointer<TAmbientOcclusionOptions>(this.address.addr + 93);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set aoType(int val) {
+    NativeLibrary.instance.setValue(Pointer<TAmbientOcclusionOptions>(this.address.addr + 93), val.toJS, 'i32');
+  }
+
   TAmbientOcclusionOptions(super.address);
 
   static Pointer<TAmbientOcclusionOptions> stackAlloc() {
-    return Pointer<TAmbientOcclusionOptions>(NativeLibrary.instance.stackAlloc<TAmbientOcclusionOptions>(81));
+    return Pointer<TAmbientOcclusionOptions>(NativeLibrary.instance.stackAlloc<TAmbientOcclusionOptions>(97));
   }
+}
+
+sealed class TAmbientOcclusionType {
+  static const SAO = 0;
+  static const GTAO = 1;
 }
 
 /// Screen Space Cone Tracing (SSCT) options
@@ -9398,6 +9424,90 @@ final class TSsct extends Struct {
 
   static Pointer<TSsct> stackAlloc() {
     return Pointer<TSsct>(NativeLibrary.instance.stackAlloc<TSsct>(39));
+  }
+}
+
+/// Ground Truth-based Ambient Occlusion (GTAO) options
+
+extension TGtaoExt on Pointer<TGtao> {
+  TGtao toDart() {
+    return TGtao(this);
+  }
+}
+
+final class TGtao extends Struct {
+  Pointer<TGtao> get address => super.address.cast();
+
+  /// !< number of slices; higher values reduce noise
+  int get sampleSliceCount {
+    final addr = Pointer<TGtao>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set sampleSliceCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 0), val.toJS, 'i8');
+  }
+
+  /// !< integration steps per slice; higher values reduce bias
+  int get sampleStepsPerSlice {
+    final addr = Pointer<TGtao>(this.address.addr + 1);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set sampleStepsPerSlice(int val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 1), val.toJS, 'i8');
+  }
+
+  /// !< ignored when visibility bitmasks are enabled
+  double get thicknessHeuristic {
+    final addr = Pointer<TGtao>(this.address.addr + 2);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set thicknessHeuristic(double val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 2), val.toJS, 'float');
+  }
+
+  /// !< enables visibility bitmasks mode
+  bool get useVisibilityBitmasks {
+    final addr = Pointer<TGtao>(this.address.addr + 6);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set useVisibilityBitmasks(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 6), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  /// !< world-space thickness used by visibility bitmasks
+  double get constThickness {
+    final addr = Pointer<TGtao>(this.address.addr + 7);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set constThickness(double val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 7), val.toJS, 'float');
+  }
+
+  /// !< increases thickness with distance
+  bool get linearThickness {
+    final addr = Pointer<TGtao>(this.address.addr + 11);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set linearThickness(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 11), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  TGtao(super.address);
+
+  static Pointer<TGtao> stackAlloc() {
+    return Pointer<TGtao>(NativeLibrary.instance.stackAlloc<TGtao>(12));
   }
 }
 
@@ -11043,6 +11153,9 @@ extension StructAllocator on Struct {
         return ptr.toDart() as T;
       case TSsct:
         final ptr = TSsct.stackAlloc();
+        return ptr.toDart() as T;
+      case TGtao:
+        final ptr = TGtao.stackAlloc();
         return ptr.toDart() as T;
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -9271,11 +9271,6 @@ final class TAmbientOcclusionOptions extends Struct {
   }
 }
 
-sealed class TAmbientOcclusionType {
-  static const SAO = 0;
-  static const GTAO = 1;
-}
-
 /// Screen Space Cone Tracing (SSCT) options
 /// Ambient shadows from dominant light
 
@@ -9509,6 +9504,11 @@ final class TGtao extends Struct {
   static Pointer<TGtao> stackAlloc() {
     return Pointer<TGtao>(NativeLibrary.instance.stackAlloc<TGtao>(12));
   }
+}
+
+sealed class TAmbientOcclusionType {
+  static const SAO = 0;
+  static const GTAO = 1;
 }
 
 /// Copied from FogOptions in View.h

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -341,6 +341,7 @@ class FFIView extends View<Pointer<TView>> {
   Future setAmbientOcclusionOptions(AmbientOcclusionOptions options) async {
     final tAmbientOcclusionOptions = StructAllocator.create<TAmbientOcclusionOptions>();
 
+    tAmbientOcclusionOptions.aoType = options.aoType.index;
     tAmbientOcclusionOptions.radius = options.radius;
     tAmbientOcclusionOptions.power = options.power;
     tAmbientOcclusionOptions.bias = options.bias;
@@ -368,6 +369,14 @@ class FFIView extends View<Pointer<TView>> {
     tAmbientOcclusionOptions.ssct.rayCount = options.ssct.rayCount;
     tAmbientOcclusionOptions.ssct.enabled = options.ssct.enabled;
 
+    // Copy GTAO options
+    tAmbientOcclusionOptions.gtao.sampleSliceCount = options.gtao.sampleSliceCount;
+    tAmbientOcclusionOptions.gtao.sampleStepsPerSlice = options.gtao.sampleStepsPerSlice;
+    tAmbientOcclusionOptions.gtao.thicknessHeuristic = options.gtao.thicknessHeuristic;
+    tAmbientOcclusionOptions.gtao.useVisibilityBitmasks = options.gtao.useVisibilityBitmasks;
+    tAmbientOcclusionOptions.gtao.constThickness = options.gtao.constThickness;
+    tAmbientOcclusionOptions.gtao.linearThickness = options.gtao.linearThickness;
+
     await withVoidCallback(
       (requestId, cb) => View_setAmbientOcclusionOptionsRenderThread(view, tAmbientOcclusionOptions, requestId, cb),
     );
@@ -378,6 +387,7 @@ class FFIView extends View<Pointer<TView>> {
     final tOptions = View_getAmbientOcclusionOptions(view);
 
     return AmbientOcclusionOptions(
+      aoType: AmbientOcclusionType.values[tOptions.aoType],
       radius: tOptions.radius,
       power: tOptions.power,
       bias: tOptions.bias,
@@ -401,6 +411,14 @@ class FFIView extends View<Pointer<TView>> {
         sampleCount: tOptions.ssct.sampleCount,
         rayCount: tOptions.ssct.rayCount,
         enabled: tOptions.ssct.enabled,
+      ),
+      gtao: GtaoOptions(
+        sampleSliceCount: tOptions.gtao.sampleSliceCount,
+        sampleStepsPerSlice: tOptions.gtao.sampleStepsPerSlice,
+        thicknessHeuristic: tOptions.gtao.thicknessHeuristic,
+        useVisibilityBitmasks: tOptions.gtao.useVisibilityBitmasks,
+        constThickness: tOptions.gtao.constThickness,
+        linearThickness: tOptions.gtao.linearThickness,
       ),
     );
   }

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -61,7 +61,29 @@ class SsctOptions {
   });
 }
 
+/// Ground Truth-based Ambient Occlusion (GTAO) options.
+class GtaoOptions {
+  final int sampleSliceCount;
+  final int sampleStepsPerSlice;
+  final double thicknessHeuristic;
+  final bool useVisibilityBitmasks;
+  final double constThickness;
+  final bool linearThickness;
+
+  const GtaoOptions({
+    this.sampleSliceCount = 4,
+    this.sampleStepsPerSlice = 3,
+    this.thicknessHeuristic = 0.004,
+    this.useVisibilityBitmasks = false,
+    this.constThickness = 0.5,
+    this.linearThickness = false,
+  });
+}
+
+enum AmbientOcclusionType { SAO, GTAO }
+
 class AmbientOcclusionOptions {
+  final AmbientOcclusionType aoType;
   final double radius;
   final double power;
   final double bias;
@@ -75,8 +97,10 @@ class AmbientOcclusionOptions {
   final bool bentNormals;
   final double minHorizonAngleRad;
   final SsctOptions ssct;
+  final GtaoOptions gtao;
 
   const AmbientOcclusionOptions({
+    this.aoType = AmbientOcclusionType.SAO,
     this.radius = 0.3,
     this.power = 1.0,
     this.bias = 0.0005,
@@ -90,6 +114,7 @@ class AmbientOcclusionOptions {
     this.bentNormals = false,
     this.minHorizonAngleRad = 0.0,
     this.ssct = const SsctOptions(),
+    this.gtao = const GtaoOptions(),
   });
 }
 

--- a/thermion_dart/native/include/c_api/TView.h
+++ b/thermion_dart/native/include/c_api/TView.h
@@ -202,8 +202,26 @@ struct TSsct {
     bool enabled = false;            //!< enables or disables SSCT
 };
 
+enum TAmbientOcclusionType {
+    SAO,
+    GTAO
+};
+typedef enum TAmbientOcclusionType TAmbientOcclusionType;
+
 /**
- * Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+ * Ground Truth-based Ambient Occlusion (GTAO) options
+ */
+struct TGtao {
+    uint8_t sampleSliceCount = 4;        //!< number of slices; higher values reduce noise
+    uint8_t sampleStepsPerSlice = 3;     //!< integration steps per slice; higher values reduce bias
+    float thicknessHeuristic = 0.004f;   //!< ignored when visibility bitmasks are enabled
+    bool useVisibilityBitmasks = false;  //!< enables visibility bitmasks mode
+    float constThickness = 0.5f;         //!< world-space thickness used by visibility bitmasks
+    bool linearThickness = false;        //!< increases thickness with distance
+};
+
+/**
+ * Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
  */
 struct TAmbientOcclusionOptions {
     float radius = 0.3f;            //!< Ambient Occlusion radius in meters, between 0 and ~10
@@ -219,6 +237,8 @@ struct TAmbientOcclusionOptions {
     bool bentNormals = false;       //!< enables bent normals computation from AO, and specular AO
     float minHorizonAngleRad = 0.0f; //!< min angle in radian to consider
     TSsct ssct;
+    TGtao gtao;
+    TAmbientOcclusionType aoType = SAO; //!< ambient occlusion algorithm
 };
 
 typedef struct TAmbientOcclusionOptions TAmbientOcclusionOptions;

--- a/thermion_dart/native/src/c_api/TEngine.cpp
+++ b/thermion_dart/native/src/c_api/TEngine.cpp
@@ -85,9 +85,6 @@ namespace thermion
                 .sharedContext(tSharedContext)
                 .config(&config)
                 .build();
-
-            Log("BUILDING WITH CUSTOM BACKEND");
-
             
             return reinterpret_cast<TEngine *>(engine);
         }

--- a/thermion_dart/native/src/c_api/TView.cpp
+++ b/thermion_dart/native/src/c_api/TView.cpp
@@ -581,6 +581,7 @@ namespace thermion
             auto view = reinterpret_cast<View *>(tView);
             AmbientOcclusionOptions aoOptions;
 
+            aoOptions.aoType = static_cast<AmbientOcclusionOptions::AmbientOcclusionType>(options.aoType);
             aoOptions.radius = options.radius;
             aoOptions.power = options.power;
             aoOptions.bias = options.bias;
@@ -606,6 +607,14 @@ namespace thermion
             aoOptions.ssct.rayCount = options.ssct.rayCount;
             aoOptions.ssct.enabled = options.ssct.enabled;
 
+            // Copy GTAO options
+            aoOptions.gtao.sampleSliceCount = options.gtao.sampleSliceCount;
+            aoOptions.gtao.sampleStepsPerSlice = options.gtao.sampleStepsPerSlice;
+            aoOptions.gtao.thicknessHeuristic = options.gtao.thicknessHeuristic;
+            aoOptions.gtao.useVisibilityBitmasks = options.gtao.useVisibilityBitmasks;
+            aoOptions.gtao.constThickness = options.gtao.constThickness;
+            aoOptions.gtao.linearThickness = options.gtao.linearThickness;
+
             view->setAmbientOcclusionOptions(aoOptions);
         }
 
@@ -615,6 +624,7 @@ namespace thermion
             auto options = view->getAmbientOcclusionOptions();
 
             TAmbientOcclusionOptions tOptions;
+            tOptions.aoType = static_cast<TAmbientOcclusionType>(options.aoType);
             tOptions.radius = options.radius;
             tOptions.power = options.power;
             tOptions.bias = options.bias;
@@ -641,6 +651,14 @@ namespace thermion
             tOptions.ssct.sampleCount = options.ssct.sampleCount;
             tOptions.ssct.rayCount = options.ssct.rayCount;
             tOptions.ssct.enabled = options.ssct.enabled;
+
+            // Copy GTAO options
+            tOptions.gtao.sampleSliceCount = options.gtao.sampleSliceCount;
+            tOptions.gtao.sampleStepsPerSlice = options.gtao.sampleStepsPerSlice;
+            tOptions.gtao.thicknessHeuristic = options.gtao.thicknessHeuristic;
+            tOptions.gtao.useVisibilityBitmasks = options.gtao.useVisibilityBitmasks;
+            tOptions.gtao.constThickness = options.gtao.constThickness;
+            tOptions.gtao.linearThickness = options.gtao.linearThickness;
 
             return tOptions;
         }

--- a/thermion_dart/test/compare_goldens.py
+++ b/thermion_dart/test/compare_goldens.py
@@ -9,11 +9,6 @@ from pathlib import Path
 from PIL import Image, ImageChops
 import numpy as np
 
-REQUIRED_GOLDEN_FILES = {
-    "view/ambient_occlusion_sao_view0.png",
-    "view/ambient_occlusion_gtao_view0.png",
-}
-
 def calculate_image_difference(img1_path, img2_path):
     """
     Calculate the difference between two images.
@@ -75,15 +70,6 @@ def main():
     golden_files = find_png_files(golden_dir)
     output_files = find_png_files(output_dir)
 
-    missing_required_goldens = REQUIRED_GOLDEN_FILES - set(golden_files)
-    missing_required_outputs = REQUIRED_GOLDEN_FILES - set(output_files)
-
-    for golden_file in sorted(missing_required_goldens):
-        print(f"❌ REQUIRED GOLDEN MISSING: {golden_file}")
-
-    for output_file in sorted(missing_required_outputs):
-        print(f"❌ REQUIRED OUTPUT MISSING: {output_file}")
-    
     print(f"Found {len(golden_files)} golden files and {len(output_files)} output files")
     
     # Track comparison results
@@ -132,8 +118,7 @@ def main():
     print(f"📊 Total golden files: {len(golden_files)}")
     
     # Exit with appropriate code
-    if (different_count > 0 or missing_count > 0 or error_count > 0 or
-            missing_required_goldens or missing_required_outputs):
+    if different_count > 0 or missing_count > 0 or error_count > 0:
         print("\n❌ COMPARISON FAILED")
         sys.exit(1)
     else:

--- a/thermion_dart/test/compare_goldens.py
+++ b/thermion_dart/test/compare_goldens.py
@@ -9,6 +9,11 @@ from pathlib import Path
 from PIL import Image, ImageChops
 import numpy as np
 
+REQUIRED_GOLDEN_FILES = {
+    "view/ambient_occlusion_sao_view0.png",
+    "view/ambient_occlusion_gtao_view0.png",
+}
+
 def calculate_image_difference(img1_path, img2_path):
     """
     Calculate the difference between two images.
@@ -69,6 +74,15 @@ def main():
     # Find PNG files in both directories
     golden_files = find_png_files(golden_dir)
     output_files = find_png_files(output_dir)
+
+    missing_required_goldens = REQUIRED_GOLDEN_FILES - set(golden_files)
+    missing_required_outputs = REQUIRED_GOLDEN_FILES - set(output_files)
+
+    for golden_file in sorted(missing_required_goldens):
+        print(f"❌ REQUIRED GOLDEN MISSING: {golden_file}")
+
+    for output_file in sorted(missing_required_outputs):
+        print(f"❌ REQUIRED OUTPUT MISSING: {output_file}")
     
     print(f"Found {len(golden_files)} golden files and {len(output_files)} output files")
     
@@ -118,7 +132,8 @@ def main():
     print(f"📊 Total golden files: {len(golden_files)}")
     
     # Exit with appropriate code
-    if different_count > 0 or missing_count > 0 or error_count > 0:
+    if (different_count > 0 or missing_count > 0 or error_count > 0 or
+            missing_required_goldens or missing_required_outputs):
         print("\n❌ COMPARISON FAILED")
         sys.exit(1)
     else:

--- a/thermion_dart/test/view_tests.dart
+++ b/thermion_dart/test/view_tests.dart
@@ -1117,6 +1117,49 @@ void main() async {
     });
   });
 
+  test('AmbientOcclusionOptions SAO and GTAO visual comparison', () async {
+    final builder = ViewerBuilder(testHelper)
+        .setBackgroundColor(kWhite)
+        .setCameraLookAt(Vector3(0, 4, 6), focus: Vector3(0, -0.2, 0))
+        .setPostProcessing(true)
+        .addCube(position: Vector3(-0.8, 0, 0), color: kRed)
+        .addCube(position: Vector3(0.8, -0.35, 0), scale: Vector3.all(0.65), color: kBlue)
+        .addPlane(position: Vector3(0, -1.05, 0), color: kWhite, createUbershader: true);
+
+    await builder.execute((result) async {
+      await result.viewer.loadIbl("file://${testHelper.assetsDir}/default_env_ibl.ktx");
+
+      await result.viewer.view.setAmbientOcclusionOptions(
+        AmbientOcclusionOptions(
+          enabled: true,
+          aoType: AmbientOcclusionType.SAO,
+          radius: 0.8,
+          intensity: 1.0,
+          quality: QualityLevel.HIGH,
+          lowPassFilter: QualityLevel.HIGH,
+        ),
+      );
+      final saoImages = await testHelper.capture(result.viewer.view, "ambient_occlusion_sao");
+
+      await result.viewer.view.setAmbientOcclusionOptions(
+        AmbientOcclusionOptions(
+          enabled: true,
+          aoType: AmbientOcclusionType.GTAO,
+          radius: 0.8,
+          intensity: 1.0,
+          quality: QualityLevel.HIGH,
+          lowPassFilter: QualityLevel.HIGH,
+          gtao: GtaoOptions(sampleSliceCount: 4, sampleStepsPerSlice: 3),
+        ),
+      );
+      final gtaoImages = await testHelper.capture(result.viewer.view, "ambient_occlusion_gtao");
+
+      expect(saoImages[result.viewer.view], isNotEmpty);
+      expect(gtaoImages[result.viewer.view], isNotEmpty);
+      expect(gtaoImages[result.viewer.view], isNot(orderedEquals(saoImages[result.viewer.view]!)));
+    });
+  });
+
   test('AmbientOcclusionOptions with SSCT enabled', () async {
     final builder = ViewerBuilder(testHelper)
         .setBackgroundColor(kWhite)

--- a/thermion_dart/test/view_tests.dart
+++ b/thermion_dart/test/view_tests.dart
@@ -948,6 +948,7 @@ void main() async {
       // Test default options
       final defaultOptions = result.viewer.view.getAmbientOcclusionOptions();
       expect(defaultOptions.enabled, isFalse);
+      expect(defaultOptions.aoType, equals(AmbientOcclusionType.SAO));
       expect(defaultOptions.radius, closeTo(0.3, 0.001));
       expect(defaultOptions.power, closeTo(1.0, 0.001));
       expect(defaultOptions.bias, closeTo(0.0005, 0.0001));
@@ -974,9 +975,18 @@ void main() async {
       expect(defaultOptions.ssct.sampleCount, equals(4));
       expect(defaultOptions.ssct.rayCount, equals(1));
 
+      // Test GTAO default options
+      expect(defaultOptions.gtao.sampleSliceCount, equals(4));
+      expect(defaultOptions.gtao.sampleStepsPerSlice, equals(3));
+      expect(defaultOptions.gtao.thicknessHeuristic, closeTo(0.004, 0.0001));
+      expect(defaultOptions.gtao.useVisibilityBitmasks, isFalse);
+      expect(defaultOptions.gtao.constThickness, closeTo(0.5, 0.001));
+      expect(defaultOptions.gtao.linearThickness, isFalse);
+
       // Test setting custom ambient occlusion options
       final customOptions = AmbientOcclusionOptions(
         enabled: true,
+        aoType: AmbientOcclusionType.GTAO,
         radius: 0.8,
         power: 1.5,
         bias: 0.001,
@@ -1000,6 +1010,14 @@ void main() async {
           sampleCount: 8,
           rayCount: 2,
         ),
+        gtao: GtaoOptions(
+          sampleSliceCount: 6,
+          sampleStepsPerSlice: 4,
+          thicknessHeuristic: 0.006,
+          useVisibilityBitmasks: true,
+          constThickness: 0.75,
+          linearThickness: true,
+        ),
       );
 
       await result.viewer.view.setAmbientOcclusionOptions(customOptions);
@@ -1007,6 +1025,7 @@ void main() async {
       // Verify the options were set correctly
       final retrievedOptions = result.viewer.view.getAmbientOcclusionOptions();
       expect(retrievedOptions.enabled, equals(customOptions.enabled));
+      expect(retrievedOptions.aoType, equals(customOptions.aoType));
       expect(retrievedOptions.radius, closeTo(customOptions.radius, 0.001));
       expect(retrievedOptions.power, closeTo(customOptions.power, 0.001));
       expect(retrievedOptions.bias, closeTo(customOptions.bias, 0.0001));
@@ -1032,6 +1051,14 @@ void main() async {
       expect(retrievedOptions.ssct.depthSlopeBias, closeTo(customOptions.ssct.depthSlopeBias, 0.001));
       expect(retrievedOptions.ssct.sampleCount, equals(customOptions.ssct.sampleCount));
       expect(retrievedOptions.ssct.rayCount, equals(customOptions.ssct.rayCount));
+
+      // Verify GTAO options
+      expect(retrievedOptions.gtao.sampleSliceCount, equals(customOptions.gtao.sampleSliceCount));
+      expect(retrievedOptions.gtao.sampleStepsPerSlice, equals(customOptions.gtao.sampleStepsPerSlice));
+      expect(retrievedOptions.gtao.thicknessHeuristic, closeTo(customOptions.gtao.thicknessHeuristic, 0.0001));
+      expect(retrievedOptions.gtao.useVisibilityBitmasks, equals(customOptions.gtao.useVisibilityBitmasks));
+      expect(retrievedOptions.gtao.constThickness, closeTo(customOptions.gtao.constThickness, 0.001));
+      expect(retrievedOptions.gtao.linearThickness, equals(customOptions.gtao.linearThickness));
     });
   });
 


### PR DESCRIPTION
This PR exposes the GTAO options added by recent Filament versions (and adds rendering tests for visual regression comparison). 