### PR TITLE
build: remove --whole-archive from Linux link flags

### DIFF
--- a/.tickets/wor-qmis.md
+++ b/.tickets/wor-qmis.md
@@ -23,3 +23,7 @@ Linux debug and release load with no unresolved symbols; rendering tests pass; n
 **2026-08-24T09:36:26Z**
 
 Implementation retains the complete library list and moves only Linux archives after object files via CBuilder.libraries. Added -Wl,-z,defs so unresolved Linux symbols fail during linking. Dart hook analysis and thermion_flutter analysis pass. Local ARM64 container exited before invoking the Dart build hook, so GitHub Linux CI is the authoritative native validation.
+
+**2026-08-24T09:45:54Z**
+
+First CI run exposed libm as an implicit Linux dependency once -Wl,-z,defs was enabled: math symbols from Thermion, Filament, basis_transcoder, geometry, matdbg, and filamat were unresolved. Added m after all static archives so the shared library records its dependency explicitly rather than relying on the host process.

--- a/.tickets/wor-qmis.md
+++ b/.tickets/wor-qmis.md
@@ -1,0 +1,25 @@
+---
+id: wor-qmis
+status: in_progress
+deps: []
+links: []
+created: 2026-08-24T09:21:30Z
+type: bug
+priority: 1
+assignee: Nick Fisher
+tags: [build, linux, linker]
+---
+# Fix Linux static archive ordering without cross-platform link changes
+
+Replace Linux whole-archive linking with correctly ordered static archives while retaining the full library list and leaving every non-Linux build path unchanged.
+
+## Acceptance Criteria
+
+Linux debug and release load with no unresolved symbols; rendering tests pass; non-Linux hook behavior is unchanged; controlled size comparison is recorded.
+
+
+## Notes
+
+**2026-08-24T09:36:26Z**
+
+Implementation retains the complete library list and moves only Linux archives after object files via CBuilder.libraries. Added -Wl,-z,defs so unresolved Linux symbols fail during linking. Dart hook analysis and thermion_flutter analysis pass. Local ARM64 container exited before invoking the Dart build hook, so GitHub Linux CI is the authoritative native validation.

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -490,23 +490,22 @@ outputDirectory : ${outputDirectory.path}
         if (objcObjectFiles.isNotEmpty) ...['-lthermion_objc', '-L${Directory.systemTemp.path}'],
         ...flags,
         ...frameworks,
-        if (targetOS == OS.linux) ...["-Wl,--whole-archive"],
-        if (targetOS != OS.windows) ...[
+        // Keep every non-Linux link command unchanged. GNU ld processes
+        // static archives from left to right, and CBuilder emits flags before
+        // the source files, so Linux archives use `libraries` below instead.
+        if (targetOS != OS.windows && targetOS != OS.linux) ...[
           ...libs.map((lib) => "-l$lib"),
-          if (targetOS == OS.linux) ...[
-            "-Wl,--no-whole-archive",
-            ...linuxDebugLibs.map((lib) => "-l$lib"),
-            '-lGL',
-            '-lEGL',
-          ] else if (targetOS != OS.android) ...[
-            "-lc++",
-            "",
-          ],
+          if (targetOS != OS.android) ...["-lc++", ""],
           "-L$libDir",
         ],
-        if (targetOS == OS.linux)
-          '-Wl,--no-as-needed'
-        else if (targetOS != OS.windows && targetOS != OS.android)
+        if (targetOS == OS.linux) "-L$libDir",
+        if (targetOS == OS.linux) ...[
+          '-Wl,--no-as-needed',
+          // Shared-library links normally permit unresolved symbols. Make
+          // Linux fail at link time instead of deferring the error to
+          // dlopen, where missing archive dependencies are harder to trace.
+          '-Wl,-z,defs',
+        ] else if (targetOS != OS.windows && targetOS != OS.android)
           '-lc++',
         if (platform == "windows") ...[
           ...includeDirs.map((d) => "/I${path.join(pkgRootFilePath, d)}"),
@@ -525,6 +524,15 @@ outputDirectory : ${outputDirectory.path}
         ],
       ],
       libraryDirectories: [libDir],
+      // CBuilder emits libraries after the source files. This lets GNU ld
+      // extract only referenced archive members instead of forcing every
+      // member into libthermion_dart.so with --whole-archive. Keep the full
+      // existing library set; the second pass resolves Filament's circular
+      // archive references. GL and EGL also belong after the objects so
+      // --as-needed cannot discard them prematurely.
+      libraries: targetOS == OS.linux
+          ? [...libs, ...linuxDebugLibs, 'GL', 'EGL', ...libs, ...linuxDebugLibs]
+          : const [],
     );
 
     await cbuilder.run(input: input, output: output, logger: logger);

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -528,10 +528,10 @@ outputDirectory : ${outputDirectory.path}
       // extract only referenced archive members instead of forcing every
       // member into libthermion_dart.so with --whole-archive. Keep the full
       // existing library set; the second pass resolves Filament's circular
-      // archive references. GL and EGL also belong after the objects so
-      // --as-needed cannot discard them prematurely.
+      // archive references. GL, EGL, and libm also belong after the objects
+      // so --as-needed cannot discard them prematurely.
       libraries: targetOS == OS.linux
-          ? [...libs, ...linuxDebugLibs, 'GL', 'EGL', ...libs, ...linuxDebugLibs]
+          ? [...libs, ...linuxDebugLibs, 'GL', 'EGL', ...libs, ...linuxDebugLibs, 'm']
           : const [],
     );
 


### PR DESCRIPTION
This PR changes the Thermion link flags on Linux:  
- add `-Wl,-z,defs` so unresolved Linux symbols fail at link time rather than later during `dlopen`.
- link libm explicitly (previously this was platform/distribution dependent)
- move the existing Linux static archive list from `CBuilder.flags` to `CBuilder.libraries`
- remove Linux `--whole-archive` while retaining the complete existing library set, including `filamat`, `imageio`, `tinyexr`, `z`, and `filameshio`.

macOS, iOS, Android, Windows, and Web link paths unchanged.