### PR TITLE
refactor: (flutter) return Future from markTextureFrameAvailable 

### DIFF
--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/android_platform_texture_descriptor.dart
@@ -34,7 +34,7 @@ class AndroidPlatformTextureDescriptor
   /// texture ID, adding one platform message per frame without changing
   /// presentation state.
   @override
-  void markTextureFrameAvailable() {}
+  Future<void> markTextureFrameAvailable() => Future<void>.value();
 
   static Future<AndroidPlatformTextureDescriptor> allocate(
     MethodChannel channel,

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/darwin_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/darwin_platform_texture_descriptor.dart
@@ -84,7 +84,7 @@ class DarwinPlatformTextureDescriptorImpl extends PlatformTextureDescriptor {
   }
 
   @override
-  void markTextureFrameAvailable() {
+  Future<void> markTextureFrameAvailable() {
     if (_destroyed) {
       throw Exception(
         "markTextureFrameAvailable cannot be called on a "
@@ -92,6 +92,7 @@ class DarwinPlatformTextureDescriptorImpl extends PlatformTextureDescriptor {
       );
     }
     _textureRegistry.textureFrameAvailable_(flutterTextureId);
+    return Future<void>.value();
   }
 
   static DarwinPlatformTextureDescriptorImpl allocate(int width, int height) {

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/method_channel_platform_texture_descriptor.dart
@@ -23,7 +23,7 @@ class MethodChannelPlatformTextureDescriptor extends PlatformTextureDescriptor {
   }
 
   @override
-  void markTextureFrameAvailable() async {
+  Future<void> markTextureFrameAvailable() async {
     if (destroyed) {
       throw Exception(
         "markTextureFrameAvailable cannot be called on a "

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor.dart
@@ -40,9 +40,11 @@ abstract class PlatformTextureDescriptor {
   @override
   int get hashCode => flutterTextureId.hashCode;
 
-  /// Instruct the Flutter framework that the content of the texture has been
-  /// updated.
-  void markTextureFrameAvailable();
+  /// Instructs Flutter that the texture content has been updated.
+  ///
+  /// The returned future completes after any platform-side publication work,
+  /// such as Linux's Vulkan export blit, has finished.
+  Future<void> markTextureFrameAvailable();
 
   /// Schedules this texture for destruction.
   ///

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/platform_texture_descriptor_registry.dart
@@ -158,7 +158,7 @@ class PlatformTextureDescriptorRegistry {
     }
 
     for (final descriptor in List<PlatformTextureDescriptor>.of(_descriptors)) {
-      descriptor.markTextureFrameAvailable();
+      unawaited(descriptor.markTextureFrameAvailable());
     }
   }
 

--- a/thermion_flutter/thermion_flutter/lib/src/platform/src/web_platform_texture_descriptor.dart
+++ b/thermion_flutter/thermion_flutter/lib/src/platform/src/web_platform_texture_descriptor.dart
@@ -20,7 +20,8 @@ class WebPlatformTextureDescriptor extends PlatformTextureDescriptor {
   }
 
   @override
-  void markTextureFrameAvailable() {
+  Future<void> markTextureFrameAvailable() {
     // No-op on web - canvas updates handled by _ImageCopyingWidget
+    return Future<void>.value();
   }
 }

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_registry_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_registry_test.dart
@@ -286,7 +286,7 @@ class _TestDescriptor extends PlatformTextureDescriptor {
   bool get isSurfaceAvailable => _surfaceAvailable;
 
   @override
-  void markTextureFrameAvailable() {
+  Future<void> markTextureFrameAvailable() async {
     markFrameAvailableCount++;
   }
 

--- a/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
+++ b/thermion_flutter/thermion_flutter/test/platform_texture_descriptor_test.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thermion_flutter/src/platform/src/android_platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/platform/src/darwin_platform_texture_descriptor.dart';
+import 'package:thermion_flutter/src/platform/src/method_channel_platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/platform/src/platform_texture_descriptor.dart';
 import 'package:thermion_flutter/src/options.dart';
 
@@ -99,10 +102,43 @@ void main() {
       height: 5,
     );
 
-    descriptor.markTextureFrameAvailable();
-    await Future<void>.delayed(Duration.zero);
+    await descriptor.markTextureFrameAvailable();
 
     expect(methodCallCount, 0);
+  });
+
+  test('awaitable frame publication waits for platform work', () async {
+    const channel = MethodChannel('thermion.test.texture.presentation');
+    final platformGate = Completer<void>();
+    var completed = false;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          expect(call.method, 'markTextureFrameAvailable');
+          await platformGate.future;
+          return null;
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    final descriptor = MethodChannelPlatformTextureDescriptor(
+      channel,
+      flutterTextureId: 1,
+      hardwareId: 2,
+      windowHandle: 3,
+      width: 4,
+      height: 5,
+    );
+    final publication = descriptor.markTextureFrameAvailable().then(
+      (_) => completed = true,
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(completed, isFalse);
+    platformGate.complete();
+    await publication;
+    expect(completed, isTrue);
   });
 
   for (final (textureSource, expectedSurfaceProducer) in [
@@ -155,7 +191,7 @@ class _TestDescriptor extends PlatformTextureDescriptor {
         );
 
   @override
-  void markTextureFrameAvailable() {}
+  Future<void> markTextureFrameAvailable() async {}
 
   @override
   Future destroy() async {}


### PR DESCRIPTION
`markTextureFrameAvailable()` now returns a future that completes when the frame is published. This is necessary for follow-up work where callers of `markTextureFrameAvailable()` need to ensure that the native-side call completes before proceeding.
