### PR TITLE
fix!: caller-managed ColorGrading lifecycle, builder-only API (removes setToneMapper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,37 @@
 ## Unreleased
 
 ### Changes
-- `FilamentApp` exposes the native engine handle as a public
+- `View` now owns the `ColorGrading` currently applied to it: replacing or
+  clearing it via `setColorGrading` destroys the previous grading, and the
+  owned grading is destroyed on view teardown. Previously, gradings created
+  via `createColorGradingBuilder` and set via `setColorGrading` were never
+  freed, and replacing a grading leaked the old one.
+- `ColorGrading` and `ColorGradingBuilder` expose `dispose()` through the
+  public interface (previously FFI-only / missing). `ColorGrading.dispose` is
+  only for gradings never attached to a view; `ColorGradingBuilder.dispose`
+  frees the builder, which is REUSABLE per Filament's pattern - `build()` may
+  be called any number of times and does not consume the builder. `dispose()`
+  is idempotent on ToneMapper, ColorGrading, and ColorGradingBuilder; using
+  a disposed builder throws.
+- `ToneMapper` factory methods take the abstract `FilamentApp` instead of
+  `FFIFilamentApp`, so callers no longer need to downcast
+  (`ToneMapper.aces(FilamentApp.instance!)` just works). To support this,
+  `FilamentApp` exposes the native engine handle as a public
   `Pointer<TEngine> get engine` (thermion_dart is FFI-backed on every
-  supported target, including web/WASM). `ToneMapper` factory methods take
-  the abstract `FilamentApp` instead of `FFIFilamentApp`, so callers no
-  longer need to downcast (`ToneMapper.aces(FilamentApp.instance!)` just
-  works).
+  supported target, including web/WASM).
 - `TranslationAxisMaterial.createMaterialInstance` takes the abstract
   `FilamentApp` too, and `FFIMaterial`/`FFIMaterialInstance` hold the
   abstract type internally (they only ever needed the engine handle).
+
+### Breaking changes
+- remove the unused `FilamentApp.createColorGrading` — it returned a raw
+  pointer nobody could destroy; use `View.createColorGradingBuilder().build()`
+  instead.
+- remove `View.setToneMapper` and `ThermionViewer.setToneMapper` (both
+  deprecated) along with the native `ColorGrading_create` /
+  `ColorGrading_createRenderThread` C entry points — use
+  `view.createColorGradingBuilder().toneMapper(...).build()` followed by
+  `view.setColorGrading()` instead.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## Unreleased
 
 ### Changes
-- `View` now owns the `ColorGrading` currently applied to it: replacing or
-  clearing it via `setColorGrading` destroys the previous grading, and the
-  owned grading is destroyed on view teardown. Previously, gradings created
-  via `createColorGradingBuilder` and set via `setColorGrading` were never
-  freed, and replacing a grading leaked the old one.
+- `ColorGrading` lifetime is now managed automatically with shared
+  ownership, matching Filament's ability to attach one grading to multiple
+  views: a grading is destroyed once the last attached view replaces,
+  clears, or destroys it, and `dispose()` destroys an unattached grading
+  immediately (deferred until the last detach while attached). Previously,
+  gradings created via `createColorGradingBuilder` and set via
+  `setColorGrading` were never freed, and replacing a grading leaked the
+  old one.
 - `ColorGrading` and `ColorGradingBuilder` expose `dispose()` through the
   public interface (previously FFI-only / missing). `ColorGrading.dispose` is
   only for gradings never attached to a view; `ColorGradingBuilder.dispose`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,40 +3,23 @@
 ## Unreleased
 
 ### Changes
-- `ColorGrading` now follows Filament's ownership model exactly: the CALLER
-  manages the lifecycle. `View.setColorGrading` performs no ownership
-  transfer and no reference counting - the view holds a non-owning
-  reference, and a grading must be dissociated from every view
+- `FilamentApp` exposes the native engine handle as a public
+- `TranslationAxisMaterial.createMaterialInstance` and `ToneMapper` factory methods
+  now take the abstract `FilamentApp` instead of
+  `FFIFilamentApp`
+- `ColorGrading` follows Filament's ownership model (caller
+  manages lifecycle). A `ColorGrading` must be dissociated from every view
   (`setColorGrading` with a replacement or null) BEFORE calling
   `ColorGrading.dispose()`. Attaching one grading to multiple views
-  remains supported, but its lifetime is entirely yours. Previously,
-  gradings created via `createColorGradingBuilder` and set via
-  `setColorGrading` were never freed, and replacing a grading leaked the
-  old one.
+  remains supported, but its lifetime is entirely yours. 
 - `ColorGrading` and `ColorGradingBuilder` expose `dispose()` through the
-  public interface (previously FFI-only / missing). `ColorGrading.dispose`
-  destroys the native grading immediately - dissociate it from all views
-  first; `ColorGradingBuilder.dispose` frees the builder, which is REUSABLE
-  per Filament's pattern - `build()` may be called any number of times and
-  does not consume the builder. `dispose()` is idempotent on ToneMapper,
-  ColorGrading, and ColorGradingBuilder; using a disposed builder throws.
-- `ToneMapper` factory methods take the abstract `FilamentApp` instead of
-  `FFIFilamentApp`, so callers no longer need to downcast
-  (`ToneMapper.aces(FilamentApp.instance!)` just works). To support this,
-  `FilamentApp` exposes the native engine handle as a public
-  `Pointer<TEngine> get engine` (thermion_dart is FFI-backed on every
-  supported target, including web/WASM).
-- `TranslationAxisMaterial.createMaterialInstance` takes the abstract
-  `FilamentApp` too, and `FFIMaterial`/`FFIMaterialInstance` hold the
-  abstract type internally (they only ever needed the engine handle).
+  public interface (previously FFI-only / missing). 
 
 ### Breaking changes
 - remove the unused `FilamentApp.createColorGrading` — it returned a raw
   pointer nobody could destroy; use `View.createColorGradingBuilder().build()`
   instead.
-- remove `View.setToneMapper` and `ThermionViewer.setToneMapper` (both
-  deprecated) along with the native `ColorGrading_create` /
-  `ColorGrading_createRenderThread` C entry points — use
+- remove `View.setToneMapper` and `ThermionViewer.setToneMapper` - use
   `view.createColorGradingBuilder().toneMapper(...).build()` followed by
   `view.setColorGrading()` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,23 @@
 ## Unreleased
 
 ### Changes
-- `ColorGrading` lifetime is now managed automatically with shared
-  ownership, matching Filament's ability to attach one grading to multiple
-  views: a grading is destroyed once the last attached view replaces,
-  clears, or destroys it, and `dispose()` destroys an unattached grading
-  immediately (deferred until the last detach while attached). Previously,
+- `ColorGrading` now follows Filament's ownership model exactly: the CALLER
+  manages the lifecycle. `View.setColorGrading` performs no ownership
+  transfer and no reference counting - the view holds a non-owning
+  reference, and a grading must be dissociated from every view
+  (`setColorGrading` with a replacement or null) BEFORE calling
+  `ColorGrading.dispose()`. Attaching one grading to multiple views
+  remains supported, but its lifetime is entirely yours. Previously,
   gradings created via `createColorGradingBuilder` and set via
   `setColorGrading` were never freed, and replacing a grading leaked the
   old one.
 - `ColorGrading` and `ColorGradingBuilder` expose `dispose()` through the
-  public interface (previously FFI-only / missing). `ColorGrading.dispose` is
-  only for gradings never attached to a view; `ColorGradingBuilder.dispose`
-  frees the builder, which is REUSABLE per Filament's pattern - `build()` may
-  be called any number of times and does not consume the builder. `dispose()`
-  is idempotent on ToneMapper, ColorGrading, and ColorGradingBuilder; using
-  a disposed builder throws.
+  public interface (previously FFI-only / missing). `ColorGrading.dispose`
+  destroys the native grading immediately - dissociate it from all views
+  first; `ColorGradingBuilder.dispose` frees the builder, which is REUSABLE
+  per Filament's pattern - `build()` may be called any number of times and
+  does not consume the builder. `dispose()` is idempotent on ToneMapper,
+  ColorGrading, and ColorGradingBuilder; using a disposed builder throws.
 - `ToneMapper` factory methods take the abstract `FilamentApp` instead of
   `FFIFilamentApp`, so callers no longer need to downcast
   (`ToneMapper.aces(FilamentApp.instance!)` just works). To support this,

