### PR TITLE
CI: update Linux golden image baseline

### DIFF
--- a/.github/workflows/run-dart-tests.yml
+++ b/.github/workflows/run-dart-tests.yml
@@ -152,8 +152,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh run download 32373595042 \
-            --name golden-images-7d723559f07771f8bb83c85824fcb2516af22940 \
+          gh run download 32448496857 \
+            --name golden-images-db9f8b471395709e1650636ddb499b24f727cdb9 \
             --dir ./thermion_dart/test/golden-downloads
       - name: Unzip golden images
         if: matrix.name == 'Linux'


### PR DESCRIPTION
## Summary

- repoint the Linux golden comparison to run `32448496857`
- use artifact `golden-images-db9f8b471395709e1650636ddb499b24f727cdb9`

## Why

PR #270 intended to update the baseline, but its merge commit was empty and the workflow remained pinned to run `32373595042` / commit `7d723559`.

The stale baseline differs from current Linux output in exactly six images, each by at most 1–2 channel values. The replacement artifact was generated on `develop`; its full 246-image output directory is byte-for-byte identical to the output from run `32462508378`, job `96712717726`.

## Validation

- downloaded and unpacked the old, replacement, and current artifacts
- `diff -qr` reports no differences between replacement and current output
- YAML parses successfully
- `git diff --check` passes

`actionlint` still reports the pre-existing shellcheck parse error for the Windows PowerShell backtick script at line 118; this two-line pin update does not touch that step.
