### PR TITLE
build: (linux) remove obsolete -Wl,--allow-shlib-undefined  workaround

### DIFF
--- a/thermion_flutter/thermion_flutter/linux/CMakeLists.txt
+++ b/thermion_flutter/thermion_flutter/linux/CMakeLists.txt
@@ -208,11 +208,9 @@ target_include_directories(${PLUGIN_NAME} PRIVATE
 )
 target_link_directories(${PLUGIN_NAME} PRIVATE "${NATIVE_ASSETS_DIR}")
 
-# thermion_dart.so has unresolved basisu/draco encoder symbols (pulled in by
-# --whole-archive on filamat). These code paths are never called at runtime.
-# Propagate --allow-shlib-undefined to the executable that links against this plugin.
-set_property(TARGET ${PLUGIN_NAME} APPEND PROPERTY
-  INTERFACE_LINK_OPTIONS "-Wl,--allow-shlib-undefined")
+# The native build links thermion_dart.so with -Wl,-z,defs, so unresolved
+# symbols fail while producing the library. Keep the final executable link
+# strict as well; --allow-shlib-undefined would hide regressions here.
 
 target_compile_options(${PLUGIN_NAME} PRIVATE -stdlib=libc++)
 target_link_options(${PLUGIN_NAME} PRIVATE -nostdlib++ -l:libc++.a -l:libc++abi.a)


### PR DESCRIPTION
`-Wl,--allow-shlib-undefined` tells GNU ld to accept unresolved symbol references found inside dependent shared libraries. It does not resolve those symbols; it merely permits the executable link to finish. A symbol may later be supplied by another loaded library, but if it is not, failure is deferred to application startup, dlopen, or the first call into the affected code.

Since we want to surface missing symbols at link time, this PR stops -Wl,--allow-shlib-undefined propagating to the built application. 