### PR TITLE
build: drop unused imageio, tinyexr and filameshio libs

### DIFF
--- a/.tickets/wor-4bno.md
+++ b/.tickets/wor-4bno.md
@@ -1,0 +1,25 @@
+---
+id: wor-4bno
+status: in_progress
+deps: []
+links: []
+created: 2026-08-24T09:38:41Z
+type: chore
+priority: 2
+assignee: Nick Fisher
+tags: [build, native, binary-size]
+---
+# Remove verified-unused native library link inputs
+
+Remove imageio, tinyexr, and filameshio from production link inputs after Linux archive ordering is fixed. Retain filamat, z, zstd, png, and all rendering/image-decoding libraries.
+
+## Acceptance Criteria
+
+Dart and Flutter CI pass on Linux, macOS, and Windows; Web and Android build; Linux has no unresolved symbols; the PR is stacked separately from the Linux linker fix.
+
+
+## Notes
+
+**2026-08-24T09:46:21Z**
+
+Source audit found no production wrapper references to imageio, tinyexr, or filameshio. Artifact build scripts and native-only test CMake files remain unchanged. Validation: Dart hook analysis passed; thermion_flutter analysis passed; Flutter Web quickstart built; macOS asset and image tests passed (11 tests), including PNG background decoding and KTX loading.

--- a/.tickets/wor-qmis.md
+++ b/.tickets/wor-qmis.md
@@ -23,3 +23,7 @@ Linux debug and release load with no unresolved symbols; rendering tests pass; n
 **2026-08-24T09:36:26Z**
 
 Implementation retains the complete library list and moves only Linux archives after object files via CBuilder.libraries. Added -Wl,-z,defs so unresolved Linux symbols fail during linking. Dart hook analysis and thermion_flutter analysis pass. Local ARM64 container exited before invoking the Dart build hook, so GitHub Linux CI is the authoritative native validation.
+
+**2026-08-24T09:45:54Z**
+
+First CI run exposed libm as an implicit Linux dependency once -Wl,-z,defs was enabled: math symbols from Thermion, Filament, basis_transcoder, geometry, matdbg, and filamat were unresolved. Added m after all static archives so the shared library records its dependency explicitly rather than relying on the host process.

--- a/.tickets/wor-qmis.md
+++ b/.tickets/wor-qmis.md
@@ -1,0 +1,25 @@
+---
+id: wor-qmis
+status: in_progress
+deps: []
+links: []
+created: 2026-08-24T09:21:30Z
+type: bug
+priority: 1
+assignee: Nick Fisher
+tags: [build, linux, linker]
+---
+# Fix Linux static archive ordering without cross-platform link changes
+
+Replace Linux whole-archive linking with correctly ordered static archives while retaining the full library list and leaving every non-Linux build path unchanged.
+
+## Acceptance Criteria
+
+Linux debug and release load with no unresolved symbols; rendering tests pass; non-Linux hook behavior is unchanged; controlled size comparison is recorded.
+
+
+## Notes
+
+**2026-08-24T09:36:26Z**
+
+Implementation retains the complete library list and moves only Linux archives after object files via CBuilder.libraries. Added -Wl,-z,defs so unresolved Linux symbols fail during linking. Dart hook analysis and thermion_flutter analysis pass. Local ARM64 container exited before invoking the Dart build hook, so GitHub Linux CI is the authoritative native validation.

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -490,23 +490,22 @@ outputDirectory : ${outputDirectory.path}
         if (objcObjectFiles.isNotEmpty) ...['-lthermion_objc', '-L${Directory.systemTemp.path}'],
         ...flags,
         ...frameworks,
