### PR TITLE
Expose Filament PCSS controls and view diagnostics

### DIFF
--- a/.github/workflows/run-dart-tests.yml
+++ b/.github/workflows/run-dart-tests.yml
@@ -158,8 +158,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh run download 32349488816 \
-            --name golden-images-b69b6d54fac83278f34e905aaede8ceffa060ae5  \
+          gh run download 32354532845 \
+            --name golden-images-3e644c631853e14cb40934961793def802e3b0b0 \
             --dir ./thermion_dart/test/golden-downloads
       - name: Unzip golden images
         if: matrix.name == 'Linux' && always()

--- a/.github/workflows/run-dart-tests.yml
+++ b/.github/workflows/run-dart-tests.yml
@@ -80,6 +80,13 @@ jobs:
         shell: bash
         run: rm -rf thermion_dart/.dart_tool/thermion_dart/lib
 
+      - name: Run PCSS visual tests (Linux)
+        if: matrix.name == 'Linux'
+        working-directory: thermion_dart
+        run: |
+          dart pub get
+          xvfb-run dart test test/pcss_controls_render_test.dart
+
       - name: Run tests (Linux)
         if: matrix.name == 'Linux'
         working-directory: thermion_dart
@@ -92,7 +99,6 @@ jobs:
             test/entity_tests.dart \
             test/geometry_tests.dart \
             test/view_tests.dart \
-            test/pcss_controls_render_test.dart \
             test/postprocessing_tests.dart \
             test/scene_tests.dart \
             test/picking_tests.dart \
@@ -137,18 +143,18 @@ jobs:
             --concurrency=1
 
       - name: Zip output
-        if: matrix.name == 'Linux'
+        if: matrix.name == 'Linux' && always()
         run: zip -r output.zip ./thermion_dart/test/output
 
       - name: Upload test output
-        if: matrix.name == 'Linux'
+        if: matrix.name == 'Linux' && always()
         uses: actions/upload-artifact@v4
         with:
           name: golden-images-${{ github.sha }}
           path: output.zip
 
       - name: Download golden images from previous run
-        if: matrix.name == 'Linux'
+        if: matrix.name == 'Linux' && always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -156,18 +162,18 @@ jobs:
             --name golden-images-b69b6d54fac83278f34e905aaede8ceffa060ae5  \
             --dir ./thermion_dart/test/golden-downloads
       - name: Unzip golden images
-        if: matrix.name == 'Linux'
+        if: matrix.name == 'Linux' && always()
         run: |
           cd thermion_dart/test/golden-downloads && unzip output.zip
 
       - name: Install Python dependencies
-        if: matrix.name == 'Linux'
+        if: matrix.name == 'Linux' && always()
         run: |
           python -m pip install --upgrade pip
           pip install Pillow numpy
 
       - name: Compare golden images
-        if: matrix.name == 'Linux'
+        if: matrix.name == 'Linux' && always()
         run: cd thermion_dart/test && python compare_goldens.py
 
       - name: Upload logs

--- a/.github/workflows/run-dart-tests.yml
+++ b/.github/workflows/run-dart-tests.yml
@@ -92,6 +92,7 @@ jobs:
             test/entity_tests.dart \
             test/geometry_tests.dart \
             test/view_tests.dart \
+            test/pcss_controls_render_test.dart \
             test/postprocessing_tests.dart \
             test/scene_tests.dart \
             test/picking_tests.dart \
