### PR TITLE
refactor: separate frame scheduling from rendering

### DIFF
--- a/examples/flutter/quickstart/integration_test/framerate_test.dart
+++ b/examples/flutter/quickstart/integration_test/framerate_test.dart
@@ -1,8 +1,8 @@
 // Integration test that verifies setTargetFramerate changes the rate at which
 // render work is accepted — not just an internal interval value.
 //
-// It counts frames admitted past the FrameScheduler's native throttle and
-// in-flight guard (via scheduledFrameCount) over wall-clock windows before and
+// It counts handlers dispatched past the FrameScheduler's native throttle and
+// in-flight guard (via dispatchedFrameCount) over wall-clock windows before and
 // after a setTargetFramerate call. The native
 // scheduler (CVDisplayLink / CADisplayLink / AChoreographer / DXGI) drives
 // the loop, so the numbers reflect work the device actually accepts.
@@ -29,20 +29,20 @@ void main() {
   /// Frames-per-second accepted over a [window] of real wall-clock time,
   /// measured with a [Stopwatch] (system clock, unaffected by any test
   /// clock). Lets the native vsync-driven scheduler tick at its own cadence.
-  Future<double> measureScheduledFps(Duration window) async {
+  Future<double> measureDispatchedFps(Duration window) async {
     final sw = Stopwatch()..start();
-    final start = FrameScheduler.instance.scheduledFrameCount;
+    final start = FrameScheduler.instance.dispatchedFrameCount;
     // Yield to the event loop in small increments so the native scheduler
     // callbacks are delivered while real time elapses.
     while (sw.elapsed < window) {
       await Future<void>.delayed(const Duration(milliseconds: 20));
     }
-    final frames = FrameScheduler.instance.scheduledFrameCount - start;
+    final frames = FrameScheduler.instance.dispatchedFrameCount - start;
     final realSeconds = sw.elapsed.inMicroseconds / 1e6;
     return frames / realSeconds;
   }
 
-  testWidgets('setTargetFramerate lowers scheduled frames-per-second',
+  testWidgets('setTargetFramerate lowers dispatched frames-per-second',
       (tester) async {
     ThermionViewer? viewer;
     final sun = DirectLight.sun(direction: Vector3(0.7, -1, -0.8).normalized());
@@ -94,9 +94,9 @@ void main() {
 
     // Let the loop settle, then measure the 60 FPS rate.
     await Future<void>.delayed(const Duration(seconds: 1));
-    final defaultFps = await measureScheduledFps(const Duration(seconds: 2));
+    final defaultFps = await measureDispatchedFps(const Duration(seconds: 2));
     debugPrint(
-      'Thermion scheduled FPS: default=${defaultFps.toStringAsFixed(1)}',
+      'Thermion dispatched FPS: default=${defaultFps.toStringAsFixed(1)}',
     );
 
     // Sanity: the loop is rendering continuously (not stalled). The absolute
@@ -105,13 +105,13 @@ void main() {
     expect(defaultFps, greaterThanOrEqualTo(15),
         reason: 'loop should render continuously; got $defaultFps');
 
-    // Cap well below the render-limited default and confirm the scheduled rate
+    // Cap well below the render-limited default and confirm the dispatched rate
     // drops to the cap. 5 FPS is unambiguously below any reasonable default.
     FilamentApp.instance!.setTargetFramerate(5);
     // Give the new interval a moment to take effect.
     await Future<void>.delayed(const Duration(milliseconds: 500));
-    final lowFps = await measureScheduledFps(const Duration(seconds: 2));
-    debugPrint('Thermion scheduled FPS: limited=${lowFps.toStringAsFixed(1)}');
+    final lowFps = await measureDispatchedFps(const Duration(seconds: 2));
+    debugPrint('Thermion dispatched FPS: limited=${lowFps.toStringAsFixed(1)}');
 
     expect(lowFps, lessThan(defaultFps / 2),
         reason: '5 FPS cap should schedule far fewer frames than the default '
@@ -126,9 +126,9 @@ void main() {
       await FrameScheduler.instance.start();
       await Future<void>.delayed(const Duration(milliseconds: 500));
       final afterRestartFps =
-          await measureScheduledFps(const Duration(seconds: 2));
+          await measureDispatchedFps(const Duration(seconds: 2));
       debugPrint(
-        'Thermion scheduled FPS: after restart='
+        'Thermion dispatched FPS: after restart='
         '${afterRestartFps.toStringAsFixed(1)}',
       );
       expect(afterRestartFps, closeTo(5, 3),
@@ -139,9 +139,9 @@ void main() {
     // Restore and confirm the rate climbs back near the default.
     FilamentApp.instance!.setTargetFramerate(60);
     await Future<void>.delayed(const Duration(milliseconds: 500));
-    final restoredFps = await measureScheduledFps(const Duration(seconds: 2));
+    final restoredFps = await measureDispatchedFps(const Duration(seconds: 2));
     debugPrint(
-      'Thermion scheduled FPS: restored=${restoredFps.toStringAsFixed(1)}',
+      'Thermion dispatched FPS: restored=${restoredFps.toStringAsFixed(1)}',
     );
     expect(restoredFps, greaterThan(lowFps * 2),
         reason: 'restoring 60 FPS should raise the rate well above the 5 FPS '

--- a/examples/flutter/quickstart/integration_test/texture_resize_test.dart
+++ b/examples/flutter/quickstart/integration_test/texture_resize_test.dart
@@ -91,7 +91,7 @@ void main() {
         () => !scheduler.isRendering,
         'the current frame to finish',
       );
-      scheduler.setOnFrame(() async {
+      scheduler.setFrameHandler(() async {
         await renderGate.future;
         await FilamentApp.instance?.render();
       });

--- a/thermion_dart/ffigen/native.yaml
+++ b/thermion_dart/ffigen/native.yaml
@@ -6,8 +6,6 @@ headers:
   include-directives:
     - '../native/include/c_api/*.h'
     - '../native/include/c_api/**/*.h'
-compiler-opts:
-  - '-DTHERMION_FFIGEN'
 ffi-native:
   asset-id: package:thermion_dart/thermion_dart.dart
 ignore-source-errors: true

--- a/thermion_dart/ffigen/native.yaml
+++ b/thermion_dart/ffigen/native.yaml
@@ -6,6 +6,8 @@ headers:
   include-directives:
     - '../native/include/c_api/*.h'
     - '../native/include/c_api/**/*.h'
+compiler-opts:
+  - '-DTHERMION_FFIGEN'
 ffi-native:
   asset-id: package:thermion_dart/thermion_dart.dart
 ignore-source-errors: true
@@ -14,9 +16,9 @@ functions:
     include:
       - '.*'
     exclude:
-      # FrameScheduler_stop joins the scheduler thread and waits for the final
-      # render task to drain. Blocking functions must not be Dart FFI leaf
-      # calls. This excludes it only from isLeaf:true, not from the bindings.
+      # FrameScheduler_stop joins the scheduler callback thread. Blocking
+      # functions must not be Dart FFI leaf calls. This excludes it only from
+      # isLeaf:true, not from the bindings.
       - 'FrameScheduler_stop'
 enums:
   as-int:

--- a/thermion_dart/ffigen/web.yaml
+++ b/thermion_dart/ffigen/web.yaml
@@ -10,7 +10,6 @@ headers:
     - '../native/include/c_api/**/*.h'
 compiler-opts:
   - '-D__EMSCRIPTEN__'
-  - '-DTHERMION_FFIGEN'
 structs:
   dependency-only: opaque
   exclude: 

--- a/thermion_dart/ffigen/web.yaml
+++ b/thermion_dart/ffigen/web.yaml
@@ -10,6 +10,7 @@ headers:
     - '../native/include/c_api/**/*.h'
 compiler-opts:
   - '-D__EMSCRIPTEN__'
+  - '-DTHERMION_FFIGEN'
 structs:
   dependency-only: opaque
   exclude: 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -4605,26 +4605,11 @@ external void Scene_setIndirectLight(ffi.Pointer<TScene> tScene, ffi.Pointer<TIn
 @ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
 external void Scene_addFilamentAsset(ffi.Pointer<TScene> tScene, ffi.Pointer<TFilamentAsset> asset);
 
-@ffi.Native<ffi.Void Function(FrameCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_start(FrameCallback callback, int targetFps);
+@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
 
 @ffi.Native<ffi.Void Function()>()
 external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void FrameScheduler_setRenderThread(ffi.Pointer<ffi.Void> renderThread);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void FrameScheduler_setRenderManager(ffi.Pointer<TRenderManager> rm);
-
-@ffi.Native<ffi.Void Function(PostRenderCallback, ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void FrameScheduler_setPostRenderCallback(PostRenderCallback callback, ffi.Pointer<ffi.Void> userData);
-
-@ffi.Native<ffi.Bool Function(ffi.Uint64)>(isLeaf: true)
-external bool FrameScheduler_requestRender(int frameTimeNanos);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startNativeRenderLoop(int targetFps);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
 external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
@@ -5734,12 +5719,9 @@ final class TShadowOptions extends ffi.Struct {
 typedef FilamentRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> owner);
 typedef DartFilamentRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> owner);
 typedef FilamentRenderCallback = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
-typedef FrameCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameCallback = ffi.Pointer<ffi.NativeFunction<FrameCallbackFunction>>;
-typedef PostRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> userData);
-typedef PostRenderCallback = ffi.Pointer<ffi.NativeFunction<PostRenderCallbackFunction>>;
+typedef FrameTickCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(int frameTimeNanos);
+typedef FrameTickCallback = ffi.Pointer<ffi.NativeFunction<FrameTickCallbackFunction>>;
 
 final class TMovementIntentCalculator extends ffi.Opaque {}
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -2376,13 +2376,8 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
   external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
   external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
-  external void _FrameScheduler_start(FrameCallback callback, int targetFps);
+  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
   external void _FrameScheduler_stop();
-  external void _FrameScheduler_setRenderThread(Pointer<Void> renderThread);
-  external void _FrameScheduler_setRenderManager(Pointer<TRenderManager> rm);
-  external void _FrameScheduler_setPostRenderCallback(PostRenderCallback callback, Pointer<Void> userData);
-  external int _FrameScheduler_requestRender(JSBigInt frameTimeNanos);
-  external void _FrameScheduler_startNativeRenderLoop(int targetFps);
   external int _FrameScheduler_initDartApi(Pointer<Void> data);
   external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
   external void _FrameScheduler_setTargetFps(int fps);
@@ -8764,9 +8759,9 @@ void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asse
   return result;
 }
 
-void FrameScheduler_start(DartFrameCallback callback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_start(
-    callback as Pointer<NativeFunction<FrameCallbackFunction>>,
+void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
+    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
     targetFps,
   );
   return result;
@@ -8774,34 +8769,6 @@ void FrameScheduler_start(DartFrameCallback callback, int targetFps) {
 
 void FrameScheduler_stop() {
   final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-void FrameScheduler_setRenderThread(Pointer<Void> renderThread) {
-  final result = GeneratedBindings.instance._FrameScheduler_setRenderThread(renderThread);
-  return result;
-}
-
-void FrameScheduler_setRenderManager(Pointer<TRenderManager> rm) {
-  final result = GeneratedBindings.instance._FrameScheduler_setRenderManager(rm.cast());
-  return result;
-}
-
-void FrameScheduler_setPostRenderCallback(DartPostRenderCallback callback, Pointer<Void> userData) {
-  final result = GeneratedBindings.instance._FrameScheduler_setPostRenderCallback(
-    callback as Pointer<NativeFunction<PostRenderCallbackFunction>>,
-    userData,
-  );
-  return result;
-}
-
-bool FrameScheduler_requestRender(BigInt frameTimeNanos) {
-  final result = GeneratedBindings.instance._FrameScheduler_requestRender(frameTimeNanos.toJSBigInt);
-  return result == 1;
-}
-
-void FrameScheduler_startNativeRenderLoop(int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startNativeRenderLoop(targetFps);
   return result;
 }
 
@@ -11292,14 +11259,10 @@ final class TSurfaceOrientation extends Struct {
   }
 }
 
-typedef FrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef DartFrameCallback = Pointer<NativeFunction<FrameCallbackFunction>>;
-typedef FrameCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameCallbackFunction = void Function(BigInt frameTimeNanos);
-typedef PostRenderCallback = Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef DartPostRenderCallback = Pointer<NativeFunction<PostRenderCallbackFunction>>;
-typedef PostRenderCallbackFunction = void Function(Pointer<Void> userData);
-typedef DartPostRenderCallbackFunction = void Function(Pointer<Void> userData);
+typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
   TMovementIntentExecutor toDart() {

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -802,6 +802,21 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
   //
   @override
   Future render() async {
+    await runRequestFrameHooks();
+
+    await renderManager.render();
+  }
+
+  /// Runs every registered request-frame hook once, in registration order.
+  ///
+  /// [render] calls this before dispatching the render. The Flutter-synced
+  /// Linux render loop calls it directly, once per native-admitted frame: its
+  /// renders are dispatched natively, so Dart only contributes the hooks
+  /// (per-frame camera controllers, procedural updates, and similar).
+  ///
+  /// Registering or unregistering a hook waits for the running pass to
+  /// finish (see [registerRequestFrameHook]).
+  Future<void> runRequestFrameHooks() async {
     _processingRenderHooks = true;
     try {
       for (final hook in _hooks) {
@@ -811,8 +826,6 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       _logger.severe(err);
     }
     _processingRenderHooks = false;
-
-    await renderManager.render();
   }
 
   int _targetFramerate = 0;

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -802,21 +802,6 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
   //
   @override
   Future render() async {
-    await runRequestFrameHooks();
-
-    await renderManager.render();
-  }
-
-  /// Runs every registered request-frame hook once, in registration order.
-  ///
-  /// [render] calls this before dispatching the render. The Flutter-synced
-  /// Linux render loop calls it directly, once per native-admitted frame: its
-  /// renders are dispatched natively, so Dart only contributes the hooks
-  /// (per-frame camera controllers, procedural updates, and similar).
-  ///
-  /// Registering or unregistering a hook waits for the running pass to
-  /// finish (see [registerRequestFrameHook]).
-  Future<void> runRequestFrameHooks() async {
     _processingRenderHooks = true;
     try {
       for (final hook in _hooks) {
@@ -826,6 +811,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       _logger.severe(err);
     }
     _processingRenderHooks = false;
+
+    await renderManager.render();
   }
 
   int _targetFramerate = 0;

--- a/thermion_dart/native/include/c_api/FrameSchedulerApi.h
+++ b/thermion_dart/native/include/c_api/FrameSchedulerApi.h
@@ -2,12 +2,6 @@
 
 #include "APIBoundaryTypes.h"
 
-// Preserve the historical generated-binding declaration order without making
-// the production timing API depend on rendering types.
-#ifdef THERMION_FFIGEN
-#include "TRenderManager.h"
-#endif
-
 #ifdef __cplusplus
 namespace thermion
 {

--- a/thermion_dart/native/include/c_api/FrameSchedulerApi.h
+++ b/thermion_dart/native/include/c_api/FrameSchedulerApi.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include "APIBoundaryTypes.h"
+
+// Preserve the historical generated-binding declaration order without making
+// the production timing API depend on rendering types.
+#ifdef THERMION_FFIGEN
 #include "TRenderManager.h"
+#endif
 
 #ifdef __cplusplus
 namespace thermion
@@ -9,17 +14,10 @@ namespace thermion
     extern "C"
     {
 #endif
-        typedef void (*FrameCallback)(uint64_t frameTimeNanos);
-        typedef void (*PostRenderCallback)(void* userData);
+        typedef void (*FrameTickCallback)(uint64_t frameTimeNanos);
 
-        EMSCRIPTEN_KEEPALIVE void FrameScheduler_start(FrameCallback callback, int targetFps);
+        EMSCRIPTEN_KEEPALIVE void FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_stop();
-
-        EMSCRIPTEN_KEEPALIVE void FrameScheduler_setRenderThread(void* renderThread);
-        EMSCRIPTEN_KEEPALIVE void FrameScheduler_setRenderManager(TRenderManager* rm);
-        EMSCRIPTEN_KEEPALIVE void FrameScheduler_setPostRenderCallback(PostRenderCallback callback, void* userData);
-        EMSCRIPTEN_KEEPALIVE bool FrameScheduler_requestRender(uint64_t frameTimeNanos);
-        EMSCRIPTEN_KEEPALIVE void FrameScheduler_startNativeRenderLoop(int targetFps);
 
         EMSCRIPTEN_KEEPALIVE int FrameScheduler_initDartApi(void* data);
         EMSCRIPTEN_KEEPALIVE void FrameScheduler_startWithPort(int64_t port, int targetFps);

--- a/thermion_dart/native/include/rendering/FrameScheduler.hpp
+++ b/thermion_dart/native/include/rendering/FrameScheduler.hpp
@@ -53,16 +53,17 @@ namespace thermion {
 class FrameScheduler {
 public:
     /// Receives a monotonic frame timestamp and the pointer supplied to start().
-    using Callback = void (*)(uint64_t frameTimeNanos, void* userData);
+    using TickCallback = void (*)(uint64_t frameTimeNanos, void* userData);
 
     virtual ~FrameScheduler() = default;
 
     /// Starts the frame source. Each source tick that passes rate gating invokes
-    /// `callback` with its timestamp and `userData`.
+    /// `tickCallback` with its timestamp and `userData`.
     ///
-    /// The scheduler does not own `userData`. The callback and `userData` must
-    /// remain valid until stop() returns. Call stop() before a second start().
-    virtual void start(Callback callback, void* userData = nullptr) = 0;
+    /// The scheduler does not own `userData`. The tick callback and `userData`
+    /// must remain valid until stop() returns. Call stop() before a second
+    /// start().
+    virtual void start(TickCallback tickCallback, void* userData = nullptr) = 0;
 
     /// Stops the frame source and waits for its callback context to stop.
     /// Work that the callback already posted can continue after this returns.
@@ -84,8 +85,8 @@ public:
     void setTargetFps(int fps);
 
 protected:
-    Callback _callback = nullptr;
-    void* _callbackUserData = nullptr;
+    TickCallback _tickCallback = nullptr;
+    void* _tickUserData = nullptr;
 
     // setTargetFps() can change _fpsLimit from another thread. The source
     // callback owns the other timing fields while the scheduler runs.
@@ -109,7 +110,7 @@ class TimerFrameScheduler : public FrameScheduler {
 public:
     explicit TimerFrameScheduler(int targetFps) : _targetFps(targetFps) {}
     ~TimerFrameScheduler() override { stop(); }
-    void start(Callback callback, void* userData = nullptr) override;
+    void start(TickCallback tickCallback, void* userData = nullptr) override;
     void stop() override;
 private:
     void run();
@@ -122,7 +123,7 @@ class CADisplayLinkScheduler : public FrameScheduler {
     void* _wrapper = nullptr;
 public:
     ~CADisplayLinkScheduler() override { stop(); }
-    void start(Callback callback, void* userData = nullptr) override;
+    void start(TickCallback tickCallback, void* userData = nullptr) override;
     void stop() override;
 private:
     static void displayLinkCallback(uint64_t frameTimeNanos, void* context);
@@ -137,7 +138,7 @@ class CVDisplayLinkScheduler : public FrameScheduler {
     mach_timebase_info_data_t _timebase{};
 public:
     ~CVDisplayLinkScheduler() override { stop(); }
-    void start(Callback callback, void* userData = nullptr) override;
+    void start(TickCallback tickCallback, void* userData = nullptr) override;
     void stop() override;
 private:
     static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
@@ -155,7 +156,7 @@ class DXGIFrameScheduler : public FrameScheduler {
 public:
     explicit DXGIFrameScheduler(int targetFps) : _targetFps(targetFps) {}
     ~DXGIFrameScheduler() override { stop(); }
-    void start(Callback callback, void* userData = nullptr) override;
+    void start(TickCallback tickCallback, void* userData = nullptr) override;
     void stop() override;
 };
 #endif
@@ -172,7 +173,7 @@ class AChoreographerFrameScheduler : public FrameScheduler {
     uint64_t _nextSourceFrameNs = 0;
 public:
     ~AChoreographerFrameScheduler() override { stop(); }
-    void start(Callback callback, void* userData = nullptr) override;
+    void start(TickCallback tickCallback, void* userData = nullptr) override;
     void stop() override;
 private:
     void scheduleNextFrame(uint64_t lastFrameTimeNanos = 0);

--- a/thermion_dart/native/src/c_api/FrameSchedulerApi.cpp
+++ b/thermion_dart/native/src/c_api/FrameSchedulerApi.cpp
@@ -1,13 +1,8 @@
 #include <atomic>
-#include <algorithm>
 #include <chrono>
-#include <thread>
 
 #include "c_api/FrameSchedulerApi.h"
-#include "c_api/TRenderManager.h"
 
-#include "rendering/RenderThread.hpp"
-#include "rendering/RenderManager.hpp"
 #include "rendering/FrameScheduler.hpp"
 
 #ifndef __EMSCRIPTEN__
@@ -20,34 +15,25 @@ extern "C"
 {
 
   static thermion::FrameScheduler* _frameScheduler = nullptr;
-  static FrameCallback _scheduledCallback = nullptr;
+  static FrameTickCallback _tickCallback = nullptr;
   static int64_t _dartPort = 0;
 
-  static TRenderManager* _nativeRenderManager = nullptr;
-  static RenderThread* _renderThread = nullptr;
-  static std::atomic<bool> _nativeRenderInProgress{false};
-  static PostRenderCallback _postRenderCallback = nullptr;
-  static void* _postRenderUserData = nullptr;
-
   static std::atomic<int> _targetFpsLimit{0};
-
-  static int _requestAppliedFpsLimit = 0;
-  static uint64_t _nextRequestRenderNs = 0;
 
   static void applyTargetFps(FrameScheduler* scheduler) {
     scheduler->setTargetFps(_targetFpsLimit.load(std::memory_order_relaxed));
   }
 
-  static void forwardScheduledFrame(
+  static void forwardScheduledTick(
       uint64_t frameTimeNanos, void* userData) {
-    auto callback = *static_cast<FrameCallback*>(userData);
+    auto callback = *static_cast<FrameTickCallback*>(userData);
     if (callback) {
       callback(frameTimeNanos);
     }
   }
 
 #ifndef __EMSCRIPTEN__
-  static void postScheduledFrameToDart(
+  static void postScheduledTickToDart(
       uint64_t frameTimeNanos, void* userData) {
     const int64_t port = *static_cast<int64_t*>(userData);
     if (port == 0) return;
@@ -59,7 +45,8 @@ extern "C"
   }
 #endif
 
-  EMSCRIPTEN_KEEPALIVE void FrameScheduler_start(FrameCallback callback, int targetFps) {
+  EMSCRIPTEN_KEEPALIVE void FrameScheduler_startWithCallback(
+      FrameTickCallback tickCallback, int targetFps) {
 #ifndef __EMSCRIPTEN__
     if (_frameScheduler) {
       _frameScheduler->stop();
@@ -68,8 +55,8 @@ extern "C"
     }
     _frameScheduler = thermion::FrameScheduler::create(targetFps);
     applyTargetFps(_frameScheduler);
-    _scheduledCallback = callback;
-    _frameScheduler->start(forwardScheduledFrame, &_scheduledCallback);
+    _tickCallback = tickCallback;
+    _frameScheduler->start(forwardScheduledTick, &_tickCallback);
 #endif
   }
 
@@ -80,16 +67,8 @@ extern "C"
       delete _frameScheduler;
       _frameScheduler = nullptr;
     }
-    _scheduledCallback = nullptr;
+    _tickCallback = nullptr;
     _dartPort = 0;
-
-    while (_nativeRenderInProgress.load(std::memory_order_acquire)) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-    _nativeRenderManager = nullptr;
-    _renderThread = nullptr;
-    _postRenderCallback = nullptr;
-    _postRenderUserData = nullptr;
 #endif
   }
 
@@ -125,7 +104,7 @@ extern "C"
     _frameScheduler = thermion::FrameScheduler::create(targetFps);
     applyTargetFps(_frameScheduler);
     _dartPort = port;
-    _frameScheduler->start(postScheduledFrameToDart, &_dartPort);
+    _frameScheduler->start(postScheduledTickToDart, &_dartPort);
 #endif
   }
 
@@ -136,104 +115,6 @@ extern "C"
     if (_frameScheduler) {
       _frameScheduler->setTargetFps(normalizedFps);
     }
-#endif
-  }
-
-  EMSCRIPTEN_KEEPALIVE void FrameScheduler_setRenderThread(void* renderThread) {
-#ifndef __EMSCRIPTEN__
-    _renderThread = static_cast<RenderThread*>(renderThread);
-#endif
-  }
-
-  EMSCRIPTEN_KEEPALIVE void FrameScheduler_setRenderManager(TRenderManager* rm) {
-    _nativeRenderManager = rm;
-  }
-
-  EMSCRIPTEN_KEEPALIVE void FrameScheduler_setPostRenderCallback(PostRenderCallback callback, void* userData) {
-    _postRenderCallback = callback;
-    _postRenderUserData = userData;
-  }
-
-  static bool _nativeFrameCallback(uint64_t frameTimeNanos) {
-    auto* renderManager = _nativeRenderManager;
-    auto* renderThread = _renderThread;
-    auto postRenderCallback = _postRenderCallback;
-    auto* postRenderUserData = _postRenderUserData;
-    if (!renderManager || !renderThread) return false;
-    if (_nativeRenderInProgress.exchange(true, std::memory_order_acq_rel)) {
-      return false;
-    }
-
-    renderThread->addDetachedTask([
-      renderManager,
-      frameTimeNanos,
-      postRenderCallback,
-      postRenderUserData
-    ]() {
-      RenderManager_render(renderManager, frameTimeNanos);
-
-      if (postRenderCallback) {
-        postRenderCallback(postRenderUserData);
-      }
-
-      _nativeRenderInProgress.store(false, std::memory_order_release);
-    });
-    return true;
-  }
-
-  static void _nativeScheduledFrameCallback(
-      uint64_t frameTimeNanos, void*) {
-    _nativeFrameCallback(frameTimeNanos);
-  }
-
-  EMSCRIPTEN_KEEPALIVE bool FrameScheduler_requestRender(uint64_t frameTimeNanos) {
-    int fps = _targetFpsLimit.load(std::memory_order_relaxed);
-    if (fps > 0) {
-      const uint64_t interval = std::max<uint64_t>(
-          1, 1000000000ULL / static_cast<uint64_t>(fps));
-      const uint64_t tolerance = 1000000ULL;
-
-      if (_requestAppliedFpsLimit != fps || _nextRequestRenderNs == 0) {
-        _requestAppliedFpsLimit = fps;
-        _nextRequestRenderNs = frameTimeNanos;
-      }
-
-      if (_nextRequestRenderNs > frameTimeNanos &&
-          _nextRequestRenderNs - frameTimeNanos > tolerance) {
-        return false;
-      }
-
-      if (!_nativeFrameCallback(frameTimeNanos)) {
-        return false;
-      }
-
-      if (_nextRequestRenderNs <= frameTimeNanos) {
-        const uint64_t missedIntervals =
-            (frameTimeNanos - _nextRequestRenderNs) / interval + 1;
-        _nextRequestRenderNs += missedIntervals * interval;
-      } else {
-        _nextRequestRenderNs += interval;
-      }
-      return true;
-    } else {
-      _requestAppliedFpsLimit = 0;
-      _nextRequestRenderNs = 0;
-    }
-    return _nativeFrameCallback(frameTimeNanos);
-  }
-
-  EMSCRIPTEN_KEEPALIVE void FrameScheduler_startNativeRenderLoop(int targetFps) {
-#ifndef __EMSCRIPTEN__
-    if (_frameScheduler) {
-      _frameScheduler->stop();
-      delete _frameScheduler;
-      _frameScheduler = nullptr;
-    }
-
-    _frameScheduler = new thermion::TimerFrameScheduler(
-        targetFps > 0 ? targetFps : 60);
-    applyTargetFps(_frameScheduler);
-    _frameScheduler->start(_nativeScheduledFrameCallback);
 #endif
   }
 

--- a/thermion_dart/native/src/rendering/FrameScheduler.cpp
+++ b/thermion_dart/native/src/rendering/FrameScheduler.cpp
@@ -74,14 +74,14 @@ void FrameScheduler::handleSourceTick(uint64_t nanos) {
         _nextDispatchNs = 0;
     }
 
-    if (_callback) {
-        _callback(nanos, _callbackUserData);
+    if (_tickCallback) {
+        _tickCallback(nanos, _tickUserData);
     }
 }
 
 void FrameScheduler::resetState() {
-    _callback = nullptr;
-    _callbackUserData = nullptr;
+    _tickCallback = nullptr;
+    _tickUserData = nullptr;
     _appliedFpsLimit = 0;
     _dispatchIntervalNs = 0;
     _nextDispatchNs = 0;
@@ -179,10 +179,10 @@ void TimerFrameScheduler::run() {
     }
 }
 
-void TimerFrameScheduler::start(Callback callback, void* userData) {
+void TimerFrameScheduler::start(TickCallback tickCallback, void* userData) {
     if (_running) return;
-    _callback = callback;
-    _callbackUserData = userData;
+    _tickCallback = tickCallback;
+    _tickUserData = userData;
     _running = true;
     _thread = new std::thread([this]() { run(); });
 }
@@ -212,10 +212,10 @@ void CADisplayLinkScheduler::displayLinkCallback(uint64_t frameTimeNanos, void* 
     self->handleSourceTick(frameTimeNanos);
 }
 
-void CADisplayLinkScheduler::start(Callback callback, void* userData) {
+void CADisplayLinkScheduler::start(TickCallback tickCallback, void* userData) {
     stop();
-    _callback = callback;
-    _callbackUserData = userData;
+    _tickCallback = tickCallback;
+    _tickUserData = userData;
     _wrapper = CADisplayLinkWrapper_create(displayLinkCallback, this);
     CADisplayLinkWrapper_setTargetFps(
         _wrapper, _fpsLimit.load(std::memory_order_relaxed));
@@ -244,10 +244,10 @@ void CADisplayLinkScheduler::stop() {
 
 #if __APPLE__ && TARGET_OS_OSX
 
-void CVDisplayLinkScheduler::start(Callback callback, void* userData) {
+void CVDisplayLinkScheduler::start(TickCallback tickCallback, void* userData) {
     stop();
-    _callback = callback;
-    _callbackUserData = userData;
+    _tickCallback = tickCallback;
+    _tickUserData = userData;
     mach_timebase_info(&_timebase);
 
     CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
@@ -286,10 +286,10 @@ CVReturn CVDisplayLinkScheduler::displayLinkCallback(CVDisplayLinkRef displayLin
 
 #ifdef _WIN32
 
-void DXGIFrameScheduler::start(Callback callback, void* userData) {
+void DXGIFrameScheduler::start(TickCallback tickCallback, void* userData) {
     stop();
-    _callback = callback;
-    _callbackUserData = userData;
+    _tickCallback = tickCallback;
+    _tickUserData = userData;
     _running = true;
 
     _thread = new std::thread([this]() {
@@ -404,10 +404,10 @@ void AChoreographerFrameScheduler::scheduleNextFrame(uint64_t lastFrameTimeNanos
     }
 }
 
-void AChoreographerFrameScheduler::start(Callback callback, void* userData) {
+void AChoreographerFrameScheduler::start(TickCallback tickCallback, void* userData) {
     stop();
-    _callback = callback;
-    _callbackUserData = userData;
+    _tickCallback = tickCallback;
+    _tickUserData = userData;
     _running = true;
 
     _thread = new std::thread([this]() {

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -47,14 +47,14 @@ On macOS, iOS, Windows, Android, Thermion use the platform vsync signal to synch
 - `DXGIFrameScheduler` (DXGI `WaitForVBlank`)  (Windows)
 - `AChoreographerFrameScheduler` (Android)
 
-On Linux, vsync is not reliably available, so Thermion uses Flutter's own `SchedulerBinding`. Its persistent frame callback feeds the same Dart `FrameScheduler` callback pipeline used by the other platforms. This keeps Thermion in lockstep with Flutter's Skia compositor without introducing a separate Linux render loop: request-frame hooks, `FilamentApp.render()`, and post-render texture notification run in the same order everywhere.
+On Linux, vsync is not reliably available, so Thermion uses Flutter's own `SchedulerBinding`. Its persistent frame callback feeds the same Dart `FrameScheduler` frame-handler pipeline used by the other platforms. This keeps Thermion in lockstep with Flutter's Skia compositor without introducing a separate Linux render loop: request-frame hooks, `FilamentApp.render()`, and post-render texture notification run in the same order everywhere.
 
-The `FrameScheduler` dispatches its callback to Dart in one of two ways:
+The native `FrameScheduler` only produces rate-limited timing ticks. It delivers accepted ticks to Dart in one of two ways:
 
 - **Release**: a raw C function pointer (`ffi.NativeCallable`) — minimum latency.
 - **Debug** (hot-restart safe): `Dart_PostCObject_DL` onto a `ReceivePort`. `Dart_PostCObject` silently drops messages to dead ports, so stale native schedulers created in a previous isolate can't crash the new one.
 
-Linux does not need either native-to-Dart transport because Flutter invokes the persistent frame callback in Dart directly. It still uses the same active, pause, in-flight, diagnostics, and render callback logic after that platform-specific entry point.
+Linux does not need either native-to-Dart transport because Flutter invokes the persistent frame callback in Dart directly. It still uses the same active, pause, in-flight, diagnostics, and frame-handler logic after that platform-specific entry point.
 
 Android intentionally keeps render admission on these Dart callback paths.
 Flutter's `ImageReaderSurfaceProducer` receives images through a listener on
@@ -69,7 +69,7 @@ By default the viewer renders on **every vsync** — i.e. at the display's nativ
 
 `FilamentApp.instance.setTargetFramerate(fps)` caps the rate *below* the display refresh by skipping vsyncs at the source, so dropped native frames never wake Dart. It's an engine-level API — the same native scheduler paces the headless CLI path — and it cannot raise the rate above the refresh. An absolute target deadline preserves the requested average on displays whose refresh is not an integer multiple of the target. For example, 60 fps on a 90 Hz display alternates one- and two-vsync presentation intervals rather than falling to 45 fps. That cadence necessarily has some judder; exact, evenly spaced 60 fps is physically impossible on a fixed 90 Hz presentation clock.
 
-The native display-link sources apply the cap in `FrameScheduler::dispatchFrame`, fed by `FrameScheduler_setTargetFps`. Linux applies the same absolute-deadline algorithm to Flutter's frame timestamps before entering the common callback pipeline. Web applies it directly in its `requestAnimationFrame` loop.
+The native display-link sources apply the cap in `FrameScheduler::handleSourceTick`, fed by `FrameScheduler_setTargetFps`. Linux applies the same absolute-deadline algorithm to Flutter's frame timestamps before entering the common frame-handler pipeline. Web applies it directly in its `requestAnimationFrame` loop.
 
 Framerate is a property of the **shared render loop**, not of any one viewer. All viewers on the same engine are pace-locked to the same rate (one scheduler drives a single `renderManager.render()` that renders every attached view each tick), so there is no per-view pacing — the last `setTargetFramerate` call wins for all viewers.
 
@@ -97,7 +97,7 @@ On each vsync tick, the following runs:
 7. Back in `_renderFrame`, for each `PlatformTextureDescriptor` we call **`markTextureFrameAvailable()`**.
 8. The Texture widget schedules a repaint; Flutter's compositor samples the updated hardware texture on its next frame.
 
-Steps 3–6 are a single Dart `await`: the Flutter frame callback does not return until `endFrame` has completed on the render thread. The render does **not** run on the platform thread — it runs on the dedicated `RenderThread` — so the UI isolate isn't blocked on GPU work beyond the round-trip wait.
+Steps 3–6 are represented by a single Dart `Future`. The timing callback starts that work without awaiting it; the `_rendering` guard skips later ticks until the future completes. Rendering runs on the dedicated `RenderThread`, not the platform thread or Dart isolate.
 
 ### `markTextureFrameAvailable`
 
@@ -121,7 +121,7 @@ Compositing itself is Flutter's responsibility — the Texture widget participat
 
 **The invariant (both platforms): pause stops rendering only. The task queue keeps draining.**
 
-`pauseFrameScheduler()` / `resumeFrameScheduler()` gate the **render pipeline** — on native, Dart's `_onFrame` short-circuits (so no `RenderManager_render` task is queued); on web, `RenderManager::tick()` skips `updateAnimationsAndPlugins` + the swapchain loop. Neither path touches `RenderThread::_tasks`, so every `*_RenderThread` FFI call (`setTransform`, `addEntity`, material/camera updates, etc.) continues to queue and execute exactly as it does when running. `await`-ing an FFI call during pause will not hang; state accumulated during pause is visible on the first render after resume.
+`pauseFrameScheduler()` / `resumeFrameScheduler()` gate the **render pipeline** — on native, Dart declines to dispatch the frame handler (so no `RenderManager_render` task is queued); on web, `RenderManager::tick()` skips `updateAnimationsAndPlugins` + the swapchain loop. Neither path touches `RenderThread::_tasks`, so every `*_RenderThread` FFI call (`setTransform`, `addEntity`, material/camera updates, etc.) continues to queue and execute exactly as it does when running. `await`-ing an FFI call during pause will not hang; state accumulated during pause is visible on the first render after resume.
 
 App lifecycle suspension is separate from an explicit caller pause. `hidden`,
 `paused`, and `detached` suspend rendering; `inactive` does not, because the app

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -47,16 +47,14 @@ On macOS, iOS, Windows, Android, Thermion use the platform vsync signal to synch
 - `DXGIFrameScheduler` (DXGI `WaitForVBlank`)  (Windows)
 - `AChoreographerFrameScheduler` (Android)
 
-On Linux, vsync is not reliably available, so Thermion uses Flutter's own `SchedulerBinding`. 
-
-Instead, we use a platform-native `FrameScheduler` (`thermion_dart/native/src/c_api/FrameSchedulerApi.cpp`) to provide the vsync signal:
-
-On Linux, we need to use Flutter's persistent frame callback to drive a non-blocking `FrameScheduler_requestRender` on the native render thread (`_initializeNativeRenderLoop` in `thermion_flutter_plugin_native.dart`). This keeps Thermion in lockstep with Flutter's Skia compositor, which matters on Linux where there is no independent display-link API we can reliably use.
+On Linux, vsync is not reliably available, so Thermion uses Flutter's own `SchedulerBinding`. Its persistent frame callback feeds the same Dart `FrameScheduler` callback pipeline used by the other platforms. This keeps Thermion in lockstep with Flutter's Skia compositor without introducing a separate Linux render loop: request-frame hooks, `FilamentApp.render()`, and post-render texture notification run in the same order everywhere.
 
 The `FrameScheduler` dispatches its callback to Dart in one of two ways:
 
 - **Release**: a raw C function pointer (`ffi.NativeCallable`) — minimum latency.
 - **Debug** (hot-restart safe): `Dart_PostCObject_DL` onto a `ReceivePort`. `Dart_PostCObject` silently drops messages to dead ports, so stale native schedulers created in a previous isolate can't crash the new one.
+
+Linux does not need either native-to-Dart transport because Flutter invokes the persistent frame callback in Dart directly. It still uses the same active, pause, in-flight, diagnostics, and render callback logic after that platform-specific entry point.
 
 Android intentionally keeps render admission on these Dart callback paths.
 Flutter's `ImageReaderSurfaceProducer` receives images through a listener on
@@ -71,7 +69,7 @@ By default the viewer renders on **every vsync** — i.e. at the display's nativ
 
 `FilamentApp.instance.setTargetFramerate(fps)` caps the rate *below* the display refresh by skipping vsyncs at the source, so dropped native frames never wake Dart. It's an engine-level API — the same native scheduler paces the headless CLI path — and it cannot raise the rate above the refresh. An absolute target deadline preserves the requested average on displays whose refresh is not an integer multiple of the target. For example, 60 fps on a 90 Hz display alternates one- and two-vsync presentation intervals rather than falling to 45 fps. That cadence necessarily has some judder; exact, evenly spaced 60 fps is physically impossible on a fixed 90 Hz presentation clock.
 
-The cap is applied in two native places, both fed by `FrameScheduler_setTargetFps`: in `FrameScheduler::dispatchFrame` (the CVDisplayLink / CADisplayLink / AChoreographer / DXGI / timer schedulers), and in `FrameScheduler_requestRender` (the Linux Flutter-synced path, which bypasses `dispatchFrame`). The desired cap is process-wide and survives scheduler destruction/recreation during app lifecycle transitions. Web applies the same deadline algorithm directly in its `requestAnimationFrame` loop.
+The native display-link sources apply the cap in `FrameScheduler::dispatchFrame`, fed by `FrameScheduler_setTargetFps`. Linux applies the same absolute-deadline algorithm to Flutter's frame timestamps before entering the common callback pipeline. Web applies it directly in its `requestAnimationFrame` loop.
 
 Framerate is a property of the **shared render loop**, not of any one viewer. All viewers on the same engine are pace-locked to the same rate (one scheduler drives a single `renderManager.render()` that renders every attached view each tick), so there is no per-view pacing — the last `setTargetFramerate` call wins for all viewers.
 
@@ -106,9 +104,8 @@ Steps 3–6 are a single Dart `await`: the Flutter frame callback does not retur
 `markTextureFrameAvailable` is how we tell Flutter "the texture you imported has new contents; please sample it on the next compositor pass." It is called **after** `endFrame` returns on the render thread (i.e. after the callback has crossed back to the main thread). Implementations:
 
 - **Darwin**: direct Objective-C call — `SwiftThermionFlutterPluginObjCAPI.markTextureFrameAvailableWithFlutterTextureId_` (`darwin_platform_texture_descriptor.dart`).
-- **Android/Linux/Windows**: platform channel — `channel.invokeMethod("markTextureFrameAvailable", flutterTextureId)` (`method_channel_platform_texture_descriptor.dart`).
-
-On Linux with `FrameScheduler_setPostRenderCallback`, the mark happens entirely in native code (`thermion_flutter_mark_textures`) without bouncing to Dart, removing one round-trip per frame.
+- **Android/Windows**: platform channel — `channel.invokeMethod("markTextureFrameAvailable", flutterTextureId)` (`method_channel_platform_texture_descriptor.dart`).
+- **Linux**: after the common Dart render future completes, one direct FFI call to `thermion_flutter_mark_textures` marks every registered external texture. This keeps texture presentation platform-specific without making rendering platform-specific.
 
 ### Composite path
 

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/frame_scheduler.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/frame_scheduler.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 import 'dart:ffi' as ffi;
 import 'dart:io';
 import 'dart:isolate';
+import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart' show kDebugMode, visibleForTesting;
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/scheduler.dart';
 import 'package:logging/logging.dart';
 // ignore: implementation_imports
@@ -14,13 +15,7 @@ import 'package:thermion_dart/src/bindings/src/thermion_dart_ffi.g.dart'
         FrameCallbackFunction,
         FrameScheduler_initDartApi,
         FrameScheduler_startWithPort,
-        FrameScheduler_setRenderThread,
-        FrameScheduler_setRenderManager,
-        FrameScheduler_setPostRenderCallback,
-        FrameScheduler_requestRender,
-        FrameScheduler_steadyClockUs,
-        PostRenderCallback,
-        TRenderManager;
+        FrameScheduler_steadyClockUs;
 
 /// Drives per-frame callbacks off the native FrameScheduler (CVDisplayLink /
 /// DXGI / AChoreographer / timer) via one of three modes:
@@ -29,10 +24,8 @@ import 'package:thermion_dart/src/bindings/src/thermion_dart_ffi.g.dart'
 ///   pointer via [ffi.NativeCallable.listener].
 /// - **Port mode** (debug builds): native posts messages to a [ReceivePort].
 ///   Hot-restart safe — messages to dead ports are silently dropped.
-/// - **Flutter-synced** (Linux native render loop): Flutter's persistent
-///   frame callback drives a non-blocking native render request. The Dart
-///   per-frame hook runs once per frame the native scheduler admits, so it
-///   stays 1:1 with rendered frames.
+/// - **Flutter-synced** (Linux): Flutter's persistent frame callback drives
+///   the same Dart callback pipeline as the native display-link sources.
 class FrameScheduler {
   FrameScheduler._();
 
@@ -41,9 +34,7 @@ class FrameScheduler {
   /// Returns the process-wide singleton.
   static FrameScheduler get instance => _instance;
 
-  /// Called once per admitted frame in every mode: per native-dispatched
-  /// frame in direct/port mode, and per native-admitted render request in
-  /// Flutter-synced mode.
+  /// Called once per admitted frame in every mode.
   Future<void> Function()? _onFrameCallback;
 
   /// Bind the per-frame callback. Must be called before [start] or
@@ -70,14 +61,9 @@ class FrameScheduler {
   ffi.NativeCallable<FrameCallbackFunction>? _frameCallable;
   ReceivePort? _framePort;
 
-  /// Performs the native render request for the Flutter-synced path and
-  /// returns whether the frame was admitted by the native throttle and
-  /// in-flight guard. Indirection exists so tests can stub admission
-  /// without driving a real render; production always uses
-  /// [FrameScheduler_requestRender].
-  @visibleForTesting
-  bool Function(int frameTimeNanos) requestRender =
-      FrameScheduler_requestRender;
+  int Function()? _flutterTargetFps;
+  int _flutterAppliedFpsLimit = 0;
+  int _nextFlutterFrameUs = 0;
 
   int _diagFrameCount = 0;
   int _diagDropCount = 0;
@@ -131,29 +117,18 @@ class FrameScheduler {
     }
   }
 
-  /// Configure the native scheduler to run the render loop entirely in
-  /// native code, synchronized to Flutter's frame clock via a persistent
-  /// frame callback.
+  /// Drive the normal frame callback pipeline from Flutter's frame clock.
   ///
-  /// The Dart per-frame callback ([setOnFrame]) runs once per frame the native
-  /// scheduler admits — the same 1:1 callback-to-render coupling as the other
-  /// modes.
-  Future<void> startFlutterSynced({
-    required ffi.Pointer<ffi.Void> renderThreadHandle,
-    required ffi.Pointer<TRenderManager> renderManagerHandle,
-    required PostRenderCallback postRenderCallback,
-    required ffi.Pointer<ffi.Void> postRenderUserData,
-  }) async {
+  /// Linux uses this because it has no reliable native display-link source
+  /// synchronized with Flutter's compositor. Rendering itself is still owned
+  /// by the callback installed with [setOnFrame], just like every other mode.
+  Future<void> startFlutterSynced({required int Function() targetFps}) async {
     if (_active) return;
     _active = true;
     _flutterSynced = true;
-
-    FrameScheduler_setRenderThread(renderThreadHandle);
-    FrameScheduler_setRenderManager(renderManagerHandle);
-    FrameScheduler_setPostRenderCallback(
-      postRenderCallback,
-      postRenderUserData,
-    );
+    _flutterTargetFps = targetFps;
+    _flutterAppliedFpsLimit = 0;
+    _nextFlutterFrameUs = 0;
 
     // Persistent callbacks cannot be unregistered. Register exactly once for
     // this isolate; stop/reset only deactivate it, and a later start reuses it.
@@ -174,6 +149,9 @@ class FrameScheduler {
   void stop() {
     _active = false;
     _flutterSynced = false;
+    _flutterTargetFps = null;
+    _flutterAppliedFpsLimit = 0;
+    _nextFlutterFrameUs = 0;
 
     // Always stop native state even when Dart has just hot-restarted and no
     // longer remembers that the previous isolate started a scheduler.
@@ -256,7 +234,7 @@ class FrameScheduler {
     // Dart-side gate here — only the callback in-flight guard below.
     final callback = _admitFrameCallback();
     if (callback != null) {
-      _runFrameCallback(callback, countAsScheduled: true);
+      _runFrameCallback(callback);
     }
   }
 
@@ -265,9 +243,8 @@ class FrameScheduler {
   Future<void> Function()? _admitFrameCallback() {
     if (!_active || _paused) return null;
     if (_rendering) {
-      // Do not admit a native Linux render without its corresponding Dart
-      // callback. This keeps callbacks and renders 1:1 even when Dart work
-      // takes longer than a Flutter frame.
+      // Keep only one callback/render in flight. Frames arriving while Dart
+      // or the render thread is still busy are dropped rather than queued.
       _diagDropCount++;
       return null;
     }
@@ -278,17 +255,10 @@ class FrameScheduler {
     return callback;
   }
 
-  /// Runs an admitted callback and records diagnostics. Direct/port mode
-  /// counts this admission here; Flutter-synced mode counts only after the
-  /// native scheduler accepts its render request.
-  void _runFrameCallback(
-    Future<void> Function() callback, {
-    required bool countAsScheduled,
-  }) {
+  /// Runs an admitted callback and records diagnostics.
+  void _runFrameCallback(Future<void> Function() callback) {
     _rendering = true;
-    if (countAsScheduled) {
-      _scheduledFrameCount++;
-    }
+    _scheduledFrameCount++;
     _diagStopwatch
       ..reset()
       ..start();
@@ -328,16 +298,44 @@ class FrameScheduler {
   void _onFlutterFrame(Duration timeStamp) {
     if (!_active || !_flutterSynced || _paused) return;
     final callback = _admitFrameCallback();
-    if (callback != null) {
-      // Native code owns Linux pacing, throttling, render-thread admission,
-      // and rendering. The Dart callback is admitted first so a slow callback
-      // cannot produce native renders with no corresponding Dart update.
-      final scheduled = requestRender(timeStamp.inMicroseconds * 1000);
-      if (scheduled) {
-        _scheduledFrameCount++;
-        _runFrameCallback(callback, countAsScheduled: false);
-      }
+    if (callback != null && _admitFlutterFrameAtTargetFps(timeStamp)) {
+      _runFrameCallback(callback);
     }
     SchedulerBinding.instance.scheduleFrame();
+  }
+
+  /// Applies the same absolute-deadline pacing used by the native frame
+  /// sources. The deadline advances only when a frame can actually run, so a
+  /// slow render does not consume future frame slots while it is in flight.
+  bool _admitFlutterFrameAtTargetFps(Duration timeStamp) {
+    final fps = _flutterTargetFps?.call() ?? 0;
+    if (fps <= 0) {
+      _flutterAppliedFpsLimit = 0;
+      _nextFlutterFrameUs = 0;
+      return true;
+    }
+
+    final frameTimeUs = timeStamp.inMicroseconds;
+    final intervalUs = math.max(1, 1000000 ~/ fps);
+    const toleranceUs = 1000;
+
+    if (_flutterAppliedFpsLimit != fps || _nextFlutterFrameUs == 0) {
+      _flutterAppliedFpsLimit = fps;
+      _nextFlutterFrameUs = frameTimeUs;
+    }
+
+    if (_nextFlutterFrameUs > frameTimeUs &&
+        _nextFlutterFrameUs - frameTimeUs > toleranceUs) {
+      return false;
+    }
+
+    if (_nextFlutterFrameUs <= frameTimeUs) {
+      final missedIntervals =
+          (frameTimeUs - _nextFlutterFrameUs) ~/ intervalUs + 1;
+      _nextFlutterFrameUs += missedIntervals * intervalUs;
+    } else {
+      _nextFlutterFrameUs += intervalUs;
+    }
+    return true;
   }
 }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/frame_scheduler.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/frame_scheduler.dart
@@ -3,7 +3,7 @@ import 'dart:ffi' as ffi;
 import 'dart:io';
 import 'dart:isolate';
 
-import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/foundation.dart' show kDebugMode, visibleForTesting;
 import 'package:flutter/scheduler.dart';
 import 'package:logging/logging.dart';
 // ignore: implementation_imports
@@ -30,8 +30,9 @@ import 'package:thermion_dart/src/bindings/src/thermion_dart_ffi.g.dart'
 /// - **Port mode** (debug builds): native posts messages to a [ReceivePort].
 ///   Hot-restart safe — messages to dead ports are silently dropped.
 /// - **Flutter-synced** (Linux native render loop): Flutter's persistent
-///   frame callback drives a non-blocking native render request. [onFrame]
-///   is not invoked in this mode.
+///   frame callback drives a non-blocking native render request. The Dart
+///   per-frame hook runs once per frame the native scheduler admits, so it
+///   stays 1:1 with rendered frames.
 class FrameScheduler {
   FrameScheduler._();
 
@@ -40,10 +41,13 @@ class FrameScheduler {
   /// Returns the process-wide singleton.
   static FrameScheduler get instance => _instance;
 
-  /// Called each frame in direct/port mode. Not invoked in Flutter-synced mode.
+  /// Called once per admitted frame in every mode: per native-dispatched
+  /// frame in direct/port mode, and per native-admitted render request in
+  /// Flutter-synced mode.
   Future<void> Function()? _onFrameCallback;
 
-  /// Bind the per-frame callback. Must be called before [start].
+  /// Bind the per-frame callback. Must be called before [start] or
+  /// [startFlutterSynced].
   void setOnFrame(Future<void> Function() onFrame) {
     _onFrameCallback = onFrame;
   }
@@ -61,9 +65,19 @@ class FrameScheduler {
   /// callback. In that mode the loop is driven by Flutter's frame clock
   /// and must be re-armed with [SchedulerBinding.scheduleFrame] on resume.
   bool _flutterSynced = false;
+  bool _flutterFrameCallbackRegistered = false;
 
   ffi.NativeCallable<FrameCallbackFunction>? _frameCallable;
   ReceivePort? _framePort;
+
+  /// Performs the native render request for the Flutter-synced path and
+  /// returns whether the frame was admitted by the native throttle and
+  /// in-flight guard. Indirection exists so tests can stub admission
+  /// without driving a real render; production always uses
+  /// [FrameScheduler_requestRender].
+  @visibleForTesting
+  bool Function(int frameTimeNanos) requestRender =
+      FrameScheduler_requestRender;
 
   int _diagFrameCount = 0;
   int _diagDropCount = 0;
@@ -119,7 +133,11 @@ class FrameScheduler {
 
   /// Configure the native scheduler to run the render loop entirely in
   /// native code, synchronized to Flutter's frame clock via a persistent
-  /// frame callback. [onFrame] is not invoked in this mode.
+  /// frame callback.
+  ///
+  /// The Dart per-frame callback ([setOnFrame]) runs once per frame the native
+  /// scheduler admits — the same 1:1 callback-to-render coupling as the other
+  /// modes.
   Future<void> startFlutterSynced({
     required ffi.Pointer<ffi.Void> renderThreadHandle,
     required ffi.Pointer<TRenderManager> renderManagerHandle,
@@ -137,7 +155,12 @@ class FrameScheduler {
       postRenderUserData,
     );
 
-    SchedulerBinding.instance.addPersistentFrameCallback(_onFlutterFrame);
+    // Persistent callbacks cannot be unregistered. Register exactly once for
+    // this isolate; stop/reset only deactivate it, and a later start reuses it.
+    if (!_flutterFrameCallbackRegistered) {
+      SchedulerBinding.instance.addPersistentFrameCallback(_onFlutterFrame);
+      _flutterFrameCallbackRegistered = true;
+    }
     SchedulerBinding.instance.scheduleFrame();
 
     _logger.info('Flutter-synced render loop started');
@@ -228,22 +251,44 @@ class FrameScheduler {
   }
 
   void _onFrame(int frameTimeNanos) {
-    if (!_active || _paused) return;
     // Framerate throttling for this path happens at the native source
     // (dispatchFrame skips dropped vsyncs before this is even called), so no
-    // Dart-side gate here — only the in-flight guard below.
+    // Dart-side gate here — only the callback in-flight guard below.
+    final callback = _admitFrameCallback();
+    if (callback != null) {
+      _runFrameCallback(callback, countAsScheduled: true);
+    }
+  }
+
+  /// Applies the common active, pause, callback, and in-flight gates before a
+  /// frame is admitted in any scheduling mode.
+  Future<void> Function()? _admitFrameCallback() {
+    if (!_active || _paused) return null;
     if (_rendering) {
-      // A vsync arrived while the previous frame is still rendering —
-      // count it as a drop and skip. (Previously uncounted.)
+      // Do not admit a native Linux render without its corresponding Dart
+      // callback. This keeps callbacks and renders 1:1 even when Dart work
+      // takes longer than a Flutter frame.
       _diagDropCount++;
-      return;
+      return null;
     }
     final callback = _onFrameCallback;
     if (callback == null) {
       throw StateError('FrameScheduler.setOnFrame must be called before start');
     }
+    return callback;
+  }
+
+  /// Runs an admitted callback and records diagnostics. Direct/port mode
+  /// counts this admission here; Flutter-synced mode counts only after the
+  /// native scheduler accepts its render request.
+  void _runFrameCallback(
+    Future<void> Function() callback, {
+    required bool countAsScheduled,
+  }) {
     _rendering = true;
-    _scheduledFrameCount++;
+    if (countAsScheduled) {
+      _scheduledFrameCount++;
+    }
     _diagStopwatch
       ..reset()
       ..start();
@@ -281,14 +326,17 @@ class FrameScheduler {
   }
 
   void _onFlutterFrame(Duration timeStamp) {
-    if (!_active || _paused) return;
-    // Pacing for this path is native. Count only requests that pass both the
-    // native throttle and render-thread in-flight guard.
-    final scheduled = FrameScheduler_requestRender(
-      timeStamp.inMicroseconds * 1000,
-    );
-    if (scheduled) {
-      _scheduledFrameCount++;
+    if (!_active || !_flutterSynced || _paused) return;
+    final callback = _admitFrameCallback();
+    if (callback != null) {
+      // Native code owns Linux pacing, throttling, render-thread admission,
+      // and rendering. The Dart callback is admitted first so a slow callback
+      // cannot produce native renders with no corresponding Dart update.
+      final scheduled = requestRender(timeStamp.inMicroseconds * 1000);
+      if (scheduled) {
+        _scheduledFrameCount++;
+        _runFrameCallback(callback, countAsScheduled: false);
+      }
     }
     SchedulerBinding.instance.scheduleFrame();
   }

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/frame_scheduler.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/frame_scheduler.dart
@@ -10,17 +10,17 @@ import 'package:logging/logging.dart';
 // ignore: implementation_imports
 import 'package:thermion_dart/src/bindings/src/thermion_dart_ffi.g.dart'
     show
-        FrameScheduler_start,
+        FrameScheduler_startWithCallback,
         FrameScheduler_stop,
-        FrameCallbackFunction,
+        FrameTickCallbackFunction,
         FrameScheduler_initDartApi,
         FrameScheduler_startWithPort,
         FrameScheduler_steadyClockUs;
 
-/// Drives per-frame callbacks off the native FrameScheduler (CVDisplayLink /
-/// DXGI / AChoreographer / timer) via one of three modes:
+/// Dispatches a frame handler from platform timing ticks via one of three
+/// modes:
 ///
-/// - **Direct callback** (release builds): native calls a Dart function
+/// - **Direct tick** (release builds): native calls a Dart function
 ///   pointer via [ffi.NativeCallable.listener].
 /// - **Port mode** (debug builds): native posts messages to a [ReceivePort].
 ///   Hot-restart safe — messages to dead ports are silently dropped.
@@ -34,13 +34,13 @@ class FrameScheduler {
   /// Returns the process-wide singleton.
   static FrameScheduler get instance => _instance;
 
-  /// Called once per admitted frame in every mode.
-  Future<void> Function()? _onFrameCallback;
+  /// Work dispatched once for each accepted timing tick.
+  Future<void> Function()? _frameHandler;
 
-  /// Bind the per-frame callback. Must be called before [start] or
-  /// [startFlutterSynced].
-  void setOnFrame(Future<void> Function() onFrame) {
-    _onFrameCallback = onFrame;
+  /// Bind the work dispatched for each accepted tick. Must be called before
+  /// [start] or [startFlutterSynced].
+  void setFrameHandler(Future<void> Function() handler) {
+    _frameHandler = handler;
   }
 
   static final _logger = Logger("FrameScheduler");
@@ -56,9 +56,9 @@ class FrameScheduler {
   /// callback. In that mode the loop is driven by Flutter's frame clock
   /// and must be re-armed with [SchedulerBinding.scheduleFrame] on resume.
   bool _flutterSynced = false;
-  bool _flutterFrameCallbackRegistered = false;
+  bool _flutterTickCallbackRegistered = false;
 
-  ffi.NativeCallable<FrameCallbackFunction>? _frameCallable;
+  ffi.NativeCallable<FrameTickCallbackFunction>? _tickCallable;
   ReceivePort? _framePort;
 
   int Function()? _flutterTargetFps;
@@ -79,16 +79,15 @@ class FrameScheduler {
   bool get isPaused => _paused;
   bool get isRendering => _rendering;
 
-  // Monotonic count of frames admitted past both the framerate throttle and
-  // in-flight guard. A scheduled frame is not necessarily rendered — the
-  // render itself can still fail — so this counts accepted work rather than
-  // completions. Never resets, unlike the rolling _diag* counters used for
-  // the periodic log line.
-  int _scheduledFrameCount = 0;
+  // Monotonic count of handlers dispatched past both the framerate throttle
+  // and in-flight guard. A dispatched handler is not necessarily a completed
+  // render, so this counts started work rather than completions. Never resets,
+  // unlike the rolling _diag* counters used for the periodic log line.
+  int _dispatchedFrameCount = 0;
 
-  /// Total number of frames scheduled (dispatched) since the scheduler was
-  /// created. Monotonic; sample deltas to measure scheduled frames-per-second.
-  int get scheduledFrameCount => _scheduledFrameCount;
+  /// Total number of frame handlers dispatched since the scheduler was
+  /// created. Monotonic; sample deltas to measure dispatched frames per second.
+  int get dispatchedFrameCount => _dispatchedFrameCount;
 
   /// Start the native scheduler. Picks port mode in debug builds on
   /// macOS/iOS/Android/Windows and a direct native callback otherwise.
@@ -110,10 +109,10 @@ class FrameScheduler {
     if (usePortMode) {
       await _initializePortMode();
     } else {
-      _frameCallable = ffi.NativeCallable<FrameCallbackFunction>.listener(
-        _onFrame,
+      _tickCallable = ffi.NativeCallable<FrameTickCallbackFunction>.listener(
+        _handleNativeFrameTick,
       );
-      FrameScheduler_start(_frameCallable!.nativeFunction, 60);
+      FrameScheduler_startWithCallback(_tickCallable!.nativeFunction, 60);
     }
   }
 
@@ -121,7 +120,8 @@ class FrameScheduler {
   ///
   /// Linux uses this because it has no reliable native display-link source
   /// synchronized with Flutter's compositor. Rendering itself is still owned
-  /// by the callback installed with [setOnFrame], just like every other mode.
+  /// by the handler installed with [setFrameHandler], just like every other
+  /// mode.
   Future<void> startFlutterSynced({required int Function() targetFps}) async {
     if (_active) return;
     _active = true;
@@ -132,9 +132,11 @@ class FrameScheduler {
 
     // Persistent callbacks cannot be unregistered. Register exactly once for
     // this isolate; stop/reset only deactivate it, and a later start reuses it.
-    if (!_flutterFrameCallbackRegistered) {
-      SchedulerBinding.instance.addPersistentFrameCallback(_onFlutterFrame);
-      _flutterFrameCallbackRegistered = true;
+    if (!_flutterTickCallbackRegistered) {
+      SchedulerBinding.instance.addPersistentFrameCallback(
+        _handleFlutterFrameTick,
+      );
+      _flutterTickCallbackRegistered = true;
     }
     SchedulerBinding.instance.scheduleFrame();
 
@@ -157,8 +159,8 @@ class FrameScheduler {
     // longer remembers that the previous isolate started a scheduler.
     FrameScheduler_stop();
 
-    _frameCallable?.close();
-    _frameCallable = null;
+    _tickCallable?.close();
+    _tickCallable = null;
 
     _framePort?.close();
     _framePort = null;
@@ -169,15 +171,15 @@ class FrameScheduler {
     stop();
     _paused = false;
     _rendering = false;
-    _onFrameCallback = null;
+    _frameHandler = null;
   }
 
   void pause() => _paused = true;
 
   /// Clear the pause flag. In Flutter-synced mode this must also re-arm the
-  /// frame callback: [pause] stops [_onFlutterFrame] from scheduling the next
-  /// frame, so without an explicit [SchedulerBinding.scheduleFrame] the loop
-  /// would stay frozen after a background→foreground transition.
+  /// frame callback: [pause] stops [_handleFlutterFrameTick] from scheduling
+  /// the next frame, so without an explicit [SchedulerBinding.scheduleFrame]
+  /// the loop would stay frozen after a background→foreground transition.
   void resume() {
     _paused = false;
     if (_active && _flutterSynced) {
@@ -216,9 +218,9 @@ class FrameScheduler {
           _diagTransitCount = 0;
           _diagTransitMax = 0;
         }
-        _onFrame(frameTimeNanos);
+        _handleNativeFrameTick(frameTimeNanos);
       } else {
-        _onFrame(message as int);
+        _handleNativeFrameTick(message as int);
       }
     });
 
@@ -228,41 +230,44 @@ class FrameScheduler {
     _logger.info('Frame scheduler started in port mode (hot restart safe)');
   }
 
-  void _onFrame(int frameTimeNanos) {
+  void _handleNativeFrameTick(int frameTimeNanos) {
     // Framerate throttling for this path happens at the native source
-    // (dispatchFrame skips dropped vsyncs before this is even called), so no
-    // Dart-side gate here — only the callback in-flight guard below.
-    final callback = _admitFrameCallback();
-    if (callback != null) {
-      _runFrameCallback(callback);
-    }
+    // (handleSourceTick skips rejected ticks before this is even called), so no
+    // Dart-side gate here — only the handler in-flight guard below.
+    _tryDispatchFrame();
   }
 
-  /// Applies the common active, pause, callback, and in-flight gates before a
-  /// frame is admitted in any scheduling mode.
-  Future<void> Function()? _admitFrameCallback() {
-    if (!_active || _paused) return null;
+  /// Applies the common active, pause, handler, and in-flight gates, then
+  /// dispatches one frame handler. An optional source-specific gate can reject
+  /// the tick before work starts (Linux uses it for target-FPS pacing).
+  bool _tryDispatchFrame({bool Function()? sourceGate}) {
+    if (!_active || _paused) return false;
     if (_rendering) {
-      // Keep only one callback/render in flight. Frames arriving while Dart
+      // Keep only one handler/render in flight. Ticks arriving while Dart
       // or the render thread is still busy are dropped rather than queued.
       _diagDropCount++;
-      return null;
+      return false;
     }
-    final callback = _onFrameCallback;
-    if (callback == null) {
-      throw StateError('FrameScheduler.setOnFrame must be called before start');
+    final handler = _frameHandler;
+    if (handler == null) {
+      throw StateError(
+        'FrameScheduler.setFrameHandler must be called before start',
+      );
     }
-    return callback;
+    if (sourceGate != null && !sourceGate()) return false;
+
+    _runFrameHandler(handler);
+    return true;
   }
 
-  /// Runs an admitted callback and records diagnostics.
-  void _runFrameCallback(Future<void> Function() callback) {
+  /// Runs a dispatched frame handler and records diagnostics.
+  void _runFrameHandler(Future<void> Function() handler) {
     _rendering = true;
-    _scheduledFrameCount++;
+    _dispatchedFrameCount++;
     _diagStopwatch
       ..reset()
       ..start();
-    callback()
+    handler()
         .then((_) {
           _diagStopwatch.stop();
           _rendering = false;
@@ -295,19 +300,18 @@ class FrameScheduler {
         });
   }
 
-  void _onFlutterFrame(Duration timeStamp) {
+  void _handleFlutterFrameTick(Duration timeStamp) {
     if (!_active || !_flutterSynced || _paused) return;
-    final callback = _admitFrameCallback();
-    if (callback != null && _admitFlutterFrameAtTargetFps(timeStamp)) {
-      _runFrameCallback(callback);
-    }
+    _tryDispatchFrame(
+      sourceGate: () => _admitFlutterTickAtTargetFps(timeStamp),
+    );
     SchedulerBinding.instance.scheduleFrame();
   }
 
   /// Applies the same absolute-deadline pacing used by the native frame
   /// sources. The deadline advances only when a frame can actually run, so a
   /// slow render does not consume future frame slots while it is in flight.
-  bool _admitFlutterFrameAtTargetFps(Duration timeStamp) {
+  bool _admitFlutterTickAtTargetFps(Duration timeStamp) {
     final fps = _flutterTargetFps?.call() ?? 0;
     if (fps <= 0) {
       _flutterAppliedFpsLimit = 0;

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
@@ -42,15 +42,21 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
 
   /// Starts the appropriate frame scheduling mode for the current platform.
   Future<void> start() async {
-    FrameScheduler.instance.setOnFrame(_renderFrame);
-
     // Android must keep render admission on the Dart callback/port path.
     // SurfaceProducer consumes ImageReader frames from Android's main looper;
     // a producer loop decoupled from Flutter can fill that pipeline and block
     // acquireLatestImage() on the main thread for seconds.
     if (Platform.isLinux) {
+      // On Linux the native render loop owns rendering and post-render
+      // texture marking, so the Dart per-frame hook must NOT go through
+      // [_renderFrame] — that would dispatch a second, blocking Dart-side
+      // render on top of the native one. It runs only the request-frame
+      // hooks (per-frame camera controllers, procedural updates, and
+      // similar), which the native loop cannot run on Dart's behalf.
+      FrameScheduler.instance.setOnFrame(_runRequestFrameHooks);
       await _startFlutterSynced();
     } else {
+      FrameScheduler.instance.setOnFrame(_renderFrame);
       await FrameScheduler.instance.start();
     }
 
@@ -142,6 +148,21 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
 
     await app.render();
     await _onFrameRendered();
+  }
+
+  /// Per-frame Dart work for the Flutter-synced (Linux) render loop.
+  ///
+  /// Unlike [_renderFrame], this never dispatches a render or marks textures:
+  /// both are owned by the native loop (the post-render callback configured
+  /// in [_startFlutterSynced] marks textures). Only the registered
+  /// request-frame hooks run here — without this, per-frame Dart updates
+  /// registered via [FilamentApp.registerRequestFrameHook] would never fire
+  /// on Linux, because the native loop never calls [FilamentApp.render].
+  Future<void> _runRequestFrameHooks() async {
+    final app = FilamentApp.instance;
+    if (app is FFIFilamentApp) {
+      await app.runRequestFrameHooks();
+    }
   }
 
   bool _suspendForLifecycle() {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ffi' as ffi;
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
@@ -42,21 +41,15 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
 
   /// Starts the appropriate frame scheduling mode for the current platform.
   Future<void> start() async {
+    FrameScheduler.instance.setOnFrame(_renderFrame);
+
     // Android must keep render admission on the Dart callback/port path.
     // SurfaceProducer consumes ImageReader frames from Android's main looper;
     // a producer loop decoupled from Flutter can fill that pipeline and block
     // acquireLatestImage() on the main thread for seconds.
     if (Platform.isLinux) {
-      // On Linux the native render loop owns rendering and post-render
-      // texture marking, so the Dart per-frame hook must NOT go through
-      // [_renderFrame] — that would dispatch a second, blocking Dart-side
-      // render on top of the native one. It runs only the request-frame
-      // hooks (per-frame camera controllers, procedural updates, and
-      // similar), which the native loop cannot run on Dart's behalf.
-      FrameScheduler.instance.setOnFrame(_runRequestFrameHooks);
       await _startFlutterSynced();
     } else {
-      FrameScheduler.instance.setOnFrame(_renderFrame);
       await FrameScheduler.instance.start();
     }
 
@@ -121,24 +114,9 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
   }
 
   Future<void> _startFlutterSynced() async {
-    final dylib = ffi.DynamicLibrary.process();
-    final getHandleFn = dylib
-        .lookupFunction<
-          ffi.Pointer<ffi.Void> Function(),
-          ffi.Pointer<ffi.Void> Function()
-        >('thermion_flutter_get_plugin_handle');
-    final pluginHandle = getHandleFn();
-    final markTexturesFnPtr = dylib
-        .lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'thermion_flutter_mark_textures',
-        );
-
     final app = FilamentApp.instance as FFIFilamentApp;
     await FrameScheduler.instance.startFlutterSynced(
-      renderThreadHandle: app.renderThreadHandle,
-      renderManagerHandle: app.renderManager.getNativeHandle(),
-      postRenderCallback: markTexturesFnPtr,
-      postRenderUserData: pluginHandle,
+      targetFps: () => app.targetFramerate,
     );
   }
 
@@ -148,21 +126,6 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
 
     await app.render();
     await _onFrameRendered();
-  }
-
-  /// Per-frame Dart work for the Flutter-synced (Linux) render loop.
-  ///
-  /// Unlike [_renderFrame], this never dispatches a render or marks textures:
-  /// both are owned by the native loop (the post-render callback configured
-  /// in [_startFlutterSynced] marks textures). Only the registered
-  /// request-frame hooks run here — without this, per-frame Dart updates
-  /// registered via [FilamentApp.registerRequestFrameHook] would never fire
-  /// on Linux, because the native loop never calls [FilamentApp.render].
-  Future<void> _runRequestFrameHooks() async {
-    final app = FilamentApp.instance;
-    if (app is FFIFilamentApp) {
-      await app.runRequestFrameHooks();
-    }
   }
 
   bool _suspendForLifecycle() {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_rendering_lifecycle_controller.dart
@@ -41,7 +41,7 @@ class NativeRenderingLifecycleController with WidgetsBindingObserver {
 
   /// Starts the appropriate frame scheduling mode for the current platform.
   Future<void> start() async {
-    FrameScheduler.instance.setOnFrame(_renderFrame);
+    FrameScheduler.instance.setFrameHandler(_renderFrame);
 
     // Android must keep render admission on the Dart callback/port path.
     // SurfaceProducer consumes ImageReader frames from Android's main looper;

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/native_texture_surface_manager.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ffi' as ffi;
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -69,6 +70,13 @@ class NativeTextureSurfaceManager {
   final NativeOptions Function() _options;
   final NativePlatformTextureDescriptorRegistry registry;
 
+  /// Linux can notify every registered external texture with one direct FFI
+  /// call. Keep this presentation detail here, after the common Dart render
+  /// future completes, rather than coupling it to frame scheduling.
+  late final void Function()? _markLinuxTextures = Platform.isLinux
+      ? _createLinuxTextureMarker()
+      : null;
+
   // The view can be redirected to an internal target in composite highlight
   // mode, so track the Flutter-facing render target independently.
   final _viewRenderTargets = <View, RenderTarget>{};
@@ -99,7 +107,12 @@ class NativeTextureSurfaceManager {
   /// Notifies live descriptors and reaps render targets deferred by Windows
   /// resize operations.
   Future<void> onFrameRendered() async {
-    registry.markFrameAvailable();
+    final markLinuxTextures = _markLinuxTextures;
+    if (markLinuxTextures != null) {
+      markLinuxTextures();
+    } else {
+      registry.markFrameAvailable();
+    }
 
     if (_deferredRenderTargets.isEmpty) return;
 
@@ -119,6 +132,22 @@ class NativeTextureSurfaceManager {
     for (final renderTarget in ready) {
       await _destroyRenderTarget(renderTarget);
     }
+  }
+
+  static void Function() _createLinuxTextureMarker() {
+    final dylib = ffi.DynamicLibrary.process();
+    final getPluginHandle = dylib
+        .lookupFunction<
+          ffi.Pointer<ffi.Void> Function(),
+          ffi.Pointer<ffi.Void> Function()
+        >('thermion_flutter_get_plugin_handle');
+    final markTextures = dylib
+        .lookupFunction<
+          ffi.Void Function(ffi.Pointer<ffi.Void>),
+          void Function(ffi.Pointer<ffi.Void>)
+        >('thermion_flutter_mark_textures');
+
+    return () => markTextures(getPluginHandle());
   }
 
   Future<PlatformTextureDescriptor> createAndBind(

--- a/thermion_flutter/thermion_flutter/linux/thermion_flutter_plugin.cc
+++ b/thermion_flutter/thermion_flutter/linux/thermion_flutter_plugin.cc
@@ -881,7 +881,7 @@ static void method_call_cb(FlMethodChannel *channel, FlMethodCall *method_call,
   thermion_flutter_plugin_handle_method_call(plugin, method_call);
 }
 
-// Global plugin instance for cross-library access (native render loop)
+// Global plugin instance used by Dart's direct post-render texture notifier.
 static ThermionFlutterPlugin* g_plugin_instance = nullptr;
 
 void thermion_flutter_plugin_register_with_registrar(FlPluginRegistrar *registrar)
@@ -907,16 +907,16 @@ void thermion_flutter_plugin_register_with_registrar(FlPluginRegistrar *registra
   g_object_unref(plugin);
 }
 
-// === Exported symbols for cross-library native render loop ===
+// === Exported symbols for Dart post-render texture notification ===
 
 extern "C" __attribute__((visibility("default")))
 void* thermion_flutter_get_plugin_handle() {
   return g_plugin_instance;
 }
 
-// Called from thermion_dart's native render loop (post-render callback)
-// after each frame. Marks all textures as frame-available so Flutter
-// picks up the new content on its next raster pass.
+// Called from Dart after the common render future completes. Marks all
+// textures as frame-available so Flutter picks up the new content on its next
+// raster pass.
 extern "C" __attribute__((visibility("default")))
 void thermion_flutter_mark_textures(void* pluginPtr) {
   auto* self = FLUTTER_FILAMENT_PLUGIN(pluginPtr);

--- a/thermion_flutter/thermion_flutter/test/frame_scheduler_flutter_synced_test.dart
+++ b/thermion_flutter/thermion_flutter/test/frame_scheduler_flutter_synced_test.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+import 'dart:ffi' as ffi;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thermion_flutter/src/platform/src/frame_scheduler.dart';
+
+/// Headless coverage for the Dart side of the Flutter-synchronized Linux
+/// render loop. Native setters only retain the null test handles, and
+/// [FrameScheduler.requestRender] replaces native render admission.
+///
+/// This remains one test because Flutter persistent frame callbacks cannot be
+/// unregistered from the shared test binding.
+void main() {
+  testWidgets(
+    'FrameScheduler owns Linux timing and pairs callbacks with admitted frames',
+    (tester) async {
+      final scheduler = FrameScheduler.instance;
+      final realRequestRender = scheduler.requestRender;
+      scheduler.reset();
+      final scheduledAtStart = scheduler.scheduledFrameCount;
+
+      addTearDown(() {
+        scheduler.requestRender = realRequestRender;
+        scheduler.reset();
+      });
+
+      var requests = 0;
+      var admitFrames = true;
+      scheduler.requestRender = (_) {
+        requests++;
+        return admitFrames;
+      };
+
+      var callbackCalls = 0;
+      Completer<void>? callbackGate;
+      scheduler.setOnFrame(() async {
+        callbackCalls++;
+        await callbackGate?.future;
+      });
+
+      Future<void> start() => scheduler.startFlutterSynced(
+        renderThreadHandle: ffi.Pointer.fromAddress(0),
+        renderManagerHandle: ffi.Pointer.fromAddress(0),
+        postRenderCallback: ffi.Pointer.fromAddress(0),
+        postRenderUserData: ffi.Pointer.fromAddress(0),
+      );
+
+      await start();
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(requests, 2);
+      expect(callbackCalls, 2);
+      expect(scheduler.scheduledFrameCount, scheduledAtStart + 2);
+
+      // Native throttle or render-thread rejections do not run the callback.
+      admitFrames = false;
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(requests, 4);
+      expect(callbackCalls, 2);
+      expect(scheduler.scheduledFrameCount, scheduledAtStart + 2);
+
+      // A callback still in flight prevents another native render admission;
+      // Linux renders and Dart callbacks therefore remain paired 1:1.
+      admitFrames = true;
+      callbackGate = Completer<void>();
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(requests, 5);
+      expect(callbackCalls, 3);
+      expect(scheduler.isRendering, isTrue);
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(requests, 5);
+      expect(callbackCalls, 3);
+
+      callbackGate.complete();
+      callbackGate = null;
+      await tester.pump();
+      expect(requests, 6);
+      expect(callbackCalls, 4);
+
+      // Pause stops requests and re-arming; resume explicitly re-arms Linux.
+      scheduler.pause();
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(requests, 6);
+      scheduler.resume();
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(requests, 7);
+      expect(callbackCalls, 5);
+
+      scheduler.stop();
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(requests, 7);
+
+      // Persistent callbacks cannot be removed. Restarting must reuse the
+      // existing registration instead of producing duplicate frame requests.
+      await start();
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(requests, 8);
+      expect(callbackCalls, 6);
+      expect(scheduler.scheduledFrameCount, scheduledAtStart + 6);
+    },
+  );
+}

--- a/thermion_flutter/thermion_flutter/test/frame_scheduler_flutter_synced_test.dart
+++ b/thermion_flutter/thermion_flutter/test/frame_scheduler_flutter_synced_test.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
-import 'dart:ffi' as ffi;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thermion_flutter/src/platform/src/frame_scheduler.dart';
 
 /// Headless coverage for the Dart side of the Flutter-synchronized Linux
-/// render loop. Native setters only retain the null test handles, and
-/// [FrameScheduler.requestRender] replaces native render admission.
+/// frame source.
 ///
 /// This remains one test because Flutter persistent frame callbacks cannot be
 /// unregistered from the shared test binding.
@@ -15,90 +13,72 @@ void main() {
     'FrameScheduler owns Linux timing and pairs callbacks with admitted frames',
     (tester) async {
       final scheduler = FrameScheduler.instance;
-      final realRequestRender = scheduler.requestRender;
       scheduler.reset();
       final scheduledAtStart = scheduler.scheduledFrameCount;
 
-      addTearDown(() {
-        scheduler.requestRender = realRequestRender;
-        scheduler.reset();
-      });
-
-      var requests = 0;
-      var admitFrames = true;
-      scheduler.requestRender = (_) {
-        requests++;
-        return admitFrames;
-      };
+      addTearDown(scheduler.reset);
 
       var callbackCalls = 0;
+      var targetFps = 0;
       Completer<void>? callbackGate;
       scheduler.setOnFrame(() async {
         callbackCalls++;
         await callbackGate?.future;
       });
 
-      Future<void> start() => scheduler.startFlutterSynced(
-        renderThreadHandle: ffi.Pointer.fromAddress(0),
-        renderManagerHandle: ffi.Pointer.fromAddress(0),
-        postRenderCallback: ffi.Pointer.fromAddress(0),
-        postRenderUserData: ffi.Pointer.fromAddress(0),
-      );
+      Future<void> start() =>
+          scheduler.startFlutterSynced(targetFps: () => targetFps);
 
       await start();
       await tester.pump(const Duration(milliseconds: 16));
       await tester.pump(const Duration(milliseconds: 16));
-      expect(requests, 2);
       expect(callbackCalls, 2);
       expect(scheduler.scheduledFrameCount, scheduledAtStart + 2);
 
-      // Native throttle or render-thread rejections do not run the callback.
-      admitFrames = false;
-      await tester.pump(const Duration(milliseconds: 16));
-      await tester.pump(const Duration(milliseconds: 16));
-      expect(requests, 4);
-      expect(callbackCalls, 2);
-      expect(scheduler.scheduledFrameCount, scheduledAtStart + 2);
-
-      // A callback still in flight prevents another native render admission;
-      // Linux renders and Dart callbacks therefore remain paired 1:1.
-      admitFrames = true;
+      // A callback still in flight prevents another frame from being
+      // admitted, matching the normal native callback path.
       callbackGate = Completer<void>();
       await tester.pump(const Duration(milliseconds: 16));
-      expect(requests, 5);
       expect(callbackCalls, 3);
       expect(scheduler.isRendering, isTrue);
       await tester.pump(const Duration(milliseconds: 16));
       await tester.pump(const Duration(milliseconds: 16));
-      expect(requests, 5);
       expect(callbackCalls, 3);
 
       callbackGate.complete();
       callbackGate = null;
       await tester.pump();
-      expect(requests, 6);
       expect(callbackCalls, 4);
+
+      // Linux applies the shared target framerate before entering the common
+      // callback pipeline.
+      scheduler.stop();
+      targetFps = 30;
+      await start();
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(callbackCalls, 5);
+      await tester.pump(const Duration(milliseconds: 24));
+      expect(callbackCalls, 6);
 
       // Pause stops requests and re-arming; resume explicitly re-arms Linux.
       scheduler.pause();
       await tester.pump(const Duration(milliseconds: 16));
-      expect(requests, 6);
+      expect(callbackCalls, 6);
       scheduler.resume();
-      await tester.pump(const Duration(milliseconds: 16));
-      expect(requests, 7);
-      expect(callbackCalls, 5);
+      await tester.pump(const Duration(milliseconds: 34));
+      expect(callbackCalls, 7);
 
       scheduler.stop();
       await tester.pump(const Duration(milliseconds: 16));
-      expect(requests, 7);
+      expect(callbackCalls, 7);
 
       // Persistent callbacks cannot be removed. Restarting must reuse the
       // existing registration instead of producing duplicate frame requests.
       await start();
       await tester.pump(const Duration(milliseconds: 16));
-      expect(requests, 8);
-      expect(callbackCalls, 6);
-      expect(scheduler.scheduledFrameCount, scheduledAtStart + 6);
+      expect(callbackCalls, 8);
+      expect(scheduler.scheduledFrameCount, scheduledAtStart + 8);
     },
   );
 }

--- a/thermion_flutter/thermion_flutter/test/frame_scheduler_flutter_synced_test.dart
+++ b/thermion_flutter/thermion_flutter/test/frame_scheduler_flutter_synced_test.dart
@@ -9,76 +9,75 @@ import 'package:thermion_flutter/src/platform/src/frame_scheduler.dart';
 /// This remains one test because Flutter persistent frame callbacks cannot be
 /// unregistered from the shared test binding.
 void main() {
-  testWidgets(
-    'FrameScheduler owns Linux timing and pairs callbacks with admitted frames',
-    (tester) async {
-      final scheduler = FrameScheduler.instance;
-      scheduler.reset();
-      final scheduledAtStart = scheduler.scheduledFrameCount;
+  testWidgets('FrameScheduler dispatches handlers for accepted Linux ticks', (
+    tester,
+  ) async {
+    final scheduler = FrameScheduler.instance;
+    scheduler.reset();
+    final dispatchedAtStart = scheduler.dispatchedFrameCount;
 
-      addTearDown(scheduler.reset);
+    addTearDown(scheduler.reset);
 
-      var callbackCalls = 0;
-      var targetFps = 0;
-      Completer<void>? callbackGate;
-      scheduler.setOnFrame(() async {
-        callbackCalls++;
-        await callbackGate?.future;
-      });
+    var handlerCalls = 0;
+    var targetFps = 0;
+    Completer<void>? handlerGate;
+    scheduler.setFrameHandler(() async {
+      handlerCalls++;
+      await handlerGate?.future;
+    });
 
-      Future<void> start() =>
-          scheduler.startFlutterSynced(targetFps: () => targetFps);
+    Future<void> start() =>
+        scheduler.startFlutterSynced(targetFps: () => targetFps);
 
-      await start();
-      await tester.pump(const Duration(milliseconds: 16));
-      await tester.pump(const Duration(milliseconds: 16));
-      expect(callbackCalls, 2);
-      expect(scheduler.scheduledFrameCount, scheduledAtStart + 2);
+    await start();
+    await tester.pump(const Duration(milliseconds: 16));
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(handlerCalls, 2);
+    expect(scheduler.dispatchedFrameCount, dispatchedAtStart + 2);
 
-      // A callback still in flight prevents another frame from being
-      // admitted, matching the normal native callback path.
-      callbackGate = Completer<void>();
-      await tester.pump(const Duration(milliseconds: 16));
-      expect(callbackCalls, 3);
-      expect(scheduler.isRendering, isTrue);
-      await tester.pump(const Duration(milliseconds: 16));
-      await tester.pump(const Duration(milliseconds: 16));
-      expect(callbackCalls, 3);
+    // A handler still in flight prevents another tick from dispatching
+    // work, matching the normal native tick path.
+    handlerGate = Completer<void>();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(handlerCalls, 3);
+    expect(scheduler.isRendering, isTrue);
+    await tester.pump(const Duration(milliseconds: 16));
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(handlerCalls, 3);
 
-      callbackGate.complete();
-      callbackGate = null;
-      await tester.pump();
-      expect(callbackCalls, 4);
+    handlerGate.complete();
+    handlerGate = null;
+    await tester.pump();
+    expect(handlerCalls, 4);
 
-      // Linux applies the shared target framerate before entering the common
-      // callback pipeline.
-      scheduler.stop();
-      targetFps = 30;
-      await start();
-      await tester.pump(const Duration(milliseconds: 16));
-      await tester.pump(const Duration(milliseconds: 10));
-      expect(callbackCalls, 5);
-      await tester.pump(const Duration(milliseconds: 24));
-      expect(callbackCalls, 6);
+    // Linux applies the shared target framerate before entering the common
+    // handler pipeline.
+    scheduler.stop();
+    targetFps = 30;
+    await start();
+    await tester.pump(const Duration(milliseconds: 16));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(handlerCalls, 5);
+    await tester.pump(const Duration(milliseconds: 24));
+    expect(handlerCalls, 6);
 
-      // Pause stops requests and re-arming; resume explicitly re-arms Linux.
-      scheduler.pause();
-      await tester.pump(const Duration(milliseconds: 16));
-      expect(callbackCalls, 6);
-      scheduler.resume();
-      await tester.pump(const Duration(milliseconds: 34));
-      expect(callbackCalls, 7);
+    // Pause stops requests and re-arming; resume explicitly re-arms Linux.
+    scheduler.pause();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(handlerCalls, 6);
+    scheduler.resume();
+    await tester.pump(const Duration(milliseconds: 34));
+    expect(handlerCalls, 7);
 
-      scheduler.stop();
-      await tester.pump(const Duration(milliseconds: 16));
-      expect(callbackCalls, 7);
+    scheduler.stop();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(handlerCalls, 7);
 
-      // Persistent callbacks cannot be removed. Restarting must reuse the
-      // existing registration instead of producing duplicate frame requests.
-      await start();
-      await tester.pump(const Duration(milliseconds: 16));
-      expect(callbackCalls, 8);
-      expect(scheduler.scheduledFrameCount, scheduledAtStart + 8);
-    },
-  );
+    // Persistent callbacks cannot be removed. Restarting must reuse the
+    // existing registration instead of producing duplicate frame requests.
+    await start();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(handlerCalls, 8);
+    expect(scheduler.dispatchedFrameCount, dispatchedAtStart + 8);
+  });
 }


### PR DESCRIPTION
This PR moves the render logic out of `FrameScheduler` and into the callback that this object invokes. `FrameScheduler` is now agnostic; it simply generates tick events and invokes an arbitrary callback (which in our implementation, now lives on the Dart side and handles dispatching a request to render a frame).

Terminology has been changed to reflect this:

- `FrameCallback` → `FrameTickCallback`
- `FrameScheduler_start` → `FrameScheduler_startWithCallback`
- `setOnFrame` → `setFrameHandler`
- internal callbacks distinguish native/Flutter ticks from dispatched frame handlers
- `scheduledFrameCount` → `dispatchedFrameCount`

The previous render-specific C API and its process-global render state were removed:

- `FrameScheduler_setRenderThread`
- `FrameScheduler_setRenderManager`
- `FrameScheduler_setPostRenderCallback`
- `FrameScheduler_requestRender`
- `FrameScheduler_startNativeRenderLoop`

The platform timing sources themselves remain the same:
- `CADisplayLink` on iOS
- `CVDisplayLink` on macOS
- `AChoreographer` on Android
- DXGI `WaitForVBlank` on Windows
- Flutter `SchedulerBinding` on Linux

Previously, Flutter-synchronized Linux ticks invoked a native render path that bypassed the normal Dart frame handler. As a result, `FilamentApp.render()` and Dart request-frame hooks such as camera controllers and procedural updates did not run.

Linux now uses Flutter's persistent frame callback only as its timing source. Accepted ticks enter the common Dart handler, which:

1. runs request-frame hooks through `FilamentApp.render()`
2. queues rendering on Thermion's render thread and waits asynchronously for completion
3. performs post-render texture notification

The timing callback does not synchronously block on rendering. A common in-flight guard drops overlapping ticks rather than queuing frames.

Linux target-FPS pacing moves from the removed native render-request API into the Flutter-tick adapter, using the same absolute-deadline policy as the native timing sources. Linux retains a direct FFI notification for its external textures, but that presentation detail now lives in `NativeTextureSurfaceManager` after the common render future completes.