--- a/examples/dart/cli_headless/bin/render_demo.dart
+++ b/examples/dart/cli_headless/bin/render_demo.dart
@@ -180,7 +180,12 @@ Future<void> main(List<String> argv) async {
   await viewer.view.setFrustumCullingEnabled(false);
   await viewer.setViewport(width, height);
   // ACES tone mapping for filmic, non-blow-out highlights.
-  await viewer.setToneMapper(await ToneMapper.aces(app));
+  final builder = await viewer.view.createColorGradingBuilder();
+  final toneMapper = await ToneMapper.aces(app);
+  final colorGrading = await builder.toneMapper(toneMapper).build();
+  await builder.dispose();
+  await toneMapper.dispose(); // builder disposed; grading holds a copy
+  await viewer.view.setColorGrading(colorGrading);
 
   // Environment: HDRI skybox + image-based lighting. `--env=<name>` selects one.
   // `--no-skybox` skips the visible skybox (background goes black) but keeps the

--- a/examples/dart/examples_lib/lib/src/post_processing.dart
+++ b/examples/dart/examples_lib/lib/src/post_processing.dart
@@ -36,5 +36,6 @@ Future<void> setupPostProcessing(
       .saturation(1.1)
       .vibrance(1.2)
       .build();
+  await builder.dispose();
   await viewer.view.setColorGrading(grading);
 }

--- a/examples/dart/examples_lib/lib/src/post_processing.dart
+++ b/examples/dart/examples_lib/lib/src/post_processing.dart
@@ -27,6 +27,11 @@ Future<void> setupPostProcessing(
 
   // Warm colour grading (skips toneMapper -- the builder defaults to
   // ACESLegacy when toneMapper is not explicitly set).
+  //
+  // The grading is caller-owned (as in Filament): it stays attached for the
+  // viewer's lifetime here. A caller tearing the view down earlier must
+  // dissociate (`setColorGrading(null)`) and dispose it - see
+  // web_gallery/web/effects_controls.dart for the full pattern.
   final builder = await viewer.view.createColorGradingBuilder();
   final grading = await builder
       .quality(QualityLevel.HIGH)

--- a/examples/dart/web_gallery/web/effects_controls.dart
+++ b/examples/dart/web_gallery/web/effects_controls.dart
@@ -44,6 +44,11 @@ Future<void> installEffectsControls(ThermionViewer viewer) async {
   Timer? gradingDebounce;
   Future<void> gradingQueue = Future.value();
 
+  // The grading currently attached to the view. The caller owns its
+  // lifecycle (as in Filament - the view holds only a non-owning
+  // reference), so it is disposed here whenever it is replaced or cleared.
+  ColorGrading? attachedGrading;
+
   Future<void> rebuildColorGrading() async {
     try {
       final builder = await viewer.view.createColorGradingBuilder();
@@ -57,11 +62,13 @@ Future<void> installEffectsControls(ThermionViewer viewer) async {
           .build();
       await builder.dispose();
       if (colorGrading.checked) {
-        // The view takes ownership of the new grading and destroys the
-        // previously-set one - no manual disposal of the old grading here.
+        // Attaching the new grading dissociates the old one, which can then
+        // be disposed.
         await viewer.view.setColorGrading(next);
+        await attachedGrading?.dispose();
+        attachedGrading = next;
       } else {
-        // Built but never attached: the caller owns it, so dispose it.
+        // Built but never attached: dispose it immediately.
         await next.dispose();
       }
     } catch (error, stackTrace) {
@@ -103,7 +110,11 @@ Future<void> installEffectsControls(ThermionViewer viewer) async {
           if (colorGrading.checked) {
             await rebuildColorGrading();
           } else {
+            // Dissociate from the view, then dispose the caller-owned
+            // grading.
             await viewer.view.setColorGrading(null);
+            await attachedGrading?.dispose();
+            attachedGrading = null;
           }
         });
       }).toJS);

--- a/examples/dart/web_gallery/web/effects_controls.dart
+++ b/examples/dart/web_gallery/web/effects_controls.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:js_interop';
 
-import 'package:thermion_dart/src/filament/src/implementation/ffi_color_grading.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 import 'package:web/web.dart';
 
@@ -42,7 +41,6 @@ Future<void> installEffectsControls(ThermionViewer viewer) async {
     document.getElementById('${input.id}-value')!.textContent = input.value;
   }
 
-  FFIColorGrading? currentGrading;
   Timer? gradingDebounce;
   Future<void> gradingQueue = Future.value();
 
@@ -56,13 +54,16 @@ Future<void> installEffectsControls(ThermionViewer viewer) async {
           .contrast(valueOf(contrast))
           .saturation(valueOf(saturation))
           .vibrance(valueOf(vibrance))
-          .build() as FFIColorGrading;
+          .build();
+      await builder.dispose();
       if (colorGrading.checked) {
+        // The view takes ownership of the new grading and destroys the
+        // previously-set one - no manual disposal of the old grading here.
         await viewer.view.setColorGrading(next);
+      } else {
+        // Built but never attached: the caller owns it, so dispose it.
+        await next.dispose();
       }
-      final previous = currentGrading;
-      currentGrading = next;
-      await previous?.dispose();
     } catch (error, stackTrace) {
       print('Failed to update color grading: $error\n$stackTrace');
     }

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -60,12 +60,6 @@ external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(ffi.Pointer<TEng
 @ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
 external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
 
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TEngine>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external ffi.Pointer<TColorGrading> ColorGrading_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TToneMapper> toneMapper,
-);
-
 @ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
 
@@ -2332,19 +2326,6 @@ external void Material_createWireframeMaterialRenderThread(
 external void Material_createTranslationAxisMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TToneMapper>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>,
-  )
->(isLeaf: true)
-external void ColorGrading_createRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TToneMapper> toneMapper,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>> callback,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>)>(

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -44,7 +44,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external Pointer<TToneMapper> _ToneMapper_createDisplayRange(Pointer<TEngine> tEngine);
   external void _ToneMapper_destroy(Pointer<TToneMapper> toneMapper);
-  external Pointer<TColorGrading> _ColorGrading_create(Pointer<TEngine> tEngine, Pointer<TToneMapper> toneMapper);
   external Pointer<TColorGradingBuilder> _ColorGradingBuilder_create();
   external Pointer<TColorGrading> _ColorGradingBuilder_build(
     Pointer<TColorGradingBuilder> builder,
@@ -1130,11 +1129,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _Material_createTranslationAxisMaterialRenderThread(
     Pointer<TEngine> tEngine,
     Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _ColorGrading_createRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TToneMapper> toneMapper,
-    Pointer<NativeFunction<void Function(PointerClass<TColorGrading>)>> callback,
   );
   external void _ColorGradingBuilder_createRenderThread(
     Pointer<NativeFunction<void Function(PointerClass<TColorGradingBuilder>)>> onComplete,
@@ -2485,11 +2479,6 @@ Pointer<TToneMapper> ToneMapper_createDisplayRange(Pointer<TEngine> tEngine) {
 void ToneMapper_destroy(Pointer<TToneMapper> toneMapper) {
   final result = GeneratedBindings.instance._ToneMapper_destroy(toneMapper.cast());
   return result;
-}
-
-Pointer<TColorGrading> ColorGrading_create(Pointer<TEngine> tEngine, Pointer<TToneMapper> toneMapper) {
-  final result = GeneratedBindings.instance._ColorGrading_create(tEngine.cast(), toneMapper.cast());
-  return Pointer<TColorGrading>(result);
 }
 
 Pointer<TColorGradingBuilder> ColorGradingBuilder_create() {
@@ -5575,19 +5564,6 @@ void Material_createTranslationAxisMaterialRenderThread(
   final result = GeneratedBindings.instance._Material_createTranslationAxisMaterialRenderThread(
     tEngine.cast(),
     onComplete.cast(),
-  );
-  return result;
-}
-
-void ColorGrading_createRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TToneMapper> toneMapper,
-  Pointer<NativeFunction<void Function(Pointer<TColorGrading>)>> callback,
-) {
-  final result = GeneratedBindings.instance._ColorGrading_createRenderThread(
-    tEngine.cast(),
-    toneMapper.cast(),
-    callback.cast(),
   );
   return result;
 }
@@ -8882,21 +8858,6 @@ final class TEngine extends Struct {
   }
 }
 
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
-}
-
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
-  }
-}
-
 extension TColorGradingBuilderExt on Pointer<TColorGradingBuilder> {
   TColorGradingBuilder toDart() {
     return TColorGradingBuilder(this);
@@ -8909,6 +8870,21 @@ final class TColorGradingBuilder extends Struct {
 
   static Pointer<TColorGradingBuilder> stackAlloc() {
     return Pointer<TColorGradingBuilder>(NativeLibrary.instance.stackAlloc<TColorGradingBuilder>(0));
+  }
+}
+
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
   }
 }
 
@@ -11193,11 +11169,11 @@ extension StructAllocator on Struct {
       case TEngine:
         final ptr = TEngine.stackAlloc();
         return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
       case TColorGradingBuilder:
         final ptr = TColorGradingBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
         return ptr.toDart() as T;
       case TRenderTarget:
         final ptr = TRenderTarget.stackAlloc();
@@ -11372,7 +11348,7 @@ extension NativeFunctionPointer17<T extends NativeType> on void Function(bool) {
   }
 }
 
-extension NativeFunctionPointer48<T extends NativeType> on void Function(int) {
+extension NativeFunctionPointer47<T extends NativeType> on void Function(int) {
   Pointer<NativeFunction<void Function(int)>> addFunction() {
     return Pointer<NativeFunction<void Function(int)>>(
       NativeLibrary.instance.addFunction<void Function(int)>(this.toJS, 'vi'),
@@ -11380,7 +11356,7 @@ extension NativeFunctionPointer48<T extends NativeType> on void Function(int) {
   }
 }
 
-extension NativeFunctionPointer62<T extends NativeType> on void Function(double) {
+extension NativeFunctionPointer61<T extends NativeType> on void Function(double) {
   Pointer<NativeFunction<void Function(double)>> addFunction() {
     return Pointer<NativeFunction<void Function(double)>>(
       NativeLibrary.instance.addFunction<void Function(double)>(this.toJS, 'vf'),

--- a/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/edge_detection_view.dart
@@ -214,6 +214,7 @@ class EdgeDetectionView extends FFIView {
     );
     colorGradingBuilder.toneMapper(linearToneMapper);
     final linearColorGrading = await colorGradingBuilder.build();
+    await colorGradingBuilder.dispose();
 
     // Create the EdgeDetectionView with all resources
     final edgeDetectionView = EdgeDetectionView._(

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
@@ -5,6 +5,7 @@ import 'ffi_filament_app.dart';
 /// FFI implementation of ColorGrading
 class FFIColorGrading extends ColorGrading {
   final Pointer<TColorGrading> pointer;
+  bool _disposed = false;
 
   final FFIFilamentApp _app;
 
@@ -13,7 +14,17 @@ class FFIColorGrading extends ColorGrading {
   @override
   Pointer<TColorGrading> getNativeHandle() => pointer;
 
+  /// Destroys the underlying native ColorGrading.
+  ///
+  /// Only safe for a grading that is NOT currently attached to a view - a view
+  /// owns whatever grading was last passed to setColorGrading and destroys it
+  /// itself when it is replaced, cleared, or when the view is destroyed.
+  /// Idempotent: a second dispose is a no-op.
   Future dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     await withVoidCallback(
       (requestId, cb) => Engine_destroyColorGradingRenderThread(_app.engine, pointer, requestId, cb),
     );
@@ -23,42 +34,44 @@ class FFIColorGrading extends ColorGrading {
 /// FFI implementation of ColorGradingBuilder
 class FFIColorGradingBuilder extends ColorGradingBuilder {
   final Pointer<TColorGradingBuilder> _builder;
-  bool _built = false;
-
   final FFIFilamentApp _app;
+  bool _disposed = false;
 
   FFIColorGradingBuilder(this._builder, this._app);
 
-  void _checkNotBuilt() {
-    if (_built) {
-      throw StateError('Builder has already been built and cannot be reused');
+  /// Matches Filament: the builder is reusable - build() may be called any
+  /// number of times, and settings may be changed between builds. Only
+  /// disposal ends its life.
+  void _checkNotDisposed() {
+    if (_disposed) {
+      throw StateError('Builder has been disposed');
     }
   }
 
   @override
   ColorGradingBuilder quality(QualityLevel level) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_quality(_builder, level.index);
     return this;
   }
 
   @override
   ColorGradingBuilder format(LutFormat format) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_format(_builder, format.index);
     return this;
   }
 
   @override
   ColorGradingBuilder dimensions(int dim) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_dimensions(_builder, dim);
     return this;
   }
 
   @override
   ColorGradingBuilder toneMapper(ToneMapper mapper) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     // Extract the native pointer from the ToneMapper object
     final Pointer<TToneMapper> toneMapperPtr = mapper.getNativeHandle();
     ColorGradingBuilder_toneMapper(_builder, toneMapperPtr);
@@ -67,49 +80,49 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
 
   @override
   ColorGradingBuilder exposure(double exposure) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_exposure(_builder, exposure);
     return this;
   }
 
   @override
   ColorGradingBuilder nightAdaptation(double adaptation) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_nightAdaptation(_builder, adaptation);
     return this;
   }
 
   @override
   ColorGradingBuilder whiteBalance(double temperature, double tint) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_whiteBalance(_builder, temperature, tint);
     return this;
   }
 
   @override
   ColorGradingBuilder contrast(double contrast) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_contrast(_builder, contrast);
     return this;
   }
 
   @override
   ColorGradingBuilder vibrance(double vibrance) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_vibrance(_builder, vibrance);
     return this;
   }
 
   @override
   ColorGradingBuilder saturation(double saturation) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_saturation(_builder, saturation);
     return this;
   }
 
   @override
   ColorGradingBuilder channelMixer(Vector3 outRed, Vector3 outGreen, Vector3 outBlue) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_channelMixer(
       _builder,
       outRed.x,
@@ -127,7 +140,7 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
 
   @override
   ColorGradingBuilder shadowsMidtonesHighlights(Vector4 shadows, Vector4 midtones, Vector4 highlights, Vector4 ranges) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_shadowsMidtonesHighlights(
       _builder,
       shadows.x,
@@ -152,7 +165,7 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
 
   @override
   ColorGradingBuilder slopeOffsetPower(Vector3 slope, Vector3 offset, Vector3 power) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_slopeOffsetPower(
       _builder,
       slope.x,
@@ -170,7 +183,7 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
 
   @override
   ColorGradingBuilder curves(Vector3 shadowGamma, Vector3 midPoint, Vector3 highlightScale) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_curves(
       _builder,
       shadowGamma.x,
@@ -188,29 +201,39 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
 
   @override
   ColorGradingBuilder luminanceScaling(bool enabled) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_luminanceScaling(_builder, enabled);
     return this;
   }
 
   @override
   ColorGradingBuilder gamutMapping(bool enabled) {
-    _checkNotBuilt();
+    _checkNotDisposed();
     ColorGradingBuilder_gamutMapping(_builder, enabled);
     return this;
   }
 
   @override
   Future<ColorGrading> build() async {
-    _checkNotBuilt();
-    _built = true;
+    _checkNotDisposed();
+    // Matches Filament: build() does not consume the builder - it may be
+    // called repeatedly, and settings may be changed between builds. Each
+    // call creates an independent ColorGrading.
     final ptr = await withPointerCallback<TColorGrading>(
       (cb) => ColorGradingBuilder_buildRenderThread(_builder, _app.engine, cb),
     );
-    await withVoidCallback((requestId, cb) => ColorGradingBuilder_destroyRenderThread(_builder, requestId, cb));
     if (ptr == nullptr) {
       throw Exception('Failed to build ColorGrading');
     }
     return FFIColorGrading(ptr, _app);
+  }
+
+  @override
+  Future dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    await withVoidCallback((requestId, cb) => ColorGradingBuilder_destroyRenderThread(_builder, requestId, cb));
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
@@ -11,6 +11,34 @@ class FFIColorGrading extends ColorGrading {
 
   FFIColorGrading(this.pointer, this._app);
 
+  // Shared-ownership bookkeeping (Filament allows one ColorGrading to be
+  // attached to multiple views). The native grading is destroyed when the
+  // last attached view detaches; a dispose() that happens while views are
+  // still attached is deferred until then.
+  static final Map<Pointer<TColorGrading>, int> _viewCounts = {};
+  static final Set<Pointer<TColorGrading>> _disposeDeferred = {};
+
+  /// Internal. Records that a view attached [pointer]; the first attach
+  /// registers it for shared ownership.
+  static void viewAttached(Pointer<TColorGrading> pointer) {
+    _viewCounts[pointer] = (_viewCounts[pointer] ?? 0) + 1;
+  }
+
+  /// Internal. Records that a view detached from [pointer]. Returns true
+  /// when that was the last attached view and the caller must destroy the
+  /// native grading (Filament requires the dissociating set/clear/destroy
+  /// to have happened first).
+  static bool viewDetached(Pointer<TColorGrading> pointer) {
+    final count = (_viewCounts[pointer] ?? 0) - 1;
+    if (count > 0) {
+      _viewCounts[pointer] = count;
+      return false;
+    }
+    _viewCounts.remove(pointer);
+    _disposeDeferred.remove(pointer);
+    return true;
+  }
+
   @override
   Pointer<TColorGrading> getNativeHandle() => pointer;
 
@@ -20,6 +48,15 @@ class FFIColorGrading extends ColorGrading {
       return;
     }
     _disposed = true;
+    if ((_viewCounts[pointer] ?? 0) > 0) {
+      // Still attached to at least one view: destroying now would leave
+      // those views with a dangling pointer. Defer - the last view to
+      // detach destroys it.
+      _disposeDeferred.add(pointer);
+      return;
+    }
+    _viewCounts.remove(pointer);
+    _disposeDeferred.remove(pointer);
     await withVoidCallback(
       (requestId, cb) => Engine_destroyColorGradingRenderThread(_app.engine, pointer, requestId, cb),
     );

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
@@ -11,34 +11,6 @@ class FFIColorGrading extends ColorGrading {
 
   FFIColorGrading(this.pointer, this._app);
 
-  // Shared-ownership bookkeeping (Filament allows one ColorGrading to be
-  // attached to multiple views). The native grading is destroyed when the
-  // last attached view detaches; a dispose() that happens while views are
-  // still attached is deferred until then.
-  static final Map<Pointer<TColorGrading>, int> _viewCounts = {};
-  static final Set<Pointer<TColorGrading>> _disposeDeferred = {};
-
-  /// Internal. Records that a view attached [pointer]; the first attach
-  /// registers it for shared ownership.
-  static void viewAttached(Pointer<TColorGrading> pointer) {
-    _viewCounts[pointer] = (_viewCounts[pointer] ?? 0) + 1;
-  }
-
-  /// Internal. Records that a view detached from [pointer]. Returns true
-  /// when that was the last attached view and the caller must destroy the
-  /// native grading (Filament requires the dissociating set/clear/destroy
-  /// to have happened first).
-  static bool viewDetached(Pointer<TColorGrading> pointer) {
-    final count = (_viewCounts[pointer] ?? 0) - 1;
-    if (count > 0) {
-      _viewCounts[pointer] = count;
-      return false;
-    }
-    _viewCounts.remove(pointer);
-    _disposeDeferred.remove(pointer);
-    return true;
-  }
-
   @override
   Pointer<TColorGrading> getNativeHandle() => pointer;
 
@@ -48,15 +20,6 @@ class FFIColorGrading extends ColorGrading {
       return;
     }
     _disposed = true;
-    if ((_viewCounts[pointer] ?? 0) > 0) {
-      // Still attached to at least one view: destroying now would leave
-      // those views with a dangling pointer. Defer - the last view to
-      // detach destroys it.
-      _disposeDeferred.add(pointer);
-      return;
-    }
-    _viewCounts.remove(pointer);
-    _disposeDeferred.remove(pointer);
     await withVoidCallback(
       (requestId, cb) => Engine_destroyColorGradingRenderThread(_app.engine, pointer, requestId, cb),
     );

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_color_grading.dart
@@ -14,12 +14,7 @@ class FFIColorGrading extends ColorGrading {
   @override
   Pointer<TColorGrading> getNativeHandle() => pointer;
 
-  /// Destroys the underlying native ColorGrading.
-  ///
-  /// Only safe for a grading that is NOT currently attached to a view - a view
-  /// owns whatever grading was last passed to setColorGrading and destroys it
-  /// itself when it is replaced, cleared, or when the view is destroyed.
-  /// Idempotent: a second dispose is a no-op.
+  @override
   Future dispose() async {
     if (_disposed) {
       return;
@@ -39,9 +34,6 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
 
   FFIColorGradingBuilder(this._builder, this._app);
 
-  /// Matches Filament: the builder is reusable - build() may be called any
-  /// number of times, and settings may be changed between builds. Only
-  /// disposal ends its life.
   void _checkNotDisposed() {
     if (_disposed) {
       throw StateError('Builder has been disposed');
@@ -216,9 +208,6 @@ class FFIColorGradingBuilder extends ColorGradingBuilder {
   @override
   Future<ColorGrading> build() async {
     _checkNotDisposed();
-    // Matches Filament: build() does not consume the builder - it may be
-    // called repeatedly, and settings may be changed between builds. Each
-    // call creates an independent ColorGrading.
     final ptr = await withPointerCallback<TColorGrading>(
       (cb) => ColorGradingBuilder_buildRenderThread(_builder, _app.engine, cb),
     );

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -1266,12 +1266,6 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     await withVoidCallback((requestId, cb) => Engine_destroySceneRenderThread(engine, scene.scene, requestId, cb));
   }
 
-  Future<Pointer<TColorGrading>> createColorGrading(ToneMapper mapper) async {
-    return withPointerCallback<TColorGrading>(
-      (cb) => ColorGrading_createRenderThread(engine, mapper.getNativeHandle(), cb),
-    );
-  }
-
   //
   Future<GizmoAsset> createGizmo(View view, GizmoType gizmoType) async {
     return FFIGizmo.create(this, view, gizmoType);

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
@@ -10,22 +10,16 @@ class FFIToneMapper extends ToneMapper {
   @override
   Pointer<TToneMapper> getNativeHandle() => _pointer;
 
-  /// Create a LinearToneMapper - returns input color clamped to 0..1 range
-  /// Useful for debugging
   static Future<ToneMapper> linear(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>((cb) => ToneMapper_createLinearRenderThread(app.engine, cb));
     return FFIToneMapper._(pointer);
   }
 
-  /// Create an ACESToneMapper - ACES Reference Rendering Transform (RRT)
-  /// combined with the Output Device Transform (ODT) for sRGB monitors
   static Future<ToneMapper> aces(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>((cb) => ToneMapper_createACESRenderThread(app.engine, cb));
     return FFIToneMapper._(pointer);
   }
 
-  /// Create an ACESLegacyToneMapper - ACES tone mapper modified to match
-  /// the perceived brightness of FilmicToneMapper (applies ~1.6x brightness)
   static Future<ToneMapper> acesLegacy(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createACESLegacyRenderThread(app.engine, cb),
@@ -33,15 +27,11 @@ class FFIToneMapper extends ToneMapper {
     return FFIToneMapper._(pointer);
   }
 
-  /// Create a FilmicToneMapper - designed to approximate ACES RRT + ODT
-  /// for Rec.709. Exists for backward compatibility.
   static Future<ToneMapper> filmic(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>((cb) => ToneMapper_createFilmicRenderThread(app.engine, cb));
     return FFIToneMapper._(pointer);
   }
 
-  /// Create a PBRNeutralToneMapper - Khronos PBR Neutral tone mapper
-  /// designed to preserve material appearance across lighting conditions
   static Future<ToneMapper> pbrNeutral(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createPBRNeutralRenderThread(app.engine, cb),
@@ -49,12 +39,6 @@ class FFIToneMapper extends ToneMapper {
     return FFIToneMapper._(pointer);
   }
 
-  /// Create an AgxToneMapper with optional look
-  ///
-  /// [look] - Optional creative adjustment to contrast and saturation:
-  ///   - AgxLook.none: Base contrast with no look applied
-  ///   - AgxLook.punchy: More chroma laden look for sRGB displays
-  ///   - AgxLook.golden: Golden tinted look for BT.1886 displays
   static Future<ToneMapper> agx(FilamentApp app, {AgxLook look = AgxLook.none}) async {
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createAGXWithLookRenderThread(app.engine, look.index, cb),
@@ -62,16 +46,6 @@ class FFIToneMapper extends ToneMapper {
     return FFIToneMapper._(pointer);
   }
 
-  /// Create a GenericToneMapper with configurable parameters
-  ///
-  /// Provides control over the tone mapping curve aesthetics and dynamic range.
-  /// Default parameters approximate an ACES tone mapping curve.
-  ///
-  /// [contrast] - Controls the contrast of the curve (must be > 0.0)
-  ///              Recommended range: 0.5..2.0 (default: 1.55)
-  /// [midGrayIn] - Input middle gray value (0.0..1.0, default: 0.18)
-  /// [midGrayOut] - Output middle gray value (0.0..1.0, default: 0.215)
-  /// [hdrMax] - Maximum input value mapped to output white (>= 1.0, default: 10.0)
   static Future<ToneMapper> generic(
     FilamentApp app, {
     double contrast = 1.55,
@@ -85,8 +59,6 @@ class FFIToneMapper extends ToneMapper {
     return FFIToneMapper._(pointer);
   }
 
-  /// Create a DisplayRangeToneMapper - converts HDR RGB to 16 debug colors
-  /// representing pixel exposure levels. Useful for validating scene lighting.
   static Future<ToneMapper> displayRange(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>(
       (cb) => ToneMapper_createDisplayRangeRenderThread(app.engine, cb),

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
@@ -3,6 +3,7 @@ import 'package:thermion_dart/thermion_dart.dart';
 /// FFI implementation of ToneMapper
 class FFIToneMapper extends ToneMapper {
   final Pointer<TToneMapper> _pointer;
+  bool _disposed = false;
 
   FFIToneMapper._(this._pointer);
 
@@ -95,6 +96,10 @@ class FFIToneMapper extends ToneMapper {
 
   @override
   Future dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     await withVoidCallback((requestId, cb) {
       ToneMapper_destroyRenderThread(_pointer, requestId, cb);
     });

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -38,12 +38,9 @@ class FFIView extends View<Pointer<TView>> {
   Future destroy() async {
     _onPickResultHolder.dispose();
 
-    await withVoidCallback((requestId, cb) => View_setColorGradingRenderThread(view, nullptr, requestId, cb));
-    if (_colorGrading != null && _colorGrading != nullptr) {
-      await withVoidCallback(
-        (requestId, cb) => Engine_destroyColorGradingRenderThread(_app.engine, _colorGrading!, requestId, cb),
-      );
-    }
+    // Dissociates and destroys the grading owned by this view, if any
+    // (Filament requires dissociation before view destruction)
+    await _setColorGradingOwned(null);
     await withVoidCallback((requestId, cb) => Engine_destroyViewRenderThread(_app.engine, view, requestId, cb));
   }
 
@@ -130,20 +127,22 @@ class FFIView extends View<Pointer<TView>> {
     });
   }
 
+  /// The ColorGrading currently owned by this view.
+  ///
+  /// Filament's View does not take ownership of a ColorGrading and performs
+  /// no reference counting; a grading must be dissociated from all views
+  /// before it is destroyed. This view therefore owns whichever grading is
+  /// currently set: [setColorGrading] destroys the previously-owned grading,
+  /// as does [destroy].
   Pointer<TColorGrading>? _colorGrading;
 
-  @override
-  Future setToneMapper(ToneMapper mapper) async {
-    final colorGrading = await withPointerCallback<TColorGrading>(
-      (cb) => ColorGrading_createRenderThread(_app.engine, mapper.getNativeHandle(), cb),
+  /// Dissociates the currently-owned ColorGrading from this view, destroys
+  /// it, then sets (and takes ownership of) [colorGrading].
+  Future _setColorGradingOwned(Pointer<TColorGrading>? colorGrading) async {
+    await withVoidCallback(
+      (requestId, cb) => View_setColorGradingRenderThread(view, colorGrading ?? nullptr, requestId, cb),
     );
-    if (colorGrading == nullptr) {
-      throw Exception("Failed to create color grading");
-    }
-
-    await withVoidCallback((requestId, cb) => View_setColorGradingRenderThread(view, colorGrading, requestId, cb));
-
-    if (_colorGrading != null) {
+    if (_colorGrading != null && _colorGrading != nullptr) {
       await withVoidCallback(
         (requestId, cb) => Engine_destroyColorGradingRenderThread(_app.engine, _colorGrading!, requestId, cb),
       );
@@ -164,15 +163,8 @@ class FFIView extends View<Pointer<TView>> {
 
   @override
   Future setColorGrading(ColorGrading? colorGrading) async {
-    if (colorGrading == null) {
-      // Clear color grading by setting nullptr
-      await withVoidCallback((requestId, cb) => View_setColorGradingRenderThread(view, nullptr, requestId, cb));
-    } else {
-      // Set color grading with provided object
-      await withVoidCallback(
-        (requestId, cb) => View_setColorGradingRenderThread(view, colorGrading.getNativeHandle(), requestId, cb),
-      );
-    }
+    // The view takes ownership: the previously-owned grading is destroyed here
+    await _setColorGradingOwned(colorGrading?.getNativeHandle());
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -37,10 +37,6 @@ class FFIView extends View<Pointer<TView>> {
 
   Future destroy() async {
     _onPickResultHolder.dispose();
-
-    // Dissociates and releases this view's grading reference (destroying the
-    // native grading if this was the last attached view)
-    await _setColorGradingShared(null);
     await withVoidCallback((requestId, cb) => Engine_destroyViewRenderThread(_app.engine, view, requestId, cb));
   }
 
@@ -127,38 +123,6 @@ class FFIView extends View<Pointer<TView>> {
     });
   }
 
-  /// The ColorGrading currently owned by this view.
-  ///
-  /// Filament's View does not take ownership of a ColorGrading and performs
-  /// no reference counting; a grading must be dissociated from all views
-  /// before it is destroyed. This view therefore owns whichever grading is
-  /// currently set: [setColorGrading] destroys the previously-owned grading,
-  /// as does [destroy].
-  Pointer<TColorGrading>? _colorGrading;
-
-  /// Dissociates the currently-attached ColorGrading from this view (setting
-  /// [colorGrading], or clearing when null), then releases this view's
-  /// reference: the native grading is destroyed only when the LAST attached
-  /// view detaches, so a grading shared between views stays alive while any
-  /// of them still use it (Filament permits one grading on many views, but
-  /// requires dissociation before destruction - the set/clear above is that
-  /// dissociation).
-  Future _setColorGradingShared(Pointer<TColorGrading>? colorGrading) async {
-    await withVoidCallback(
-      (requestId, cb) => View_setColorGradingRenderThread(view, colorGrading ?? nullptr, requestId, cb),
-    );
-    final previous = _colorGrading;
-    if (previous != null && previous != nullptr && FFIColorGrading.viewDetached(previous)) {
-      await withVoidCallback(
-        (requestId, cb) => Engine_destroyColorGradingRenderThread(_app.engine, previous, requestId, cb),
-      );
-    }
-    if (colorGrading != null && colorGrading != nullptr) {
-      FFIColorGrading.viewAttached(colorGrading);
-    }
-    _colorGrading = colorGrading;
-  }
-
   @override
   Future<ColorGradingBuilder> createColorGradingBuilder() async {
     final builderPtr = await withPointerCallback<TColorGradingBuilder>(
@@ -172,9 +136,13 @@ class FFIView extends View<Pointer<TView>> {
 
   @override
   Future setColorGrading(ColorGrading? colorGrading) async {
-    // Attaches the grading (shared with any other views it is attached to)
-    // and releases this view's reference to the previously-attached grading
-    await _setColorGradingShared(colorGrading?.getNativeHandle());
+    // Non-owning, like Filament's View::setColorGrading: the caller remains
+    // responsible for destroying the grading (after dissociating it from all
+    // views) - see [View.setColorGrading].
+    await withVoidCallback(
+      (requestId, cb) =>
+          View_setColorGradingRenderThread(view, colorGrading?.getNativeHandle() ?? nullptr, requestId, cb),
+    );
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -38,9 +38,9 @@ class FFIView extends View<Pointer<TView>> {
   Future destroy() async {
     _onPickResultHolder.dispose();
 
-    // Dissociates and destroys the grading owned by this view, if any
-    // (Filament requires dissociation before view destruction)
-    await _setColorGradingOwned(null);
+    // Dissociates and releases this view's grading reference (destroying the
+    // native grading if this was the last attached view)
+    await _setColorGradingShared(null);
     await withVoidCallback((requestId, cb) => Engine_destroyViewRenderThread(_app.engine, view, requestId, cb));
   }
 
@@ -136,16 +136,25 @@ class FFIView extends View<Pointer<TView>> {
   /// as does [destroy].
   Pointer<TColorGrading>? _colorGrading;
 
-  /// Dissociates the currently-owned ColorGrading from this view, destroys
-  /// it, then sets (and takes ownership of) [colorGrading].
-  Future _setColorGradingOwned(Pointer<TColorGrading>? colorGrading) async {
+  /// Dissociates the currently-attached ColorGrading from this view (setting
+  /// [colorGrading], or clearing when null), then releases this view's
+  /// reference: the native grading is destroyed only when the LAST attached
+  /// view detaches, so a grading shared between views stays alive while any
+  /// of them still use it (Filament permits one grading on many views, but
+  /// requires dissociation before destruction - the set/clear above is that
+  /// dissociation).
+  Future _setColorGradingShared(Pointer<TColorGrading>? colorGrading) async {
     await withVoidCallback(
       (requestId, cb) => View_setColorGradingRenderThread(view, colorGrading ?? nullptr, requestId, cb),
     );
-    if (_colorGrading != null && _colorGrading != nullptr) {
+    final previous = _colorGrading;
+    if (previous != null && previous != nullptr && FFIColorGrading.viewDetached(previous)) {
       await withVoidCallback(
-        (requestId, cb) => Engine_destroyColorGradingRenderThread(_app.engine, _colorGrading!, requestId, cb),
+        (requestId, cb) => Engine_destroyColorGradingRenderThread(_app.engine, previous, requestId, cb),
       );
+    }
+    if (colorGrading != null && colorGrading != nullptr) {
+      FFIColorGrading.viewAttached(colorGrading);
     }
     _colorGrading = colorGrading;
   }
@@ -163,8 +172,9 @@ class FFIView extends View<Pointer<TView>> {
 
   @override
   Future setColorGrading(ColorGrading? colorGrading) async {
-    // The view takes ownership: the previously-owned grading is destroyed here
-    await _setColorGradingOwned(colorGrading?.getNativeHandle());
+    // Attaches the grading (shared with any other views it is attached to)
+    // and releases this view's reference to the previously-attached grading
+    await _setColorGradingShared(colorGrading?.getNativeHandle());
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/interface/filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/interface/filament_app.dart
@@ -354,9 +354,6 @@ abstract class FilamentApp<T> {
   });
 
   //
-  Future<T> createColorGrading(ToneMapper mapper);
-
-  //
   Future<GizmoAsset> createGizmo(View view, GizmoType type);
 
   //

--- a/thermion_dart/lib/src/filament/src/interface/tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/interface/tone_mapper.dart
@@ -103,6 +103,12 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
     return FFIToneMapper.displayRange(app);
   }
 
-  /// Destroy the tone mapper and free its resources
+  /// Destroys the tone mapper and frees its native resources. Idempotent.
+  ///
+  /// A ColorGradingBuilder that references this mapper re-reads it on every
+  /// build, so only dispose the mapper after disposing the builder (or after
+  /// its final build, if you are certain no more builds will run). Every
+  /// built ColorGrading holds a copy of this mapper's state, so disposing
+  /// never affects an applied grading.
   Future dispose();
 }

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -426,6 +426,12 @@ abstract class View<T> extends NativeHandle<T> {
   /// is replaced, cleared, or when the view is destroyed. Do not call
   /// dispose() on a ColorGrading that is currently attached to a view.
   ///
+  /// A ColorGrading may only be attached to ONE view at a time: each view
+  /// destroys what it owns, so sharing an instance across views leads to a
+  /// dangling pointer. To apply the same look to several views, build one
+  /// grading per view - the builder is reusable, so a single builder can
+  /// produce them all before being disposed.
+  ///
   /// Pass null to clear any existing color grading from this view (the
   /// previously-set grading, if any, is destroyed).
   Future setColorGrading(ColorGrading? colorGrading);

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -138,28 +138,47 @@ enum QualityLevel { LOW, MEDIUM, HIGH, ULTRA }
 
 enum LutFormat { INTEGER, FLOAT }
 
-// ColorGrading object that holds color grading configuration.
-// ColorGrading is treated as const
-// Created via View.createColorGradingBuilder().build() and applied to a view.
-// Will be disposed when View.setColorGrading is called.
-abstract class ColorGrading extends NativeHandle<dynamic> {}
+/// Immutable color grading configuration.
+///
+/// Created via `View.createColorGradingBuilder().build()` and applied to a
+/// view with `View.setColorGrading()`. Ownership transfers to the view when
+/// set: the view destroys the ColorGrading when it is replaced, cleared
+/// (null), or when the view itself is destroyed. Do not dispose an attached
+/// ColorGrading - [dispose] is only for gradings that were never attached.
+abstract class ColorGrading extends NativeHandle<dynamic> {
+  /// Destroys the underlying native ColorGrading. Idempotent.
+  ///
+  /// Only call this for a grading that was never attached to a view - a view
+  /// owns whatever grading was last passed to setColorGrading and destroys it
+  /// itself when it is replaced, cleared, or when the view is destroyed.
+  Future dispose();
+}
 
 ///
 /// Builder for creating ColorGrading objects with the full Filament color pipeline.
 ///
 /// Usage:
 /// ```dart
-/// final colorGrading = await view.createColorGradingBuilder()
-///   .toneMapper(ToneMapper.ACES)
+/// final builder = await view.createColorGradingBuilder();
+/// final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
+/// final colorGrading = await builder
+///   .toneMapper(toneMapper)
 ///   .exposure(1.0)
 ///   .contrast(1.1)
 ///   .saturation(1.05)
 ///   .build();
-/// await view.setColorGrading(colorGrading);
+/// await builder.dispose();
+/// // safe once the builder is disposed (no further builds will read it):
+/// await toneMapper.dispose();
+/// await view.setColorGrading(colorGrading); // view takes ownership
 /// ```
 ///
 /// All methods return this builder for method chaining.
-/// The builder is consumed after build() and cannot be reused.
+///
+/// Like Filament's ColorGrading::Builder, this builder is REUSABLE: [build]
+/// may be called any number of times (settings may also be changed between
+/// builds), and each call creates an independent ColorGrading. Free the
+/// builder itself with [dispose] when you are done building.
 ///
 abstract class ColorGradingBuilder {
   // ============================================================================
@@ -186,8 +205,13 @@ abstract class ColorGradingBuilder {
 
   /// Sets the tone mapping operator.
   ///
-  /// Default is ACESLegacy. The tone mapper must have a lifecycle that
-  /// exceeds this method call.
+  /// Default is ACESLegacy. The builder stores a reference to [mapper] and
+  /// copies its state each time [build] executes on the render thread, so the
+  /// mapper must NOT be disposed while this builder is still usable - dispose
+  /// it only after [dispose]ding the builder (or after your final build if
+  /// you are certain no more builds will run). Each built ColorGrading holds
+  /// a copy, never a reference, so an applied grading is never affected by
+  /// disposing the mapper.
   ColorGradingBuilder toneMapper(ToneMapper mapper);
 
   // ============================================================================
@@ -305,9 +329,23 @@ abstract class ColorGradingBuilder {
 
   /// Builds the ColorGrading object.
   ///
-  /// The builder is consumed after this call and cannot be reused.
-  /// The returned ColorGrading must be disposed when no longer needed.
+  /// Like Filament's ColorGrading::Builder, this does NOT consume the
+  /// builder: it may be called any number of times, and each call creates an
+  /// independent ColorGrading owned by the caller (or by the view once
+  /// attached - see [ColorGrading]). Each build reads the builder's current
+  /// settings and the current state of its tone mapper.
+  ///
+  /// Throws if the build fails on the render thread or the builder has been
+  /// disposed.
   Future<ColorGrading> build();
+
+  /// Destroys the native builder.
+  ///
+  /// Required once you are done building - a builder that is never disposed
+  /// leaks its native resources. Idempotent; using a disposed builder
+  /// (building or setting values) throws. Dispose the builder before
+  /// disposing any tone mapper it references (each build reads the mapper).
+  Future dispose();
 }
 
 abstract class View<T> extends NativeHandle<T> {
@@ -366,11 +404,16 @@ abstract class View<T> extends NativeHandle<T> {
   ///
   /// Example:
   /// ```dart
-  /// final colorGrading = await view.createColorGradingBuilder()
-  ///   .toneMapper(ToneMapper.ACES)
+  /// final builder = await view.createColorGradingBuilder();
+  /// final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
+  /// final colorGrading = await builder
+  ///   .toneMapper(toneMapper)
   ///   .exposure(1.0)
   ///   .contrast(1.1)
   ///   .build();
+  /// await builder.dispose();
+  /// await toneMapper.dispose(); // safe: builder disposed, grading holds a copy
+  /// // the view takes ownership from here
   /// await view.setColorGrading(colorGrading);
   /// ```
   Future<ColorGradingBuilder> createColorGradingBuilder();
@@ -378,24 +421,21 @@ abstract class View<T> extends NativeHandle<T> {
   /// Sets the color grading for this view.
   ///
   /// The ColorGrading object must be created via createColorGradingBuilder().
-  /// The view does not take ownership - you must dispose the ColorGrading
-  /// when no longer needed.
+  /// The view takes ownership of the ColorGrading: any grading previously set
+  /// on this view is destroyed, and the new one is destroyed in turn when it
+  /// is replaced, cleared, or when the view is destroyed. Do not call
+  /// dispose() on a ColorGrading that is currently attached to a view.
   ///
-  /// Pass null to clear any existing color grading from this view.
+  /// Pass null to clear any existing color grading from this view (the
+  /// previously-set grading, if any, is destroyed).
   Future setColorGrading(ColorGrading? colorGrading);
 
   /// Gets the current color grading from this view.
   ///
-  /// Returns null if no color grading is currently set.
+  /// Returns null if no color grading is currently set. The returned object is
+  /// a non-owning wrapper around the grading owned by this view - do not
+  /// dispose it.
   Future<ColorGrading?> getColorGrading();
-
-  /// Sets the tone mapper for this view (deprecated).
-  ///
-  /// @deprecated Use createColorGradingBuilder().toneMapper(...).build()
-  /// followed by setColorGrading() instead. This provides access to the
-  /// full color grading pipeline.
-  @Deprecated('Use createColorGradingBuilder() instead')
-  Future setToneMapper(ToneMapper mapper);
 
   Future setTransparentPickingEnabled(bool enabled);
   Future<bool> isTransparentPickingEnabled();

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -140,17 +140,18 @@ enum LutFormat { INTEGER, FLOAT }
 
 /// Immutable color grading configuration.
 ///
-/// Created via `View.createColorGradingBuilder().build()` and applied to a
-/// view with `View.setColorGrading()`. Ownership transfers to the view when
-/// set: the view destroys the ColorGrading when it is replaced, cleared
-/// (null), or when the view itself is destroyed. Do not dispose an attached
-/// ColorGrading - [dispose] is only for gradings that were never attached.
+/// Created via `View.createColorGradingBuilder().build()` and applied to one
+/// or more views with `View.setColorGrading()`. Like Filament, a single
+/// ColorGrading may be attached to multiple views simultaneously; it is
+/// destroyed once no view references it any more (the last view to replace,
+/// clear, or destroy it) - or earlier via [dispose] when unattached.
 abstract class ColorGrading extends NativeHandle<dynamic> {
   /// Destroys the underlying native ColorGrading. Idempotent.
   ///
-  /// Only call this for a grading that was never attached to a view - a view
-  /// owns whatever grading was last passed to setColorGrading and destroys it
-  /// itself when it is replaced, cleared, or when the view is destroyed.
+  /// If the grading is currently attached to one or more views, destruction
+  /// is deferred until the last view detaches (destroying it now would leave
+  /// those views with a dangling pointer). If it is not attached to any view,
+  /// it is destroyed immediately.
   Future dispose();
 }
 
@@ -421,26 +422,19 @@ abstract class View<T> extends NativeHandle<T> {
   /// Sets the color grading for this view.
   ///
   /// The ColorGrading object must be created via createColorGradingBuilder().
-  /// The view takes ownership of the ColorGrading: any grading previously set
-  /// on this view is destroyed, and the new one is destroyed in turn when it
-  /// is replaced, cleared, or when the view is destroyed. Do not call
-  /// dispose() on a ColorGrading that is currently attached to a view.
+  /// A grading may be attached to several views at once (as in Filament) and
+  /// is destroyed once the last attached view replaces, clears, or destroys
+  /// it - this view releasing a grading it previously had set never affects
+  /// other views still using it.
   ///
-  /// A ColorGrading may only be attached to ONE view at a time: each view
-  /// destroys what it owns, so sharing an instance across views leads to a
-  /// dangling pointer. To apply the same look to several views, build one
-  /// grading per view - the builder is reusable, so a single builder can
-  /// produce them all before being disposed.
-  ///
-  /// Pass null to clear any existing color grading from this view (the
-  /// previously-set grading, if any, is destroyed).
+  /// Pass null to clear any existing color grading from this view.
   Future setColorGrading(ColorGrading? colorGrading);
 
   /// Gets the current color grading from this view.
   ///
   /// Returns null if no color grading is currently set. The returned object is
-  /// a non-owning wrapper around the grading owned by this view - do not
-  /// dispose it.
+  /// a non-owning wrapper - the grading's lifetime is managed by its attached
+  /// views (see [setColorGrading]).
   Future<ColorGrading?> getColorGrading();
 
   Future setTransparentPickingEnabled(bool enabled);

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -141,17 +141,22 @@ enum LutFormat { INTEGER, FLOAT }
 /// Immutable color grading configuration.
 ///
 /// Created via `View.createColorGradingBuilder().build()` and applied to one
-/// or more views with `View.setColorGrading()`. Like Filament, a single
-/// ColorGrading may be attached to multiple views simultaneously; it is
-/// destroyed once no view references it any more (the last view to replace,
-/// clear, or destroy it) - or earlier via [dispose] when unattached.
+/// or more views with `View.setColorGrading()`.
+///
+/// Like Filament, ownership is entirely the CALLER's responsibility:
+/// `View.setColorGrading` performs no ownership transfer and no reference
+/// counting - the view merely holds a non-owning reference. A single
+/// ColorGrading may be attached to multiple views simultaneously, but you
+/// must dissociate it from every view (via `setColorGrading` with a
+/// replacement or null) BEFORE calling [dispose]. Disposing a grading that
+/// is still attached to a view leaves that view with a dangling pointer
+/// (undefined behaviour on the next render).
 abstract class ColorGrading extends NativeHandle<dynamic> {
   /// Destroys the underlying native ColorGrading. Idempotent.
   ///
-  /// If the grading is currently attached to one or more views, destruction
-  /// is deferred until the last view detaches (destroying it now would leave
-  /// those views with a dangling pointer). If it is not attached to any view,
-  /// it is destroyed immediately.
+  /// The caller is responsible for the grading's lifetime: dissociate it
+  /// from every view first (see [ColorGrading]) - destroying a grading that
+  /// is still attached to a view is undefined behaviour.
   Future dispose();
 }
 
@@ -171,7 +176,10 @@ abstract class ColorGrading extends NativeHandle<dynamic> {
 /// await builder.dispose();
 /// // safe once the builder is disposed (no further builds will read it):
 /// await toneMapper.dispose();
-/// await view.setColorGrading(colorGrading); // view takes ownership
+/// await view.setColorGrading(colorGrading);
+/// // ...later, once no view uses it:
+/// await view.setColorGrading(null);
+/// await colorGrading.dispose();
 /// ```
 ///
 /// All methods return this builder for method chaining.
@@ -332,8 +340,8 @@ abstract class ColorGradingBuilder {
   ///
   /// Like Filament's ColorGrading::Builder, this does NOT consume the
   /// builder: it may be called any number of times, and each call creates an
-  /// independent ColorGrading owned by the caller (or by the view once
-  /// attached - see [ColorGrading]). Each build reads the builder's current
+  /// independent ColorGrading owned by the caller (see [ColorGrading] for
+  /// the caller-managed lifetime). Each build reads the builder's current
   /// settings and the current state of its tone mapper.
   ///
   /// Throws if the build fails on the render thread or the builder has been
@@ -414,27 +422,35 @@ abstract class View<T> extends NativeHandle<T> {
   ///   .build();
   /// await builder.dispose();
   /// await toneMapper.dispose(); // safe: builder disposed, grading holds a copy
-  /// // the view takes ownership from here
   /// await view.setColorGrading(colorGrading);
+  /// // ...later, once no view uses it:
+  /// await view.setColorGrading(null);
+  /// await colorGrading.dispose();
   /// ```
   Future<ColorGradingBuilder> createColorGradingBuilder();
 
   /// Sets the color grading for this view.
   ///
   /// The ColorGrading object must be created via createColorGradingBuilder().
-  /// A grading may be attached to several views at once (as in Filament) and
-  /// is destroyed once the last attached view replaces, clears, or destroys
-  /// it - this view releasing a grading it previously had set never affects
-  /// other views still using it.
+  /// Like Filament's `View::setColorGrading`, this performs NO ownership
+  /// transfer and NO reference counting - the view holds a non-owning
+  /// reference and the caller remains responsible for the grading's lifetime
+  /// (see [ColorGrading]). A grading may be attached to several views at
+  /// once, but it must be dissociated from every view before being disposed.
   ///
-  /// Pass null to clear any existing color grading from this view.
+  /// Pass null to clear any existing color grading from this view (this does
+  /// NOT destroy the grading - dispose it yourself once no view uses it).
   Future setColorGrading(ColorGrading? colorGrading);
 
   /// Gets the current color grading from this view.
   ///
-  /// Returns null if no color grading is currently set. The returned object is
-  /// a non-owning wrapper - the grading's lifetime is managed by its attached
-  /// views (see [setColorGrading]).
+  /// Returns null if no color grading is currently set. The returned object
+  /// is a non-owning wrapper; the grading's lifetime is the caller's
+  /// responsibility (see [setColorGrading]). Do not dispose the returned
+  /// wrapper - dispose the ColorGrading instance you created instead (both
+  /// wrap the same native object; disposing both would destroy it twice).
+  /// Note that a view with no grading set still reports Filament's internal
+  /// default grading here - never dispose that either.
   Future<ColorGrading?> getColorGrading();
 
   Future setTransparentPickingEnabled(bool enabled);

--- a/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
+++ b/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
@@ -587,12 +587,6 @@ class ThermionViewerFFI extends ThermionViewer {
 
   //
   @override
-  Future setToneMapper(ToneMapper mapper) async {
-    await view.setToneMapper(mapper);
-  }
-
-  //
-  @override
   Future setPostProcessing(bool enabled) async {
     await view.setPostProcessing(enabled);
   }

--- a/thermion_dart/lib/src/viewer/src/thermion_viewer_base.dart
+++ b/thermion_dart/lib/src/viewer/src/thermion_viewer_base.dart
@@ -199,9 +199,6 @@ abstract class ThermionViewer {
   // this method is complete.
   Future destroyAssets();
 
-  // Sets the tone mapping (requires postprocessing).
-  Future setToneMapper(ToneMapper mapper);
-
   // Enable/disable bloom.
   Future setBloom(bool enabled, double strength);
 

--- a/thermion_dart/native/include/c_api/TView.h
+++ b/thermion_dart/native/include/c_api/TView.h
@@ -74,9 +74,6 @@ EMSCRIPTEN_KEEPALIVE TToneMapper *ToneMapper_createGeneric(TEngine* tEngine, flo
 EMSCRIPTEN_KEEPALIVE TToneMapper *ToneMapper_createDisplayRange(TEngine* tEngine);
 EMSCRIPTEN_KEEPALIVE void ToneMapper_destroy(TToneMapper *toneMapper);
 
-// Legacy ColorGrading API (deprecated - use ColorGradingBuilder instead)
-EMSCRIPTEN_KEEPALIVE TColorGrading *ColorGrading_create(TEngine* tEngine, TToneMapper *toneMapper);
-
 // ColorGrading Builder API
 typedef struct TColorGradingBuilder TColorGradingBuilder;
 

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -114,8 +114,6 @@ namespace thermion
         EMSCRIPTEN_KEEPALIVE void Material_createWireframeMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *));
         EMSCRIPTEN_KEEPALIVE void Material_createTranslationAxisMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *));
 
-        EMSCRIPTEN_KEEPALIVE void ColorGrading_createRenderThread(TEngine *tEngine, TToneMapper *toneMapper, void (*callback)(TColorGrading *));
-
         EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_createRenderThread(void (*onComplete)(TColorGradingBuilder *));
         EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_buildRenderThread(TColorGradingBuilder *tBuilder, TEngine *tEngine, void (*onComplete)(TColorGrading *));
         EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_destroyRenderThread(TColorGradingBuilder *tBuilder, uint32_t requestId, VoidCallback onComplete);

--- a/thermion_dart/native/src/c_api/TView.cpp
+++ b/thermion_dart/native/src/c_api/TView.cpp
@@ -235,17 +235,6 @@ namespace thermion
             TRACE("Destroyed ToneMapper");
         }
 
-        EMSCRIPTEN_KEEPALIVE TColorGrading *ColorGrading_create(TEngine *tEngine, TToneMapper *toneMapper)
-        {
-            auto engine = reinterpret_cast<Engine *>(tEngine);
-            auto tm = reinterpret_cast<ToneMapper *>(toneMapper);
-
-            TRACE("Creating ColorGrading with ToneMapper");
-            auto colorGrading = ColorGrading::Builder().toneMapper(tm).build(*engine);
-
-            return reinterpret_cast<TColorGrading *>(colorGrading);
-        }
-
         // ============================================================================
         // ColorGrading Builder API
         // ============================================================================

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -1153,19 +1153,6 @@ extern "C"
     auto fut = rt->addTask(lambda);
   }
 
-  EMSCRIPTEN_KEEPALIVE void ColorGrading_createRenderThread(TEngine *tEngine, TToneMapper *toneMapper, void (*callback)(TColorGrading *))
-  {
-    auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
-        [=]
-        {
-          auto cg = ColorGrading_create(tEngine, toneMapper);
-
-          setOwner(cg, rt);          PROXY(callback(cg));
-        });
-    auto fut = rt->addTask(lambda);
-  }
-
   EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_createRenderThread(void (*onComplete)(TColorGradingBuilder *))
   {
     auto *rt = RT(nullptr);

--- a/thermion_dart/test/color_grading_tests.dart
+++ b/thermion_dart/test/color_grading_tests.dart
@@ -217,61 +217,59 @@ void main() async {
   });
 
   test('ColorGrading shared between views', () async {
-    await ViewerBuilder(testHelper)
-        .setPostProcessing(true)
-        .addCube(color: kWhite, createUbershader: true)
-        .execute((result) async {
-          final app = FilamentApp.instance!;
-          final view1 = result.viewer.view;
-          final view2 = await app.createView();
-          await view2.setViewport(512, 512);
-          try {
-            final builder = await view1.createColorGradingBuilder();
-            final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
-            final shared = await builder.toneMapper(toneMapper).saturation(2.0).build();
-            await builder.dispose();
-            await toneMapper.dispose();
+    await ViewerBuilder(testHelper).setPostProcessing(true).addCube(color: kWhite, createUbershader: true).execute((
+      result,
+    ) async {
+      final app = FilamentApp.instance!;
+      final view1 = result.viewer.view;
+      final view2 = await app.createView();
+      await view2.setViewport(512, 512);
+      try {
+        final builder = await view1.createColorGradingBuilder();
+        final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
+        final shared = await builder.toneMapper(toneMapper).saturation(2.0).build();
+        await builder.dispose();
+        await toneMapper.dispose();
 
-            // One grading, two views - Filament allows this and so do we
-            await view1.setColorGrading(shared);
-            await view2.setColorGrading(shared);
+        // One grading, two views - Filament allows this and so do we
+        await view1.setColorGrading(shared);
+        await view2.setColorGrading(shared);
 
-            // view1 detaching must NOT destroy the grading (view2 still
-            // references it) - if it did, the capture below would crash or
-            // render garbage
-            await view1.setColorGrading(null);
-            await testHelper.capture(view2, "color_grading_shared_view2");
+        // view1 detaching must NOT destroy the grading (view2 still
+        // references it) - if it did, the capture below would crash or
+        // render garbage
+        await view1.setColorGrading(null);
+        await testHelper.capture(view2, "color_grading_shared_view2");
 
-            // the last detach destroys it
-            await view2.setColorGrading(null);
-          } finally {
-            await app.destroyView(view2);
-          }
-        });
+        // the last detach destroys it
+        await view2.setColorGrading(null);
+      } finally {
+        await app.destroyView(view2);
+      }
+    });
   });
 
   test('ColorGrading dispose defers while attached', () async {
-    await ViewerBuilder(testHelper)
-        .setPostProcessing(true)
-        .addCube(color: kWhite, createUbershader: true)
-        .execute((result) async {
-          final view = result.viewer.view;
-          final builder = await view.createColorGradingBuilder();
-          final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
-          final colorGrading = await builder.toneMapper(toneMapper).build();
-          await builder.dispose();
-          await toneMapper.dispose();
+    await ViewerBuilder(testHelper).setPostProcessing(true).addCube(color: kWhite, createUbershader: true).execute((
+      result,
+    ) async {
+      final view = result.viewer.view;
+      final builder = await view.createColorGradingBuilder();
+      final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
+      final colorGrading = await builder.toneMapper(toneMapper).build();
+      await builder.dispose();
+      await toneMapper.dispose();
 
-          await view.setColorGrading(colorGrading);
+      await view.setColorGrading(colorGrading);
 
-          // Disposing while attached defers destruction - the view must keep
-          // rendering correctly...
-          await colorGrading.dispose();
-          await testHelper.capture(view, "color_grading_dispose_deferred");
+      // Disposing while attached defers destruction - the view must keep
+      // rendering correctly...
+      await colorGrading.dispose();
+      await testHelper.capture(view, "color_grading_dispose_deferred");
 
-          // ...until the last view detaches, which destroys it
-          await view.setColorGrading(null);
-        });
+      // ...until the last view detaches, which destroys it
+      await view.setColorGrading(null);
+    });
   });
 
   test('ColorGrading builder can be disposed without building', () async {

--- a/thermion_dart/test/color_grading_tests.dart
+++ b/thermion_dart/test/color_grading_tests.dart
@@ -216,6 +216,64 @@ void main() async {
         });
   });
 
+  test('ColorGrading shared between views', () async {
+    await ViewerBuilder(testHelper)
+        .setPostProcessing(true)
+        .addCube(color: kWhite, createUbershader: true)
+        .execute((result) async {
+          final app = FilamentApp.instance!;
+          final view1 = result.viewer.view;
+          final view2 = await app.createView();
+          await view2.setViewport(512, 512);
+          try {
+            final builder = await view1.createColorGradingBuilder();
+            final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
+            final shared = await builder.toneMapper(toneMapper).saturation(2.0).build();
+            await builder.dispose();
+            await toneMapper.dispose();
+
+            // One grading, two views - Filament allows this and so do we
+            await view1.setColorGrading(shared);
+            await view2.setColorGrading(shared);
+
+            // view1 detaching must NOT destroy the grading (view2 still
+            // references it) - if it did, the capture below would crash or
+            // render garbage
+            await view1.setColorGrading(null);
+            await testHelper.capture(view2, "color_grading_shared_view2");
+
+            // the last detach destroys it
+            await view2.setColorGrading(null);
+          } finally {
+            await app.destroyView(view2);
+          }
+        });
+  });
+
+  test('ColorGrading dispose defers while attached', () async {
+    await ViewerBuilder(testHelper)
+        .setPostProcessing(true)
+        .addCube(color: kWhite, createUbershader: true)
+        .execute((result) async {
+          final view = result.viewer.view;
+          final builder = await view.createColorGradingBuilder();
+          final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
+          final colorGrading = await builder.toneMapper(toneMapper).build();
+          await builder.dispose();
+          await toneMapper.dispose();
+
+          await view.setColorGrading(colorGrading);
+
+          // Disposing while attached defers destruction - the view must keep
+          // rendering correctly...
+          await colorGrading.dispose();
+          await testHelper.capture(view, "color_grading_dispose_deferred");
+
+          // ...until the last view detaches, which destroys it
+          await view.setColorGrading(null);
+        });
+  });
+
   test('ColorGrading builder can be disposed without building', () async {
     await ViewerBuilder(testHelper).setPostProcessing(true).addCube(color: kWhite, createUbershader: true).execute((
       result,

--- a/thermion_dart/test/color_grading_tests.dart
+++ b/thermion_dart/test/color_grading_tests.dart
@@ -2,7 +2,6 @@
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:thermion_dart/thermion_dart.dart';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'helpers.dart';
 
 void main() async {
@@ -63,8 +62,13 @@ void main() async {
             final name = toneMappers[i + 1] as String;
             final toneMapper = await toneMapperFactory();
 
-            // Set the tone mapper directly to the view
-            await result.viewer.view.setToneMapper(toneMapper);
+            // Apply the tone mapper via the color grading builder
+            final builder = await result.viewer.view.createColorGradingBuilder();
+            final colorGrading = await builder.toneMapper(toneMapper).build();
+            // done building: dispose the builder, then the mapper it referenced
+            await builder.dispose();
+            await toneMapper.dispose();
+            await result.viewer.view.setColorGrading(colorGrading);
 
             // Capture the viewport after changing tone mapper
             await testHelper.capture(result.viewer.view, "tone_mapper_$name");
@@ -87,6 +91,7 @@ void main() async {
         .execute((result) async {
           // Create a complex color grading using the builder
           final builder = await result.viewer.view.createColorGradingBuilder();
+          final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
           final colorGrading = await builder
               .quality(QualityLevel.HIGH)
               .exposure(0.7) // Slight exposure adjustment
@@ -96,7 +101,7 @@ void main() async {
               .saturation(0.95) // Slight desaturation
               .luminanceScaling(true) // Better HDR handling
               .gamutMapping(true) // Prevent hue shifts
-              .toneMapper(await ToneMapper.aces(FilamentApp.instance!)) // Add a tone mapper
+              .toneMapper(toneMapper) // Add a tone mapper
               .shadowsMidtonesHighlights(
                 Vector4(0.8, 0.9, 1.0, 0.5), // Slightly cool shadows
                 Vector4(1.0, 1.0, 1.0, 1.0), // Neutral midtones
@@ -107,11 +112,26 @@ void main() async {
 
           expect(colorGrading, isNotNull);
 
+          // The builder is reusable (Filament's pattern): change a setting
+          // and build again to get an independent grading.
+          final brighterColorGrading = await builder.exposure(2.0).build();
+
+          // Done building: dispose the builder, then the mapper it referenced
+          await builder.dispose();
+          await toneMapper.dispose();
+
           // Apply the color grading to the view
           await result.viewer.view.setColorGrading(colorGrading);
 
           // Capture the viewport after applying color grading
           await testHelper.capture(result.viewer.view, "color_grading_builder_applied");
+          // No manual dispose: the view owns the grading and destroys it on
+          // replacement/clear/teardown
+
+          // Replacing it with the second grading destroys the first
+          // (view-owned)
+          await result.viewer.view.setColorGrading(brighterColorGrading);
+          await testHelper.capture(result.viewer.view, "color_grading_builder_rebuilt_brighter");
         });
   });
 
@@ -139,15 +159,20 @@ void main() async {
 
           for (final (format, dim, name) in configs) {
             final builder = await result.viewer.view.createColorGradingBuilder();
+            final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
             final colorGrading = await builder
                 .format(format)
                 .dimensions(dim)
-                .toneMapper(await ToneMapper.aces(FilamentApp.instance!))
+                .toneMapper(toneMapper)
                 .saturation(1.3)
                 .contrast(1.2)
                 .build();
+            // done building: dispose the builder, then the mapper it referenced
+            await builder.dispose();
+            await toneMapper.dispose();
 
             expect(colorGrading, isNotNull);
+            // Setting the new grading destroys the previous one (view-owned)
             await result.viewer.view.setColorGrading(colorGrading);
             await testHelper.capture(result.viewer.view, "color_grading_lut_$name");
           }
@@ -177,16 +202,40 @@ void main() async {
 
           for (final (outRed, outGreen, outBlue, name) in configs) {
             final builder = await result.viewer.view.createColorGradingBuilder();
-            final colorGrading = await builder
-                .toneMapper(await ToneMapper.linear(FilamentApp.instance!))
-                .channelMixer(outRed, outGreen, outBlue)
-                .build();
+            final toneMapper = await ToneMapper.linear(FilamentApp.instance!);
+            final colorGrading = await builder.toneMapper(toneMapper).channelMixer(outRed, outGreen, outBlue).build();
+            // done building: dispose the builder, then the mapper it referenced
+            await builder.dispose();
+            await toneMapper.dispose();
 
             expect(colorGrading, isNotNull);
+            // Setting the new grading destroys the previous one (view-owned)
             await result.viewer.view.setColorGrading(colorGrading);
             await testHelper.capture(result.viewer.view, "color_grading_channel_mixer_$name");
           }
         });
+  });
+
+  test('ColorGrading builder can be disposed without building', () async {
+    await ViewerBuilder(testHelper).setPostProcessing(true).addCube(color: kWhite, createUbershader: true).execute((
+      result,
+    ) async {
+      final builder = await result.viewer.view.createColorGradingBuilder();
+      await builder.exposure(1.5);
+
+      // Abandoning a builder without building must not leak: dispose it.
+      await builder.dispose();
+      // A second dispose is a no-op
+      await builder.dispose();
+      // Using a disposed builder throws
+      expect(() => builder.exposure(1.0), throwsStateError);
+      await expectLater(builder.build(), throwsStateError);
+
+      // Tone mapper dispose is also idempotent
+      final toneMapper = await ToneMapper.linear(FilamentApp.instance!);
+      await toneMapper.dispose();
+      await toneMapper.dispose();
+    });
   });
 
   test('getColorGrading - retrieve and verify color grading', () async {
@@ -211,13 +260,16 @@ void main() async {
 
           // Create and apply a color grading
           final builder = await result.viewer.view.createColorGradingBuilder();
+          final toneMapper = await ToneMapper.aces(FilamentApp.instance!);
           final colorGrading = await builder
               .quality(QualityLevel.HIGH)
               .exposure(0.5)
               .contrast(1.2)
               .saturation(1.1)
-              .toneMapper(await ToneMapper.aces(FilamentApp.instance!))
+              .toneMapper(toneMapper)
               .build();
+          await builder.dispose();
+          await toneMapper.dispose();
 
           // Apply the color grading to the view
           await result.viewer.view.setColorGrading(colorGrading);
@@ -230,7 +282,8 @@ void main() async {
           // Capture the viewport with color grading applied
           await testHelper.capture(result.viewer.view, "color_grading_get_test");
 
-          // Clear the color grading by passing null
+          // Clear the color grading by passing null (this destroys the
+          // view-owned grading)
           await result.viewer.view.setColorGrading(null);
 
           // Capture the viewport with color grading cleared

--- a/thermion_dart/test/color_grading_tests.dart
+++ b/thermion_dart/test/color_grading_tests.dart
@@ -72,6 +72,10 @@ void main() async {
 
             // Capture the viewport after changing tone mapper
             await testHelper.capture(result.viewer.view, "tone_mapper_$name");
+
+            // The grading is caller-owned: dissociate, then dispose
+            await result.viewer.view.setColorGrading(null);
+            await colorGrading.dispose();
           }
         });
   });
@@ -125,13 +129,16 @@ void main() async {
 
           // Capture the viewport after applying color grading
           await testHelper.capture(result.viewer.view, "color_grading_builder_applied");
-          // No manual dispose: the view owns the grading and destroys it on
-          // replacement/clear/teardown
 
-          // Replacing it with the second grading destroys the first
-          // (view-owned)
+          // Attaching the second grading dissociates the first, so the first
+          // can now be disposed (caller-owned lifecycle)
           await result.viewer.view.setColorGrading(brighterColorGrading);
+          await colorGrading.dispose();
           await testHelper.capture(result.viewer.view, "color_grading_builder_rebuilt_brighter");
+
+          // Dissociate, then dispose the second grading
+          await result.viewer.view.setColorGrading(null);
+          await brighterColorGrading.dispose();
         });
   });
 
@@ -172,9 +179,12 @@ void main() async {
             await toneMapper.dispose();
 
             expect(colorGrading, isNotNull);
-            // Setting the new grading destroys the previous one (view-owned)
             await result.viewer.view.setColorGrading(colorGrading);
             await testHelper.capture(result.viewer.view, "color_grading_lut_$name");
+
+            // The grading is caller-owned: dissociate, then dispose
+            await result.viewer.view.setColorGrading(null);
+            await colorGrading.dispose();
           }
         });
   });
@@ -209,9 +219,12 @@ void main() async {
             await toneMapper.dispose();
 
             expect(colorGrading, isNotNull);
-            // Setting the new grading destroys the previous one (view-owned)
             await result.viewer.view.setColorGrading(colorGrading);
             await testHelper.capture(result.viewer.view, "color_grading_channel_mixer_$name");
+
+            // The grading is caller-owned: dissociate, then dispose
+            await result.viewer.view.setColorGrading(null);
+            await colorGrading.dispose();
           }
         });
   });
@@ -231,25 +244,27 @@ void main() async {
         await builder.dispose();
         await toneMapper.dispose();
 
-        // One grading, two views - Filament allows this and so do we
+        // One grading, two views - Filament allows this. Lifetime is the
+        // caller's responsibility: neither view destroys or releases it.
         await view1.setColorGrading(shared);
         await view2.setColorGrading(shared);
-
-        // view1 detaching must NOT destroy the grading (view2 still
-        // references it) - if it did, the capture below would crash or
-        // render garbage
-        await view1.setColorGrading(null);
         await testHelper.capture(view2, "color_grading_shared_view2");
 
-        // the last detach destroys it
+        // Detaching view1 leaves the grading untouched (view2 still uses
+        // it) - the caller, not the view, decides when it is destroyed
+        await view1.setColorGrading(null);
+        await testHelper.capture(view2, "color_grading_shared_view2_after_detach");
+
+        // Dissociate from the last view, then dispose
         await view2.setColorGrading(null);
+        await shared.dispose();
       } finally {
         await app.destroyView(view2);
       }
     });
   });
 
-  test('ColorGrading dispose defers while attached', () async {
+  test('ColorGrading dispose is idempotent', () async {
     await ViewerBuilder(testHelper).setPostProcessing(true).addCube(color: kWhite, createUbershader: true).execute((
       result,
     ) async {
@@ -260,15 +275,10 @@ void main() async {
       await builder.dispose();
       await toneMapper.dispose();
 
-      await view.setColorGrading(colorGrading);
-
-      // Disposing while attached defers destruction - the view must keep
-      // rendering correctly...
-      await colorGrading.dispose();
-      await testHelper.capture(view, "color_grading_dispose_deferred");
-
-      // ...until the last view detaches, which destroys it
+      // Dissociate, then dispose - twice; the second is a no-op
       await view.setColorGrading(null);
+      await colorGrading.dispose();
+      await colorGrading.dispose();
     });
   });
 
@@ -310,7 +320,8 @@ void main() async {
           // Setting the color grading to null will clear the color grading
           await result.viewer.view.setColorGrading(null);
           // but internally, View resets this to a "default" color grading,
-          // so this will be non-null
+          // so this will be non-null. This is a non-owning wrapper around
+          // Filament's internal default - never dispose it.
           var initialColorGrading = await result.viewer.view.getColorGrading();
           expect(initialColorGrading, isNotNull);
 
@@ -330,7 +341,9 @@ void main() async {
           // Apply the color grading to the view
           await result.viewer.view.setColorGrading(colorGrading);
 
-          // Retrieve the color grading from the view
+          // Retrieve the color grading from the view. This wraps the same
+          // native grading as [colorGrading] - a non-owning view of it, not a
+          // separate object to dispose.
           var retrievedColorGrading = await result.viewer.view.getColorGrading();
           expect(retrievedColorGrading, isNotNull);
           expect(retrievedColorGrading, isA<ColorGrading>());
@@ -338,9 +351,10 @@ void main() async {
           // Capture the viewport with color grading applied
           await testHelper.capture(result.viewer.view, "color_grading_get_test");
 
-          // Clear the color grading by passing null (this destroys the
-          // view-owned grading)
+          // Clear the color grading by passing null. This only dissociates -
+          // it does NOT destroy the grading, so dispose it explicitly.
           await result.viewer.view.setColorGrading(null);
+          await colorGrading.dispose();
 
           // Capture the viewport with color grading cleared
           await testHelper.capture(result.viewer.view, "color_grading_cleared");

--- a/thermion_dart/test/destructor_tests.dart
+++ b/thermion_dart/test/destructor_tests.dart
@@ -10,6 +10,7 @@ void main() async {
     await testHelper.setup();
     final viewer = (await testHelper.createViewer()).$1;
     await viewer.dispose();
+    await testHelper.disposeColorGradings();
     await FilamentApp.instance!.destroy();
     await testHelper.setup();
   });

--- a/thermion_dart/test/helpers.dart
+++ b/thermion_dart/test/helpers.dart
@@ -325,7 +325,7 @@ class TestHelper {
 
     await viewer.setPostProcessing(postProcessing);
 
-    await viewer.setToneMapper(await ToneMapper.aces(FilamentApp.instance!));
+    await applyToneMapper(viewer.view, await ToneMapper.aces(FilamentApp.instance!));
     return (viewer, swapChain);
   }
 
@@ -397,6 +397,18 @@ class _PlaneConfig {
     this.createUbershader = false,
     this.unlit = false,
   });
+}
+
+/// Applies [mapper] as the tone mapper on [view] via the color grading
+/// builder API. Disposes the builder and [mapper] (each build reads the
+/// mapper, so the builder goes first), and the view takes ownership of the
+/// grading.
+Future applyToneMapper(View view, ToneMapper mapper) async {
+  final builder = await view.createColorGradingBuilder();
+  final colorGrading = await builder.toneMapper(mapper).build();
+  await builder.dispose();
+  await mapper.dispose();
+  await view.setColorGrading(colorGrading);
 }
 
 /// Result class containing all components created by ViewerBuilder
@@ -629,7 +641,7 @@ class ViewerBuilder {
 
     // Apply tone mapping if specified
     if (_toneMapper != null) {
-      viewer.setToneMapper(_toneMapper!);
+      await applyToneMapper(viewer.view, _toneMapper!);
     }
 
     // Add direct lights and store their entities

--- a/thermion_dart/test/helpers.dart
+++ b/thermion_dart/test/helpers.dart
@@ -65,6 +65,10 @@ class TestHelper {
   late String testDir;
   late String assetsDir;
 
+  /// ColorGradings attached by [createViewer]; caller-owned (like Filament),
+  /// so [disposeColorGradings] must run once the viewers are destroyed.
+  final List<ColorGrading> _colorGradings = [];
+
   TestHelper(String? subDir) {
     final packageUri = findPackageRoot('thermion_dart').toFilePath();
     assetsDir = p.normalize(p.join(packageUri, '..', 'examples', 'assets'));
@@ -325,8 +329,18 @@ class TestHelper {
 
     await viewer.setPostProcessing(postProcessing);
 
-    await applyToneMapper(viewer.view, await ToneMapper.aces(FilamentApp.instance!));
+    _colorGradings.add(await applyToneMapper(viewer.view, await ToneMapper.aces(FilamentApp.instance!)));
     return (viewer, swapChain);
+  }
+
+  /// Disposes the ColorGradings attached by [createViewer]. Call after the
+  /// viewer is destroyed - destroying the view dissociates them, and a
+  /// grading must not be disposed while still attached to a view.
+  Future disposeColorGradings() async {
+    for (final grading in _colorGradings) {
+      await grading.dispose();
+    }
+    _colorGradings.clear();
   }
 
   Future withViewer(
@@ -351,6 +365,7 @@ class TestHelper {
 
     await fn.call(viewer.$1);
     await viewer.$1.dispose();
+    await disposeColorGradings();
     await FilamentApp.instance!.destroySwapChain(viewer.$2);
   }
 }
@@ -400,15 +415,17 @@ class _PlaneConfig {
 }
 
 /// Applies [mapper] as the tone mapper on [view] via the color grading
-/// builder API. Disposes the builder and [mapper] (each build reads the
-/// mapper, so the builder goes first), and the view takes ownership of the
-/// grading.
-Future applyToneMapper(View view, ToneMapper mapper) async {
+/// builder API and returns the attached ColorGrading. Disposes the builder
+/// and [mapper] (each build reads the mapper, so the builder goes first).
+/// The grading is caller-owned (like Filament): dissociate it from the view
+/// (`setColorGrading(null)`) and dispose it when done.
+Future<ColorGrading> applyToneMapper(View view, ToneMapper mapper) async {
   final builder = await view.createColorGradingBuilder();
   final colorGrading = await builder.toneMapper(mapper).build();
   await builder.dispose();
   await mapper.dispose();
   await view.setColorGrading(colorGrading);
+  return colorGrading;
 }
 
 /// Result class containing all components created by ViewerBuilder
@@ -435,6 +452,10 @@ class ViewerBuilder {
   ShadowType? _shadowType;
   final List<DirectLight> _directLights = [];
   ToneMapper? _toneMapper;
+
+  /// ColorGradings attached during [buildWithAssets]; caller-owned (like
+  /// Filament), disposed in [execute] after the viewer is destroyed.
+  final List<ColorGrading> _colorGradings = [];
   late TestHelper _testHelper;
 
   // Store cube and plane configurations
@@ -641,7 +662,7 @@ class ViewerBuilder {
 
     // Apply tone mapping if specified
     if (_toneMapper != null) {
-      await applyToneMapper(viewer.view, _toneMapper!);
+      _colorGradings.add(await applyToneMapper(viewer.view, _toneMapper!));
     }
 
     // Add direct lights and store their entities
@@ -770,6 +791,10 @@ class ViewerBuilder {
       await fn.call(viewerBuildResult);
     } finally {
       await buildResult.viewer.dispose();
+      for (final grading in _colorGradings) {
+        await grading.dispose();
+      }
+      _colorGradings.clear();
       await FilamentApp.instance!.destroySwapChain(buildResult.swapChain);
     }
   }

--- a/thermion_dart/test/unlit_material_tests.dart
+++ b/thermion_dart/test/unlit_material_tests.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 import 'package:thermion_dart/thermion_dart.dart';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:test/test.dart';
 import 'helpers.dart';
 
@@ -40,7 +39,7 @@ void main() async {
   test('unlit + baseColorFactor', () async {
     await testHelper.withViewer((viewer) async {
       await viewer.setPostProcessing(true);
-      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance!));
+      await applyToneMapper(viewer.view, await ToneMapper.linear(FilamentApp.instance!));
 
       var materialInstance = await FilamentApp.instance!.createUnlitMaterialInstance();
       var cube = await viewer.createGeometry(
@@ -192,7 +191,7 @@ void main() async {
   test('unlit material with color + alpha', () async {
     await testHelper.withViewer((viewer) async {
       await viewer.setPostProcessing(true);
-      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance!));
+      await applyToneMapper(viewer.view, await ToneMapper.linear(FilamentApp.instance!));
 
       var materialInstance = await FilamentApp.instance!.createUnlitMaterialInstance();
       var cube = await viewer.createGeometry(
@@ -217,7 +216,7 @@ void main() async {
     await viewer.setCameraPosition(0, 0, 6);
     await viewer.setBackgroundColor(1.0, 0.0, 0.0, 1.0);
     await viewer.setPostProcessing(true);
-    await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance!));
+    await applyToneMapper(viewer.view, await ToneMapper.linear(FilamentApp.instance!));
 
     var materialInstance = await viewer.createUnlitFixedSizeMaterialInstance();
     var cube = await viewer.createGeometry(


### PR DESCRIPTION
This PR changes ColorGrading/ColorColorGradingBuilder lifecycle to match Filament's ownership contract exactly (i.e. user-managed) and, removes the deprecated tone-mapper APIs