-        if (targetOS == OS.linux) ...["-Wl,--whole-archive"],
-        if (targetOS != OS.windows) ...[
+        // Keep every non-Linux link command unchanged. GNU ld processes
+        // static archives from left to right, and CBuilder emits flags before
+        // the source files, so Linux archives use `libraries` below instead.
+        if (targetOS != OS.windows && targetOS != OS.linux) ...[
           ...libs.map((lib) => "-l$lib"),
-          if (targetOS == OS.linux) ...[
-            "-Wl,--no-whole-archive",
-            ...linuxDebugLibs.map((lib) => "-l$lib"),
-            '-lGL',
-            '-lEGL',
-          ] else if (targetOS != OS.android) ...[
-            "-lc++",
-            "",
-          ],
+          if (targetOS != OS.android) ...["-lc++", ""],
           "-L$libDir",
         ],
-        if (targetOS == OS.linux)
-          '-Wl,--no-as-needed'
-        else if (targetOS != OS.windows && targetOS != OS.android)
+        if (targetOS == OS.linux) "-L$libDir",
+        if (targetOS == OS.linux) ...[
+          '-Wl,--no-as-needed',
+          // Shared-library links normally permit unresolved symbols. Make
+          // Linux fail at link time instead of deferring the error to
+          // dlopen, where missing archive dependencies are harder to trace.
+          '-Wl,-z,defs',
+        ] else if (targetOS != OS.windows && targetOS != OS.android)
           '-lc++',
         if (platform == "windows") ...[
           ...includeDirs.map((d) => "/I${path.join(pkgRootFilePath, d)}"),
@@ -525,6 +524,15 @@ outputDirectory : ${outputDirectory.path}
         ],
       ],
       libraryDirectories: [libDir],
+      // CBuilder emits libraries after the source files. This lets GNU ld
+      // extract only referenced archive members instead of forcing every
+      // member into libthermion_dart.so with --whole-archive. Keep the full
+      // existing library set; the second pass resolves Filament's circular
+      // archive references. GL and EGL also belong after the objects so
+      // --as-needed cannot discard them prematurely.
+      libraries: targetOS == OS.linux
+          ? [...libs, ...linuxDebugLibs, 'GL', 'EGL', ...libs, ...linuxDebugLibs]
+          : const [],
     );
 
     await cbuilder.run(input: input, output: output, logger: logger);

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -227,7 +227,6 @@ outputDirectory : ${outputDirectory.path}
     var libs = [
       "filament",
       "backend",
-      "filameshio",
       if (targetOS != OS.iOS) "filamat",
       if (targetOS == OS.linux) "shaders",
       "utils",
@@ -245,8 +244,6 @@ outputDirectory : ${outputDirectory.path}
       if (targetOS != OS.android && targetOS != OS.iOS) "gltfio",
       "filament-iblprefilter",
       "image",
-      "imageio",
-      "tinyexr",
       "filaflat",
       "dracodec",
       "ibl",

--- a/thermion_dart/hook/build.dart
+++ b/thermion_dart/hook/build.dart
@@ -528,10 +528,10 @@ outputDirectory : ${outputDirectory.path}
       // extract only referenced archive members instead of forcing every
       // member into libthermion_dart.so with --whole-archive. Keep the full
       // existing library set; the second pass resolves Filament's circular
-      // archive references. GL and EGL also belong after the objects so
-      // --as-needed cannot discard them prematurely.
+      // archive references. GL, EGL, and libm also belong after the objects
+      // so --as-needed cannot discard them prematurely.
       libraries: targetOS == OS.linux
-          ? [...libs, ...linuxDebugLibs, 'GL', 'EGL', ...libs, ...linuxDebugLibs]
+          ? [...libs, ...linuxDebugLibs, 'GL', 'EGL', ...libs, ...linuxDebugLibs, 'm']
           : const [],
     );
 

--- a/thermion_dart/native/include/ThermionWin32.h
+++ b/thermion_dart/native/include/ThermionWin32.h
@@ -18,8 +18,6 @@
 #pragma comment(lib, "gltfio_core.lib")
 #pragma comment(lib, "filament-iblprefilter.lib")
 #pragma comment(lib, "image.lib")
