### PR TITLE
fix: throw Exception when setStencilHighlight or setFlatShading  is called without preserved geometry

### DIFF
--- a/docs/src/content/docs/materials.mdx
+++ b/docs/src/content/docs/materials.mdx
@@ -48,6 +48,15 @@ await asset.setMaterialInstanceForAll(unlit);
 await asset.setMaterialInstanceAt(unlit);
 ```
 
+:::note
+Materials that need extra vertex attributes — **wireframe** (barycentric
+coordinates), **stencil highlight outlines**, and **flat shading** — only
+work on assets loaded with `loadGltf(..., rebuildVertices: true)`, which
+rebuilds vertex buffers with a superset of attributes at the cost of ~3x
+vertex memory. `setFlatShading` and `setStencilHighlight` **throw** if the
+asset wasn't loaded this way.
+:::
+
 ## Textures
 
 Load an image, create a sampler, and bind both to a material parameter:

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -279,6 +279,14 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   @override
   Future setFlatShading(bool flatShading) async {
+    // Flat shading swaps TANGENTS on the preserved (rebuilt) vertex buffers;
+    // without them it would silently do nothing — throw instead.
+    if (getVertexBuffer() == null) {
+      throw Exception(
+        "setFlatShading: asset has no preserved geometry. "
+        "Load it with loadGltf(..., rebuildVertices: true).",
+      );
+    }
     await withVoidCallback((requestId, cb) => SceneAsset_setFlatShadingRenderThread(asset, flatShading, requestId, cb));
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_view.dart
@@ -578,14 +578,24 @@ class FFIView extends View<Pointer<TView>> {
     final geoAsset = geometrySource ?? asset;
     final ffiGeoAsset = geoAsset as FFIAsset;
 
+    // Misuse check: highlighting needs the preserved (rebuilt) vertex
+    // buffers, which only exist when the glTF was loaded with
+    // rebuildVertices: true. Throw rather than silently doing nothing.
+    if (ffiGeoAsset.getVertexBuffer() == null) {
+      throw Exception(
+        "setStencilHighlight: asset has no preserved geometry. "
+        "Load it with loadGltf(..., rebuildVertices: true).",
+      );
+    }
+
     // Get the starting primitive offset for this entity
     final offset = await ffiGeoAsset.getPrimitiveOffsetForEntity(entity);
     if (offset < 0) {
+      // The asset has preserved geometry, but this particular entity has no
+      // rebuilt buffers (e.g. its primitives are all lines/points).
       _logger.warning(
-        "Stencil highlight: no preserved geometry for entity $entity. "
-        "Either the asset wasn't loaded with rebuildVertices: true, or this "
-        "entity's primitives are all non-triangles (lines/points) and have "
-        "no rebuilt buffers.",
+        "Stencil highlight: no preserved geometry for entity $entity "
+        "(its primitives are all non-triangles and have no rebuilt buffers).",
       );
       return;
     }

--- a/thermion_dart/lib/src/filament/src/interface/asset.dart
+++ b/thermion_dart/lib/src/filament/src/interface/asset.dart
@@ -73,7 +73,8 @@ abstract class ThermionAsset<T> extends NativeHandle<T> {
   }
 
   // Toggle between flat (per-face) and smooth (per-vertex) shading.
-  // Only has effect if the asset was loaded with rebuildVertices: true.
+  // Throws unless the asset was loaded with rebuildVertices: true (flat
+  // shading swaps TANGENTS on the rebuilt vertex buffers).
   Future setFlatShading(bool flatShading) {
     throw UnimplementedError();
   }

--- a/thermion_dart/lib/src/filament/src/interface/view.dart
+++ b/thermion_dart/lib/src/filament/src/interface/view.dart
@@ -482,6 +482,9 @@ abstract class View<T> extends NativeHandle<T> {
   /// Uses a stencil-based two-pass rendering approach for clean, flicker-free
   /// outlines.
   ///
+  /// Throws if the asset (or [geometrySource]) has no preserved geometry —
+  /// glTF assets must be loaded with `rebuildVertices: true` for outlining.
+  ///
   /// The [scale] parameter is deprecated and ignored; use [outlineWidth] instead.
   Future setStencilHighlight(
     ThermionAsset asset, {

--- a/thermion_dart/test/overlay_tests.dart
+++ b/thermion_dart/test/overlay_tests.dart
@@ -221,4 +221,23 @@ void main() async {
       await testHelper.capture(viewer.view, "translation_axis_switch_to_z");
     }, postProcessing: true);
   });
+
+  test('setStencilHighlight and setFlatShading throw without rebuildVertices', () async {
+    await testHelper.withViewer((viewer) async {
+      final cube = await viewer.loadGltf("file://${testHelper.assetsDir}/cube.glb", addToScene: true);
+
+      // Outlining and flat shading both need the preserved (rebuilt) vertex
+      // buffers — without rebuildVertices these used to silently do nothing;
+      // they must now throw with an actionable message.
+      await viewer.view.setHighlightOverlayEnabled(true);
+      expect(
+        () => viewer.view.setStencilHighlight(cube),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('rebuildVertices: true'))),
+      );
+      expect(
+        () => cube.setFlatShading(true),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('rebuildVertices: true'))),
+      );
+    });
+  });
 }


### PR DESCRIPTION
`setStencilHighlight` and `setFlatShading` currently log a warning or silently fail if the glTF asset was loaded without `rebuildVertices: true`. These now throw an exception.