### PR TITLE
refactor: expose engine handle on FilamentApp; abstract-app for engine-only consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 > Shared changelog for `thermion_dart` and `thermion_flutter` (released in lockstep).
 
+## Unreleased
+
+### Changes
+- `FilamentApp` exposes the native engine handle as a public
+  `Pointer<TEngine> get engine` (thermion_dart is FFI-backed on every
+  supported target, including web/WASM). `ToneMapper` factory methods take
+  the abstract `FilamentApp` instead of `FFIFilamentApp`, so callers no
+  longer need to downcast (`ToneMapper.aces(FilamentApp.instance!)` just
+  works).
+- `TranslationAxisMaterial.createMaterialInstance` takes the abstract
+  `FilamentApp` too, and `FFIMaterial`/`FFIMaterialInstance` hold the
+  abstract type internally (they only ever needed the engine handle).
+
 ## 0.6.0
 
 Update to Filament v1.75.0!

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_material.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_material.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_texture.dart';
 import 'package:thermion_dart/thermion_dart.dart';
-import 'ffi_filament_app.dart';
 
 class FFIMaterial extends Material<Pointer<TMaterial>> {
   final Pointer<TMaterial> pointer;
 
-  final FFIFilamentApp _app;
+  final FilamentApp _app;
 
   FFIMaterial(this.pointer, this._app);
 
@@ -43,7 +42,7 @@ class FFIMaterial extends Material<Pointer<TMaterial>> {
 class FFIMaterialInstance extends MaterialInstance<Pointer<TMaterialInstance>> {
   final Pointer<TMaterialInstance> pointer;
 
-  final FFIFilamentApp _app;
+  final FilamentApp _app;
 
   FFIMaterialInstance(this.pointer, this._app) {
     if (pointer == nullptr) {

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_tone_mapper.dart
@@ -1,4 +1,3 @@
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/thermion_dart.dart';
 
 /// FFI implementation of ToneMapper
@@ -12,50 +11,39 @@ class FFIToneMapper extends ToneMapper {
 
   /// Create a LinearToneMapper - returns input color clamped to 0..1 range
   /// Useful for debugging
-  static Future<ToneMapper> linear(FFIFilamentApp app) async {
-    final filamentApp = app;
-    final pointer = await withPointerCallback<TToneMapper>(
-      (cb) => ToneMapper_createLinearRenderThread(filamentApp.engine, cb),
-    );
+  static Future<ToneMapper> linear(FilamentApp app) async {
+    final pointer = await withPointerCallback<TToneMapper>((cb) => ToneMapper_createLinearRenderThread(app.engine, cb));
     return FFIToneMapper._(pointer);
   }
 
   /// Create an ACESToneMapper - ACES Reference Rendering Transform (RRT)
   /// combined with the Output Device Transform (ODT) for sRGB monitors
-  static Future<ToneMapper> aces(FFIFilamentApp app) async {
-    final filamentApp = app;
-    final pointer = await withPointerCallback<TToneMapper>(
-      (cb) => ToneMapper_createACESRenderThread(filamentApp.engine, cb),
-    );
+  static Future<ToneMapper> aces(FilamentApp app) async {
+    final pointer = await withPointerCallback<TToneMapper>((cb) => ToneMapper_createACESRenderThread(app.engine, cb));
     return FFIToneMapper._(pointer);
   }
 
   /// Create an ACESLegacyToneMapper - ACES tone mapper modified to match
   /// the perceived brightness of FilmicToneMapper (applies ~1.6x brightness)
-  static Future<ToneMapper> acesLegacy(FFIFilamentApp app) async {
-    final filamentApp = app;
+  static Future<ToneMapper> acesLegacy(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>(
-      (cb) => ToneMapper_createACESLegacyRenderThread(filamentApp.engine, cb),
+      (cb) => ToneMapper_createACESLegacyRenderThread(app.engine, cb),
     );
     return FFIToneMapper._(pointer);
   }
 
   /// Create a FilmicToneMapper - designed to approximate ACES RRT + ODT
   /// for Rec.709. Exists for backward compatibility.
-  static Future<ToneMapper> filmic(FFIFilamentApp app) async {
-    final filamentApp = app;
-    final pointer = await withPointerCallback<TToneMapper>(
-      (cb) => ToneMapper_createFilmicRenderThread(filamentApp.engine, cb),
-    );
+  static Future<ToneMapper> filmic(FilamentApp app) async {
+    final pointer = await withPointerCallback<TToneMapper>((cb) => ToneMapper_createFilmicRenderThread(app.engine, cb));
     return FFIToneMapper._(pointer);
   }
 
   /// Create a PBRNeutralToneMapper - Khronos PBR Neutral tone mapper
   /// designed to preserve material appearance across lighting conditions
-  static Future<ToneMapper> pbrNeutral(FFIFilamentApp app) async {
-    final filamentApp = app;
+  static Future<ToneMapper> pbrNeutral(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>(
-      (cb) => ToneMapper_createPBRNeutralRenderThread(filamentApp.engine, cb),
+      (cb) => ToneMapper_createPBRNeutralRenderThread(app.engine, cb),
     );
     return FFIToneMapper._(pointer);
   }
@@ -66,10 +54,9 @@ class FFIToneMapper extends ToneMapper {
   ///   - AgxLook.none: Base contrast with no look applied
   ///   - AgxLook.punchy: More chroma laden look for sRGB displays
   ///   - AgxLook.golden: Golden tinted look for BT.1886 displays
-  static Future<ToneMapper> agx(FFIFilamentApp app, {AgxLook look = AgxLook.none}) async {
-    final filamentApp = app;
+  static Future<ToneMapper> agx(FilamentApp app, {AgxLook look = AgxLook.none}) async {
     final pointer = await withPointerCallback<TToneMapper>(
-      (cb) => ToneMapper_createAGXWithLookRenderThread(filamentApp.engine, look.index, cb),
+      (cb) => ToneMapper_createAGXWithLookRenderThread(app.engine, look.index, cb),
     );
     return FFIToneMapper._(pointer);
   }
@@ -85,25 +72,23 @@ class FFIToneMapper extends ToneMapper {
   /// [midGrayOut] - Output middle gray value (0.0..1.0, default: 0.215)
   /// [hdrMax] - Maximum input value mapped to output white (>= 1.0, default: 10.0)
   static Future<ToneMapper> generic(
-    FFIFilamentApp app, {
+    FilamentApp app, {
     double contrast = 1.55,
     double midGrayIn = 0.18,
     double midGrayOut = 0.215,
     double hdrMax = 10.0,
   }) async {
-    final filamentApp = app;
     final pointer = await withPointerCallback<TToneMapper>(
-      (cb) => ToneMapper_createGenericRenderThread(filamentApp.engine, contrast, midGrayIn, midGrayOut, hdrMax, cb),
+      (cb) => ToneMapper_createGenericRenderThread(app.engine, contrast, midGrayIn, midGrayOut, hdrMax, cb),
     );
     return FFIToneMapper._(pointer);
   }
 
   /// Create a DisplayRangeToneMapper - converts HDR RGB to 16 debug colors
   /// representing pixel exposure levels. Useful for validating scene lighting.
-  static Future<ToneMapper> displayRange(FFIFilamentApp app) async {
-    final filamentApp = app;
+  static Future<ToneMapper> displayRange(FilamentApp app) async {
     final pointer = await withPointerCallback<TToneMapper>(
-      (cb) => ToneMapper_createDisplayRangeRenderThread(filamentApp.engine, cb),
+      (cb) => ToneMapper_createDisplayRangeRenderThread(app.engine, cb),
     );
     return FFIToneMapper._(pointer);
   }

--- a/thermion_dart/lib/src/filament/src/implementation/translation_axis_material.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/translation_axis_material.dart
@@ -1,6 +1,5 @@
 import 'package:thermion_dart/src/filament/src/implementation/ffi_material.dart';
 import 'package:thermion_dart/thermion_dart.dart';
-import 'ffi_filament_app.dart';
 
 /// FFI implementation for creating translation axis material instances.
 class FFITranslationAxisMaterial {
@@ -17,7 +16,7 @@ class FFITranslationAxisMaterial {
   ///
   /// Returns a configured [MaterialInstance] ready to use.
   static Future<MaterialInstance> createTranslationAxisMaterialInstance({
-    required FFIFilamentApp app,
+    required FilamentApp app,
     required double originX,
     required double originY,
     required double originZ,

--- a/thermion_dart/lib/src/filament/src/interface/filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/interface/filament_app.dart
@@ -27,7 +27,13 @@ class FilamentConfig<T, U> {
 abstract class FilamentApp<T> {
   static FilamentApp? instance;
 
-  T get engine;
+  /// The native Filament engine handle.
+  ///
+  /// thermion_dart is FFI-backed on every supported target (native and
+  /// web/WASM), so the raw engine pointer is part of the public interface -
+  /// engine-scoped factories (e.g. ToneMapper) accept any [FilamentApp]
+  /// without callers having to downcast to a concrete implementation.
+  Pointer<TEngine> get engine;
   T get gltfAssetLoader;
   T get renderer;
   AnimationManager<T> get animationManager;

--- a/thermion_dart/lib/src/filament/src/interface/filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/interface/filament_app.dart
@@ -27,12 +27,7 @@ class FilamentConfig<T, U> {
 abstract class FilamentApp<T> {
   static FilamentApp? instance;
 
-  /// The native Filament engine handle.
-  ///
-  /// thermion_dart is FFI-backed on every supported target (native and
-  /// web/WASM), so the raw engine pointer is part of the public interface -
-  /// engine-scoped factories (e.g. ToneMapper) accept any [FilamentApp]
-  /// without callers having to downcast to a concrete implementation.
+  /// A handle to the native Filament Engine instance attached to this application.
   Pointer<TEngine> get engine;
   T get gltfAssetLoader;
   T get renderer;

--- a/thermion_dart/lib/src/filament/src/interface/tone_mapper.dart
+++ b/thermion_dart/lib/src/filament/src/interface/tone_mapper.dart
@@ -1,5 +1,5 @@
+import 'package:thermion_dart/src/filament/src/interface/filament_app.dart';
 import 'package:thermion_dart/src/filament/src/interface/native_handle.dart';
-import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
 import 'package:thermion_dart/src/filament/src/implementation/ffi_tone_mapper.dart';
 
 /// Look options for AgX tone mapper
@@ -21,31 +21,31 @@ enum AgxLook {
 abstract class ToneMapper extends NativeHandle<dynamic> {
   /// Create a LinearToneMapper - returns input color clamped to 0..1 range
   /// Useful for debugging
-  static Future<ToneMapper> linear(FFIFilamentApp app) async {
+  static Future<ToneMapper> linear(FilamentApp app) async {
     return FFIToneMapper.linear(app);
   }
 
   /// Create an ACESToneMapper - ACES Reference Rendering Transform (RRT)
   /// combined with the Output Device Transform (ODT) for sRGB monitors
-  static Future<ToneMapper> aces(FFIFilamentApp app) async {
+  static Future<ToneMapper> aces(FilamentApp app) async {
     return FFIToneMapper.aces(app);
   }
 
   /// Create an ACESLegacyToneMapper - ACES tone mapper modified to match
   /// the perceived brightness of FilmicToneMapper (applies ~1.6x brightness)
-  static Future<ToneMapper> acesLegacy(FFIFilamentApp app) async {
+  static Future<ToneMapper> acesLegacy(FilamentApp app) async {
     return FFIToneMapper.acesLegacy(app);
   }
 
   /// Create a FilmicToneMapper - designed to approximate ACES RRT + ODT
   /// for Rec.709. Exists for backward compatibility.
-  static Future<ToneMapper> filmic(FFIFilamentApp app) async {
+  static Future<ToneMapper> filmic(FilamentApp app) async {
     return FFIToneMapper.filmic(app);
   }
 
   /// Create a PBRNeutralToneMapper - Khronos PBR Neutral tone mapper
   /// designed to preserve material appearance across lighting conditions
-  static Future<ToneMapper> pbrNeutral(FFIFilamentApp app) async {
+  static Future<ToneMapper> pbrNeutral(FilamentApp app) async {
     return FFIToneMapper.pbrNeutral(app);
   }
 
@@ -55,7 +55,7 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
   ///   - AgxLook.none: Base contrast with no look applied
   ///   - AgxLook.punchy: More chroma laden look for sRGB displays
   ///   - AgxLook.golden: Golden tinted look for BT.1886 displays
-  static Future<ToneMapper> agx(FFIFilamentApp app, {AgxLook look = AgxLook.none}) async {
+  static Future<ToneMapper> agx(FilamentApp app, {AgxLook look = AgxLook.none}) async {
     return FFIToneMapper.agx(app, look: look);
   }
 
@@ -70,7 +70,7 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
   /// [midGrayOut] - Output middle gray value (0.0..1.0, default: 0.215)
   /// [hdrMax] - Maximum input value mapped to output white (>= 1.0, default: 10.0)
   static Future<ToneMapper> generic(
-    FFIFilamentApp app, {
+    FilamentApp app, {
     double contrast = 1.55,
     double midGrayIn = 0.18,
     double midGrayOut = 0.215,
@@ -99,7 +99,7 @@ abstract class ToneMapper extends NativeHandle<dynamic> {
   /// - +8EV: magenta
   /// - +9EV: purple
   /// - +10EV: white
-  static Future<ToneMapper> displayRange(FFIFilamentApp app) async {
+  static Future<ToneMapper> displayRange(FilamentApp app) async {
     return FFIToneMapper.displayRange(app);
   }
 

--- a/thermion_dart/lib/src/filament/src/interface/translation_axis_material.dart
+++ b/thermion_dart/lib/src/filament/src/interface/translation_axis_material.dart
@@ -1,5 +1,4 @@
 import 'package:thermion_dart/thermion_dart.dart';
-import '../implementation/ffi_filament_app.dart';
 
 import '../implementation/translation_axis_material.dart';
 
@@ -35,7 +34,7 @@ class TranslationAxisMaterial {
   /// );
   /// ```
   static Future<MaterialInstance> createMaterialInstance({
-    FFIFilamentApp? app,
+    FilamentApp? app,
     required double originX,
     required double originY,
     required double originZ,
@@ -44,7 +43,7 @@ class TranslationAxisMaterial {
     double lineLength = 100.0,
   }) {
     return FFITranslationAxisMaterial.createTranslationAxisMaterialInstance(
-      app: app ?? (FilamentApp.instance as FFIFilamentApp),
+      app: app ?? FilamentApp.instance!,
       originX: originX,
       originY: originY,
       originZ: originZ,

--- a/thermion_dart/test/color_grading_tests.dart
+++ b/thermion_dart/test/color_grading_tests.dart
@@ -16,27 +16,27 @@ void main() async {
   test('all available ToneMappers', () async {
     // Test all available ToneMapper factory methods using ViewerBuilder
     final toneMappers = [
-      () => ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp),
+      () => ToneMapper.linear(FilamentApp.instance!),
       'linear',
-      () => ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp),
+      () => ToneMapper.aces(FilamentApp.instance!),
       'aces',
-      () => ToneMapper.acesLegacy(FilamentApp.instance! as FFIFilamentApp),
+      () => ToneMapper.acesLegacy(FilamentApp.instance!),
       'aces_legacy',
-      () => ToneMapper.filmic(FilamentApp.instance! as FFIFilamentApp),
+      () => ToneMapper.filmic(FilamentApp.instance!),
       'filmic',
-      () => ToneMapper.pbrNeutral(FilamentApp.instance! as FFIFilamentApp),
+      () => ToneMapper.pbrNeutral(FilamentApp.instance!),
       'pbr_neutral',
-      () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp),
+      () => ToneMapper.agx(FilamentApp.instance!),
       'agx_none',
-      () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp, look: AgxLook.punchy),
+      () => ToneMapper.agx(FilamentApp.instance!, look: AgxLook.punchy),
       'agx_punchy',
-      () => ToneMapper.agx(FilamentApp.instance! as FFIFilamentApp, look: AgxLook.golden),
+      () => ToneMapper.agx(FilamentApp.instance!, look: AgxLook.golden),
       'agx_golden',
-      () => ToneMapper.generic(FilamentApp.instance! as FFIFilamentApp),
+      () => ToneMapper.generic(FilamentApp.instance!),
       'generic_default',
-      () => ToneMapper.generic(FilamentApp.instance! as FFIFilamentApp, contrast: 2.0),
+      () => ToneMapper.generic(FilamentApp.instance!, contrast: 2.0),
       'generic_contrast_2_0',
-      () => ToneMapper.displayRange(FilamentApp.instance! as FFIFilamentApp),
+      () => ToneMapper.displayRange(FilamentApp.instance!),
       'display_range',
     ];
 
@@ -96,7 +96,7 @@ void main() async {
               .saturation(0.95) // Slight desaturation
               .luminanceScaling(true) // Better HDR handling
               .gamutMapping(true) // Prevent hue shifts
-              .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp)) // Add a tone mapper
+              .toneMapper(await ToneMapper.aces(FilamentApp.instance!)) // Add a tone mapper
               .shadowsMidtonesHighlights(
                 Vector4(0.8, 0.9, 1.0, 0.5), // Slightly cool shadows
                 Vector4(1.0, 1.0, 1.0, 1.0), // Neutral midtones
@@ -142,7 +142,7 @@ void main() async {
             final colorGrading = await builder
                 .format(format)
                 .dimensions(dim)
-                .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp))
+                .toneMapper(await ToneMapper.aces(FilamentApp.instance!))
                 .saturation(1.3)
                 .contrast(1.2)
                 .build();
@@ -178,7 +178,7 @@ void main() async {
           for (final (outRed, outGreen, outBlue, name) in configs) {
             final builder = await result.viewer.view.createColorGradingBuilder();
             final colorGrading = await builder
-                .toneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp))
+                .toneMapper(await ToneMapper.linear(FilamentApp.instance!))
                 .channelMixer(outRed, outGreen, outBlue)
                 .build();
 
@@ -216,7 +216,7 @@ void main() async {
               .exposure(0.5)
               .contrast(1.2)
               .saturation(1.1)
-              .toneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp))
+              .toneMapper(await ToneMapper.aces(FilamentApp.instance!))
               .build();
 
           // Apply the color grading to the view

--- a/thermion_dart/test/helpers.dart
+++ b/thermion_dart/test/helpers.dart
@@ -325,7 +325,7 @@ class TestHelper {
 
     await viewer.setPostProcessing(postProcessing);
 
-    await viewer.setToneMapper(await ToneMapper.aces(FilamentApp.instance! as FFIFilamentApp));
+    await viewer.setToneMapper(await ToneMapper.aces(FilamentApp.instance!));
     return (viewer, swapChain);
   }
 

--- a/thermion_dart/test/unlit_material_tests.dart
+++ b/thermion_dart/test/unlit_material_tests.dart
@@ -40,7 +40,7 @@ void main() async {
   test('unlit + baseColorFactor', () async {
     await testHelper.withViewer((viewer) async {
       await viewer.setPostProcessing(true);
-      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp));
+      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance!));
 
       var materialInstance = await FilamentApp.instance!.createUnlitMaterialInstance();
       var cube = await viewer.createGeometry(
@@ -192,7 +192,7 @@ void main() async {
   test('unlit material with color + alpha', () async {
     await testHelper.withViewer((viewer) async {
       await viewer.setPostProcessing(true);
-      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp));
+      await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance!));
 
       var materialInstance = await FilamentApp.instance!.createUnlitMaterialInstance();
       var cube = await viewer.createGeometry(
@@ -217,7 +217,7 @@ void main() async {
     await viewer.setCameraPosition(0, 0, 6);
     await viewer.setBackgroundColor(1.0, 0.0, 0.0, 1.0);
     await viewer.setPostProcessing(true);
-    await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance! as FFIFilamentApp));
+    await viewer.setToneMapper(await ToneMapper.linear(FilamentApp.instance!));
 
     var materialInstance = await viewer.createUnlitFixedSizeMaterialInstance();
     var cube = await viewer.createGeometry(


### PR DESCRIPTION
This PR exposes the native engine handle on the abstract `FilamentApp` interface, and make engine-only consumers take the abstract type instead of `FFIFilamentApp`:

```dart
abstract class FilamentApp<T> {
  /// The native Filament engine handle.
  Pointer<TEngine> get engine;
```

This obviates the need to downcast `FilamentApp.instance` to `FFIFilamentApp` purely to reach the engine pointer. 