@@ -123,6 +124,7 @@ jobs:
             test/entity_tests.dart `
             test/geometry_tests.dart `
             test/view_tests.dart `
+            test/pcss_controls_render_test.dart `
             test/postprocessing_tests.dart `
             test/scene_tests.dart `
             test/picking_tests.dart `

--- a/.github/workflows/run-dart-tests.yml
+++ b/.github/workflows/run-dart-tests.yml
@@ -80,13 +80,6 @@ jobs:
         shell: bash
         run: rm -rf thermion_dart/.dart_tool/thermion_dart/lib
 
-      - name: Run PCSS visual tests (Linux)
-        if: matrix.name == 'Linux'
-        working-directory: thermion_dart
-        run: |
-          dart pub get
-          xvfb-run dart test test/pcss_controls_render_test.dart
-
       - name: Run tests (Linux)
         if: matrix.name == 'Linux'
         working-directory: thermion_dart
@@ -99,6 +92,7 @@ jobs:
             test/entity_tests.dart \
             test/geometry_tests.dart \
             test/view_tests.dart \
+            test/pcss_controls_render_test.dart \
             test/postprocessing_tests.dart \
             test/scene_tests.dart \
             test/picking_tests.dart \
@@ -143,18 +137,18 @@ jobs:
             --concurrency=1
 
       - name: Zip output
-        if: matrix.name == 'Linux' && always()
+        if: matrix.name == 'Linux'
         run: zip -r output.zip ./thermion_dart/test/output
 
       - name: Upload test output
-        if: matrix.name == 'Linux' && always()
+        if: matrix.name == 'Linux'
         uses: actions/upload-artifact@v4
         with:
           name: golden-images-${{ github.sha }}
           path: output.zip
 
       - name: Download golden images from previous run
-        if: matrix.name == 'Linux' && always()
+        if: matrix.name == 'Linux'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -162,18 +156,18 @@ jobs:
             --name golden-images-3e644c631853e14cb40934961793def802e3b0b0 \
             --dir ./thermion_dart/test/golden-downloads
       - name: Unzip golden images
-        if: matrix.name == 'Linux' && always()
+        if: matrix.name == 'Linux'
         run: |
           cd thermion_dart/test/golden-downloads && unzip output.zip
 
       - name: Install Python dependencies
-        if: matrix.name == 'Linux' && always()
+        if: matrix.name == 'Linux'
         run: |
           python -m pip install --upgrade pip
           pip install Pillow numpy
 
       - name: Compare golden images
-        if: matrix.name == 'Linux' && always()
+        if: matrix.name == 'Linux'
         run: cd thermion_dart/test && python compare_goldens.py
 
       - name: Upload logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Update to Filament v1.75.0!
 - `allocate` FFI shim now takes `byteCount` instead of `count`
 - Add SAO/GTAO algorithm selection and GTAO sampling, thickness, and
   visibility-bitmask controls to `AmbientOcclusionOptions`.
+- Expose global and per-light PCSS penumbra and blocker-search controls.
+- Expose visible-renderable diagnostics on views.
 
 ### Breaking changes
 - `LightManager.setShadowCaster`/`setShadowOptions` and

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -264,6 +264,9 @@ external void View_setRenderTarget(ffi.Pointer<TView> view, ffi.Pointer<TRenderT
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
 external void View_setFrustumCullingEnabled(ffi.Pointer<TView> view, bool enabled);
 
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TView>)>(isLeaf: true)
+external int View_getVisibleRenderableCount(ffi.Pointer<TView> view);
+
 @ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(isLeaf: true)
 external ffi.Pointer<TRenderTarget> View_getRenderTarget(ffi.Pointer<TView> tView);
 
@@ -4959,6 +4962,12 @@ final class TSoftShadowOptions extends ffi.Struct {
 
   @ffi.Float()
   external double penumbraRatioScale;
+
+  @ffi.Float()
+  external double maxPenumbraRatio;
+
+  @ffi.Float()
+  external double maxSearchRadius;
 }
 
 /// Options for VSM Shadowing.
@@ -5601,6 +5610,18 @@ final class TShadowOptions extends ffi.Struct {
 
   @ffi.Float()
   external double shadowBulbRadius;
+
+  @ffi.Float()
+  external double penumbraScale;
+
+  @ffi.Float()
+  external double penumbraRatioScale;
+
+  @ffi.Float()
+  external double maxPenumbraRatio;
+
+  @ffi.Float()
+  external double maxSearchRadius;
 
   @ffi.Float()
   external double transformX;

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -2725,7 +2725,8 @@ void View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled) {
 }
 
 int View_getVisibleRenderableCount(Pointer<TView> view) {
-  return GeneratedBindings.instance._View_getVisibleRenderableCount(view.cast());
+  final result = GeneratedBindings.instance._View_getVisibleRenderableCount(view.cast());
+  return result;
 }
 
 Pointer<TRenderTarget> View_getRenderTarget(Pointer<TView> tView) {

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -129,6 +129,7 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _View_setViewport(Pointer<TView> view, int width, int height);
   external void _View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget);
   external void _View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled);
+  external int _View_getVisibleRenderableCount(Pointer<TView> view);
   external Pointer<TRenderTarget> _View_getRenderTarget(Pointer<TView> tView);
   external void _View_setPostProcessing(Pointer<TView> tView, bool enabled);
   external void _View_setShadowsEnabled(Pointer<TView> tView, bool enabled);
@@ -2721,6 +2722,10 @@ void View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarg
 void View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled) {
   final result = GeneratedBindings.instance._View_setFrustumCullingEnabled(view.cast(), enabled);
   return result;
+}
+
+int View_getVisibleRenderableCount(Pointer<TView> view) {
+  return GeneratedBindings.instance._View_getVisibleRenderableCount(view.cast());
 }
 
 Pointer<TRenderTarget> View_getRenderTarget(Pointer<TView> tView) {
@@ -8968,10 +8973,30 @@ final class TSoftShadowOptions extends Struct {
     NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 4), val.toJS, 'float');
   }
 
+  double get maxPenumbraRatio {
+    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxPenumbraRatio(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 8), val.toJS, 'float');
+  }
+
+  double get maxSearchRadius {
+    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxSearchRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 12), val.toJS, 'float');
+  }
+
   TSoftShadowOptions(super.address);
 
   static Pointer<TSoftShadowOptions> stackAlloc() {
-    return Pointer<TSoftShadowOptions>(NativeLibrary.instance.stackAlloc<TSoftShadowOptions>(8));
+    return Pointer<TSoftShadowOptions>(NativeLibrary.instance.stackAlloc<TSoftShadowOptions>(16));
   }
 }
 
@@ -10939,50 +10964,90 @@ final class TShadowOptions extends Struct {
     NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
   }
 
-  double get transformX {
+  double get penumbraScale {
     final addr = Pointer<TShadowOptions>(this.address.addr + 62);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set transformX(double val) {
+  set penumbraScale(double val) {
     NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
   }
 
-  double get transformY {
+  double get penumbraRatioScale {
     final addr = Pointer<TShadowOptions>(this.address.addr + 66);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set transformY(double val) {
+  set penumbraRatioScale(double val) {
     NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
   }
 
-  double get transformZ {
+  double get maxPenumbraRatio {
     final addr = Pointer<TShadowOptions>(this.address.addr + 70);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set transformZ(double val) {
+  set maxPenumbraRatio(double val) {
     NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
   }
 
-  double get transformW {
+  double get maxSearchRadius {
     final addr = Pointer<TShadowOptions>(this.address.addr + 74);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set transformW(double val) {
+  set maxSearchRadius(double val) {
     NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
   }
 
   TShadowOptions(super.address);
 
   static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(78));
+    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
   }
 }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_light_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_light_manager.dart
@@ -217,6 +217,10 @@ class FFILightManager extends LightManager<Pointer<TLightManager>> {
     tShadowOptions.vsmElvsm = options.vsmElvsm;
     tShadowOptions.vsmBlurWidth = options.vsmBlurWidth;
     tShadowOptions.shadowBulbRadius = options.shadowBulbRadius;
+    tShadowOptions.penumbraScale = options.penumbraScale;
+    tShadowOptions.penumbraRatioScale = options.penumbraRatioScale;
+    tShadowOptions.maxPenumbraRatio = options.maxPenumbraRatio;
+    tShadowOptions.maxSearchRadius = options.maxSearchRadius;
     tShadowOptions.transformW = options.transform.w;
     tShadowOptions.transformX = options.transform.x;
     tShadowOptions.transformY = options.transform.y;
@@ -257,6 +261,10 @@ class FFILightManager extends LightManager<Pointer<TLightManager>> {
       vsmElvsm: tShadowOptions.vsmElvsm,
       vsmBlurWidth: tShadowOptions.vsmBlurWidth,
       shadowBulbRadius: tShadowOptions.shadowBulbRadius,
+      penumbraScale: tShadowOptions.penumbraScale,
+      penumbraRatioScale: tShadowOptions.penumbraRatioScale,
+      maxPenumbraRatio: tShadowOptions.maxPenumbraRatio,
+      maxSearchRadius: tShadowOptions.maxSearchRadius,
       transform: Quaternion(
         tShadowOptions.transformX,
         tShadowOptions.transformY,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -450,6 +450,8 @@ class FFIView extends View<Pointer<TView>> {
     final tSoftShadowOptions = StructAllocator.create<TSoftShadowOptions>();
     tSoftShadowOptions.penumbraScale = options.penumbraScale;
     tSoftShadowOptions.penumbraRatioScale = options.penumbraRatioScale;
+    tSoftShadowOptions.maxPenumbraRatio = options.maxPenumbraRatio;
+    tSoftShadowOptions.maxSearchRadius = options.maxSearchRadius;
     await withVoidCallback(
       (requestId, cb) => View_setSoftShadowOptionsRenderThread(view, tSoftShadowOptions, requestId, cb),
     );
@@ -461,8 +463,13 @@ class FFIView extends View<Pointer<TView>> {
     return SoftShadowOptions(
       penumbraScale: tSoftShadowOptions.penumbraScale,
       penumbraRatioScale: tSoftShadowOptions.penumbraRatioScale,
+      maxPenumbraRatio: tSoftShadowOptions.maxPenumbraRatio,
+      maxSearchRadius: tSoftShadowOptions.maxSearchRadius,
     );
   }
+
+  @override
+  int getVisibleRenderableCount() => View_getVisibleRenderableCount(view);
 
   @override
   Future setVsmShadowOptions(VsmShadowOptions options) async {

--- a/thermion_dart/lib/src/filament/src/interface/shadow.dart
+++ b/thermion_dart/lib/src/filament/src/interface/shadow.dart
@@ -63,6 +63,22 @@ class ShadowOptions {
   /// Light bulb radius for soft shadows (used with DPCF/PCSS).
   final double shadowBulbRadius;
 
+  /// Light-specific multiplier applied to the final PCSS penumbra size.
+  final double penumbraScale;
+
+  /// Light-specific multiplier applied to the PCSS geometric penumbra ratio.
+  final double penumbraRatioScale;
+
+  /// Light-specific maximum PCSS penumbra ratio.
+  ///
+  /// Values less than or equal to zero use the view-level default.
+  final double maxPenumbraRatio;
+
+  /// Light-specific maximum PCSS blocker-search radius in world units.
+  ///
+  /// Values less than or equal to zero use the view-level default.
+  final double maxSearchRadius;
+
   /// Shadow direction transform (quaternion: w, x, y, z).
   final Quaternion transform;
 
@@ -85,6 +101,10 @@ class ShadowOptions {
     this.vsmElvsm = false,
     this.vsmBlurWidth = 0.0,
     this.shadowBulbRadius = 0.02,
+    this.penumbraScale = 1.0,
+    this.penumbraRatioScale = 1.0,
+    this.maxPenumbraRatio = 0.0,
+    this.maxSearchRadius = 0.0,
     Quaternion? transform,
   }) : transform = transform ?? Quaternion.identity();
 
@@ -108,6 +128,10 @@ class ShadowOptions {
     bool? vsmElvsm,
     double? vsmBlurWidth,
     double? shadowBulbRadius,
+    double? penumbraScale,
+    double? penumbraRatioScale,
+    double? maxPenumbraRatio,
+    double? maxSearchRadius,
     Quaternion? transform,
   }) {
     return ShadowOptions(
@@ -129,6 +153,10 @@ class ShadowOptions {
       vsmElvsm: vsmElvsm ?? this.vsmElvsm,
       vsmBlurWidth: vsmBlurWidth ?? this.vsmBlurWidth,
       shadowBulbRadius: shadowBulbRadius ?? this.shadowBulbRadius,
+      penumbraScale: penumbraScale ?? this.penumbraScale,
+      penumbraRatioScale: penumbraRatioScale ?? this.penumbraRatioScale,
+      maxPenumbraRatio: maxPenumbraRatio ?? this.maxPenumbraRatio,
+      maxSearchRadius: maxSearchRadius ?? this.maxSearchRadius,
       transform: transform ?? this.transform,
     );
   }
@@ -183,5 +211,20 @@ class SoftShadowOptions {
   /// Acceptable values are equal to or greater than 1.
   final double penumbraRatioScale;
 
-  const SoftShadowOptions({this.penumbraScale = 1.0, this.penumbraRatioScale = 1.0});
+  /// Maximum geometric ratio used to calculate PCSS penumbra size.
+  ///
+  /// Lower values suppress oversized ghost shadows from layered occluders.
+  final double maxPenumbraRatio;
+
+  /// Maximum PCSS blocker-search radius in world-space units.
+  ///
+  /// Lower values keep shadows anchored near complex contact geometry.
+  final double maxSearchRadius;
+
+  const SoftShadowOptions({
+    this.penumbraScale = 1.0,
+    this.penumbraRatioScale = 1.0,
+    this.maxPenumbraRatio = 10.0,
+    this.maxSearchRadius = 1.0,
+  });
 }

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -349,6 +349,13 @@ abstract class View<T> extends NativeHandle<T> {
   SoftShadowOptions getSoftShadowOptions();
   Future setVsmShadowOptions(VsmShadowOptions options);
   VsmShadowOptions getVsmShadowOptions();
+
+  /// Returns the number of renderables visible during the most recent render.
+  ///
+  /// Returns -1 before the first render or while the visibility cache is
+  /// invalid.
+  int getVisibleRenderableCount();
+
   Future setLayerVisibility(VisibilityLayers layer, bool visible);
 
   /// Creates a builder for configuring color grading.

--- a/thermion_dart/native/include/c_api/TLightManager.h
+++ b/thermion_dart/native/include/c_api/TLightManager.h
@@ -38,6 +38,10 @@ extern "C"
 		bool vsmElvsm;
 		float vsmBlurWidth;
 		float shadowBulbRadius;
+		float penumbraScale;
+		float penumbraRatioScale;
+		float maxPenumbraRatio;
+		float maxSearchRadius;
 		float transformX;
 		float transformY;
 		float transformZ;

--- a/thermion_dart/native/include/c_api/TView.h
+++ b/thermion_dart/native/include/c_api/TView.h
@@ -133,6 +133,7 @@ EMSCRIPTEN_KEEPALIVE void View_setBlendMode(TView *view, TBlendMode blendMode);
 EMSCRIPTEN_KEEPALIVE void View_setViewport(TView *view, uint32_t width, uint32_t height);
 EMSCRIPTEN_KEEPALIVE void View_setRenderTarget(TView *view, TRenderTarget *renderTarget);
 EMSCRIPTEN_KEEPALIVE void View_setFrustumCullingEnabled(TView *view, bool enabled);
+EMSCRIPTEN_KEEPALIVE int32_t View_getVisibleRenderableCount(TView *view);
 EMSCRIPTEN_KEEPALIVE void View_setRenderTarget(TView* tView, TRenderTarget* tRenderTarget);
 EMSCRIPTEN_KEEPALIVE TRenderTarget *View_getRenderTarget(TView* tView);
 EMSCRIPTEN_KEEPALIVE void View_setFrustumCullingEnabled(TView* tView, bool enabled);
@@ -147,6 +148,8 @@ EMSCRIPTEN_KEEPALIVE int View_getShadowType(TView* tView);
 struct TSoftShadowOptions {
     float penumbraScale;
     float penumbraRatioScale;
+    float maxPenumbraRatio;
+    float maxSearchRadius;
 };
 typedef struct TSoftShadowOptions TSoftShadowOptions;
 

--- a/thermion_dart/native/src/c_api/TLightManager.cpp
+++ b/thermion_dart/native/src/c_api/TLightManager.cpp
@@ -338,6 +338,10 @@ EMSCRIPTEN_KEEPALIVE void LightManager_setShadowOptions(TLightManager *tLightMan
     shadowOpts.vsm.elvsm = options.vsmElvsm;
     shadowOpts.vsm.blurWidth = options.vsmBlurWidth;
     shadowOpts.shadowBulbRadius = options.shadowBulbRadius;
+    shadowOpts.penumbraScale = options.penumbraScale;
+    shadowOpts.penumbraRatioScale = options.penumbraRatioScale;
+    shadowOpts.maxPenumbraRatio = options.maxPenumbraRatio;
+    shadowOpts.maxSearchRadius = options.maxSearchRadius;
     shadowOpts.transform = filament::math::quatf{
         options.transformW,
         options.transformX,
@@ -378,6 +382,10 @@ EMSCRIPTEN_KEEPALIVE TShadowOptions LightManager_getShadowOptions(TLightManager 
     outOptions.vsmElvsm = shadowOpts.vsm.elvsm;
     outOptions.vsmBlurWidth = shadowOpts.vsm.blurWidth;
     outOptions.shadowBulbRadius = shadowOpts.shadowBulbRadius;
+    outOptions.penumbraScale = shadowOpts.penumbraScale;
+    outOptions.penumbraRatioScale = shadowOpts.penumbraRatioScale;
+    outOptions.maxPenumbraRatio = shadowOpts.maxPenumbraRatio;
+    outOptions.maxSearchRadius = shadowOpts.maxSearchRadius;
     outOptions.transformW = shadowOpts.transform.w;
     outOptions.transformX = shadowOpts.transform.x;
     outOptions.transformY = shadowOpts.transform.y;

--- a/thermion_dart/native/src/c_api/TView.cpp
+++ b/thermion_dart/native/src/c_api/TView.cpp
@@ -64,6 +64,12 @@ namespace thermion
             view->setFrustumCullingEnabled(enabled);
         }
 
+        EMSCRIPTEN_KEEPALIVE int32_t View_getVisibleRenderableCount(TView *tView)
+        {
+            auto view = reinterpret_cast<View *>(tView);
+            return view->getVisibleRenderableCount();
+        }
+
         EMSCRIPTEN_KEEPALIVE void View_setPostProcessing(TView *tView, bool enabled)
         {
             auto view = reinterpret_cast<View *>(tView);
@@ -95,6 +101,8 @@ namespace thermion
             SoftShadowOptions opts;
             opts.penumbraRatioScale = options.penumbraRatioScale;
             opts.penumbraScale = options.penumbraScale;
+            opts.maxPenumbraRatio = options.maxPenumbraRatio;
+            opts.maxSearchRadius = options.maxSearchRadius;
             view->setSoftShadowOptions(opts);
         }
 
@@ -105,6 +113,8 @@ namespace thermion
             TSoftShadowOptions tOptions;
             tOptions.penumbraRatioScale = options.penumbraRatioScale;
             tOptions.penumbraScale = options.penumbraScale;
+            tOptions.maxPenumbraRatio = options.maxPenumbraRatio;
+            tOptions.maxSearchRadius = options.maxSearchRadius;
             return tOptions;
         }
 

--- a/thermion_dart/test/light_tests.dart
+++ b/thermion_dart/test/light_tests.dart
@@ -241,6 +241,10 @@ void main() async {
         constantBias: 0.002,
         normalBias: 2.0,
         stable: true,
+        penumbraScale: 1.5,
+        penumbraRatioScale: 2.5,
+        maxPenumbraRatio: 4.0,
+        maxSearchRadius: 0.2,
       );
       await lightManager.setShadowOptions(sunLight, shadowOptions);
       await testHelper.capture(result.viewer.view, "shadow_options_configured");
@@ -252,6 +256,10 @@ void main() async {
       expect(retrievedOptions.constantBias, closeTo(0.002, 0.0001));
       expect(retrievedOptions.normalBias, closeTo(2.0, 0.0001));
       expect(retrievedOptions.stable, isTrue);
+      expect(retrievedOptions.penumbraScale, closeTo(1.5, 0.0001));
+      expect(retrievedOptions.penumbraRatioScale, closeTo(2.5, 0.0001));
+      expect(retrievedOptions.maxPenumbraRatio, closeTo(4.0, 0.0001));
+      expect(retrievedOptions.maxSearchRadius, closeTo(0.2, 0.0001));
 
       await scene.removeEntity(sunLight);
       lightManager.destroyLight(sunLight);

--- a/thermion_dart/test/pcss_controls_render_test.dart
+++ b/thermion_dart/test/pcss_controls_render_test.dart
@@ -1,0 +1,56 @@
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+
+import 'helpers.dart';
+
+void main() async {
+  final testHelper = TestHelper('pcss_controls');
+  await testHelper.setup();
+
+  test('render global and per-light PCSS controls', () async {
+    final builder = ViewerBuilder(testHelper)
+        .setRenderTargetEnabled(true)
+        .setCameraLookAt(Vector3(4, 5, 7), focus: Vector3.zero())
+        .setShadowsEnabled(true)
+        .setShadowType(ShadowType.PCSS)
+        .addSun(
+          intensity: 100000,
+          castShadows: true,
+          direction: Vector3(-0.5, -1, -0.35).normalized(),
+          sunAngularRadius: 5.0,
+        )
+        .addCube(position: Vector3.zero(), castShadows: true, createUbershader: true)
+        .addPlane(
+          position: Vector3(0, -1.1, 0),
+          scale: Vector3.all(2),
+          receiveShadows: true,
+          castShadows: false,
+          createUbershader: true,
+          color: null,
+        );
+
+    await builder.execute((result) async {
+      final lightManager = FilamentApp.instance!.lightManager;
+
+      await result.viewer.view.setSoftShadowOptions(const SoftShadowOptions());
+      await testHelper.capture(result.viewer.view, 'pcss_controls_default');
+
+      await result.viewer.view.setSoftShadowOptions(
+        const SoftShadowOptions(maxPenumbraRatio: 2.0, maxSearchRadius: 0.08),
+      );
+      await testHelper.capture(result.viewer.view, 'pcss_controls_global_clamped');
+
+      final lightOptions = lightManager.getShadowOptions(result.sun!);
+      await lightManager.setShadowOptions(
+        result.sun!,
+        lightOptions.copyWith(
+          penumbraScale: 3.0,
+          penumbraRatioScale: 4.0,
+          maxPenumbraRatio: 6.0,
+          maxSearchRadius: 0.75,
+        ),
+      );
+      await testHelper.capture(result.viewer.view, 'pcss_controls_per_light_override');
+    });
+  });
+}

--- a/thermion_dart/test/view_tests.dart
+++ b/thermion_dart/test/view_tests.dart
@@ -896,9 +896,16 @@ void main() async {
       final defaultOptions = result.viewer.view.getSoftShadowOptions();
       expect(defaultOptions.penumbraScale, closeTo(1.0, 0.001));
       expect(defaultOptions.penumbraRatioScale, closeTo(1.0, 0.001));
+      expect(defaultOptions.maxPenumbraRatio, closeTo(10.0, 0.001));
+      expect(defaultOptions.maxSearchRadius, closeTo(1.0, 0.001));
 
       // Test custom soft shadow options
-      const customOptions = SoftShadowOptions(penumbraScale: 2.5, penumbraRatioScale: 3.0);
+      const customOptions = SoftShadowOptions(
+        penumbraScale: 2.5,
+        penumbraRatioScale: 3.0,
+        maxPenumbraRatio: 4.0,
+        maxSearchRadius: 0.25,
+      );
 
       await result.viewer.view.setSoftShadowOptions(customOptions);
 
@@ -906,6 +913,8 @@ void main() async {
       final retrievedOptions = result.viewer.view.getSoftShadowOptions();
       expect(retrievedOptions.penumbraScale, closeTo(2.5, 0.001));
       expect(retrievedOptions.penumbraRatioScale, closeTo(3.0, 0.001));
+      expect(retrievedOptions.maxPenumbraRatio, closeTo(4.0, 0.001));
+      expect(retrievedOptions.maxSearchRadius, closeTo(0.25, 0.001));
 
       // Test with DPCF shadow type (supports soft shadows)
       await result.viewer.view.setShadowType(ShadowType.DPCF);
@@ -940,6 +949,13 @@ void main() async {
       final precisionOptions = result.viewer.view.getSoftShadowOptions();
       expect(precisionOptions.penumbraScale, closeTo(0.1, 0.001));
       expect(precisionOptions.penumbraRatioScale, closeTo(1.33, 0.001));
+    });
+  });
+
+  test('visible renderable diagnostics', () async {
+    await ViewerBuilder(testHelper).setRenderTargetEnabled(true).addCube().addPlane().execute((result) async {
+      await testHelper.capture(result.viewer.view, null);
+      expect(result.viewer.view.getVisibleRenderableCount(), greaterThanOrEqualTo(2));
     });
   });
 


### PR DESCRIPTION
Minor updates to expose newer Filament API surface:
- global and per-light PCSS penumbra and blocker-search controls
- visible-renderable count from a View