### PR TITLE
fix(windows): prevent max macro collision

### DIFF
--- a/thermion_dart/native/src/rendering/FrameScheduler.cpp
+++ b/thermion_dart/native/src/rendering/FrameScheduler.cpp
@@ -8,6 +8,9 @@
 #endif
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <dxgi.h>
 #pragma comment(lib, "dxgi.lib")
 #endif


### PR DESCRIPTION
Fixes a regression on Windows builds where the Windows SDK max macro corrupted std::max. Solved by defining NOMINMAX before including DXGI in FrameScheduler.cpp