### PR TITLE
ci: parallelize Android example builds

### DIFF
--- a/.github/workflows/run-flutter-builds.yml
+++ b/.github/workflows/run-flutter-builds.yml
@@ -48,6 +48,8 @@ jobs:
           flutter-version: '3.44.8'
           channel: ${{ matrix.flutter-channel }}
           architecture: ${{ matrix.flutter-arch }}
+          cache: true
+          pub-cache: true
 
       # The plugin's CMake configure runs BEFORE the in-build hook step that
       # extracts the Filament headers from the R2 artifact and writes
@@ -71,28 +73,7 @@ jobs:
           flutter pub get
           flutter test
 
-      # macOS: build native macOS + Android + web
-      - name: Set up JDK 17
-        if: matrix.name == 'macOS'
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Install Android SDK
-        if: matrix.name == 'macOS'
-        uses: android-actions/setup-android@v3
-        with:
-          api-level: 34
-          build-tools: 34.0.0
-          cmake-version: 3.22.1
-          ndk-version: 25.1.893739
-
-      - name: Accept Android SDK licenses
-        if: matrix.name == 'macOS'
-        run: |
-          yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
-
+      # macOS: build native macOS examples and run the lifecycle test.
       - name: Build quickstart (macOS)
         if: matrix.name == 'macOS'
         run: cd quickstart && flutter pub get && flutter build macos
@@ -113,38 +94,6 @@ jobs:
       - name: Run lifecycle integration test (macOS)
         if: matrix.name == 'macOS'
         run: cd quickstart && flutter test integration_test/lifecycle_test.dart -d macos
-
-      - name: Build quickstart (appbundle)
-        if: matrix.name == 'macOS'
-        run: cd quickstart && flutter build appbundle
-
-      - name: Build picking (appbundle)
-        if: matrix.name == 'macOS'
-        run: cd picking && flutter build appbundle
-
-      - name: Build viewer (appbundle)
-        if: matrix.name == 'macOS'
-        run: cd viewer && flutter build appbundle
-
-      # materials.backends e2e for Android: rebuild the quickstart appbundle
-      # with the vulkan-only material variant selected via user_defines.
-      # Backs up the pubspec and strips any existing hooks block first (the
-      # strip-then-append pattern from run-dart-tests.yml), restoring it
-      # afterwards so the define applies to exactly this build.
-      - name: Build quickstart (appbundle, android vulkan-only materials)
-        if: matrix.name == 'macOS'
-        run: |
-          cd quickstart
-          cp pubspec.yaml pubspec.yaml.orig
-          awk '
-            /^hooks:/ { skip=1; next }
-            skip && /^[^[:space:]#]/ { skip=0 }
-            !skip { print }
-          ' pubspec.yaml > pubspec.yaml.tmp
-          mv pubspec.yaml.tmp pubspec.yaml
-          printf '\nhooks:\n  user_defines:\n    thermion_dart:\n      materials:\n        backends:\n          android: vulkan\n' >> pubspec.yaml
-          flutter build appbundle
-          mv pubspec.yaml.orig pubspec.yaml
 
       # Windows: build native Windows
       - name: Build quickstart (Windows)
@@ -188,6 +137,80 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-logs-flutter-${{ matrix.name }}
+          path: |
+            ${{ github.workspace }}/thermion_dart/.dart_tool/thermion_dart/log/build.log
+          retention-days: 5
+
+  android-examples:
+    name: Android (${{ matrix.app }}, ${{ matrix.variant }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include:
+          - app: quickstart
+            variant: default
+          - app: picking
+            variant: default
+          - app: viewer
+            variant: default
+          - app: quickstart
+            variant: vulkan
+    defaults:
+      run:
+        working-directory: examples/flutter/${{ matrix.app }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.head_ref || github.ref }}
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.44.8'
+          channel: stable
+          architecture: X64
+          cache: true
+          pub-cache: true
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          packages: 'platform-tools cmake;3.22.1 ndk;28.2.13676358'
+
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v6
+
+      # materials.backends e2e for Android: build quickstart with the
+      # vulkan-only material variant selected via user_defines. Strip any
+      # existing hooks block first so this define applies to exactly this job.
+      - name: Configure Vulkan-only materials
+        if: matrix.variant == 'vulkan'
+        shell: bash
+        run: |
+          awk '
+            /^hooks:/ { skip=1; next }
+            skip && /^[^[:space:]#]/ { skip=0 }
+            !skip { print }
+          ' pubspec.yaml > pubspec.yaml.tmp
+          mv pubspec.yaml.tmp pubspec.yaml
+          printf '\nhooks:\n  user_defines:\n    thermion_dart:\n      materials:\n        backends:\n          android: vulkan\n' >> pubspec.yaml
+
+      - name: Build app bundle
+        run: flutter build appbundle
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-flutter-android-${{ matrix.app }}-${{ matrix.variant }}
           path: |
             ${{ github.workspace }}/thermion_dart/.dart_tool/thermion_dart/log/build.log
           retention-days: 5


### PR DESCRIPTION
Speed up CI by parallelizing Android example builds:
- move Android app-bundle builds from the macOS job to Ubuntu
- run quickstart, picking, viewer, and Vulkan-only quickstart as a four-way matrix
- enable Flutter, Pub, and Gradle caching
- install the Android CMake and NDK versions used by the plugin