-#pragma comment(lib, "imageio.lib")
-#pragma comment(lib, "tinyexr.lib")
 #pragma comment(lib, "filaflat.lib")
 #pragma comment(lib, "dracodec.lib")
 #pragma comment(lib, "ibl.lib")

--- a/thermion_dart/native/src/c_api/TEngine.cpp
+++ b/thermion_dart/native/src/c_api/TEngine.cpp
@@ -28,8 +28,6 @@
 #include <gltfio/math.h>
 #include <gltfio/materials/uberarchive.h>
 
-#include <imageio/ImageDecoder.h>
-#include <imageio/ImageEncoder.h>
 #include <image/ColorTransform.h>
 
 #include <utils/EntityManager.h>

--- a/thermion_dart/native/web/CMakeLists.txt
+++ b/thermion_dart/native/web/CMakeLists.txt
@@ -205,11 +205,6 @@ set_property(TARGET filament PROPERTY IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_S
 set_property(TARGET filament PROPERTY IMPORTED_IMPLIB_PROFILE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libfilament.a")
 set_property(TARGET filament PROPERTY IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libfilament.a")
 
-add_library(filameshio STATIC IMPORTED)
-set_property(TARGET filameshio PROPERTY IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_SOURCE_DIR}/lib/debug/libfilameshio.a")
-set_property(TARGET filameshio PROPERTY IMPORTED_IMPLIB_PROFILE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libfilameshio.a")
-set_property(TARGET filameshio PROPERTY IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libfilameshio.a")
-
 add_library(filamat STATIC IMPORTED)
 set_property(TARGET filamat PROPERTY IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_SOURCE_DIR}/lib/debug/libfilamat.a")
 set_property(TARGET filamat  PROPERTY IMPORTED_IMPLIB_PROFILE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libfilamat.a")
@@ -234,16 +229,6 @@ add_library(image STATIC IMPORTED)
 set_property(TARGET image PROPERTY IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_SOURCE_DIR}/lib/debug/libimage.a")
 set_property(TARGET image PROPERTY IMPORTED_IMPLIB_PROFILE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libimage.a")
 set_property(TARGET image PROPERTY IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libimage.a")
-
-add_library(imageio STATIC IMPORTED)
-set_property(TARGET imageio PROPERTY IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_SOURCE_DIR}/lib/debug/libimageio.a")
-set_property(TARGET imageio  PROPERTY IMPORTED_LOCATION_PROFILE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libimageio.a")
-set_property(TARGET imageio  PROPERTY IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libimageio.a")
-
-add_library(tinyexr STATIC IMPORTED)
-set_property(TARGET tinyexr PROPERTY IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_SOURCE_DIR}/lib/debug/libtinyexr.a")
-set_property(TARGET tinyexr PROPERTY IMPORTED_LOCATION_PROFILE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libtinyexr.a")
-set_property(TARGET tinyexr PROPERTY IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libtinyexr.a")
 
 add_library(camutils STATIC IMPORTED)
 set_property(TARGET camutils PROPERTY IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_SOURCE_DIR}/lib/debug/libcamutils.a")
@@ -343,7 +328,6 @@ target_link_libraries(${MODULE_NAME}
  filaflat
  filabridge
  image
- imageio
  utils
  stb
  uberzlib
@@ -354,7 +338,6 @@ target_link_libraries(${MODULE_NAME}
  z
  zstd
  png
- tinyexr
  ${EXTERNAL_ALL_LIBRARIES}
 )
 
@@ -368,4 +351,3 @@ if(DEFINED EXTERNAL_ALL_LIBRARIES)
   endforeach()
   message(STATUS "Added --whole-archive flags for external libraries to prevent dead code elimination")
 endif()
-


### PR DESCRIPTION
We no longer need to link with `imageio`, `tinyexr`, and `filameshio`. These are currently unused (or other libraries provide the same functionality, e.g. `stb_image`). These are still built and can be reinstated if we actually have a need for them. There is some forthcoming follow-up work to enable compile-time opt-in for certain libs.