### PR TITLE
docs: add agent skills for Thermion API usage

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,7 @@
+analyzer:
+  exclude:
+    # Skill reference examples are standalone programs meant to be copied into
+    # user projects (see skills/README.md) — they import thermion_dart /
+    # thermion_flutter, which are not dependencies of the repo root. They are
+    # verified separately against those packages.
+    - skills/**

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,9 @@ export default defineConfig({
             { label: 'Getting Started', slug: 'getting_started' },
             { label: 'Quick Start', slug: 'quickstart' },
             { label: 'Viewer', slug: 'viewer' },
+            { label: 'Entities', slug: 'entities' },
+            { label: 'Lighting', slug: 'lighting' },
+            { label: 'Shadows', slug: 'shadows' },
             { label: 'Camera Manipulation', slug: 'camera_manipulation' },
             { label: 'Animations', slug: 'animations' },
             { label: 'Materials & Textures', slug: 'materials' },
@@ -48,7 +51,6 @@ export default defineConfig({
           items: [
             { label: 'Filament', slug: 'filament' },
             { label: 'Filament API', slug: 'filament_api' },
-            { label: 'Showcase', slug: 'showcase' },
             { label: 'Build Configuration', slug: 'build_configuration' },
             { label: 'Debugging', slug: 'debugging' },
             { label: 'Contributing', slug: 'contributing' },

--- a/docs/src/content/docs/animations.mdx
+++ b/docs/src/content/docs/animations.mdx
@@ -41,11 +41,13 @@ each frame — this advances all active animations on the render thread.
 You can also scrub to a specific time with `setGltfAnimationTime(index, seconds)`.
 
 :::note
-Prefer `playGltfAnimation` + `animationManager.update(dt)` for animations that
-contain morph targets. `setGltfAnimationTime` applies morph weights
-synchronously off the render thread, which can trip Filament's backend thread
-assertion. See `examples/dart/cli_headless` for a runnable example that uses
-`animationManager.update(dt)` for exactly this reason.
+`setGltfAnimationTime` is dispatched on the render thread and is safe to use
+with morph-target animations (earlier versions applied morph weights
+synchronously off the render thread and could trip Filament's backend thread
+assertion; this was fixed when the call moved to the render thread).
+`playGltfAnimation` + `animationManager.update(dt)` remains the natural tool
+for continuous playback; use `setGltfAnimationTime` when you need to jump to
+an exact time.
 :::
 
 ## Morph targets

--- a/docs/src/content/docs/entities.mdx
+++ b/docs/src/content/docs/entities.mdx
@@ -1,0 +1,134 @@
+---
+title: Entities
+description: The entity model, loading glTF assets, transforms, hierarchy, and instancing.
+---
+
+Everything in a Thermion scene is an **entity**: models, meshes, lights,
+cameras. A loaded glTF becomes a `ThermionAsset` whose root entity owns a
+subtree of child entities (meshes, bones, embedded lights). This page covers
+loading assets, positioning them, building hierarchies, and cleanup.
+
+## Loading glTF
+
+```dart
+final asset = await viewer.loadGltf('assets/scene.glb');
+```
+
+Useful parameters:
+
+- `addToScene` (default `true`) — add renderables to the scene immediately.
+- `initialInstances` — pre-allocate GPU instances (see
+  [instancing](#gpu-instancing) below).
+- `rebuildVertices` — rebuild vertex buffers with a superset of attributes
+  (barycentrics, unwelded vertices). Required for wireframe, flat shading,
+  and stencil highlights; costs ~3x vertex memory.
+  See [Materials & Textures](/materials/).
+- `releaseSourceData` — free the CPU-side glTF copy after loading (disables
+  creating further instances).
+
+Paths are asset-bundle paths in Flutter; use `file://` URIs to load from the
+filesystem (also the scheme used by pure-Dart applications). `.gltf` files
+resolve their resources relative to their own URI unless you pass
+`resourceUri`.
+
+## Positions and movement
+
+There is **no `setPosition`/`setRotation`/`setScale`** — every transform is a
+`Matrix4` from `package:vector_math`:
+
+```dart
+// Pure translation:
+await asset.setTransform(Matrix4.translation(Vector3(0, 1, 2)));
+
+// Position + rotation + scale composed:
+await asset.setTransform(Matrix4.compose(
+  Vector3(0, 1, 2),
+  Quaternion.fromEulerAngles(0, pi / 4, 0),
+  Vector3(1, 1, 1),
+));
+
+// Continuous spin (e.g. from a Timer or ticker):
+await asset.setTransform(Matrix4.rotationY(elapsedSeconds));
+```
+
+`setTransform` **replaces** the transform rather than accumulating — compose
+the complete matrix you want. To move relative to the current pose, read,
+mutate, and write back:
+
+```dart
+final current = await asset.getLocalTransform();
+current.translate(Vector3(0, 0.5, 0));
+await asset.setTransform(current);
+```
+
+Setting a child entity's transform (rather than the asset root) is supported
+via the `entity:` parameter. The camera is positioned separately with
+`camera.lookAt` — see [Camera Manipulation](/camera-manipulation/).
+
+## Hierarchy
+
+Parent a child entity to a parent entity and the child follows the parent:
+
+```dart
+await viewer.app.setParent(childEntity, parentEntity);
+
+// Moving the parent now carries the child:
+await parentAsset.setTransform(Matrix4.translation(Vector3(-1, 0, 0)));
+```
+
+`viewer.app.transformManager` exposes the same operations on any entity
+(`setParent`, `getParent`, `getChildren`), plus local-vs-world transforms
+(`getLocalTransform`, `getWorldTransform`) and batched edits
+(`openLocalTransformTransaction` / `commitLocalTransformTransaction`).
+
+## Querying an asset
+
+```dart
+final root = asset.entity;
+final names = await asset.getChildEntityNames();  // child entities by name
+final child = await asset.getChildEntity('Wheel'); // by name (nullable)
+final children = await asset.getChildEntities();
+final bounds = await asset.getBoundingBox();       // Aabb3
+
+await asset.transformToUnitCube(); // normalize to a 1x1x1 cube at the origin
+```
+
+:::note
+`transformToUnitCube()` reads the root entity's bounding box, which can be
+bogus when the root has no renderable component. If you know the object-space
+box, normalize through the transform manager instead:
+
+```dart
+viewer.app.transformManager.transformToUnitCube(asset.entity, knownBox);
+```
+:::
+
+## GPU instancing
+
+Efficient copies of one asset, positioned per instance:
+
+```dart
+final asset = await viewer.loadGltf('assets/rock.glb', initialInstances: 100);
+for (var i = 0; i < 100; i++) {
+  final instance = await asset.getInstance(i);
+  await instance.setTransform(Matrix4.translation(Vector3(i * 2.0, 0, 0)));
+}
+```
+
+Allocating `initialInstances` at load time is more efficient than creating
+instances later (`asset.createInstance()`), which also requires that the
+asset was not loaded with `releaseSourceData: true`.
+
+## Cleanup
+
+```dart
+await viewer.destroyAsset(asset); // destroys the asset and its instances
+await viewer.destroyAssets();     // destroys ALL renderable entities
+```
+
+`destroyAsset` does not destroy material instances you created manually —
+destroy those yourself. After `destroyAssets()`, every entity handle is
+invalid; discard all references immediately.
+
+Next: [Lighting](/lighting/), [Shadows](/shadows/), or
+[Animations](/animations/) for animating what you loaded.

--- a/docs/src/content/docs/lighting.mdx
+++ b/docs/src/content/docs/lighting.mdx
@@ -1,0 +1,125 @@
+---
+title: Lighting
+description: Direct lights, image-based lighting, and backgrounds.
+---
+
+Without a light source, a Thermion scene renders black. There are two sources
+of light: **direct lights** (sun, point, spot) and **image-based lighting**
+(IBL). Most scenes combine an IBL with a skybox generated from the same
+environment plus a sun:
+
+```dart
+await viewer.loadIbl('assets/default_env_ibl.ktx');
+await viewer.loadSkybox('assets/default_env_skybox.ktx');
+await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+```
+
+## Direct lights
+
+Construct a [`DirectLight`](https://pub.dev/documentation/thermion_dart/latest/)
+and add it to the scene. `addDirectLight` returns the light's entity handle,
+which you need for removing or modifying it later.
+
+```dart
+// Sun / directional light. `direction` is a direction (not a position).
+final sun = await viewer.addDirectLight(
+  DirectLight.sun(
+    direction: Vector3(-0.5, -1, -0.3),
+    intensity: 100000,        // lux
+    castShadows: true,        // see the Shadows page
+  ),
+);
+
+// Point light — a world-space position with distance falloff.
+await viewer.addDirectLight(DirectLight.point(
+  position: Vector3(3.5, 2.5, 2.0),
+  intensity: 90000,           // lumens
+  falloffRadius: 8.0,
+  color: LinearColor(1.0, 0.82, 0.55), // warm key light
+));
+
+// Spot light — position, direction, and cone angles (radians).
+await viewer.addDirectLight(DirectLight.spot(
+  position: Vector3(0, 4, 0),
+  direction: Vector3(0, -1, 0),
+  spotLightConeInner: pi / 8,
+  spotLightConeOuter: pi / 4,
+));
+```
+
+Remove lights with `viewer.removeLight(entity)` (one) or
+`viewer.destroyLights()` (all).
+
+Intensity uses different physical units per light type:
+
+| Type | Unit | Constructor default |
+|---|---|---|
+| Sun / directional | lux | 100000 |
+| Point | lumens | 100000 |
+| Spot | candela | 100000 |
+
+## Modifying lights
+
+The viewer moves lights asynchronously:
+
+```dart
+await viewer.setLightPosition(lightEntity, 1.0, 2.0, 3.0);
+await viewer.setLightDirection(lightEntity, Vector3(0, -1, 0));
+```
+
+Everything else — color, intensity, falloff, cone angles — goes through the
+light manager, whose setters are synchronous:
+
+```dart
+final lm = FilamentApp.instance!.lightManager;
+
+lm.setColor(lightEntity, 1.0, 0.9, 0.8);          // linear RGB in [0, 1]
+lm.setColorTemperature(lightEntity, 6500);         // Kelvin
+lm.setIntensity(lightEntity, 120000);
+lm.setFalloff(lightEntity, 8.0);                   // point/spot
+lm.setSpotLightCone(lightEntity, pi / 8, pi / 4);
+lm.setSunAngularRadius(lightEntity, 0.545);        // degrees
+```
+
+:::note
+`color` and `colorTemperature` are alternatives — set one, not both.
+`sunAngularRadius` is in **degrees** while `spotLightConeInner/Outer` are in
+**radians**.
+:::
+
+## Image-based lighting (IBL)
+
+An IBL provides ambient and reflection lighting precomputed from a HDRI,
+usually with Filament's `cmgen` tool (which produces a matching
+`*_ibl.ktx` / `*_skybox.ktx` pair):
+
+```dart
+await viewer.loadIbl('assets/env_ibl.ktx', intensity: 30000); // default 30000
+await viewer.rotateIbl(Matrix3.rotationY(pi / 4)); // rotate the environment
+await viewer.removeIbl();
+```
+
+Only one IBL is active at a time — loading another replaces it.
+
+## Skybox and backgrounds
+
+The **skybox** is the image rendered behind everything else, and pairs
+naturally with an IBL from the same environment:
+
+```dart
+await viewer.loadSkybox('assets/env_skybox.ktx'); // .ktx cubemap
+
+// Or a solid color instead:
+final skybox = await viewer.setBackgroundColor(0.1, 0.2, 0.4, 1.0);
+await skybox.setColor(1.0, 0.0, 0.0, 1.0); // mutable afterwards
+
+// A flat image behind everything (renders behind the skybox too):
+await viewer.setBackgroundImage('assets/bg.png', fillHeight: true);
+```
+
+:::note
+`removeSkybox()` detaches the skybox but does not destroy it — the caller
+owns the returned `Skybox` (and its texture) from that point on.
+:::
+
+See the [Shadows](/shadows/) page for shadow-casting lights.

--- a/docs/src/content/docs/shadows.mdx
+++ b/docs/src/content/docs/shadows.mdx
@@ -1,0 +1,97 @@
+---
+title: Shadows
+description: Shadow mapping, shadow types, and per-light shadow options.
+---
+
+Shadows need **three things switched on** — miss any one and nothing casts:
+
+1. shadows enabled on the view,
+2. a light that **casts** shadows,
+3. a surface that **receives** shadows.
+
+```dart
+// 1) A receiver: a ground plane. There is no dedicated "ground shadow" API —
+//    shadows land on receiving geometry like any other surface.
+final ground = await viewer.createGeometry(GeometryUtils.plane(width: 10, height: 10));
+await ground.setReceiveShadows(true);
+
+// 2) A caster: a cube floating above the plane.
+final cube = await viewer.loadGltf('assets/cube.glb');
+await cube.setTransform(Matrix4.translation(Vector3(0, 0.5, 0)));
+
+// 3) A shadow-casting sun...
+await viewer.addDirectLight(
+  DirectLight.sun(castShadows: true, direction: Vector3(-1, -2, -1)),
+);
+
+// ...and the view-level switches.
+await viewer.setShadowsEnabled(true);
+await viewer.setShadowType(ShadowType.PCF);
+```
+
+The three switches live at different levels:
+
+| Level | API | Default |
+|---|---|---|
+| View | `viewer.setShadowsEnabled(true)` / `setShadowType(...)` | disabled |
+| Light | `DirectLight(castShadows:)` (sun constructor defaults to `true`) | `false` |
+| Renderable | `asset.setCastShadows(...)` / `asset.setReceiveShadows(...)` | cast on, receive on |
+
+## Shadow types
+
+```dart
+await viewer.setShadowType(ShadowType.PCF);  // percentage-closer filtering — the default choice
+await viewer.setShadowType(ShadowType.VSM);  // variance shadow maps — softer, may leak light
+await viewer.setShadowType(ShadowType.DPCF); // soft shadows, cheaper than PCSS
+await viewer.setShadowType(ShadowType.PCSS); // physically-based soft shadows
+```
+
+For DPCF/PCSS, penumbra tuning lives on the view:
+
+```dart
+await viewer.view.setSoftShadowOptions(
+  SoftShadowOptions(penumbraScale: 0.5, penumbraRatioScale: 0.5),
+);
+```
+
+## Per-light shadow options
+
+Directional (sun) lights support cascaded shadow maps, configured through
+the light manager using the entity returned by `addDirectLight`:
+
+```dart
+await FilamentApp.instance!.lightManager.setShadowOptions(
+  sunEntity,
+  ShadowOptions(
+    mapSize: 1024,
+    shadowCascades: 4,
+    cascadeSplitPositions: [0.125, 0.25, 0.50], // N-1 splits for N cascades
+    constantBias: 0.001,
+    normalBias: 0.01,
+    screenSpaceContactShadows: true,
+  ),
+);
+```
+
+Helper functions compute split positions as fractions of the shadow distance:
+
+```dart
+final lm = FilamentApp.instance!.lightManager;
+lm.computeUniformSplits(4);
+lm.computeLogSplits(4, near, far);
+lm.computePracticalSplits(4, near, far, 0.5);
+```
+
+## Troubleshooting
+
+- **Shadow acne** (striped self-shadowing): raise `constantBias`/`normalBias`
+  or increase `mapSize`.
+- **Peter-panning** (shadows detached from their casters): the biases are too
+  high — lower them.
+- **Pixelated edges**: higher `mapSize`, more cascades, or switch
+  PCF → DPCF/PCSS.
+- **Softer edges**: increase the sun's angular radius
+  (`lightManager.setSunAngularRadius`, degrees).
+
+See [Lighting](/lighting/) for creating and positioning lights, and
+[Entities](/entities/) for the ground-plane geometry used above.

--- a/docs/src/content/docs/viewer.mdx
+++ b/docs/src/content/docs/viewer.mdx
@@ -76,7 +76,9 @@ final asset = await viewer.loadGltf('assets/cube.glb');
 A **skybox** is the background image rendered behind everything else in the scene.
 **Image-based lighting (IBL)** uses an image to determine the direction and intensity
 of ambient light. Anything added to the scene — models, lights, cameras — is an
-**entity**, and entities are placed at position `(0, 0, 0)`.
+**entity**, and entities are placed at position `(0, 0, 0)`. See
+[Entities](/entities/) for the entity model, transforms, and instancing, and
+[Lighting](/lighting/) for the full lighting API.
 
 The default camera sits at the origin looking down `-Z`, so a model placed at the
 origin starts *inside* the camera. Move the camera back to see it.
@@ -106,6 +108,10 @@ await viewer.addDirectLight(
   DirectLight.sun(direction: v.Vector3(0, -1, -1)),
 );
 ```
+
+Point lights, spot lights, color/temperature, and the light manager are
+covered in [Lighting](/lighting/); shadow-casting lights in
+[Shadows](/shadows/).
 
 ## 7. Run it
 

--- a/examples/dart/cli_headless/bin/render_demo.dart
+++ b/examples/dart/cli_headless/bin/render_demo.dart
@@ -104,11 +104,10 @@ const double iblIntensity = 30000.0;
 
 // glTF animation playback. The BusterDrone's only animation ("CINEMA_4D_Basis",
 // index 0) drives the rotors/rig. We activate it (looping) and advance it on the
-// render thread each frame. Note: setGltfAnimationTime() applies morph weights
-// synchronously off the render thread and trips Filament's backend thread
-// assertion on this asset — so we use animationManager.update(dt) instead,
-// which advances active animations on the render thread. dt = 1/fps plays the
-// animation at its authored (1x) speed.
+// render thread each frame via animationManager.update(dt), which advances all
+// active animations — the right tool for continuous playback. (Scrubbing with
+// setGltfAnimationTime is also safe for morph animations; it is dispatched on
+// the render thread.) dt = 1/fps plays the animation at its authored (1x) speed.
 const int gltfAnimIndex = 0;
 const double animSpeed = 1.0; // animation playback speed multiplier
 

--- a/examples/flutter/viewer/lib/main.dart
+++ b/examples/flutter/viewer/lib/main.dart
@@ -61,7 +61,7 @@ class _MyHomePageState extends State<MyHomePage> {
     // file containing a plain cube.
     // By default, all paths are treated as asset paths. To load from a file
     // instead, use file:// URIs.
-    // Setting preserveGeometry: true rebuilds vertex buffers with a superset
+    // Setting rebuildVertices: true rebuilds vertex buffers with a superset
     // of attributes, enabling free material swapping (wireframe, solid, etc).
     var asset = await _thermionViewer!
         .loadGltf("assets/FlightHelmet/FlightHelmet.gltf");

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,47 @@
+# Thermion agent skills
+
+Installable [agent skills](https://code.claude.com/docs/en/skills) that teach AI
+assistants to write correct [Thermion](https://thermion.dev) code — the calls,
+parameter names, and footguns that aren't guessable from a generic 3D API.
+
+Each skill is self-contained: inline snippets plus bundled runnable examples,
+covering the **Flutter** (`thermion_flutter`) and **pure Dart** (`thermion_dart`,
+including headless/offscreen rendering) surfaces equally.
+
+## Install
+
+Copy the skill directories you want into your project's `.claude/skills/` (or
+your agent harness's equivalent):
+
+```bash
+cp -r path/to/thermion/skills/thermion-lighting  your_project/.claude/skills/
+cp -r path/to/thermion/skills/thermion-animation your_project/.claude/skills/
+# ...or all of them:
+cp -r path/to/thermion/skills/. your_project/.claude/skills/
+```
+
+Each skill directory contains a `SKILL.md` (the instructions your agent reads)
+and a `references/` folder with complete example programs.
+
+## Skills
+
+| Skill | Use it for |
+|---|---|
+| `thermion-getting-started` | First scene: viewer creation (ViewerWidget / `createViewer` / headless `FFIFilamentApp`), glTF + IBL + skybox + sun, camera, dispose lifecycle |
+| `thermion-loading-gltf` | Loading glTF/GLB, `loadGltf` parameters, entity queries, bounding boxes, GPU instancing, cleanup, visibility layers |
+| `thermion-transforms-hierarchy` | Positioning and moving objects — everything is `Matrix4` (there are no `setPosition`/`setRotation` helpers), scene-graph parenting, local vs world transforms |
+| `thermion-lighting` | `DirectLight` sun/point/spot, light color & intensity units, IBL, skybox, background color/image |
+| `thermion-shadows` | Enabling shadows, shadow types (PCF/VSM/DPCF/PCSS), per-light and per-renderable cast/receive, `ShadowOptions` and cascades |
+| `thermion-animation` | glTF animation playback, the `animationManager.update` clock, morph targets, bone/skeletal animation — and the `setGltfAnimationTime` thread-safety trap |
+| `thermion-materials` | PBR ubershader (metallic/roughness/emissive/clearcoat/…), unlit & wireframe, parameter setters, textures, swapping materials on assets |
+| `thermion-geometry` | Procedural geometry without glTF: `GeometryUtils` primitives, custom vertex/index buffers, `createGeometry` |
+| `thermion-camera-input` | Camera `lookAt`/projection/exposure, orbit & free-flight controls, input handlers and sensitivity |
+| `thermion-picking-selection` | Click/tap picking via `View.pick`, stencil-pixel highlight outlines, gizmos |
+| `thermion-post-processing` | Post-processing toggle, anti-aliasing, bloom, color grading & tone mappers, fog, ambient occlusion |
+| `thermion-headless-capture` | Pure-Dart offscreen rendering: headless swapchain, rendering to PNG, render loops |
+
+## Version
+
+These skills reflect the Thermion API on the `develop` branch as of **August
+2026**. The API evolves — for the latest reference see [thermion.dev](https://thermion.dev)
+and the `examples/` directories in the [thermion repository](https://github.com/nmfisher/thermion).

--- a/skills/thermion-animation/SKILL.md
+++ b/skills/thermion-animation/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: thermion-animation
+description: >
+  Play and control 3D animation in Thermion: glTF animation clips (play, stop,
+  loop, crossfade, speed, reverse, scrubbing), manual morph target / blend
+  shape weights, and bone/skeletal animation (bone inspection, BoneAnimationData,
+  bone transforms). Includes the critical rule that animations must be ticked
+  every frame with animationManager.update and that update takes an absolute
+  monotonic clock rather than a delta. Use when playing, pausing, blending,
+  scrubbing, or hand-driving character animation.
+  Triggers: animation, animations, play
+  animation, gltf animation, animation clip, morph target, blend shape, morph
+  weights, bone, skeleton, skeletal animation, skinning, crossfade, animation
+  speed, loop, scrub, animation manager, reset pose.
+---
+
+Thermion supports three kinds of animation, all reached through the
+`ThermionAsset` returned by `loadGltf`:
+
+1. **glTF animations** — clips baked into the file,
+2. **morph targets** — manually driving blend-shape weights,
+3. **bone animation** — hand-built per-bone frame data.
+
+## glTF animation clips
+
+```dart
+final asset = await viewer.loadGltf('assets/character.glb');
+
+// Attach an animation component if the asset might not have one:
+await asset.addAnimationComponent();
+
+final names = await asset.getGltfAnimationNames(); // e.g. ["Walk", "Run"]
+final duration = await asset.getGltfAnimationDuration(0); // seconds
+
+await asset.playGltfAnimation(
+  0,
+  loop: true,
+  crossfade: 0.2,       // seconds to blend in from the current pose
+  replaceActive: true,  // stop other clips (default)
+  speed: 1.0,           // playback rate multiplier
+  startOffset: 0.0,     // begin at this time within the clip
+  reverse: false,
+);
+// or by name:
+await asset.playGltfAnimationByName('Walk', loop: true);
+
+await asset.stopGltfAnimation(0);
+await asset.stopGltfAnimationByName('Walk');
+```
+
+## Ticking: `animationManager.update` — the part everyone misses
+
+Playing a clip does nothing visible until **you advance the clock every
+frame**:
+
+```dart
+// Flutter: a ticker/timer each frame:
+final animationManager = viewer.app.animationManager;
+await animationManager.update(elapsedNanos);
+
+// Pure Dart / headless: inside the render loop:
+await app.animationManager.update(clockNanos);
+```
+
+The argument is an **absolute monotonic clock in nanoseconds**, not a delta —
+`update` computes elapsed time as `clock - firstClock`. Accumulate it:
+
+```dart
+final dtNanos = (1e9 / fps).round();
+var clockNanos = 0;
+for (var i = 0; i < frameCount; i++) {
+  clockNanos += dtNanos;               // advance by one frame's worth
+  await app.animationManager.update(clockNanos); // must increase each call
+  // ...render/capture the frame...
+}
+```
+
+Start the clock at `dtNanos` (not 0) on the first frame so the manager's
+"first call" sentinel triggers exactly once. With `speed: s`, use
+`dtNanos = (1e9 / fps * s).round()`.
+
+The first `update()` after `playGltfAnimation` applies animation frame 0 —
+no extra priming call is needed.
+
+## Scrubbing
+
+`setGltfAnimationTime(index, seconds)` jumps to a specific time. It is
+dispatched on the render thread and is safe for morph-target animations.
+For continuous playback, prefer `playGltfAnimation` + `animationManager.update`
+and control time via `speed`/`startOffset` (or `reverse`) — calling
+`setGltfAnimationTime` every frame works but re-scrubs the whole clip each
+call.
+
+## Morph targets (blend shapes)
+
+```dart
+// Morph targets live on child (renderable) entities, NOT the asset root.
+final children = await asset.getChildEntities();
+
+ThermionEntity morphEntity = children.first;
+for (final child in children) {
+  final names = await asset.getMorphTargetNames(entity: child);
+  if (names.isNotEmpty) {
+    morphEntity = child;
+    break;
+  }
+}
+
+final names = await asset.getMorphTargetNames(entity: morphEntity);
+// e.g. ["Open", "Close"]
+
+// setMorphTargetWeights takes ALL weights at once — inactive targets get 0.
+final weights = List<double>.filled(names.length, 0.0);
+weights[0] = 1.0; // fully apply "Open"
+await asset.setMorphTargetWeights(morphEntity, weights);
+```
+
+Keyframed morph animation: build a `MorphAnimationData` and
+`await asset.setMorphAnimationData(data, targetMeshNames: [...])`;
+clear with `asset.clearMorphAnimationData(entity)`. Weight changes only show
+once animation frames tick (`update` as above).
+
+## Bones / skeletal
+
+```dart
+final bones = await asset.getBones();          // List<ThermionEntity>
+final boneNames = await asset.getBoneNames();  // aligned List<String>
+final count = await asset.getBoneCount();
+
+// Hand-animate: reset to rest pose FIRST, then enqueue animation data.
+await asset.resetBones();
+await asset.addBoneAnimation(boneAnimationData,
+    fadeInInSecs: 0.2, fadeOutInSecs: 0.2, loop: true);
+
+// Or pose a bone directly:
+await asset.setBoneTransform(boneIndex, Matrix4.compose(...));
+```
+
+`BoneAnimationData(bones, frameData, frameLengthInMs:, space:)` — the `Space`
+enum selects how frame rotations are interpreted: `Space.Bone` (default,
+rotation around each bone's rest-position local axes),
+`Space.ParentWorldRotation` (BVH-style), plus `Space.World` / `Space.Model`.
+`resetToRestPose(asset)` is the manager-level equivalent of `resetBones`.
+
+## Gotchas
+
+- **No ticking, no motion** — `playGltfAnimation` alone renders the rest pose.
+  Call `animationManager.update` every frame.
+- `update` takes an **absolute clock** (accumulate!), and the value must
+  increase between calls.
+- `setGltfAnimationTime` is render-thread-dispatched and safe for morph
+  animations; use it to scrub to an exact time, `playGltfAnimation` +
+  `update` for continuous playback (thermion.dev/animations).
+- Don't call animation methods while the app is backgrounded (render thread
+  paused) — see the "Animations when backgrounded" note at
+  https://thermion.dev/filament/.
+- Morph weights are an all-targets array — to activate one target, zero the
+  rest.
+- `resetBones()` before `addBoneAnimation`, or results are unpredictable.
+- Per-frame `speed`-scaled dt: `(1e9 / fps * speed).round()`.
+
+## References
+
+- `references/flutter-animation-player.dart` — Flutter app listing an asset's
+  clips by name with play/stop/crossfade controls.
+- `references/dart-animation-render.dart` — pure-Dart render loop with the
+  accumulated-clock update pattern, capturing animated frames to PNGs.
+
+## Docs
+
+- https://thermion.dev/animations/ — animations, morph targets, bones

--- a/skills/thermion-animation/references/dart-animation-render.dart
+++ b/skills/thermion-animation/references/dart-animation-render.dart
@@ -1,0 +1,83 @@
+// Pure-Dart headless example: render an animated glTF frame-by-frame to PNGs,
+// using the accumulated-clock animationManager.update pattern.
+//
+// Run with:  dart run dart_animation_render.dart [assets_dir] [frames]
+// (defaults: assets_dir=examples/assets, frames=10)
+//
+// Adapted from examples/dart/cli_headless/bin/render_demo.dart in the thermion
+// repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  final frameCount = argv.length > 1 ? int.parse(argv[1]) : 10;
+  const fps = 30;
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(
+      near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+  await camera.lookAt(Vector3(3, 2, 3), focus: Vector3(0, 0, 0));
+
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+
+  final asset = await viewer.loadGltf(assetUri('BusterDrone/scene.gltf'));
+  await asset.transformToUnitCube();
+  await asset.addAnimationComponent();
+
+  final clipNames = await asset.getGltfAnimationNames();
+  print('Clips: $clipNames');
+  final duration = await asset.getGltfAnimationDuration(0);
+  print('Clip 0 duration: ${duration.toStringAsFixed(2)}s');
+
+  // playGltfAnimation + update is the right tool for continuous playback.
+  // (setGltfAnimationTime is also safe for morph clips — render-thread
+  // dispatched — but is meant for scrubbing to an exact time.)
+  await asset.playGltfAnimation(0, loop: true, speed: 1.0);
+
+  // update() takes an ABSOLUTE monotonic clock (nanos), not a delta —
+  // accumulate one frame's worth per iteration. Starting at dtNanos (not 0)
+  // triggers the manager's first-call sentinel exactly once; the first update
+  // applies animation frame 0.
+  final dtNanos = (1e9 / fps).round();
+  var clockNanos = 0;
+
+  final outDir = io.Directory('anim_frames')..createSync(recursive: true);
+  for (var i = 0; i < frameCount; i++) {
+    clockNanos += dtNanos;
+    await app.animationManager.update(clockNanos);
+
+    final result = await app.capture(
+      swapChain,
+      view: viewer.view,
+      pixelDataFormat: PixelDataFormat.RGBA,
+      pixelDataType: PixelDataType.FLOAT,
+    );
+    final png = await pixelBufferToPng(result.first.$2, width, height,
+        hasAlpha: true, isFloat: true);
+    await io.File('${outDir.path}/frame_${i.toString().padLeft(4, '0')}.png')
+        .writeAsBytes(png);
+  }
+  print('Wrote $frameCount frames to ${outDir.path}');
+
+  io.exit(0);
+}

--- a/skills/thermion-animation/references/flutter-animation-player.dart
+++ b/skills/thermion-animation/references/flutter-animation-player.dart
@@ -1,0 +1,125 @@
+// Flutter example: a minimal glTF animation player. Lists the asset's clips,
+// plays the selected one with a crossfade, and ticks animationManager.update
+// every frame (without this, nothing moves).
+//
+// Expects assets/ declared in pubspec.yaml with an animated glTF (e.g.
+// BusterDrone/scene.gltf from the thermion examples assets).
+//
+// Adapted from examples/flutter/animations in the thermion repository.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:thermion_flutter/thermion_flutter.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) => const MaterialApp(home: PlayerPage());
+}
+
+class PlayerPage extends StatefulWidget {
+  const PlayerPage({super.key});
+
+  @override
+  State<PlayerPage> createState() => _PlayerPageState();
+}
+
+class _PlayerPageState extends State<PlayerPage> {
+  ThermionViewer? _viewer;
+  ThermionAsset? _asset;
+  List<String> _clipNames = [];
+  String? _selected;
+  Timer? _tickTimer;
+
+  Future<void> _load() async {
+    final viewer = await ThermionFlutterPlugin.createViewer();
+    await viewer.setPostProcessing(true);
+
+    await viewer.loadIbl('assets/default_env_ibl.ktx');
+    await viewer.addDirectLight(
+        DirectLight.sun(direction: Vector3(0, -1, -1)));
+
+    final asset = await viewer.loadGltf('assets/BusterDrone/scene.gltf');
+    await asset.transformToUnitCube();
+    await asset.addAnimationComponent();
+
+    final camera = await viewer.getActiveCamera();
+    await camera.lookAt(Vector3(2, 1.5, 3), focus: Vector3(0, 0, 0));
+
+    // Tick the animation clock every frame. update() takes an ABSOLUTE
+    // monotonic clock in nanos — accumulate ~60fps deltas.
+    final animationManager = viewer.app.animationManager;
+    var clockNanos = 0;
+    final dtNanos = (1e9 / 60).round();
+    _tickTimer?.cancel();
+    _tickTimer = Timer.periodic(const Duration(milliseconds: 16), (_) async {
+      clockNanos += dtNanos;
+      await animationManager.update(clockNanos);
+    });
+
+    final clipNames = await asset.getGltfAnimationNames();
+    setState(() {
+      _viewer = viewer;
+      _asset = asset;
+      _clipNames = clipNames;
+      _selected = clipNames.isNotEmpty ? clipNames.first : null;
+    });
+
+    if (_selected != null) {
+      await asset.playGltfAnimationByName(_selected!,
+          loop: true, crossfade: 0.2);
+    }
+  }
+
+  Future<void> _play(String? name) async {
+    if (name == null || _asset == null) return;
+    setState(() => _selected = name);
+    await _asset!.playGltfAnimationByName(name,
+        loop: true, crossfade: 0.2, replaceActive: true);
+  }
+
+  Future<void> _stop() async {
+    if (_selected == null || _asset == null) return;
+    await _asset!.stopGltfAnimationByName(_selected!);
+  }
+
+  @override
+  void dispose() {
+    _tickTimer?.cancel();
+    _viewer?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        body: _viewer == null
+            ? Center(child: FilledButton(onPressed: _load, child: const Text('Load')))
+            : Stack(children: [
+                Positioned.fill(child: ThermionWidget(viewer: _viewer!)),
+                Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        DropdownButton<String>(
+                          value: _selected,
+                          items: _clipNames
+                              .map((n) => DropdownMenuItem(value: n, child: Text(n)))
+                              .toList(),
+                          onChanged: _play,
+                        ),
+                        const SizedBox(width: 16),
+                        FilledButton(onPressed: _stop, child: const Text('Stop')),
+                      ],
+                    ),
+                  ),
+                ),
+              ]),
+      );
+}

--- a/skills/thermion-camera-input/SKILL.md
+++ b/skills/thermion-camera-input/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: thermion-camera-input
+description: >
+  Position and control the camera, and add user interaction, in a Thermion
+  scene. Covers camera lookAt (there is no setCameraPosition), lens
+  projection (focal length) and field-of-view projections, exposure, multiple
+  cameras, orbit and free-flight controls via ManipulatorType on ViewerWidget
+  or DelegateInputHandler with ThermionListenerWidget, sensitivity tuning, and
+  writing custom input handlers. Use when framing a shot, moving the camera,
+  adding drag/scroll/zoom controls, or handling touch and mouse input.
+  Triggers: camera, lookAt, camera position, move camera, orbit, orbit
+  controls, free flight, first person, field of view, fov, projection, focal
+  length, zoom, exposure, aperture, input handler, mouse, touch, scroll wheel,
+  sensitivity, manipulator, drag rotate.
+---
+
+There is **no `setCameraPosition`** on the viewer. Get the active camera and
+aim it with `lookAt` — first argument is the camera's position, then an
+optional focus point (defaults to the origin) and up vector (defaults to +Y):
+
+```dart
+final camera = await viewer.getActiveCamera();
+await camera.lookAt(Vector3(3, 3, 3), focus: Vector3(0, 0, 0));
+final Vector3 pos = camera.getPosition();
+```
+
+The default camera sits at `(0, 0, 0)` looking down −Z — inside any object
+placed at the origin. Always `lookAt` from a distance after loading.
+
+## Projection
+
+```dart
+// Physical lens (default feel): focal length in mm.
+await camera.setLensProjection(near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+
+// Or an explicit field of view:
+await camera.setProjectionFromVerticalFieldOfView(45.0, 0.1, 1000.0, aspect);
+await camera.setProjectionFromHorizontalFieldOfView(60.0, 0.1, 1000.0, aspect);
+
+// Exposure (aperture f-number, shutter speed seconds, sensitivity ISO):
+await camera.setExposure(16.0, 1 / 125, 100.0);
+```
+
+After `viewer.setViewport(w, h)` cameras update to the new aspect ratio.
+
+## Multiple cameras
+
+```dart
+final cam2 = await viewer.createCamera();
+await cam2.lookAt(Vector3(0, 10, 0), focus: Vector3(0, 0, 0));
+await viewer.setActiveCamera(cam2);       // render from cam2
+await viewer.destroyCamera(cam2);          // cleanup
+final count = viewer.getCameraCount();
+```
+
+## Flutter — built-in controls (ViewerWidget)
+
+```dart
+ViewerWidget(
+  assetPath: 'assets/cube.glb',
+  initialCameraPosition: Vector3(0, 2, 4),
+  manipulatorType: ManipulatorType.ORBIT, // ORBIT | FREE_FLIGHT | NONE
+);
+```
+
+## Flutter — manual controls (ThermionListenerWidget)
+
+Wrap `ThermionWidget` in a `ThermionListenerWidget` with a delegate input
+handler — this is the low-level path when you create the viewer yourself:
+
+```dart
+ThermionListenerWidget(
+  inputHandler: DelegateInputHandler.fixedOrbit(
+    viewer,
+    minimumDistance: 0.1,     // how close the camera may zoom
+    sensitivity: InputSensitivityOptions(
+      scrollWheelSensitivity: 0.005,
+    ),
+  ),
+  child: ThermionWidget(viewer: viewer),
+);
+
+// Free-flight (WASD-style) instead of orbit:
+DelegateInputHandler.flight(viewer, freeLook: true)
+```
+
+`fixedOrbit` options: `target` (orbit center), `minimumDistance`,
+`moveOnHover`, `sensitivity`. `flight` options: `freeLook`, `moveOnHover`,
+`sensitivity`. Sensitivity covers touch, mouse, scroll, and keys via
+`InputSensitivityOptions`.
+
+## Custom input handling
+
+Implement an input handler delegate to route arbitrary Flutter gestures into
+camera motion (or picking — see the `thermion-picking-selection` skill):
+
+```dart
+GestureDetector(
+  onPanUpdate: (details) {
+    // Convert deltas to orbit angles and call camera.lookAt yourself.
+  },
+  child: ThermionWidget(viewer: viewer),
+)
+```
+
+## Gotchas
+
+- Camera motion is `lookAt` / `setModelMatrix` / `setTransform(Matrix4)` — not
+  `setPosition`.
+- `lookAt` positions the camera at the FIRST argument; the focus is what it
+  looks AT. Swapping them is the classic mistake.
+- +Y is up, −Z is into the screen (right-handed).
+- FOV functions take **degrees**; `setLensProjection` takes millimeters.
+- `ViewerWidget` installs its own manipulator; don't add a
+  `ThermionListenerWidget` around it.
+
+## References
+
+- `references/dart-camera-projections.dart` — complete pure-Dart program
+  comparing lens and FOV projections.
+
+## Docs
+
+- https://thermion.dev/camera-manipulation/ — orbit/free-flight/custom input

--- a/skills/thermion-camera-input/references/dart-camera-projections.dart
+++ b/skills/thermion-camera-input/references/dart-camera-projections.dart
@@ -1,0 +1,71 @@
+// Pure-Dart headless example: camera positioning and projections — lookAt,
+// lens projection (focal length), and vertical field-of-view projection.
+//
+// Run with:  dart run dart_camera_projections.dart [assets_dir] [mode]
+//   mode: lens | fov  (default lens)
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/examples_lib (camera_basics) in the thermion
+// repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  final mode = argv.length > 1 ? argv[1] : 'lens';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+
+  final asset = await viewer.loadGltf(assetUri('cube.glb'));
+  await asset.transformToUnitCube();
+
+  final camera = await viewer.getActiveCamera();
+
+  if (mode == 'fov') {
+    // Explicit vertical field of view (degrees) — deterministic framing.
+    await camera.setProjectionFromVerticalFieldOfView(
+        45.0, 0.1, 100.0, width / height);
+  } else {
+    // Physical lens: 28mm focal length by default feel.
+    await camera.setLensProjection(
+        near: 0.1, far: 100.0, aspect: width / height, focalLength: 28.0);
+  }
+
+  // Position the camera and aim it at the origin.
+  await camera.lookAt(Vector3(2, 2, 2), focus: Vector3(0, 0, 0));
+  print('Camera at ${camera.getPosition()} ($mode mode)');
+
+  // Capture a frame.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final png = await pixelBufferToPng(result.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('camera_$mode.png').writeAsBytes(png);
+  print('Wrote camera_$mode.png');
+
+  io.exit(0);
+}

--- a/skills/thermion-geometry/SKILL.md
+++ b/skills/thermion-geometry/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: thermion-geometry
+description: >
+  Create 3D geometry procedurally in Thermion without a glTF file. Covers
+  GeometryUtils primitives (cube, sphere, cylinder, conic, plane, groundPlane,
+  halfPyramid, fullscreenQuad, fromAabb3), building a custom Geometry from
+  hand-specified vertex positions and triangle indices (plus normals, UVs,
+  colors), turning geometry into a scene entity with viewer.createGeometry
+  (optionally with your own material instances), and positioning the result.
+  Use when you need a simple shape (cube, plane, sphere), a debug ground plane,
+  a custom mesh from raw vertex data, or a bounding-box visualization.
+  Triggers: geometry, primitive, cube, sphere, cylinder, cone, plane, ground
+  plane, custom mesh, vertices, indices, triangle, procedural geometry,
+  createGeometry, GeometryUtils, vertex buffer, draw a shape.
+---
+
+Not everything needs a glTF file. `GeometryUtils` provides ready-made
+primitives; a `Geometry` object wraps raw vertex/index data; and
+`viewer.createGeometry` turns either into a `ThermionAsset` in the scene —
+positioned and transformed exactly like a loaded glTF.
+
+## Primitives
+
+```dart
+final cube = await viewer.createGeometry(GeometryUtils.cube());
+final sphere = await viewer.createGeometry(GeometryUtils.sphere());
+final cylinder = await viewer.createGeometry(GeometryUtils.cylinder(uvs: false));
+final cone = await viewer.createGeometry(GeometryUtils.conic(uvs: false));
+final plane = await viewer.createGeometry(GeometryUtils.plane(width: 10, height: 10));
+final ground = await viewer.createGeometry(GeometryUtils.groundPlane());
+
+await cube.setTransform(Matrix4.translation(Vector3(-4, 0, 0)));
+await sphere.setTransform(Matrix4.translation(Vector3(-2, 0, 0)));
+```
+
+Options: `cube(normals:, uvs:, flipUvs:)`,
+`sphere(latitudeBands: 20, longitudeBands: 20)`, `cylinder(radius:, length:)`,
+`conic(radius:, length:)`, `plane(width:, height:)`. By default primitives
+generate normals + UVs (cylinder/conic take `uvs:` explicitly).
+
+Bounding-box helper (debug visualization):
+
+```dart
+final boxMesh = await viewer.createGeometry(GeometryUtils.fromAabb3(bounds));
+```
+
+`viewer.showBoundingBox(asset)` / `viewer.hideBoundingBox(asset)` render an
+asset's box directly.
+
+## Custom geometry
+
+Supply vertex positions (a flat `Float32List` of x,y,z triplets) and triangle
+indices:
+
+```dart
+// A pyramid: 5 vertices, 6 triangles.
+final vertices = Float32List.fromList([
+  // Base (y = -1)
+  -1.0, -1.0, -1.0, // 0
+   1.0, -1.0, -1.0, // 1
+   1.0, -1.0,  1.0, // 2
+  -1.0, -1.0,  1.0, // 3
+  // Apex (y = 1)
+   0.0,  1.0,  0.0, // 4
+]);
+final indices = <int>[
+  0, 2, 1,  0, 3, 2, // base (two triangles)
+  0, 1, 4,  1, 2, 4,  // sides
+  2, 3, 4,  3, 0, 4,
+];
+
+final geo = Geometry(vertices, indices);
+final pyramid = await viewer.createGeometry(geo);
+await pyramid.setTransform(Matrix4.translation(Vector3(0, 1, 0)));
+```
+
+Optional named parameters on `Geometry`:
+
+```dart
+Geometry(
+  vertices, indices,
+  normals: normalList,   // Float32List of x,y,z per vertex
+  uvs: uvList,           // Float32List of u,v per vertex
+  colors: colorList,     // Float32List of r,g,b[,a] per vertex
+  primitiveType: PrimitiveType.TRIANGLES,
+  // createDummyColors/createDummyUvs/createDummyUvs1 pad missing attributes
+);
+```
+
+## Materials at creation time
+
+Without a material the default ubershader is used. Pass material instances to
+control appearance (create them first — see the `thermion-materials` skill):
+
+```dart
+final material = await viewer.app.createUbershaderMaterial();
+await material.setBaseColorFactor(0.8, 0.2, 0.2, 1.0);
+
+final asset = await viewer.createGeometry(
+  GeometryUtils.sphere(),
+  materialInstances: [material.materialInstance],
+);
+```
+
+`materialInstances` is a list — one entry per primitive (primitives from
+`GeometryUtils` are single-primitive).
+
+## Gotchas
+
+- Winding order matters: counter-clockwise when viewed from outside
+  (front-facing). Back faces are culled by default.
+- One position = one vertex — duplicate vertices at sharp edges if you want
+  per-face normals.
+- Geometry assets are `ThermionAsset`s: `setTransform`, `setCastShadows`,
+  `destroyAsset`, instancing-free but otherwise the same lifecycle as glTF.
+- Wireframe rendering of custom geometry needs barycentric-duplicated
+  vertices: `GeometryUtils.duplicateVerticesWithBarycentrics(vertices, indices)`.
+
+## References
+
+- `references/dart-primitives-and-pyramid.dart` — complete pure-Dart program:
+  the five primitives in a row plus a hand-built pyramid.
+
+## Docs
+
+- https://thermion.dev/materials/ includes procedural geometry; the bundled
+  reference and `examples/dart/examples_lib/lib/src/geometry_primitives.dart`
+  / `custom_geometry.dart` in the thermion repository are canonical.

--- a/skills/thermion-geometry/references/dart-primitives-and-pyramid.dart
+++ b/skills/thermion-geometry/references/dart-primitives-and-pyramid.dart
@@ -1,0 +1,88 @@
+// Pure-Dart headless example: procedural geometry — the five GeometryUtils
+// primitives arranged in a row, plus a hand-built pyramid from raw vertices
+// and indices.
+//
+// Run with:  dart run dart_primitives_and_pyramid.dart [assets_dir]
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/examples_lib (geometry_primitives and
+// custom_geometry setups) in the thermion repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(
+      near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+  await camera.lookAt(Vector3(0, 4, 8), focus: Vector3(0, 0, 0));
+
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+
+  // The five primitives, in a row.
+  final cube = await viewer.createGeometry(GeometryUtils.cube());
+  await cube.setTransform(Matrix4.translation(Vector3(-4, 0, 0)));
+
+  final sphere = await viewer.createGeometry(GeometryUtils.sphere());
+  await sphere.setTransform(Matrix4.translation(Vector3(-2, 0, 0)));
+
+  final cylinder = await viewer.createGeometry(GeometryUtils.cylinder(uvs: false));
+  await cylinder.setTransform(Matrix4.translation(Vector3(0, 0, 0)));
+
+  final conic = await viewer.createGeometry(GeometryUtils.conic(uvs: false));
+  await conic.setTransform(Matrix4.translation(Vector3(2, 0, 0)));
+
+  final plane = await viewer.createGeometry(GeometryUtils.plane());
+  await plane.setTransform(Matrix4.translation(Vector3(4, 0, 0)));
+
+  // A custom pyramid: 5 vertices, 6 triangles (2 base + 4 sides).
+  final vertices = Float32List.fromList([
+    -1.0, -1.0, -1.0, // 0
+     1.0, -1.0, -1.0, // 1
+     1.0, -1.0,  1.0, // 2
+    -1.0, -1.0,  1.0, // 3
+     0.0,  1.0,  0.0, // 4 (apex)
+  ]);
+  final indices = <int>[
+    0, 2, 1, 0, 3, 2, // base
+    0, 1, 4, 1, 2, 4, // sides
+    2, 3, 4, 3, 0, 4,
+  ];
+  final pyramid = await viewer.createGeometry(Geometry(vertices, indices));
+  await pyramid.setTransform(Matrix4.translation(Vector3(0, 2, -4)));
+
+  // Capture a frame.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final png = await pixelBufferToPng(result.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('geometry.png').writeAsBytes(png);
+  print('Wrote geometry.png');
+
+  io.exit(0);
+}

--- a/skills/thermion-getting-started/SKILL.md
+++ b/skills/thermion-getting-started/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: thermion-getting-started
+description: >
+  Set up and render a first 3D scene with Thermion, on Flutter or pure Dart.
+  Covers creating a ThermionViewer (ViewerWidget, ThermionFlutterPlugin.createViewer,
+  or headless FFIFilamentApp), loading a glTF model with image-based lighting and
+  a skybox, adding a sun light, positioning the camera, enabling post-processing,
+  and disposing the viewer. Use when starting a Thermion project, creating a
+  viewer, wiring ThermionWidget, or setting up a headless/offscreen renderer.
+  Triggers: thermion setup, first scene, create viewer, ThermionViewer,
+  ViewerWidget, ThermionWidget, createViewer, FilamentApp, headless viewer,
+  hello world 3d, thermion flutter, thermion dart.
+---
+
+Teaches the three ways to bring up a Thermion renderer and the canonical
+"hello world" scene. Read this before any other Thermion skill — it defines
+the setup boilerplate the others assume.
+
+There is **no `ThermionController`** class. The central object is a
+`ThermionViewer` (one Scene + Camera + View). Low-level engine access is
+`viewer.app`, a `FilamentApp`.
+
+## Flutter — high level (`ViewerWidget`)
+
+One widget does everything: creates a viewer, loads an asset, IBL + skybox,
+a light, and orbit controls. Start here unless you need custom scene setup.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:thermion_flutter/thermion_flutter.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+ViewerWidget(
+  assetPath: 'assets/cube.glb',          // glTF/GLB to load
+  skyboxPath: 'assets/default_env_skybox.ktx',
+  iblPath: 'assets/default_env_ibl.ktx',
+  directLight: DirectLight.sun(direction: Vector3(0, -1, -1)),
+  transformToUnitCube: true,             // normalize model scale to a unit cube
+  initialCameraPosition: Vector3(0, 0, 6),
+  manipulatorType: ManipulatorType.ORBIT, // or FREE_FLIGHT, NONE
+  onViewerAvailable: (viewer) async {
+    // Optional: grab the ThermionViewer for further scene control.
+  },
+  onAssetLoaded: (viewer, asset) async {
+    // Optional: called once the glTF is in the scene.
+  },
+)
+```
+
+## Flutter — low level (`createViewer` + `ThermionWidget`)
+
+For custom scene setup, create the viewer yourself and render it with
+`ThermionWidget`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:thermion_flutter/thermion_flutter.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+ThermionViewer? _viewer;
+
+// e.g. in initState:
+_viewer = await ThermionFlutterPlugin.createViewer();
+await _viewer!.loadIbl('assets/default_env_ibl.ktx');
+await _viewer!.loadSkybox('assets/default_env_skybox.ktx');
+final asset = await _viewer!.loadGltf('assets/cube.glb');
+
+// The default camera sits at the origin looking down -Z — inside your model.
+// Move it back with lookAt (camera position first, optional focus point):
+final camera = await _viewer!.getActiveCamera();
+await camera.lookAt(Vector3(0, 1, 10), focus: Vector3(0, 0, 0));
+
+// Without a light source the scene renders black. A sun is the usual choice:
+await _viewer!.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+
+// Post-processing (tone mapping, anti-aliasing, bloom) is OFF by default.
+// If unsure, turn it on:
+await _viewer!.setPostProcessing(true);
+
+// In build:
+// ThermionWidget(viewer: _viewer!)
+```
+
+Declare assets in `pubspec.yaml`:
+
+```yaml
+flutter:
+  assets:
+    - assets/
+```
+
+## Pure Dart — headless (no Flutter, no window)
+
+Used for CLI rendering, server-side rendering, and tests. Rendering goes to an
+offscreen swapchain you capture to pixels — see the `thermion-headless-capture`
+skill for capture details.
+
+```dart
+import 'dart:io' as io;
+import 'package:thermion_dart/thermion_dart.dart';
+// FFIFilamentApp is not exported from the public barrel — import from src,
+// exactly as the canonical examples do:
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+await FFIFilamentApp.create(
+  config: FFIFilamentConfig(
+    loadResource: (uri) async {
+      // The default loader chokes on file:// — strip it and read from disk.
+      final path = uri.replaceAll('file://', '');
+      return io.File(path).readAsBytes();
+    },
+  ),
+);
+final app = FilamentApp.instance!;
+final swapChain = await app.createHeadlessSwapChain(width, height);
+
+final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+await viewer.initialized;
+await app.renderManager.attach(viewer.view, swapChain); // give rendering a target
+await viewer.setViewport(width, height);
+
+// ...same scene setup as above: loadIbl / loadSkybox / loadGltf / lookAt...
+```
+
+In pure Dart, load assets with **`file://` URIs** (`file:///abs/path/cube.glb`).
+In Flutter, plain paths are asset-bundle paths; `file://` selects the filesystem.
+
+## Disposal
+
+```dart
+// Flutter teardown, in order:
+// 1) remove all ThermionWidget/ViewerWidget instances from the widget tree
+// 2) drop all references to the ThermionViewer
+// 3) await viewer.dispose();
+await viewer.dispose();
+```
+
+## Gotchas
+
+- **Only one viewer can be active at a time** (native). Creating a new viewer
+  before `dispose()` on the old one throws. (Web is per-viewer.)
+- **The default camera is at `(0, 0, 0)` looking down `-Z`** — a model loaded at
+  the origin starts inside the camera. Always `lookAt` from a distance.
+- Coordinates are right-handed, **+Y up, −Z into the screen**.
+- Without a light (sun or IBL) everything renders black.
+- `setPostProcessing(true)` is off by default — enable it for tone mapping and
+  anti-aliasing unless you specifically need it off.
+- The first native build downloads prebuilt Filament binaries (cached after);
+  `flutter clean` triggers a fresh download.
+- Nearly every Thermion API is asynchronous — `await` every call.
+
+## References
+
+- `references/flutter-viewerwidget.dart` — minimal complete Flutter app using
+  the high-level widget.
+- `references/dart-headless-minimal.dart` — minimal pure-Dart program that sets
+  up a headless renderer and captures one frame to PNG.
+
+## Docs
+
+- https://thermion.dev/quickstart/ — ViewerWidget walkthrough
+- https://thermion.dev/viewer/ — ThermionViewer in Flutter
+- https://thermion.dev/filament-api/ — dropping down to FilamentApp

--- a/skills/thermion-getting-started/references/dart-headless-minimal.dart
+++ b/skills/thermion-getting-started/references/dart-headless-minimal.dart
@@ -1,0 +1,70 @@
+// Minimal pure-Dart headless Thermion program: sets up an offscreen renderer,
+// loads the canonical hello-world scene (cube + skybox + IBL + sun), and
+// captures one frame to a PNG. No Flutter, no window.
+//
+// Run with:  dart run dart_headless_minimal.dart [assets_dir] [output.png]
+// (defaults: assets_dir=examples/assets, output=cube.png)
+//
+// Adapted from examples/dart/cli_headless/bin/render_demo.dart in the thermion
+// repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+// FFIFilamentApp is not exported from the public barrel — import from src,
+// exactly as the canonical examples do:
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  final outPath = argv.length > 1 ? argv[1] : 'cube.png';
+  const width = 512, height = 512;
+  // In pure Dart, assets are addressed with file:// URIs.
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  // 1) Engine. The default resource loader does raw File reads and chokes on
+  //    the file:// scheme, so strip it in a custom loadResource.
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async {
+        final path = uri.replaceAll('file://', '');
+        return io.File(path).readAsBytes();
+      },
+    ),
+  );
+  final app = FilamentApp.instance!;
+
+  // 2) Offscreen rendering target + viewer.
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  // 3) The canonical hello-world scene.
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+  final asset = await viewer.loadGltf(assetUri('cube.glb'));
+  await asset.transformToUnitCube();
+
+  final camera = await viewer.getActiveCamera();
+  await camera.lookAt(Vector3(3, 3, 3), focus: Vector3(0, 0, 0));
+
+  // 4) Capture one frame to a PNG.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final pixels = result.first.$2;
+  final png = await pixelBufferToPng(pixels, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File(outPath).writeAsBytes(png);
+  print('Wrote $outPath');
+
+  // Hard-exit: Filament teardown can race gltfio material-instance destruction
+  // and panic noisily; the PNG is already flushed, so just exit cleanly.
+  io.exit(0);
+}

--- a/skills/thermion-getting-started/references/flutter-viewerwidget.dart
+++ b/skills/thermion-getting-started/references/flutter-viewerwidget.dart
@@ -1,0 +1,72 @@
+// Minimal Thermion Flutter app using the high-level ViewerWidget.
+//
+// Expects an assets/ folder (declared in pubspec.yaml) containing:
+//   cube.glb, default_env_skybox.ktx, default_env_ibl.ktx
+//
+// Adapted from examples/flutter/quickstart in the thermion repository.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:thermion_flutter/thermion_flutter.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+        title: 'Thermion quickstart',
+        theme: ThemeData(useMaterial3: true),
+        home: const HomePage(),
+      );
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  Timer? _spinTimer;
+
+  @override
+  void dispose() {
+    _spinTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        body: ViewerWidget(
+          assetPath: 'assets/cube.glb',
+          skyboxPath: 'assets/default_env_skybox.ktx',
+          iblPath: 'assets/default_env_ibl.ktx',
+          directLight: DirectLight.sun(direction: Vector3(0, -1, -1)),
+          transformToUnitCube: true,
+          initialCameraPosition: Vector3(0, 2, 4),
+          manipulatorType: ManipulatorType.ORBIT,
+          onViewerAvailable: (viewer) async {
+            // Post-processing (tone mapping, anti-aliasing) is off by default.
+            await viewer.setPostProcessing(true);
+          },
+          onAssetLoaded: (viewer, asset) async {
+            // Spin the model: set a fresh transform ~60x per second. There are
+            // no setPosition/setRotation helpers — transforms are Matrix4.
+            final started = DateTime.now();
+            _spinTimer?.cancel();
+            _spinTimer = Timer.periodic(const Duration(milliseconds: 16),
+                (timer) async {
+              final elapsed = DateTime.now()
+                      .difference(started)
+                      .inMilliseconds /
+                  1000;
+              await asset.setTransform(Matrix4.rotationY(elapsed));
+            });
+          },
+        ),
+      );
+}

--- a/skills/thermion-headless-capture/SKILL.md
+++ b/skills/thermion-headless-capture/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: thermion-headless-capture
+description: >
+  Render Thermion scenes to images without a display, in pure Dart (no
+  Flutter). Covers FFIFilamentApp.create with a custom loadResource, the
+  headless swapchain, creating and attaching a viewer, viewport sizing,
+  capturing frames with FilamentApp.capture (RGBA float or byte pixels), and
+  converting to PNG with pixelBufferToPng. Use for CLI renderers, server-side
+  rendering, test golden images, screenshots, batch frame rendering, or video
+  frame export. Triggers: headless, offscreen, off-screen, render to image,
+  screenshot, capture, png, pixel buffer, server side rendering, batch
+  render, no window, cli, pure dart, desktop, test images, golden files.
+---
+
+Thermion renders without any window: create the engine, attach a viewer to a
+headless swapchain, and capture pixels. This is pure Dart — the
+`thermion_flutter` package is not involved.
+
+## The full setup
+
+```dart
+import 'dart:io' as io;
+import 'package:thermion_dart/thermion_dart.dart';
+// FFIFilamentApp is not exported from the public barrel — import from src:
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+// 1) Engine with a resource loader that understands file:// URIs.
+await FFIFilamentApp.create(
+  config: FFIFilamentConfig(
+    loadResource: (uri) async {
+      final path = uri.replaceAll('file://', '');
+      return io.File(path).readAsBytes();
+    },
+  ),
+);
+final app = FilamentApp.instance!;
+
+// 2) Offscreen target sized to your desired output resolution.
+final swapChain = await app.createHeadlessSwapChain(width, height);
+
+// 3) Viewer attached to that target.
+final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+await viewer.initialized;
+await app.renderManager.attach(viewer.view, swapChain);
+await viewer.setViewport(width, height);
+
+// 4) Normal scene setup: loadIbl / loadGltf / lookAt / addDirectLight...
+
+// 5) Capture.
+final result = await app.capture(
+  swapChain,
+  view: viewer.view,
+  pixelDataFormat: PixelDataFormat.RGBA,
+  pixelDataType: PixelDataType.FLOAT, // or UBYTE for 8-bit output
+);
+final pixels = result.first.$2; // Uint8List of packed pixels
+```
+
+`capture` returns one `(View, pixels)` pair per captured view — hence
+`.first.$2`.
+
+## Pixels → PNG
+
+```dart
+final png = await pixelBufferToPng(
+  pixels, width, height,
+  hasAlpha: true,  // RGBA vs RGB
+  isFloat: true,   // must match pixelDataType (FLOAT vs UBYTE)
+);
+await io.File('frame.png').writeAsBytes(png);
+```
+
+## Render loops (animation, camera motion)
+
+Advance animations with the accumulated-clock `animationManager.update`
+pattern (see the `thermion-animation` skill), move the camera with `lookAt`,
+and capture per frame:
+
+```dart
+for (var i = 0; i < frameCount; i++) {
+  clockNanos += dtNanos;
+  await app.animationManager.update(clockNanos);
+  await camera.lookAt(nextOrbitPosition(i), focus: focus);
+  // capture + write PNG (as above)
+}
+```
+
+Cap the engine's frame rate for continuous (non-capture) rendering (sync):
+
+```dart
+app.setTargetFramerate(60);
+```
+
+## Teardown
+
+```dart
+io.exit(0); // after flushing output
+```
+
+Gotcha: on exit, Filament's teardown can race gltfio material-instance
+destruction and panic ("N instances still alive"). It's harmless once your
+output is flushed, so canonical examples skip teardown with a hard exit.
+
+## Gotchas
+
+- **Desktop platforms only** — headless rendering needs a native Filament
+  backend (OpenGL/Metal/Vulkan); there is no browser headless path.
+- The default resource loader does raw `File` reads and chokes on `file://` —
+  always pass a `loadResource` that strips the scheme.
+- `isFloat` in `pixelBufferToPng` must match the `pixelDataType` used in
+  `capture`.
+- Assets are addressed with `file://` URIs (no Flutter asset bundle here).
+- Call `viewer.setViewport(width, height)` so aspect ratios match the output.
+- For scenes that pop at frame edges during camera motion, disable frustum
+  culling: `await viewer.view.setFrustumCullingEnabled(false)`.
+
+## References
+
+- `references/dart-headless-capture.dart` — minimal program capturing one
+  frame in both HDR float and 8-bit formats.
+- The `thermion-getting-started` skill's `references/dart-headless-minimal.dart`
+  is the smallest end-to-end example.
+
+## Docs
+
+- https://thermion.dev/filament-api/ — headless rendering with FilamentApp

--- a/skills/thermion-headless-capture/references/dart-headless-capture.dart
+++ b/skills/thermion-headless-capture/references/dart-headless-capture.dart
@@ -1,0 +1,70 @@
+// Pure-Dart headless example: capture the same frame twice — once as HDR
+// float pixels, once as 8-bit — demonstrating the capture pixel formats.
+//
+// Run with:  dart run dart_headless_capture.dart [assets_dir]
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/cli_headless/bin/render_demo.dart in the thermion
+// repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.lookAt(Vector3(3, 3, 3), focus: Vector3(0, 0, 0));
+
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+  final asset = await viewer.loadGltf(assetUri('cube.glb'));
+  await asset.transformToUnitCube();
+
+  // HDR float capture.
+  final floatResult = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final floatPng = await pixelBufferToPng(floatResult.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('capture_hdr.png').writeAsBytes(floatPng);
+  print('Wrote capture_hdr.png');
+
+  // 8-bit capture (isFloat must match!).
+  final byteResult = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.UBYTE,
+  );
+  final bytePng = await pixelBufferToPng(byteResult.first.$2, width, height,
+      hasAlpha: true, isFloat: false);
+  await io.File('capture_8bit.png').writeAsBytes(bytePng);
+  print('Wrote capture_8bit.png');
+
+  // Skip Filament teardown — it can race gltfio material-instance destruction
+  // and panic noisily after the PNGs are already flushed.
+  io.exit(0);
+}

--- a/skills/thermion-lighting/SKILL.md
+++ b/skills/thermion-lighting/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: thermion-lighting
+description: >
+  Light a Thermion scene: direct lights (sun/directional, point, spot) plus
+  image-based lighting and backgrounds. Covers DirectLight.sun/.point/.spot
+  construction, addDirectLight/removeLight, moving lights, the LightManager
+  (color, Kelvin color temperature, intensity units per light type, falloff,
+  spot cone angles, sun radius and halo), IBL via loadIbl (intensity, rotation),
+  skyboxes (loadSkybox, solid color, background images), and the standard
+  IBL+skybox+sun combination. Use when a scene is black, too dark, needs a
+  sun/lamp/highlight, or when setting up environment lighting or backgrounds.
+  Triggers: light, lighting, sun, directional light, point light, spot light,
+  ibl, image based lighting, environment map, skybox, ambient, intensity,
+  lux, lumens, candela, color temperature, kelvin, falloff, highlight,
+  background color, background image, hdri.
+---
+
+Without a light source a Thermion scene renders **black**. There are two light
+sources: direct lights (sun/point/spot) and image-based lighting (IBL). The
+canonical setup combines an IBL with a skybox from the same environment plus a
+sun — that combination is the most flattering default:
+
+```dart
+await viewer.loadIbl('assets/default_env_ibl.ktx');
+await viewer.loadSkybox('assets/default_env_skybox.ktx');
+await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+```
+
+## Direct lights
+
+Build a `DirectLight` with a named constructor, add it with `addDirectLight`,
+which returns the light's entity handle:
+
+```dart
+// Sun / directional — direction is a normalized vector, NOT a position.
+final sunEntity = await viewer.addDirectLight(
+  DirectLight.sun(
+    direction: Vector3(-0.5, -1, -0.3),
+    intensity: 100000,          // lux (default)
+    castShadows: true,          // default true for sun
+    colorTemperature: 6500,     // Kelvin; alternative to color:
+    // color: LinearColor(1.0, 0.9, 0.8),
+    sunAngularRadius: 0.545,    // degrees; bigger = softer shadows
+  ),
+);
+
+// Point — has a world position and falloff.
+await viewer.addDirectLight(DirectLight.point(
+  position: Vector3(3.5, 2.5, 2.0),
+  intensity: 90000,             // lumens
+  falloffRadius: 8.0,           // world units; 0 disables falloff
+  color: LinearColor(1.0, 0.82, 0.55),
+));
+
+// Spot — position + direction + cone.
+await viewer.addDirectLight(DirectLight.spot(
+  position: Vector3(0, 4, 0),
+  direction: Vector3(0, -1, 0),
+  intensity: 100000,            // candela
+  spotLightConeInner: pi / 8,   // radians
+  spotLightConeOuter: pi / 4,   // radians
+  falloffRadius: 10.0,
+));
+```
+
+Removal:
+
+```dart
+await viewer.removeLight(lightEntity); // one light
+await viewer.destroyLights();          // all direct lights
+```
+
+## Moving / mutating lights
+
+Viewer-level (async):
+
+```dart
+await viewer.setLightPosition(lightEntity, 1.0, 2.0, 3.0);
+await viewer.setLightDirection(lightEntity, Vector3(0, -1, 0));
+```
+
+Everything else goes through the light manager. Its setters are
+**synchronous** (the exceptions — `setShadowCaster`, `setShadowOptions` — are
+async and covered in the shadows skill):
+
+```dart
+final lm = viewer.app.lightManager;
+
+lm.setColor(lightEntity, 1.0, 0.9, 0.8);          // linear [0, 1]
+lm.setColorTemperature(lightEntity, 6500);         // Kelvin
+lm.setIntensity(lightEntity, 120000);              // units per light type
+lm.setIntensityCandela(lightEntity, 50000);        // spot: candela explicitly
+lm.setIntensityWatts(lightEntity, 60, 0.8);        // watts + efficacy
+lm.setFalloff(lightEntity, 8.0);                   // point/spot
+lm.setSpotLightCone(lightEntity, pi / 8, pi / 4);  // radians
+lm.setSunAngularRadius(lightEntity, 0.545);        // degrees
+lm.setSunHaloSize(lightEntity, 10.0);
+lm.setSunHaloFalloff(lightEntity, 80.0);
+
+final pos = lm.getPosition(lightEntity);
+final dir = lm.getDirection(lightEntity);
+```
+
+Intensity units by light type (Filament convention):
+
+| Type | Unit | Default in `DirectLight` |
+|---|---|---|
+| Sun / directional | lux | 100000 |
+| Point | lumens | 100000 |
+| Spot | candela | 100000 |
+
+## IBL (image-based lighting)
+
+An IBL is precomputed ambient/reflection lighting, usually generated from an
+HDRI with Filament's `cmgen` (produces `_ibl.ktx` + `_skybox.ktx` pairs):
+
+```dart
+await viewer.loadIbl('assets/env_ibl.ktx', intensity: 30000); // default 30000
+await viewer.loadIblFromTexture(texture, reflectionsTexture: reflections);
+
+await viewer.rotateIbl(Matrix3.rotationY(pi / 4)); // rotate environment
+await viewer.removeIbl();                          // destroy: true by default
+```
+
+Only **one** IBL is active at a time — `loadIbl` replaces the existing one.
+
+## Skybox & backgrounds
+
+```dart
+await viewer.loadSkybox('assets/env_skybox.ktx');  // .ktx cubemap
+
+// Solid color skybox instead:
+final skybox = await viewer.setBackgroundColor(0.1, 0.2, 0.4, 1.0);
+// ... mutable later:
+await skybox.setColor(1.0, 0.0, 0.0, 1.0);
+
+// Background image behind everything (even behind the skybox):
+await viewer.setBackgroundImage('assets/bg.png', fillHeight: true);
+await viewer.clearBackgroundImage();
+
+final current = await viewer.getSkybox();
+final removed = await viewer.removeSkybox(); // detaches; caller destroys it
+```
+
+Gotcha: `removeSkybox` detaches but does **not** destroy — you own the returned
+`Skybox` (and its texture) after removal.
+
+## Gotchas
+
+- No light → black screen. Either add a sun or load an IBL.
+- Sun `direction` points where the light travels (typically downward); it is a
+  direction, not a location. Point/spot lights use `position`.
+- `color` and `colorTemperature` are alternatives — set one, not both.
+- `sunAngularRadius` is in **degrees**; `spotLightConeInner/Outer` are in
+  **radians**.
+- IBL is replaced (not stacked) by a subsequent `loadIbl`.
+- LightManager setters are sync; viewer methods are async — don't `await` the
+  manager's `void` setters (it won't compile) and don't skip `await` on viewer
+  futures.
+
+## References
+
+- `references/dart-lighting.dart` — complete pure-Dart program: IBL + skybox +
+  sun plus a three-point (key/fill/rim) setup of colored point lights.
+
+## Docs
+
+- https://thermion.dev/lighting/ — dedicated lighting page (direct lights,
+  light manager, IBL, skybox/backgrounds)
+- https://thermion.dev/viewer/ — lighting section of the viewer walkthrough

--- a/skills/thermion-lighting/references/dart-lighting.dart
+++ b/skills/thermion-lighting/references/dart-lighting.dart
@@ -1,0 +1,84 @@
+// Pure-Dart headless example: IBL + skybox + sun, plus a three-point
+// (key/fill/rim) setup of colored point lights.
+//
+// Run with:  dart run dart_lighting.dart [assets_dir]
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/examples_lib (lighting_setup) and
+// examples/dart/cli_headless (point-light rig) in the thermion repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(
+      near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+  await camera.lookAt(Vector3(2, 2, 2), focus: Vector3(0, 0, 0));
+
+  // Subject.
+  final asset = await viewer.loadGltf(assetUri('cube.glb'));
+  await asset.transformToUnitCube();
+
+  // Environment: IBL (ambient/reflection lighting) + visible skybox from the
+  // same HDRI.
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+
+  // A directional sun.
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, 0)));
+
+  // Three-point rig: warm key, cool fill, white rim. Intensity for point
+  // lights is luminous flux in lumens; falloffRadius is world units.
+  await viewer.addDirectLight(DirectLight.point(
+    position: Vector3(3.5, 2.5, 2.0),
+    color: LinearColor(1.0, 0.82, 0.55),
+    intensity: 90000,
+    falloffRadius: 8.0,
+  ));
+  await viewer.addDirectLight(DirectLight.point(
+    position: Vector3(-3.2, 1.6, -1.5),
+    color: LinearColor(0.55, 0.72, 1.0),
+    intensity: 60000,
+    falloffRadius: 8.0,
+  ));
+  await viewer.addDirectLight(DirectLight.point(
+    position: Vector3(0.0, 3.8, -3.5),
+    color: LinearColor(1.0, 1.0, 1.0),
+    intensity: 70000,
+    falloffRadius: 8.0,
+  ));
+
+  // Capture a frame.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final png = await pixelBufferToPng(result.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('lighting.png').writeAsBytes(png);
+  print('Wrote lighting.png');
+
+  io.exit(0);
+}

--- a/skills/thermion-loading-gltf/SKILL.md
+++ b/skills/thermion-loading-gltf/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: thermion-loading-gltf
+description: >
+  Load, inspect, instance, and clean up glTF/GLB models in Thermion. Covers
+  loadGltf and loadGltfFromBuffer parameters (addToScene, initialInstances,
+  releaseSourceData, rebuildVertices, resourceUri), the ThermionAsset API
+  (entity, child-entity queries, bounding boxes, transformToUnitCube,
+  createInstance/getInstance for GPU instancing), scene add/remove, visibility
+  layers, and destroyAsset/destroyAssets. Use when loading 3d models, spawning
+  copies or instances, traversing an asset's entities, or freeing assets.
+  Triggers: load gltf, load glb, load model, ThermionAsset, instances,
+  gpu instancing, child entities, bounding box, unit cube, visibility layer,
+  destroy asset, free asset, assimp, obj.
+---
+
+Everything in a Thermion scene is an **entity**; a loaded glTF becomes a
+`ThermionAsset` whose root `entity` owns a subtree of child entities (meshes,
+bones, lights). This skill covers loading that asset, querying it, instancing
+it, and destroying it.
+
+## Loading
+
+```dart
+final asset = await viewer.loadGltf('assets/scene.glb');
+```
+
+Key parameters:
+
+```dart
+final asset = await viewer.loadGltf(
+  'assets/scene.gltf',
+  addToScene: true,          // add renderables to the scene immediately
+  initialInstances: 4,       // pre-allocate N GPU instances (>= 1)
+  releaseSourceData: false,  // true: no further createInstance calls possible
+  rebuildVertices: false,    // true: rebuild vertices with barycentrics/etc,
+                             //      enabling free material swapping (wireframe,
+                             //      flat shading, stencil highlights). ~3x vertex memory.
+  resourceUri: null,         // for .gltf: where relative resources live
+                             //      (defaults to the .gltf file's own URI)
+);
+```
+
+URI schemes: **`file://` always works**; **`asset://`** (and plain paths, which
+are treated as asset paths) only inside a Flutter application. `.glb` is
+self-contained; `.gltf` resolves its `.bin`/textures relative to its own URI
+unless you pass `resourceUri`.
+
+From an in-memory buffer:
+
+```dart
+final asset = await viewer.loadGltfFromBuffer(bytes);
+```
+
+Non-glTF formats (OBJ, FBX, …) are not built in — load them via the
+[`assimp_dart`](https://pub.dev/packages/assimp_dart) package, which converts
+to glTF buffers first.
+
+## Querying the asset
+
+```dart
+final ThermionEntity root = asset.entity;
+
+final names = await asset.getChildEntityNames();   // e.g. meshes by name
+final child = await asset.getChildEntity('Wheel'); // lookup by name (nullable)
+final children = await asset.getChildEntities();   // all child entities
+final hasIt = await asset.containsChild(someEntity);
+
+final Aabb3 bounds = await asset.getBoundingBox();
+await asset.transformToUnitCube();                 // normalize to a 1x1x1 cube at the origin
+```
+
+Gotcha: `asset.transformToUnitCube()` reads the root entity's bounds, which can
+be bogus when the root has no renderable component. If you know the object-space
+box, normalize through the transform manager instead:
+
+```dart
+viewer.app.transformManager.transformToUnitCube(
+  asset.entity, Aabb3.minMax(Vector3(-1, -1, -1), Vector3(1, 1, 1)),
+);
+```
+
+## GPU instancing
+
+Efficient copies of the same asset, driven by the GPU:
+
+```dart
+final asset = await viewer.loadGltf('assets/rock.glb', initialInstances: 100);
+for (var i = 0; i < 100; i++) {
+  final instance = await asset.getInstance(i);
+  await instance.setTransform(Matrix4.translation(Vector3(i * 2.0, 0, 0)));
+}
+```
+
+- `initialInstances` at load time is more efficient than creating instances
+  later.
+- Dynamic creation (only while `releaseSourceData` is false):
+  `await asset.createInstance()`, then `asset.getInstanceCount()` /
+  `asset.getInstances()`.
+- With exactly one instance, the parent asset and its instance are
+  interchangeable.
+
+## Scene membership & visibility
+
+```dart
+await viewer.removeFromScene(asset); // hide but keep valid
+await viewer.addToScene(asset);      // show again
+
+// Layers: put entities on a non-default layer, then toggle that layer.
+await asset.setVisibilityLayer(childEntity, VisibilityLayers.LAYER_1);
+await viewer.setLayerVisibility(VisibilityLayers.LAYER_1, false);
+```
+
+## Cleanup
+
+```dart
+await viewer.destroyAsset(asset);  // destroys asset + instances
+                                  // (NOT manually created material instances —
+                                  // destroy those yourself)
+await viewer.destroyAssets();      // destroys all renderable entities incl. cameras
+```
+
+After `destroyAssets()`, **every** `ThermionEntity` handle is invalid — discard
+all references immediately.
+
+## Gotchas
+
+- Default camera sits at the origin — a model at the origin is inside it.
+  `camera.lookAt(Vector3(3, 3, 3))` after loading.
+- `releaseSourceData: true` (at load or via `asset.releaseSourceData()`) frees
+  the CPU-side glTF copy but permanently disables `createInstance`.
+- `rebuildVertices: true` is required for later wireframe/flat-shading swaps and
+  stencil highlights (`setFlatShading`/`setStencilHighlight` throw without it);
+  it costs ~3x vertex memory but preserves animations, skeletons, and
+  instancing.
+
+## References
+
+- `references/dart-instancing.dart` — complete pure-Dart program loading one
+  cube as four GPU instances.
+- `references/flutter-load-destroy.dart` — Flutter load/unload lifecycle with
+  correct teardown order.
+
+## Docs
+
+- https://thermion.dev/entities/ — loading, entity queries, instancing, cleanup
+- https://thermion.dev/viewer/ — loading section of the viewer walkthrough

--- a/skills/thermion-loading-gltf/references/dart-instancing.dart
+++ b/skills/thermion-loading-gltf/references/dart-instancing.dart
@@ -1,0 +1,65 @@
+// Pure-Dart headless example: GPU instancing via loadGltf(initialInstances: N)
+// with a transform per instance.
+//
+// Run with:  dart run dart_instancing.dart [assets_dir]
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/examples_lib (instancing setup) in the thermion
+// repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(
+      near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+  await camera.lookAt(Vector3(3, 3, 3), focus: Vector3(0, 0, 0));
+
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+
+  // One asset, four pre-allocated GPU instances.
+  final asset = await viewer.loadGltf(assetUri('cube.glb'), initialInstances: 4);
+  await asset.transformToUnitCube();
+
+  final offsets = [-2.25, -0.75, 0.75, 2.25];
+  for (var i = 0; i < offsets.length; i++) {
+    final instance = await asset.getInstance(i);
+    await instance.setTransform(Matrix4.translation(Vector3(offsets[i], 0, 0)));
+  }
+
+  // Capture a frame so the run produces something visible.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final png = await pixelBufferToPng(result.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('instances.png').writeAsBytes(png);
+  print('Wrote instances.png');
+
+  io.exit(0);
+}

--- a/skills/thermion-loading-gltf/references/flutter-load-destroy.dart
+++ b/skills/thermion-loading-gltf/references/flutter-load-destroy.dart
@@ -1,0 +1,75 @@
+// Flutter example: the load/unload lifecycle of a ThermionViewer with a glTF
+// asset — create viewer, load, render, then correct teardown order.
+//
+// Expects assets/ declared in pubspec.yaml containing FlightHelmet/ or swap
+// in any .glb.
+//
+// Adapted from examples/flutter/viewer in the thermion repository.
+
+import 'package:flutter/material.dart';
+import 'package:thermion_flutter/thermion_flutter.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) => const MaterialApp(home: HomePage());
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  ThermionViewer? _viewer;
+
+  Future<void> _load() async {
+    if (_viewer != null) return;
+
+    // Only one viewer can be active at a time; creating a new one before
+    // disposing the old one throws.
+    final viewer = await ThermionFlutterPlugin.createViewer();
+
+    await viewer.loadGltf('assets/FlightHelmet/FlightHelmet.gltf');
+    await viewer.loadSkybox('assets/default_env_skybox.ktx');
+    await viewer.loadIbl('assets/default_env_ibl.ktx');
+
+    final camera = await viewer.getActiveCamera();
+    await camera.lookAt(Vector3(0, 1, 6));
+
+    await viewer.setPostProcessing(true);
+
+    setState(() => _viewer = viewer);
+  }
+
+  Future<void> _unload() async {
+    final viewer = _viewer;
+    if (viewer == null) return;
+
+    // Teardown order matters:
+    // 1) remove ThermionWidget from the tree (setState below)
+    // 2) drop local references
+    // 3) dispose the viewer
+    setState(() => _viewer = null);
+    await viewer.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        body: Stack(children: [
+          if (_viewer != null)
+            Positioned.fill(child: ThermionWidget(viewer: _viewer!)),
+          Center(
+            child: FilledButton(
+              onPressed: _viewer == null ? _load : _unload,
+              child: Text(_viewer == null ? 'Load' : 'Unload'),
+            ),
+          ),
+        ]),
+      );
+}

--- a/skills/thermion-materials/SKILL.md
+++ b/skills/thermion-materials/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: thermion-materials
+description: >
+  Control surface appearance in Thermion: create and configure materials.
+  Covers the PBR ubershader (base color, metallic, roughness, emissive,
+  textures), unlit and wireframe built-in material instances, generic
+  parameter setters (setParameterFloat/Float3/Float4/Int/Bool/Texture/Mat3/Mat4),
+  texture binding with samplers, swapping materials on loaded assets
+  (setMaterialInstanceForAll, setMaterialInstanceAt), flat vs smooth shading,
+  and the rebuildVertices requirement. Use when changing an object's color,
+  making it metallic/rough/glowing, showing wireframe, applying textures, or
+  swapping materials at runtime. Triggers: material, materials, pbr, metallic,
+  roughness, base color, color, texture, unlit, wireframe, flat shading,
+  material instance, setParameter, transparency, emissive, appearance, shader.
+---
+
+A material instance controls how a surface is shaded. Thermion ships three
+built-in materials — the PBR **ubershader**, **unlit**, and **wireframe** —
+created from the app (`viewer.app`, or `FilamentApp.instance!` in
+single-viewer apps) and applied to assets or geometry.
+
+## PBR ubershader
+
+```dart
+final mat = await viewer.app.createUbershaderMaterial();
+
+// Factors:
+await mat.setBaseColorFactor(0.85, 0.5, 0.2, 1.0); // linear RGBA
+await mat.setMetallicFactor(1.0);   // 0 = dielectric, 1 = metal
+await mat.setRoughnessFactor(0.15); // 0 = mirror, 1 = fully diffuse
+await mat.setEmissiveFactor(1.0, 0.0, 0.0, 1.0);
+await mat.setDoubleSided(true);
+
+// Textures (see below for creating them):
+await mat.setBaseColorTexture(texture, sampler);
+
+// Apply to everything in the asset:
+await asset.setMaterialInstanceForAll(mat.materialInstance);
+```
+
+Note the `.materialInstance` getter — the typed wrapper wraps a plain
+`MaterialInstance`, and the asset APIs take the plain one. The two factories
+differ in what they return: `createUbershaderMaterial()` gives you the typed
+wrapper with named PBR setters; `createUbershaderMaterialInstance(...)` gives
+you a plain `MaterialInstance` (configure it with `setParameter*`, e.g.
+`setParameterFloat4('baseColorFactor', ...)`).
+
+PBR really shows under image-based lighting — load an IBL alongside (see the
+`thermion-lighting` skill).
+
+Limitation: Filament's ubershader does **not** support
+transmission/volume/sheen/IOR together with clearcoat — pick either the
+clearcoat family or the transmission family of features, not both.
+
+## Unlit and wireframe
+
+```dart
+// Unlit: flat color, ignores all lighting.
+final unlit = await viewer.app.createUnlitMaterialInstance();
+
+// Wireframe: edges + faces with separate colors (requires the asset to have
+// been loaded with rebuildVertices: true — see Gotchas).
+final wireframe = await viewer.app.createWireframeMaterialInstance();
+await wireframe.setEdgeColor(0.3, 0.3, 0.3, 1.0);
+await wireframe.setFaceColor(0.1, 0.1, 0.1, 1.0);
+await wireframe.setEdgeWidth(0.5);
+await asset.setMaterialInstanceForAll(wireframe.materialInstance);
+```
+
+`setEdgeWidth` is in pixels.
+
+## Swapping materials on an asset
+
+```dart
+// Whole asset:
+await asset.setMaterialInstanceForAll(newInstance);
+
+// One primitive of one entity (index-based):
+await asset.setMaterialInstanceAt(newInstance, entity: meshEntity, primitiveIndex: 0);
+final current = await asset.getMaterialInstanceAt(entity: meshEntity, index: 0);
+
+// Snapshot/restore all instances at once:
+final saved = await asset.getMaterialInstancesAsMap();
+await asset.setMaterialInstancesFromMap(saved);
+```
+
+Loading with `rebuildVertices: true` makes these swaps work on any glTF
+(the loader rebuilds vertex buffers with a superset of attributes).
+
+## Generic parameter setters
+
+Any `MaterialInstance` (including ones inside loaded glTFs) exposes typed
+setters keyed by the material's parameter names:
+
+```dart
+final instance = await asset.getMaterialInstanceAt(index: 0);
+
+await instance.setParameterFloat('metallic', 0.8);
+await instance.setParameterFloat4('baseColorFactor', 1.0, 0.0, 0.0, 1.0);
+await instance.setParameterFloat3('emissiveFactor', 0.0, 1.0, 0.0);
+await instance.setParameterInt('mode', 2);
+await instance.setParameterBool('flipUVs', true);
+await instance.setParameterTexture('baseColorMap', texture, sampler);
+await instance.setParameterMat4('transform', matrix4);
+```
+
+Parameter names come from the material definition — for glTF-embedded
+materials, check the glTF's `extra`/extension data or the source `.mat` for
+what a given material supports.
+
+## Textures
+
+```dart
+// Decode encoded bytes (PNG/JPEG) into a caller-owned LinearImage:
+final image = await viewer.app.decodeImage(pngBytes);
+// ...then upload into a texture sized to the image:
+final texture = await viewer.app.createTexture(width, height);
+
+final sampler = await viewer.app.createTextureSampler(
+  minFilter: TextureMinFilter.LINEAR,
+  magFilter: TextureMagFilter.LINEAR,
+);
+
+await mat.setBaseColorTexture(texture, sampler);
+```
+
+Dispose textures, samplers, and decoded `LinearImage`s (`image.destroy()`)
+when done — GPU memory is not garbage-collected.
+
+## Flat vs smooth shading
+
+```dart
+final asset = await viewer.loadGltf('assets/rock.glb', rebuildVertices: true);
+await asset.setFlatShading(true);   // per-face normals
+await asset.setFlatShading(false);  // per-vertex (smooth)
+```
+
+Throws unless the asset was loaded with `rebuildVertices: true` (flat
+shading swaps TANGENTS on the rebuilt vertex buffers).
+
+## Gotchas
+
+- `setFlatShading` and `setStencilHighlight` **throw** unless the asset was
+  loaded with `loadGltf(..., rebuildVertices: true)` (~3x vertex memory);
+  wireframe swaps also need it.
+- Color values are **linear** (not sRGB) floats in `[0, 1]`.
+- Unlit materials ignore lights and IBL entirely.
+- The ubershader's clearcoat can't coexist with transmission/sheen/IOR.
+- Typed wrappers (`UbershaderMaterialInstance`, `WireframeMaterialInstance`)
+  expose `.materialInstance` — the asset APIs want the inner instance.
+
+## References
+
+- `references/dart-materials.dart` — complete pure-Dart program: PBR metallic
+  cube plus a wireframe cube side by side.
+
+## Docs
+
+- https://thermion.dev/materials/ — materials, textures, and procedural
+  geometry walkthrough

--- a/skills/thermion-materials/references/dart-materials.dart
+++ b/skills/thermion-materials/references/dart-materials.dart
@@ -1,0 +1,80 @@
+// Pure-Dart headless example: PBR ubershader (metallic/roughness/base color)
+// on one cube, wireframe on another.
+//
+// Run with:  dart run dart_materials.dart [assets_dir]
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/examples_lib (materials_pbr and
+// wireframe_and_flat_shading setups) in the thermion repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(
+      near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+  await camera.lookAt(Vector3(2, 2, 4), focus: Vector3(0, 0, 0));
+
+  // PBR reads best with an environment to reflect.
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, 0)));
+
+  // Left cube: polished copper.
+  final pbrAsset = await viewer.loadGltf(assetUri('cube.glb'));
+  await pbrAsset.transformToUnitCube();
+  await pbrAsset.setTransform(Matrix4.translation(Vector3(-1.2, 0, 0)));
+
+  final mat = await app.createUbershaderMaterial();
+  await mat.setMetallicFactor(1.0);
+  await mat.setRoughnessFactor(0.15);
+  await mat.setBaseColorFactor(0.85, 0.5, 0.2, 1.0);
+  await pbrAsset.setMaterialInstanceForAll(mat.materialInstance);
+
+  // Right cube: wireframe. rebuildVertices: true rebuilds vertex buffers with
+  // barycentric attributes so the wireframe material can be swapped in freely.
+  final wireAsset =
+      await viewer.loadGltf(assetUri('cube.glb'), rebuildVertices: true);
+  await wireAsset.transformToUnitCube();
+  await wireAsset.setTransform(Matrix4.translation(Vector3(1.2, 0, 0)));
+
+  final wireframe = await app.createWireframeMaterialInstance();
+  await wireframe.setEdgeColor(0.3, 0.9, 0.3, 1.0);
+  await wireframe.setFaceColor(0.05, 0.15, 0.05, 1.0);
+  await wireframe.setEdgeWidth(0.5);
+  await wireAsset.setMaterialInstanceForAll(wireframe.materialInstance);
+
+  // Capture a frame.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final png = await pixelBufferToPng(result.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('materials.png').writeAsBytes(png);
+  print('Wrote materials.png');
+
+  io.exit(0);
+}

--- a/skills/thermion-picking-selection/SKILL.md
+++ b/skills/thermion-picking-selection/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: thermion-picking-selection
+description: >
+  Detect which 3D object a user clicked or tapped in Thermion, and show visual
+  selection. Covers View.pick ray casting with PickResult (entity, depth),
+  screen-to-viewport coordinate mapping, stencil highlight outlines
+  (setStencilHighlight with outlineWidth, highlight overlay setup, the
+  rebuildVertices requirement), and translation gizmos. Use for click/tap
+  detection on 3d objects, selecting meshes, selection outlines, highlighting,
+  or dragging objects with a gizmo. Triggers: pick, picking, raycast, ray
+  cast, click detection, tap, hit test, hit test, which object was clicked,
+  select, selection, highlight, outline, silhouette, stencil, gizmo, drag
+  object, transform gizmo.
+---
+
+Picking answers "what did the pointer hit?" — `View.pick` ray-casts from the
+camera through a screen point and reports the entity and depth.
+
+## Picking
+
+```dart
+// x, y are integer logical (viewport) coordinates, origin at the TOP-LEFT.
+await viewer.view.pick(x, y, (PickResult result) {
+  if (result.entity != 0) {
+    print('Hit entity ${result.entity} at depth ${result.depth}');
+    // Map back to an asset: compare against asset.entity / child entities /
+    // instance entities you tracked when loading.
+  }
+});
+```
+
+`PickResult` is a record: `entity`, `x`, `y`, `depth`, `fragX`, `fragY`,
+`fragZ`. An entity of 0 means no hit.
+
+In Flutter, pointer coordinates are widget-local logical coordinates, top-left
+origin — they already match the viewport (round to `int`, which `pick` takes):
+
+```dart
+GestureDetector(
+  onTapUp: (details) async {
+    final pos = details.localPosition;
+    await viewer.view.pick(pos.dx.round(), pos.dy.round(), (result) { ... });
+  },
+  child: ThermionWidget(viewer: viewer),
+)
+```
+
+To map a hit back to a loaded asset, keep the handles you got at load time
+(`asset.entity`, `asset.getChildEntities()`, instance entities) and compare —
+or tag entities on a visibility layer for coarse filtering.
+
+## Selection outline (stencil highlight)
+
+A screen-space outline around a selected asset:
+
+```dart
+// 1) Load with rebuilt vertices (REQUIRED — barycentric-aware buffers):
+final asset = await viewer.loadGltf('assets/scene.gltf', rebuildVertices: true);
+
+// 2) Enable the overlay + stencil buffer once:
+await viewer.view.setHighlightOverlayEnabled(true);
+await viewer.view.setStencilBufferEnabled(true);
+
+// 3) Highlight / clear:
+await viewer.view.setStencilHighlight(
+  asset,
+  r: 0.0, g: 1.0, b: 0.0,
+  outlineWidth: 3.0,  // pixels; constant regardless of camera distance
+);
+await viewer.view.removeStencilHighlight(asset);
+```
+
+`setStencilHighlight` can target a single entity (`entity:` param) and
+primitive (`primitiveIndex:`). It **throws** if the asset wasn't loaded with
+`rebuildVertices: true`.
+
+## Gizmos (drag manipulators)
+
+```dart
+final gizmo = await viewer.getGizmo(GizmoType.translation);
+// also: GizmoType.rotation
+// gizmo.pick(x, y, handler:) reports axis drags (returns the axis + coords)
+```
+
+Only one gizmo can be visible per viewer. Combine with picking: pick to
+select, then attach the gizmo for dragging.
+
+## Gotchas
+
+- Pick coordinates are **top-left origin, logical pixels** — the same as
+  Flutter's `localPosition`; don't flip Y yourself.
+- Stencil highlights require `loadGltf(..., rebuildVertices: true)` (~3x
+  vertex memory) — the call throws otherwise.
+- Enable the highlight overlay **before** the first `setStencilHighlight`.
+- An entity handle of `0` in `PickResult` = no hit.
+- Pick works on what's rendered — hidden layers aren't pickable.
+
+## References
+
+- `references/flutter-picking.dart` — complete Flutter app: three instanced
+  cubes, tap to pick, green outline on the tapped instance.
+
+## Docs
+
+- No dedicated picking page on thermion.dev yet — the bundled reference and
+  `examples/flutter/picking` in the thermion repository are canonical.

--- a/skills/thermion-picking-selection/references/flutter-picking.dart
+++ b/skills/thermion-picking-selection/references/flutter-picking.dart
@@ -1,0 +1,112 @@
+// Flutter example: tap picking with a selection outline. Three cubes; tapping
+// one picks it (View.pick) and gives it a green stencil outline.
+//
+// Expects assets/ declared in pubspec.yaml containing cube.glb plus the
+// default environment ktx files.
+//
+// Adapted from examples/flutter/picking in the thermion repository.
+
+import 'package:flutter/material.dart';
+import 'package:thermion_flutter/thermion_flutter.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) => const MaterialApp(home: PickPage());
+}
+
+class PickPage extends StatefulWidget {
+  const PickPage({super.key});
+
+  @override
+  State<PickPage> createState() => _PickPageState();
+}
+
+class _PickPageState extends State<PickPage> {
+  ThermionViewer? _viewer;
+  ThermionAsset? _selected;
+
+  Future<void> _load() async {
+    final viewer = await ThermionFlutterPlugin.createViewer();
+    await viewer.setPostProcessing(true);
+
+    await viewer.loadIbl('assets/default_env_ibl.ktx');
+    await viewer.addDirectLight(
+        DirectLight.sun(direction: Vector3(0, -1, -1)));
+
+    // Outline rendering needs rebuilt (barycentric-aware) vertex buffers.
+    final cubes = <ThermionAsset>[];
+    for (final x in [-1.5, 0.0, 1.5]) {
+      final cube = await viewer.loadGltf('assets/cube.glb',
+          rebuildVertices: true);
+      await cube.transformToUnitCube();
+      await cube.setTransform(Matrix4.translation(Vector3(x, 0, 0)));
+      cubes.add(cube);
+    }
+
+    // Enable the highlight overlay once, before any setStencilHighlight.
+    await viewer.view.setHighlightOverlayEnabled(true);
+    await viewer.view.setStencilBufferEnabled(true);
+
+    final camera = await viewer.getActiveCamera();
+    await camera.lookAt(Vector3(2, 2, 4), focus: Vector3(0, 0, 0));
+
+    // Stash for the pick handler.
+    _cubes = cubes;
+
+    setState(() => _viewer = viewer);
+  }
+
+  late List<ThermionAsset> _cubes;
+
+  Future<void> _onTapUp(TapUpDetails details) async {
+    final viewer = _viewer;
+    if (viewer == null) return;
+    final pos = details.localPosition;
+
+    // Pointer coordinates are logical, top-left origin — same as the pick
+    // API expects (rounded to int). Don't flip Y.
+    await viewer.view.pick(pos.dx.round(), pos.dy.round(), (result) async {
+      if (result.entity == 0) return;
+
+      // Map the hit entity back to one of our assets.
+      ThermionAsset? hit;
+      for (final cube in _cubes) {
+        if (result.entity == cube.entity ||
+            await cube.containsChild(result.entity)) {
+          hit = cube;
+          break;
+        }
+      }
+      if (hit == null) return;
+
+      // Clear the previous outline, draw the new one.
+      if (_selected != null) {
+        await viewer.view.removeStencilHighlight(_selected!);
+      }
+      await viewer.view.setStencilHighlight(
+        hit,
+        r: 0.0, g: 1.0, b: 0.0,
+        outlineWidth: 3.0,
+      );
+      setState(() => _selected = hit);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        body: _viewer == null
+            ? Center(
+                child: FilledButton(
+                    onPressed: _load, child: const Text('Load')))
+            : GestureDetector(
+                onTapUp: _onTapUp,
+                child: Stack(children: [
+                  Positioned.fill(child: ThermionWidget(viewer: _viewer!)),
+                ]),
+              ),
+      );
+}

--- a/skills/thermion-post-processing/SKILL.md
+++ b/skills/thermion-post-processing/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: thermion-post-processing
+description: >
+  Enable and configure post-processing in Thermion: the post-processing toggle,
+  anti-aliasing (MSAA, FXAA, TAA), bloom, color grading with tone mappers
+  (ACES, filmic, AgX, pbrNeutral) plus exposure/white balance/contrast/
+  saturation/vibrance, fog, and ambient occlusion (SAO/GTAO). Use for tone
+  mapping, glow, jagged edges, washed-out or flat colors, color correction,
+  atmosphere/fog, or contact darkening in crevices. Triggers: post processing,
+  postprocessing, anti aliasing, antialiasing, fxaa, msaa, taa, jagged edges,
+  bloom, glow, tone mapping, tone mapper, aces, agx, filmic, color grading,
+  color correction, exposure, white balance, contrast, saturation, vibrance,
+  lut, fog, haze, ambient occlusion, sao, gtao.
+---
+
+Post-processing is **off by default**. Without it there is no tone mapping,
+no anti-aliasing, and HDR scenes look wrong. If unsure, turn it on:
+
+```dart
+await viewer.setPostProcessing(true);
+```
+
+## Anti-aliasing
+
+```dart
+await viewer.setAntiAliasing(msaa, fxaa, taa);
+// e.g. FXAA only — the common lightweight choice:
+await viewer.setAntiAliasing(false, true, false);
+```
+
+## Bloom
+
+```dart
+await viewer.setBloom(true, 0.5); // enabled, strength
+```
+
+## Color grading & tone mapping
+
+Grading is caller-owned: build with a builder chain, dispose the builder (and
+tone mapper) after `build()`, and keep the grading attached for the view's
+lifetime — or `setColorGrading(null)` + dispose when replacing it.
+
+```dart
+// Tone-mapped grading (ACES):
+final builder = await viewer.view.createColorGradingBuilder();
+final toneMapper = await ToneMapper.aces(viewer.app);
+final grading = await builder
+    .toneMapper(toneMapper)
+    .quality(QualityLevel.HIGH)
+    .exposure(1.2)
+    .whiteBalance(0.3, 0.05) // temperature shift, tint
+    .contrast(1.1)
+    .saturation(1.1)
+    .vibrance(1.2)
+    .build();
+await builder.dispose();
+await toneMapper.dispose(); // grading holds a copy
+await viewer.view.setColorGrading(grading);
+```
+
+Available tone mappers: `ToneMapper.aces`, `.acesLegacy`, `.filmic`,
+`.pbrNeutral`, `.agx(app, look:)`, `.generic(...)`, `.displayRange`. If you
+skip `toneMapper(...)`, the builder defaults to ACES (legacy).
+
+Builder also supports `.nightAdaptation()`, `.channelMixer()`,
+`.shadowsMidtonesHighlights()`, `.slopeOffsetPower()`, `.curves()`,
+`.luminanceScaling()`, `.gamutMapping()`, `.dimensions()`/`.format()` for LUT
+configuration.
+
+## Fog
+
+```dart
+await viewer.view.setFogOptions(FogOptions(
+  enabled: true,
+  density: 0.1,
+  distance: 0.0,
+  cutOffDistance: double.infinity,
+  maximumOpacity: 1.0,
+  linearColor: Vector3(0.8, 0.85, 0.9),
+  height: 0.0,
+  heightFalloff: 1.0,
+  fogColorFromIbl: false, // tint fog from the skybox instead of linearColor
+));
+```
+
+## Ambient occlusion
+
+```dart
+await viewer.view.setAmbientOcclusionOptions(
+  AmbientOcclusionOptions(enabled: true, radius: 0.3, intensity: 1.0),
+);
+```
+
+(SAO/GTAO variants and full field list live on `AmbientOcclusionOptions` /
+`View.setAmbientOcclusionOptions`.)
+
+## Gotchas
+
+- `setPostProcessing(true)` gates everything else — no point tuning bloom or
+  grading while it's off.
+- Builder and tone mapper are **disposable**: dispose both after `build()`;
+  the built `ColorGrading` is yours to detach (`setColorGrading(null)`) and
+  dispose when replacing.
+- `setAntiAliasing` is a three-flag tuple `(msaa, fxaa, taa)`.
+- Grading quality: use `QualityLevel.HIGH` for stills, lower for mobile.
+- Fog with `fogColorFromIbl: true` ignores `linearColor`.
+
+## References
+
+- `references/dart-post-processing.dart` — complete pure-Dart program with
+  FXAA, bloom, ACES tone-mapped warm grading, and fog.
+
+## Docs
+
+- https://thermion.dev/materials/ and the bundled reference; Filament's docs
+  cover the underlying model: https://google.github.io/filament/Filament.html

--- a/skills/thermion-post-processing/references/dart-post-processing.dart
+++ b/skills/thermion-post-processing/references/dart-post-processing.dart
@@ -1,0 +1,87 @@
+// Pure-Dart headless example: post-processing — FXAA, bloom, ACES tone-mapped
+// warm color grading, and fog.
+//
+// Run with:  dart run dart_post_processing.dart [assets_dir]
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/examples_lib (post_processing setup) in the
+// thermion repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  // Post-processing gates everything below.
+  await viewer.setPostProcessing(true);
+  await viewer.setAntiAliasing(false, true, false); // FXAA only
+  await viewer.setBloom(true, 0.5);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(
+      near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+  await camera.lookAt(Vector3(3, 2, 3), focus: Vector3(0, 0, 0));
+
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+
+  final asset = await viewer.loadGltf(assetUri('cube.glb'));
+  await asset.transformToUnitCube();
+
+  // Warm ACES grading. The grading is caller-owned: dispose the builder and
+  // tone mapper after build; detach with setColorGrading(null) when replacing.
+  final builder = await viewer.view.createColorGradingBuilder();
+  final toneMapper = await ToneMapper.aces(app);
+  final grading = await builder
+      .toneMapper(toneMapper)
+      .quality(QualityLevel.HIGH)
+      .exposure(1.2)
+      .whiteBalance(0.3, 0.05)
+      .contrast(1.1)
+      .saturation(1.1)
+      .vibrance(1.2)
+      .build();
+  await builder.dispose();
+  await toneMapper.dispose();
+  await viewer.view.setColorGrading(grading);
+
+  // Light atmospheric fog.
+  await viewer.view.setFogOptions(FogOptions(
+    enabled: true,
+    density: 0.02,
+    linearColor: Vector3(0.8, 0.85, 0.9),
+  ));
+
+  // Capture a frame.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final png = await pixelBufferToPng(result.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('post_processing.png').writeAsBytes(png);
+  print('Wrote post_processing.png');
+
+  io.exit(0);
+}

--- a/skills/thermion-shadows/SKILL.md
+++ b/skills/thermion-shadows/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: thermion-shadows
+description: >
+  Enable and configure shadows in Thermion. Covers the three switches that all
+  must be on (view-level setShadowsEnabled, a shadow-casting light, and a
+  shadow-receiving surface), shadow types (PCF, VSM, DPCF, PCSS), per-light
+  castShadows and ShadowOptions via the LightManager (map size, cascades and
+  split positions, biases, screen-space contact shadows), per-renderable
+  setCastShadows/setReceiveShadows, soft-shadow tuning, and ground-plane
+  shadows. Use when objects should cast or receive shadows, shadows look wrong
+  (acne, peter-panning, pixelated), or for cascaded shadow setup.
+  Triggers: shadow, shadows, cast shadow, receive shadow, shadow map, shadow
+  type, pcf, vsm, dpcf, pcss, soft shadows, shadow cascade, split positions,
+  shadow bias, shadow acne, contact shadows, ground shadow, drop shadow.
+---
+
+Shadows in Thermion need **three things switched on** — miss any one and you
+get no shadows:
+
+1. Shadows enabled on the view,
+2. a light that **casts** shadows,
+3. a surface that **receives** shadows.
+
+The minimal working setup (a floating cube over a ground plane):
+
+```dart
+// A ground plane to receive shadows (there is no dedicated ground-shadow API —
+// you add receiving geometry):
+final ground = await viewer.createGeometry(GeometryUtils.plane(width: 10, height: 10));
+await ground.setReceiveShadows(true);
+
+final cube = await viewer.loadGltf('assets/cube.glb');
+await cube.setTransform(Matrix4.translation(Vector3(0, 0.5, 0)));
+
+// A shadow-casting sun:
+await viewer.addDirectLight(
+  DirectLight.sun(castShadows: true, direction: Vector3(-1, -2, -1)),
+);
+
+// View-level switches:
+await viewer.setShadowsEnabled(true);
+await viewer.setShadowType(ShadowType.PCF);
+```
+
+## The three switches live at different levels
+
+| Level | API | Default |
+|---|---|---|
+| View | `viewer.setShadowsEnabled(bool)` / `viewer.setShadowType(...)` | disabled |
+| Light | `DirectLight(castShadows:)` or `lightManager.setShadowCaster(entity, true)` | `false` (sun constructor: `true`) |
+| Renderable | `asset.setCastShadows(bool)` / `asset.setReceiveShadows(bool)` | cast: on, receive: on for geometry |
+
+## Shadow types
+
+```dart
+await viewer.setShadowType(ShadowType.PCF);  // percentage-closer filtering — default choice
+await viewer.setShadowType(ShadowType.VSM);  // variance shadow maps — softer, may leak light
+await viewer.setShadowType(ShadowType.DPCF); // soft, cheaper than PCSS
+await viewer.setShadowType(ShadowType.PCSS); // physically-based soft shadows
+```
+
+(Equivalently `viewer.view.setShadowType(...)`.)
+
+Tuning soft shadows (DPCF/PCSS):
+
+```dart
+await viewer.view.setSoftShadowOptions(
+  SoftShadowOptions(penumbraScale: 0.5, penumbraRatioScale: 0.5),
+);
+```
+
+## Per-light ShadowOptions
+
+Via the light manager (`setShadowOptions` is one of its few **async** methods),
+using the entity returned by `addDirectLight`:
+
+```dart
+final sunEntity = await viewer.addDirectLight(
+    DirectLight.sun(castShadows: true, direction: Vector3(0, -1, -1)));
+
+await viewer.app.lightManager.setShadowOptions(
+  sunEntity,
+  ShadowOptions(
+    mapSize: 1024,              // shadow map resolution
+    shadowCascades: 4,          // directional lights only
+    cascadeSplitPositions: [0.125, 0.25, 0.50], // N-1 splits for N cascades
+    constantBias: 0.001,
+    normalBias: 0.01,
+    shadowFar: 100.0,
+    screenSpaceContactShadows: true, // per-light contact shadows
+  ),
+);
+```
+
+Cascade split helpers (fractions of the shadow distance):
+
+```dart
+final lm = viewer.app.lightManager;
+final uniform = lm.computeUniformSplits(4);
+final log = lm.computeLogSplits(4, near, far);
+final practical = lm.computePracticalSplits(4, near, far, 0.5); // lambda blend
+```
+
+VSM-specific view options:
+
+```dart
+await viewer.view.setVsmShadowOptions(VsmShadowOptions(msaaSamples: 4));
+```
+
+## Moving shadows
+
+Shadow direction follows the light: move the sun and the shadows follow.
+
+```dart
+await viewer.setLightDirection(sunEntity, Vector3(-0.5, -1, -0.2));
+```
+
+Softer shadow edges: increase the sun's angular radius.
+
+```dart
+viewer.app.lightManager.setSunAngularRadius(sunEntity, 2.0); // degrees
+```
+
+## Gotchas
+
+- **No dedicated ground-shadow API** — "a shadow on the floor" means a plane
+  (or any geometry) with `setReceiveShadows(true)`.
+- `setShadowsEnabled(true)` alone is not enough — the light must cast and a
+  surface must receive.
+- Shadow **acne** (striping): raise `constantBias`/`normalBias` or `mapSize`.
+  **Peter-panning** (detached shadows): biases too high — lower them.
+- Pixelated shadow edges: higher `mapSize`, more cascades, or switch
+  PCF → DPCF/PCSS.
+- Cascade count vs splits: N cascades take exactly N−1 split positions.
+- Directional/sun lights support cascades; point/spot lights do not.
+
+## References
+
+- `references/dart-shadows.dart` — complete pure-Dart program: cube over a
+  ground plane with PCF shadows from a shadow-casting sun, plus ShadowOptions
+  tuning.
+
+## Docs
+
+- https://thermion.dev/shadows/ — dedicated shadows page (the three switches,
+  shadow types, per-light options, troubleshooting)
+- Filament's own shadow docs describe the underlying model:
+  https://google.github.io/filament/Filament.html#shadowing

--- a/skills/thermion-shadows/references/dart-shadows.dart
+++ b/skills/thermion-shadows/references/dart-shadows.dart
@@ -1,0 +1,79 @@
+// Pure-Dart headless example: a cube floating above a ground plane, lit by a
+// shadow-casting sun with PCF shadows and tuned ShadowOptions.
+//
+// Run with:  dart run dart_shadows.dart [assets_dir]
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/examples_lib (shadows setup) in the thermion
+// repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(
+      near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+  await camera.lookAt(Vector3(3, 3, 3), focus: Vector3(0, 0, 0));
+
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+
+  // 1) A receiver: a ground plane that receives shadows.
+  final ground =
+      await viewer.createGeometry(GeometryUtils.plane(width: 10, height: 10));
+  await ground.setReceiveShadows(true);
+
+  // 2) A caster: a cube floating above the plane.
+  final cube = await viewer.loadGltf(assetUri('cube.glb'));
+  await cube.transformToUnitCube();
+  await cube.setTransform(Matrix4.translation(Vector3(0, 0.5, 0)));
+
+  // 3) A shadow-casting sun, plus per-light shadow tuning.
+  final sunEntity = await viewer.addDirectLight(
+      DirectLight.sun(castShadows: true, direction: Vector3(-1, -2, -1)));
+  await app.lightManager.setShadowOptions(
+    sunEntity,
+    ShadowOptions(
+      mapSize: 1024,
+      constantBias: 0.001,
+      normalBias: 0.01,
+    ),
+  );
+
+  // 4) View-level switches.
+  await viewer.setShadowsEnabled(true);
+  await viewer.setShadowType(ShadowType.PCF);
+
+  // Capture a frame.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final png = await pixelBufferToPng(result.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('shadows.png').writeAsBytes(png);
+  print('Wrote shadows.png');
+
+  io.exit(0);
+}

--- a/skills/thermion-transforms-hierarchy/SKILL.md
+++ b/skills/thermion-transforms-hierarchy/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: thermion-transforms-hierarchy
+description: >
+  Position, rotate, scale, and move 3D objects in Thermion. Thermion has NO
+  setPosition/setRotation/setScale helpers — every transform is a Matrix4 from
+  vector_math_64. Covers asset.setTransform, Matrix4.compose with Quaternion,
+  common transform recipes (translation, rotationY spin, orbiting), the
+  TransformManager (local vs world transforms, setTransformAsync, transform
+  transactions), and scene-graph parenting via setParent. Use when moving,
+  placing, rotating, scaling, or animating object positions, or building
+  parent/child hierarchies. Triggers: set position, move object, translate,
+  rotate, scale, spin, matrix4, quaternion, transform manager, parent entity,
+  child entity, scene graph, hierarchy, world transform, local transform,
+  pivot, orbit object.
+---
+
+**There is no `setPosition`, `setRotation`, or `setScale` in Thermion.** Every
+placement is a `Matrix4` (from `package:vector_math/vector_math_64.dart`)
+applied with `setTransform`. If you find yourself looking for those helpers,
+compose a matrix instead.
+
+## The everyday pattern
+
+```dart
+import 'package:vector_math/vector_math_64.dart';
+
+// Pure translation:
+await asset.setTransform(Matrix4.translation(Vector3(0, 1, 2)));
+
+// Compose position + rotation + scale in one matrix:
+final transform = Matrix4.compose(
+  Vector3(0, 1, 2),                      // position
+  Quaternion.fromEulerAngles(0, pi / 4, 0), // rotation
+  Vector3(1, 1, 1),                      // scale
+);
+await asset.setTransform(transform);
+
+// Set a child entity's transform instead of the asset root:
+await asset.setTransform(Matrix4.translation(Vector3(1, 0, 0)),
+    entity: childEntity);
+```
+
+`setTransform` **replaces** the whole transform — it does not accumulate. To
+move relative to the current pose, read, modify, write:
+
+```dart
+final current = await asset.getLocalTransform();
+current.translate(Vector3(0, 0.5, 0)); // mutate in place
+await asset.setTransform(current);
+```
+
+## Common recipes
+
+```dart
+// Continuous spin (e.g. from a Timer.periodic or ticker):
+await asset.setTransform(Matrix4.rotationY(elapsedSeconds));
+await asset.setTransform(Matrix4.rotationX(elapsedSeconds));
+
+// Translate THEN rotate (order matters — matrix multiplication is not
+// commutative; the rightmost operation applies first):
+await asset.setTransform(Matrix4.translation(pos) * Matrix4.rotationY(angle));
+
+// Orbit a moon around a planet at radius r:
+final orbit = Matrix4.translation(Vector3(r * cos(t), 0, r * sin(t)));
+await moon.setTransform(orbit);
+```
+
+## Per-frame movement (Flutter)
+
+```dart
+late Timer _timer;
+final _started = DateTime.now();
+
+_timer = Timer.periodic(const Duration(milliseconds: 16), (_) async {
+  final elapsed =
+      DateTime.now().difference(_started).inMilliseconds / 1000;
+  await asset.setTransform(Matrix4.rotationY(elapsed));
+});
+// cancel in State.dispose()
+```
+
+## Scene-graph hierarchy
+
+Parenting makes the child follow the parent:
+
+```dart
+await viewer.app.setParent(childEntity, parentEntity);
+
+// Moving the parent now moves the child along with it:
+await parentAsset.setTransform(Matrix4.translation(Vector3(-1, 0, 0)));
+```
+
+- Unparent with `setParent(childEntity, null)`.
+- `preserveScaling: true` keeps the child's world scale when re-parenting.
+- Query the graph: `getParent`, `getAncestor`, `getChildren`,
+  `getChildCount` on the transform manager.
+
+## TransformManager (lower level)
+
+`viewer.app.transformManager` works on any entity, no asset required:
+
+```dart
+final tm = viewer.app.transformManager;
+
+tm.setTransform(entity, Matrix4.identity());     // synchronous
+await tm.setTransformAsync(entity, Matrix4.identity()); // applied on render thread
+
+final Matrix4 local = tm.getLocalTransform(entity);   // relative to parent
+final Matrix4 world = tm.getWorldTransform(entity);   // world space
+
+tm.setParent(child, parent);
+final children = tm.getChildren(entity);
+
+// Batch many transform edits without intermediate recomputation:
+tm.openLocalTransformTransaction();
+// ... many setTransform calls ...
+tm.commitLocalTransformTransaction();
+```
+
+`viewer.app.setTransform(entity, matrix)` and
+`viewer.app.getLocalTransform(entity)` / `getWorldTransform(entity)` are
+equivalent conveniences on the app.
+
+## Camera movement is different
+
+The camera is not moved with `setTransform` — aim it with
+`camera.lookAt(position, focus: target)` (see the `thermion-camera-input`
+skill).
+
+## Gotchas
+
+- `setTransform` replaces (not accumulates) — compose the full matrix you want.
+- Matrix multiplication order matters: `A * B` applies B first.
+- Euler angles are radians; `Quaternion.fromEulerAngles(x, y, z)` is the
+  easiest rotation constructor.
+- Scale is baked into the same matrix — a non-uniform scale changes how
+  rotations look.
+- The camera at the origin looks down −Z; +Y is up (right-handed).
+
+## References
+
+- `references/dart-hierarchy.dart` — complete pure-Dart program with a parent
+  cube and a parented child cube that follows the parent's movement.
+
+## Docs
+
+- https://thermion.dev/entities/ — positions, movement, and hierarchy section
+  of the Entities page

--- a/skills/thermion-transforms-hierarchy/references/dart-hierarchy.dart
+++ b/skills/thermion-transforms-hierarchy/references/dart-hierarchy.dart
@@ -1,0 +1,69 @@
+// Pure-Dart headless example: scene-graph hierarchy. Two cubes — a parent and
+// a child parented via FilamentApp.setParent — then the parent moves and the
+// child follows.
+//
+// Run with:  dart run dart_hierarchy.dart [assets_dir]
+// (default assets_dir=examples/assets)
+//
+// Adapted from examples/dart/examples_lib (transforms_and_hierarchy setup) in
+// the thermion repository.
+
+import 'dart:io' as io;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> argv) async {
+  final assetsDir = argv.isNotEmpty ? argv.first : 'examples/assets';
+  const width = 512, height = 512;
+  final assetUri = (String rel) => 'file://$assetsDir/$rel';
+
+  await FFIFilamentApp.create(
+    config: FFIFilamentConfig(
+      loadResource: (uri) async =>
+          io.File(uri.replaceAll('file://', '')).readAsBytes(),
+    ),
+  );
+  final app = FilamentApp.instance!;
+  final swapChain = await app.createHeadlessSwapChain(width, height);
+  final viewer = ThermionViewerFFI(app: app as FFIFilamentApp);
+  await viewer.initialized;
+  await app.renderManager.attach(viewer.view, swapChain);
+  await viewer.setViewport(width, height);
+
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(
+      near: 0.1, far: 100.0, aspect: 1.0, focalLength: 28.0);
+  await camera.lookAt(Vector3(3, 3, 3), focus: Vector3(0, 0, 0));
+
+  await viewer.addDirectLight(DirectLight.sun(direction: Vector3(0, -1, -1)));
+  await viewer.loadSkybox(assetUri('default_env_skybox.ktx'));
+  await viewer.loadIbl(assetUri('default_env_ibl.ktx'));
+
+  final parent = await viewer.loadGltf(assetUri('cube.glb'));
+  await parent.transformToUnitCube();
+
+  final child = await viewer.loadGltf(assetUri('cube.glb'));
+  await child.transformToUnitCube();
+  await child.setTransform(Matrix4.translation(Vector3(1.0, 0.0, 0.0)));
+
+  // Parent the child to the parent — from now on the child follows.
+  await viewer.app.setParent(child.entity, parent.entity);
+
+  // Moving the parent carries the (locally offset) child with it.
+  await parent.setTransform(Matrix4.translation(Vector3(-1.0, 0.0, 0.0)));
+
+  // Capture a frame for verification.
+  final result = await app.capture(
+    swapChain,
+    view: viewer.view,
+    pixelDataFormat: PixelDataFormat.RGBA,
+    pixelDataType: PixelDataType.FLOAT,
+  );
+  final png = await pixelBufferToPng(result.first.$2, width, height,
+      hasAlpha: true, isFloat: true);
+  await io.File('hierarchy.png').writeAsBytes(png);
+  print('Wrote hierarchy.png');
+
+  io.exit(0);
+}


### PR DESCRIPTION
Adds a top-level **`skills/`** folder that uses markdown documents in the SKILL.md format to assist agents with writing code against the Thermion API. Users copy the skill directories into their own project's `.claude/skills/` (see `skills/README.md`).

12 skills, covering the Flutter and pure-Dart (incl. headless) surfaces equally:

| Skill | Covers |
|---|---|
| `thermion-getting-started` | viewer creation (ViewerWidget / createViewer / FFIFilamentApp), hello-world scene, lifecycle |
| `thermion-loading-gltf` | loadGltf params, entity queries, GPU instancing, cleanup |
| `thermion-transforms-hierarchy` | Matrix4-only transforms (no setPosition/setRotation), parenting |
| `thermion-lighting` | sun/point/spot, LightManager, IBL, skybox, backgrounds |
| `thermion-shadows` | the 3 required switches, ShadowType, ShadowOptions, cascades |
| `thermion-animation` | clips, the animationManager.update clock, morphs, bones + gotchas |
| `thermion-materials` | PBR ubershader, unlit/wireframe, params, textures, swapping |
| `thermion-geometry` | GeometryUtils primitives, custom vertex/index meshes |
| `thermion-camera-input` | lookAt, projections, orbit/free-flight controls |
| `thermion-picking-selection` | View.pick, stencil outlines, gizmos |
| `thermion-post-processing` | anti-aliasing, bloom, color grading, fog, AO |
| `thermion-headless-capture` | pure-Dart offscreen rendering to PNG |

We also update the docs with pages for  `entities`, `lighting`, and `shadows`. The skills link to them instead of substituting for them.
