### PR TITLE
fix: replace morph target API with MorphTargetSet and fix related memory/threading errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
   entity, index, and optional name of every morph target. Named and indexed
   updates no longer require callers to construct an opaque full weight array;
   strict full-pose updates remain available through `setAllWeights`.
+- Apply overlapping custom morph animations oldest-first so the most recently
+  added animation has final priority for shared targets. Active animations
+  continue to overwrite manual weights on their next update.
 
 ### Breaking changes
 - remove the unused `FilamentApp.createColorGrading` — it returned a raw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   source ranges, copying FFI payloads before asynchronous dispatch, and
   applying updates on the owning render thread. This also prevents temporary
   morph-weight buffers from leaking Emscripten stack space on web.
+- Add `MorphTarget` and asset-bound `MorphTargetSet` APIs for discovering the
+  entity, index, and optional name of every morph target. Named and indexed
+  updates no longer require callers to construct an opaque full weight array;
+  strict full-pose updates remain available through `setAllWeights`.
 
 ### Breaking changes
 - remove the unused `FilamentApp.createColorGrading` — it returned a raw
@@ -40,6 +44,10 @@
 - remove `View.setToneMapper` and `ThermionViewer.setToneMapper` - use
   `view.createColorGradingBuilder().toneMapper(...).build()` followed by
   `view.setColorGrading()` instead.
+- Replace `ThermionAsset.getMorphTargetNames` and `setMorphTargetWeights` with
+  `getMorphTargets` / `getMorphTargetSets`. `RenderableManager.setMorphWeights`
+  now infers and enforces the complete target count; use `setMorphWeightAt` for
+  a single indexed update.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   non-indexed geometry, so procedural geometry (e.g. particles) can render
   without an `IndexBuffer`, including attribute-less vertex buffers built
   with `bufferCount(0)`. Native library rebuild required.
+- Fix intermittent `RenderableManager.setMorphWeights` crashes by validating
+  source ranges, copying FFI payloads before asynchronous dispatch, and
+  applying updates on the owning render thread. This also prevents temporary
+  morph-weight buffers from leaking Emscripten stack space on web.
 
 ### Breaking changes
 - remove the unused `FilamentApp.createColorGrading` — it returned a raw

--- a/docs/src/content/docs/animations.mdx
+++ b/docs/src/content/docs/animations.mdx
@@ -53,24 +53,30 @@ an exact time.
 ## Morph targets
 
 Morph targets let you blend between vertex states (e.g. facial expressions).
-First discover the targets on a renderable entity, then set all weights at once:
+Discovering them returns both the renderable entity and an ordered list of
+targets, so you do not need to guess which entity owns them or how long a weight
+list should be:
 
 ```dart
 final asset = await viewer.loadGltf("assets/cube_with_morph_targets.glb");
 
-// Names for the asset's root entity:
-final targetNames = await asset.getMorphTargetNames();
-// e.g. ["Open", "Close"]
+final morphs = (await asset.getMorphTargetSets()).single;
+for (final target in morphs.targets) {
+  print('${target.index}: ${target.name ?? '(unnamed)'}');
+}
 
-// setMorphTargetWeights takes weights for ALL morph targets on the entity.
-// To activate only one, set the rest to 0.
-await asset.setMorphTargetWeights(entity, [1.0, 0.0]);
+// Named and indexed updates leave all other target weights unchanged.
+await morphs.setWeight('Open', 1.0);
+await morphs.setWeightAt(1, 0.25);
+
+// A complete pose must contain exactly one value per target, in target order.
+await morphs.setAllWeights(List.filled(morphs.targets.length, 0.0));
 ```
 
-> **Important:** `setMorphTargetWeights` accepts the *child mesh entity* that
-> owns the morph targets, not the asset root. Use `getChildEntity` /
-> `getChildEntityNames` to find the right entity. `getMorphTargetNames`, by
-> contrast, takes the parent entity and a mesh name.
+Use `asset.getMorphTargets(entity)` when you already know the renderable entity.
+Target names are optional, so indexed updates remain available for procedural or
+unnamed targets. Weights must be finite; `0.0` is the base shape and `1.0` fully
+applies a target.
 
 For keyframed morph animation, build a `MorphAnimationData` and pass it to
 `setMorphAnimationData`. Clear it later with `clearMorphAnimationData(entity)`.

--- a/docs/src/content/docs/animations.mdx
+++ b/docs/src/content/docs/animations.mdx
@@ -79,7 +79,20 @@ unnamed targets. Weights must be finite; `0.0` is the base shape and `1.0` fully
 applies a target.
 
 For keyframed morph animation, build a `MorphAnimationData` and pass it to
-`setMorphAnimationData`. Clear it later with `clearMorphAnimationData(entity)`.
+`setMorphAnimationData`. An active animation writes its target weights on every
+animation tick, so a manual `setWeight`, `setWeightAt`, or `setAllWeights` call
+is temporary for any target that animation controls. Stop custom morph
+animations before taking persistent manual control:
+
+```dart
+await asset.clearMorphAnimationData(morphs.entity);
+await morphs.setWeight('Open', 0.8);
+```
+
+When multiple custom morph animations control the same target, the most
+recently added animation has priority. `clearMorphAnimationData` clears all
+custom morph animations for the entity; it does not stop morph channels in an
+active glTF animation.
 
 ## Bones / skeletal animation
 

--- a/examples/dart/examples_lib/lib/src/morph_targets.dart
+++ b/examples/dart/examples_lib/lib/src/morph_targets.dart
@@ -1,8 +1,6 @@
 import 'package:thermion_dart/thermion_dart.dart';
 
-/// Loads a cube with morph targets and blends the first two targets at 0.5 each
-/// to show a mid-morph pose. Requires per-frame animation ticking for the
-/// weights to take visual effect.
+/// Loads a cube with morph targets and applies a named target.
 Future<void> setupMorphTargets(
   ThermionViewer viewer, {
   required String assetsDir,
@@ -20,32 +18,12 @@ Future<void> setupMorphTargets(
   await viewer.loadSkybox("$assetsDir/default_env_skybox.ktx");
   await viewer.loadIbl("$assetsDir/default_env_ibl.ktx");
 
-  final asset =
-      await viewer.loadGltf("$assetsDir/cube_with_morph_targets.glb");
+  final asset = await viewer.loadGltf("$assetsDir/cube_with_morph_targets.glb");
   await asset.transformToUnitCube();
 
-  // Morph targets live on child (renderable) entities, not the root.
-  final children = await asset.getChildEntities();
-
-  // Find the child entity that has morph targets.
-  ThermionEntity morphEntity = children.first;
-  for (final child in children) {
-    final names = await asset.getMorphTargetNames(entity: child);
-    if (names.isNotEmpty) {
-      morphEntity = child;
-      break;
-    }
-  }
-
-  final names = await asset.getMorphTargetNames(entity: morphEntity);
-
-  // Blend the first two targets equally.
-  final weights = List<double>.filled(names.length, 0.0);
-  if (names.length >= 2) {
-    weights[0] = 0.5;
-    weights[1] = 0.5;
-  } else if (names.isNotEmpty) {
-    weights[0] = 1.0;
-  }
-  await asset.setMorphTargetWeights(morphEntity, weights);
+  // Each set identifies the renderable entity and its targets, including their
+  // names and indices. This asset has one renderable with one named target.
+  final morphTargets = (await asset.getMorphTargetSets()).single;
+  final targetName = morphTargets.targets.single.name!;
+  await morphTargets.setWeight(targetName, 1.0);
 }

--- a/skills/thermion-animation/SKILL.md
+++ b/skills/thermion-animation/SKILL.md
@@ -108,8 +108,11 @@ await morphs.setAllWeights(List.filled(morphs.targets.length, 0.0));
 
 Keyframed morph animation: build a `MorphAnimationData` and
 `await asset.setMorphAnimationData(data, targetMeshNames: [...])`;
-clear with `asset.clearMorphAnimationData(entity)`. Weight changes only show
-once animation frames tick (`update` as above).
+clear with `asset.clearMorphAnimationData(entity)`. Active animations overwrite
+manual weights on their next tick; clear the custom animation before taking
+persistent manual control. When custom animations overlap, the most recently
+added animation has priority. Weight changes only show once animation frames
+tick (`update` as above).
 
 ## Bones / skeletal
 

--- a/skills/thermion-animation/SKILL.md
+++ b/skills/thermion-animation/SKILL.md
@@ -94,25 +94,16 @@ call.
 ## Morph targets (blend shapes)
 
 ```dart
-// Morph targets live on child (renderable) entities, NOT the asset root.
-final children = await asset.getChildEntities();
+// Discover every renderable entity with morph targets. Each set exposes the
+// exact target order as well as optional glTF names.
+final morphs = (await asset.getMorphTargetSets()).single;
+// e.g. MorphTarget(index: 0, name: "Open")
 
-ThermionEntity morphEntity = children.first;
-for (final child in children) {
-  final names = await asset.getMorphTargetNames(entity: child);
-  if (names.isNotEmpty) {
-    morphEntity = child;
-    break;
-  }
-}
+await morphs.setWeight("Open", 1.0); // leaves other targets unchanged
+await morphs.setWeightAt(1, 0.5);    // works for unnamed targets
 
-final names = await asset.getMorphTargetNames(entity: morphEntity);
-// e.g. ["Open", "Close"]
-
-// setMorphTargetWeights takes ALL weights at once — inactive targets get 0.
-final weights = List<double>.filled(names.length, 0.0);
-weights[0] = 1.0; // fully apply "Open"
-await asset.setMorphTargetWeights(morphEntity, weights);
+// Full-pose updates require exactly one value per target, in target order.
+await morphs.setAllWeights(List.filled(morphs.targets.length, 0.0));
 ```
 
 Keyframed morph animation: build a `MorphAnimationData` and

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -3560,6 +3560,27 @@ external void RenderableManager_destroyEntityRenderThread(
     VoidCallback,
   )
 >(isLeaf: true)
+external void RenderableManager_setMorphWeightsRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> weights,
+  int count,
+  int offset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderableManager_setBonesFromMat4RenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1799,6 +1799,15 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
+  external void _RenderableManager_setMorphWeightsRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    Pointer<Float32> weights,
+    size_t count,
+    size_t offset,
+    int requestId,
+    VoidCallback onComplete,
+  );
   external void _RenderableManager_setBonesFromMat4RenderThread(
     Pointer<TRenderableManager> tRenderableManager,
     EntityId entityId,
@@ -7213,6 +7222,27 @@ void RenderableManager_destroyEntityRenderThread(
   final result = GeneratedBindings.instance._RenderableManager_destroyEntityRenderThread(
     tRenderableManager.cast(),
     entityId,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderableManager_setMorphWeightsRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> weights,
+  Dartsize_t count,
+  Dartsize_t offset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMorphWeightsRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    weights,
+    count,
+    offset,
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_animation_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_animation_manager.dart
@@ -150,34 +150,6 @@ class FFIAnimationManager extends AnimationManager<Pointer<TAnimationManager>> {
   }
 
   @override
-  Future<bool> setMorphTargetWeights(ThermionEntity entityId, List<double> weights) async {
-    late Pointer stackPtr;
-    if (FILAMENT_WASM) {
-      stackPtr = stackSave();
-    }
-
-    final weightsPtr = makeFloat32List(weights.length);
-    weightsPtr.setRange(0, weights.length, weights);
-
-    try {
-      return await withBoolCallback(
-        (cb) => AnimationManager_setMorphTargetWeightsRenderThread(
-          animationManager,
-          entityId,
-          weightsPtr.address,
-          weights.length,
-          cb,
-        ),
-      );
-    } finally {
-      weightsPtr.free();
-      if (FILAMENT_WASM) {
-        stackRestore(stackPtr);
-      }
-    }
-  }
-
-  @override
   bool setMorphAnimation(
     ThermionEntity entityId,
     List<double> morphData,

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_animation_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_animation_manager.dart
@@ -186,6 +186,31 @@ class FFIAnimationManager extends AnimationManager<Pointer<TAnimationManager>> {
     int numFrames,
     double frameLengthInMs,
   ) {
+    if (numMorphTargets <= 0) {
+      throw RangeError.range(numMorphTargets, 1, null, 'numMorphTargets');
+    }
+    if (numFrames <= 0) {
+      throw RangeError.range(numFrames, 1, null, 'numFrames');
+    }
+    if (!frameLengthInMs.isFinite || frameLengthInMs <= 0) {
+      throw ArgumentError.value(frameLengthInMs, 'frameLengthInMs', 'Must be finite and greater than zero');
+    }
+    if (morphIndices.length != numMorphTargets) {
+      throw ArgumentError.value(
+        morphIndices.length,
+        'morphIndices.length',
+        'Must equal numMorphTargets ($numMorphTargets)',
+      );
+    }
+    final expectedValues = numFrames * numMorphTargets;
+    if (morphData.length != expectedValues) {
+      throw ArgumentError.value(
+        morphData.length,
+        'morphData.length',
+        'Must equal numFrames * numMorphTargets ($expectedValues)',
+      );
+    }
+
     late Pointer stackPtr;
     if (FILAMENT_WASM) {
       stackPtr = stackSave();

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -386,34 +386,44 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
     await _app.renderableManager.setVisibilityLayer(entity, layer.value);
   }
 
-  //
   @override
-  Future setMorphTargetWeights(ThermionEntity entity, List<double> weights) async {
-    if (weights.isEmpty) {
-      throw Exception("Weights must not be empty");
+  Future<MorphTargetSet> getMorphTargets(ThermionEntity entity) async {
+    if (entity != this.entity && !await containsChild(entity)) {
+      throw ArgumentError.value(entity, 'entity', 'Entity does not belong to this asset');
     }
-
-    final success = await _app.animationManager.setMorphTargetWeights(entity, weights);
-    if (!success) {
-      throw Exception("Failed to set morph target weights, check logs for details");
+    if (!_app.renderableManager.isRenderable(entity)) {
+      throw ArgumentError.value(entity, 'entity', 'Entity is not renderable');
     }
+    return _createMorphTargetSet(entity);
   }
 
-  //
   @override
-  Future<List<String>> getMorphTargetNames({ThermionEntity? entity}) async {
-    entity ??= this.entity;
-
-    var names = <String>[];
-    var count = _app.animationManager.getMorphTargetNameCount(this, entity);
-
-    for (int i = 0; i < count; i++) {
-      final name = _app.animationManager.getMorphTargetName(this, entity, i);
-      if (name != null) {
-        names.add(name);
+  Future<List<MorphTargetSet>> getMorphTargetSets() async {
+    final result = <MorphTargetSet>[];
+    for (final candidate in [entity, ...await getChildEntities()]) {
+      if (_app.renderableManager.isRenderable(candidate) && _app.renderableManager.getMorphTargetCount(candidate) > 0) {
+        result.add(_createMorphTargetSet(candidate));
       }
     }
-    return names;
+    return result;
+  }
+
+  MorphTargetSet _createMorphTargetSet(ThermionEntity entity) {
+    final targetCount = _app.renderableManager.getMorphTargetCount(entity);
+    var nameCount = 0;
+    if (type == SceneAssetType.gltf) {
+      nameCount = _app.animationManager.getMorphTargetNameCount(this, entity);
+    }
+
+    final targets = <MorphTarget>[];
+    for (var i = 0; i < targetCount; i++) {
+      String? name;
+      if (i < nameCount) {
+        name = _app.animationManager.getMorphTargetName(this, entity, i);
+      }
+      targets.add(MorphTarget(index: i, name: name));
+    }
+    return _FFIMorphTargetSet(entity, targets, _app.renderableManager);
   }
 
   //
@@ -526,7 +536,18 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
         continue;
       }
 
-      var meshMorphTargets = await getMorphTargetNames(entity: meshEntity);
+      final morphTargetSet = await getMorphTargets(meshEntity);
+      final targetsByName = <String, MorphTarget>{};
+      for (final target in morphTargetSet.targets) {
+        final name = target.name;
+        if (name != null) {
+          if (targetsByName.containsKey(name)) {
+            throw StateError('Morph target name "$name" is not unique on entity $meshEntity');
+          }
+          targetsByName[name] = target;
+        }
+      }
+      final meshMorphTargets = targetsByName.keys.toList();
 
       var intersection = animation.morphTargets.toSet().intersection(meshMorphTargets.toSet()).toList();
 
@@ -538,7 +559,7 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
             Child entities: ${childNames}""");
       }
 
-      var indices = Uint32List.fromList(intersection.map((m) => meshMorphTargets.indexOf(m)).toList());
+      var indices = Uint32List.fromList(intersection.map((name) => targetsByName[name]!.index).toList());
 
       // var frameData = animation.data;
       var frameData = animation.subset(intersection);
@@ -885,5 +906,57 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
       return null;
     }
     return FFIVertexBuffer(vbPtr, _app.engine);
+  }
+}
+
+final class _FFIMorphTargetSet implements MorphTargetSet {
+  @override
+  final ThermionEntity entity;
+
+  @override
+  final List<MorphTarget> targets;
+
+  final RenderableManager _renderableManager;
+
+  _FFIMorphTargetSet(this.entity, List<MorphTarget> targets, this._renderableManager)
+    : targets = List.unmodifiable(targets);
+
+  @override
+  Future<void> setWeight(String name, double weight) => setWeights({name: weight});
+
+  @override
+  Future<void> setWeights(Map<String, double> weights) async {
+    final updates = <(MorphTarget, double)>[];
+    for (final entry in weights.entries) {
+      if (!entry.value.isFinite) {
+        throw ArgumentError.value(entry.value, entry.key, 'Morph weights must be finite');
+      }
+      updates.add((_targetNamed(entry.key), entry.value));
+    }
+
+    for (final (target, weight) in updates) {
+      await _renderableManager.setMorphWeightAt(entity, target.index, weight);
+    }
+  }
+
+  @override
+  Future<void> setWeightAt(int index, double weight) {
+    return _renderableManager.setMorphWeightAt(entity, index, weight);
+  }
+
+  @override
+  Future<void> setAllWeights(List<double> weights) {
+    return _renderableManager.setMorphWeights(entity, weights);
+  }
+
+  MorphTarget _targetNamed(String name) {
+    final matches = targets.where((target) => target.name == name).toList();
+    if (matches.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'No morph target has this name');
+    }
+    if (matches.length > 1) {
+      throw StateError('Morph target name "$name" is not unique; use setWeightAt instead');
+    }
+    return matches.single;
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -917,20 +917,39 @@ final class _FFIMorphTargetSet implements MorphTargetSet {
   final List<MorphTarget> targets;
 
   final RenderableManager _renderableManager;
+  late final Map<String, MorphTarget> _targetsByName;
+  late final Set<String> _duplicateNames;
 
   _FFIMorphTargetSet(this.entity, List<MorphTarget> targets, this._renderableManager)
-    : targets = List.unmodifiable(targets);
+    : targets = List.unmodifiable(targets) {
+    final targetsByName = <String, MorphTarget>{};
+    final duplicateNames = <String>{};
+    for (final target in targets) {
+      final name = target.name;
+      if (name == null) {
+        continue;
+      }
+      if (targetsByName.containsKey(name)) {
+        duplicateNames.add(name);
+      } else {
+        targetsByName[name] = target;
+      }
+    }
+    _targetsByName = Map.unmodifiable(targetsByName);
+    _duplicateNames = Set.unmodifiable(duplicateNames);
+  }
 
   @override
-  Future<void> setWeight(String name, double weight) => setWeights({name: weight});
+  Future<void> setWeight(String name, double weight) async {
+    _validateWeight(weight, 'weight');
+    await _renderableManager.setMorphWeightAt(entity, _targetNamed(name).index, weight);
+  }
 
   @override
   Future<void> setWeights(Map<String, double> weights) async {
     final updates = <(MorphTarget, double)>[];
     for (final entry in weights.entries) {
-      if (!entry.value.isFinite) {
-        throw ArgumentError.value(entry.value, entry.key, 'Morph weights must be finite');
-      }
+      _validateWeight(entry.value, 'weights["${entry.key}"]');
       updates.add((_targetNamed(entry.key), entry.value));
     }
 
@@ -950,13 +969,19 @@ final class _FFIMorphTargetSet implements MorphTargetSet {
   }
 
   MorphTarget _targetNamed(String name) {
-    final matches = targets.where((target) => target.name == name).toList();
-    if (matches.isEmpty) {
-      throw ArgumentError.value(name, 'name', 'No morph target has this name');
-    }
-    if (matches.length > 1) {
+    if (_duplicateNames.contains(name)) {
       throw StateError('Morph target name "$name" is not unique; use setWeightAt instead');
     }
-    return matches.single;
+    final target = _targetsByName[name];
+    if (target == null) {
+      throw ArgumentError.value(name, 'name', 'No morph target has this name');
+    }
+    return target;
+  }
+
+  void _validateWeight(double weight, String argumentName) {
+    if (!weight.isFinite) {
+      throw ArgumentError.value(weight, argumentName, 'Morph weights must be finite');
+    }
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
@@ -268,13 +268,30 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
   // ============================================================================
 
   @override
-  Future setMorphWeights(ThermionEntity entity, List<double> weights, int count, {int offset = 0}) async {
-    RangeError.checkNotNegative(count, 'count');
-    RangeError.checkNotNegative(offset, 'offset');
-    if (count > weights.length) {
-      throw RangeError.range(count, 0, weights.length, 'count', 'Cannot exceed weights.length');
+  Future<void> setMorphWeights(ThermionEntity entity, List<double> weights) async {
+    final targetCount = getMorphTargetCount(entity);
+    if (weights.length != targetCount) {
+      throw ArgumentError.value(weights.length, 'weights.length', 'Must equal the morph target count ($targetCount)');
     }
-    if (count == 0) {
+    _validateMorphWeights(weights);
+    await _setMorphWeights(entity, weights, 0);
+  }
+
+  @override
+  Future<void> setMorphWeightAt(ThermionEntity entity, int targetIndex, double weight) async {
+    final targetCount = getMorphTargetCount(entity);
+    if (targetIndex < 0 || targetIndex >= targetCount) {
+      if (targetCount == 0) {
+        throw RangeError.value(targetIndex, 'targetIndex', 'Renderable has no morph targets');
+      }
+      throw RangeError.range(targetIndex, 0, targetCount - 1, 'targetIndex');
+    }
+    _validateMorphWeights([weight]);
+    await _setMorphWeights(entity, [weight], targetIndex);
+  }
+
+  Future<void> _setMorphWeights(ThermionEntity entity, List<double> weights, int offset) async {
+    if (weights.isEmpty) {
       return;
     }
 
@@ -283,8 +300,8 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
       stackPtr = stackSave();
     }
 
-    final weightsPtr = makeFloat32List(count);
-    weightsPtr.setRange(0, count, weights);
+    final weightsPtr = makeFloat32List(weights.length);
+    weightsPtr.setRange(0, weights.length, weights);
 
     try {
       await withVoidCallback(
@@ -292,7 +309,7 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
           renderableManager,
           entity,
           weightsPtr.address,
-          count,
+          weights.length,
           offset,
           requestId,
           cb,
@@ -302,6 +319,14 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
       weightsPtr.free();
       if (FILAMENT_WASM) {
         stackRestore(stackPtr);
+      }
+    }
+  }
+
+  void _validateMorphWeights(List<double> weights) {
+    for (var i = 0; i < weights.length; i++) {
+      if (!weights[i].isFinite) {
+        throw ArgumentError.value(weights[i], 'weights[$i]', 'Must be finite');
       }
     }
   }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
@@ -269,15 +269,40 @@ class FFIRenderableManager extends RenderableManager<Pointer<TRenderableManager>
 
   @override
   Future setMorphWeights(ThermionEntity entity, List<double> weights, int count, {int offset = 0}) async {
-    final weightsPtr = makeFloat32List(weights.length);
-    for (int i = 0; i < weights.length; i++) {
-      weightsPtr[i] = weights[i];
+    RangeError.checkNotNegative(count, 'count');
+    RangeError.checkNotNegative(offset, 'offset');
+    if (count > weights.length) {
+      throw RangeError.range(count, 0, weights.length, 'count', 'Cannot exceed weights.length');
+    }
+    if (count == 0) {
+      return;
     }
 
-    RenderableManager_setMorphWeights(renderableManager, entity, weightsPtr.address, count, offset);
-
+    late Pointer stackPtr;
     if (FILAMENT_WASM) {
+      stackPtr = stackSave();
+    }
+
+    final weightsPtr = makeFloat32List(count);
+    weightsPtr.setRange(0, count, weights);
+
+    try {
+      await withVoidCallback(
+        (requestId, cb) => RenderableManager_setMorphWeightsRenderThread(
+          renderableManager,
+          entity,
+          weightsPtr.address,
+          count,
+          offset,
+          requestId,
+          cb,
+        ),
+      );
+    } finally {
       weightsPtr.free();
+      if (FILAMENT_WASM) {
+        stackRestore(stackPtr);
+      }
     }
   }
 

--- a/thermion_dart/lib/src/filament/src/interface/animation_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/animation_manager.dart
@@ -99,13 +99,6 @@ abstract class AnimationManager<T> extends NativeHandle<T> {
   // Returns the animation name, or null if not found
   String? getGltfAnimationName(ThermionAsset asset, int index);
 
-  // Sets morph target weights for an entity.
-  //
-  // [entityId] The entity to set weights for
-  // [weights] List of morph target weights (0.0 to 1.0)
-  // Returns true if successful, false otherwise
-  Future<bool> setMorphTargetWeights(ThermionEntity entityId, List<double> weights);
-
   // Sets up a morph animation with keyframe data.
   //
   // [entityId] The entity to animate

--- a/thermion_dart/lib/src/filament/src/interface/asset.dart
+++ b/thermion_dart/lib/src/filament/src/interface/asset.dart
@@ -27,6 +27,12 @@ final class MorphTarget {
 /// A weight of `0.0` uses the base shape and `1.0` applies the complete target.
 /// Multiple targets can contribute simultaneously. Finite values outside that
 /// range are passed through to Filament for intentional extrapolation.
+///
+/// Active glTF or custom morph animations can write the same weights on every
+/// animation update. A manual update to an animated target is therefore
+/// temporary and is replaced by the next animation tick. Call
+/// [ThermionAsset.clearMorphAnimationData] before setting a persistent manual
+/// value for a target driven by a custom morph animation.
 abstract interface class MorphTargetSet {
   ThermionEntity get entity;
 
@@ -302,22 +308,23 @@ abstract class ThermionAsset<T> extends NativeHandle<T> {
     throw UnimplementedError();
   }
 
-  // Construct animation(s) for every entity under [asset]. If [targetMeshNames]
-  // is provided, only entities with matching names will be animated.
-  // [MorphTargetAnimation] for an explanation as to how to construct the
-  // animation frame data. This method will check the morph target names
-  // specified in [animation] against the morph target names that actually exist
-  // exist under [meshName] in [entity], throwing an exception if any cannot be
-  // found. It is permissible for [animation] to omit any targets that do exist
-  // under [meshName]; these simply won't be animated.
-  //
+  /// Adds a custom morph animation to matching renderable entities.
+  ///
+  /// If [targetMeshNames] is provided, only entities with matching names are
+  /// animated. The names in [animation] are matched to each entity's targets;
+  /// targets omitted from [animation] are not changed.
+  ///
+  /// Active animations overwrite manual [MorphTargetSet] updates on their next
+  /// tick. If several custom animations drive the same target, the most
+  /// recently added animation has priority. Use [clearMorphAnimationData] to
+  /// return the entity to persistent manual control.
   Future setMorphAnimationData(MorphAnimationData animation, {List<String>? targetMeshNames}) {
     throw UnimplementedError();
   }
 
-  //
-  // Clear all current morph animations for [entity].
-  //
+  /// Stops all custom morph animations on [entity].
+  ///
+  /// This does not stop morph channels belonging to an active glTF animation.
   Future clearMorphAnimationData(ThermionEntity entity) {
     throw UnimplementedError();
   }

--- a/thermion_dart/lib/src/filament/src/interface/asset.dart
+++ b/thermion_dart/lib/src/filament/src/interface/asset.dart
@@ -7,6 +7,49 @@ export 'geometry.dart';
 
 enum SceneAssetType { gltf, geometry, light, skybox, ibl, image, gizmo }
 
+/// Describes one morph target on a renderable entity.
+///
+/// [name] is null for targets that do not have a name, such as targets on
+/// procedurally-created renderables. [index] is always available and matches
+/// the order expected by [MorphTargetSet.setAllWeights].
+final class MorphTarget {
+  final int index;
+  final String? name;
+
+  const MorphTarget({required this.index, this.name});
+
+  @override
+  String toString() => name == null ? 'MorphTarget($index)' : 'MorphTarget($index, $name)';
+}
+
+/// Morph targets and mutation methods bound to a single renderable [entity].
+///
+/// A weight of `0.0` uses the base shape and `1.0` applies the complete target.
+/// Multiple targets can contribute simultaneously. Finite values outside that
+/// range are passed through to Filament for intentional extrapolation.
+abstract interface class MorphTargetSet {
+  ThermionEntity get entity;
+
+  /// Targets in the exact order expected by [setAllWeights].
+  List<MorphTarget> get targets;
+
+  /// Updates one uniquely named target without changing other targets.
+  Future<void> setWeight(String name, double weight);
+
+  /// Updates several uniquely named targets without changing other targets.
+  ///
+  /// Every name is validated before any update is applied.
+  Future<void> setWeights(Map<String, double> weights);
+
+  /// Updates one target by index without changing other targets.
+  Future<void> setWeightAt(int index, double weight);
+
+  /// Replaces the complete morph pose in [targets] order.
+  ///
+  /// The length of [weights] must equal [targets].length.
+  Future<void> setAllWeights(List<double> weights);
+}
+
 // filament::utils::Entity is the core C++ Filament "handle" type, used to
 // represent lights, renderables, cameras, etc. ThermionEntity is the equivalent
 // Dart type.
@@ -220,22 +263,17 @@ abstract class ThermionAsset<T> extends NativeHandle<T> {
     throw UnimplementedError();
   }
 
-  // Set the weights for all morph targets in [entity] to [weights]. Note that
-  // [weights] must contain values for ALL morph targets, but no exception will
-  // be thrown if you don't do so (you'll just get incorrect results). If you
-  // only want to set one value, set all others to zero (check
-  // [getMorphTargetNames] if you need the get a list of all morph targets).
-  // IMPORTANT - this accepts the actual ThermionEntity with the relevant morph
-  // targets (unlike [getMorphTargetNames], which uses the parent entity and the
-  // child mesh name). Use [getChildEntityByName] if you are setting the weights
-  // for a child mesh.
-  Future setMorphTargetWeights(ThermionEntity entity, List<double> weights) {
+  /// Returns the morph targets attached to the renderable [entity].
+  ///
+  /// The returned object is bound to [entity] and supports named, indexed, and
+  /// strict bulk updates. Throws if [entity] does not belong to this asset or
+  /// is not renderable.
+  Future<MorphTargetSet> getMorphTargets(ThermionEntity entity) {
     throw UnimplementedError();
   }
 
-  // Gets the names of all morph targets for [entity] (which must be a
-  // renderable entity)
-  Future<List<String>> getMorphTargetNames({ThermionEntity? entity}) {
+  /// Discovers every renderable entity in this asset that has morph targets.
+  Future<List<MorphTargetSet>> getMorphTargetSets() {
     throw UnimplementedError();
   }
 

--- a/thermion_dart/lib/src/filament/src/interface/renderable_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/renderable_manager.dart
@@ -246,16 +246,17 @@ abstract class RenderableManager<T> extends NativeHandle<T> {
   /// [enabled] True for global blend ordering, false for local (default)
   Future setGlobalBlendOrderEnabledAt(ThermionEntity entity, int primitiveIndex, bool enabled);
 
-  /// Updates vertex morphing weights.
+  /// Replaces all vertex morphing weights.
   ///
   /// The renderable must have been built with morphing enabled.
   /// For legacy morphing, only the first 4 weights are used.
   ///
   /// [entity] The entity containing the renderable
-  /// [weights] Array of morph target weights
-  /// [count] Number of weights to set; must not exceed [weights].length
-  /// [offset] Non-negative index of the first weight to set (default 0)
-  Future setMorphWeights(ThermionEntity entity, List<double> weights, int count, {int offset = 0});
+  /// [weights] One value per morph target, in target-index order
+  Future<void> setMorphWeights(ThermionEntity entity, List<double> weights);
+
+  /// Updates one vertex morphing weight without changing the other targets.
+  Future<void> setMorphWeightAt(ThermionEntity entity, int targetIndex, double weight);
 
   /// Returns the number of morph targets.
   int getMorphTargetCount(ThermionEntity entity);

--- a/thermion_dart/lib/src/filament/src/interface/renderable_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/renderable_manager.dart
@@ -253,8 +253,8 @@ abstract class RenderableManager<T> extends NativeHandle<T> {
   ///
   /// [entity] The entity containing the renderable
   /// [weights] Array of morph target weights
-  /// [count] Number of weights to set
-  /// [offset] Index of the first weight to set (default 0)
+  /// [count] Number of weights to set; must not exceed [weights].length
+  /// [offset] Non-negative index of the first weight to set (default 0)
   Future setMorphWeights(ThermionEntity entity, List<double> weights, int count, {int offset = 0});
 
   /// Returns the number of morph targets.

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -480,6 +480,16 @@ namespace thermion
             VoidCallback onComplete
         );
 
+        EMSCRIPTEN_KEEPALIVE void RenderableManager_setMorphWeightsRenderThread(
+            TRenderableManager *tRenderableManager,
+            EntityId entityId,
+            const float *weights,
+            size_t count,
+            size_t offset,
+            uint32_t requestId,
+            VoidCallback onComplete
+        );
+
         EMSCRIPTEN_KEEPALIVE void RenderableManager_setBonesFromMat4RenderThread(
             TRenderableManager *tRenderableManager,
             EntityId entityId,

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -1719,10 +1719,17 @@ extern "C"
       void (*callback)(bool))
   {
     auto *rt = RT(tAnimationManager);
+    const bool valid = numWeights >= 0 && (numWeights == 0 || morphData != nullptr);
+    std::vector<float> weights;
+    if (valid && numWeights > 0) {
+      weights.assign(morphData, morphData + numWeights);
+    }
     std::packaged_task<void()> lambda(
-        [=]() mutable
+        [=, weights = std::move(weights)]() mutable
         {
-          bool result = AnimationManager_setMorphTargetWeights(tAnimationManager, entityId, morphData, numWeights);
+          const bool result = valid && (weights.empty() ||
+              AnimationManager_setMorphTargetWeights(
+                  tAnimationManager, entityId, weights.data(), static_cast<int>(weights.size())));
           PROXY(callback(result));
         });
     auto fut = rt->addTask(lambda);
@@ -2714,6 +2721,35 @@ extern "C"
         [=]() mutable
         {
           RenderableManager_destroyEntity(tRenderableManager, entityId);
+          PROXY(onComplete(requestId));
+        });
+    auto fut = rt->addTask(lambda);
+  }
+
+  // Copy the caller-owned payload before returning across the FFI boundary.
+  // Native Dart typed data is pinned only for the duration of the leaf call,
+  // and ffigen_js uses Emscripten stack storage for makeFloat32List().
+  EMSCRIPTEN_KEEPALIVE void RenderableManager_setMorphWeightsRenderThread(
+      TRenderableManager *tRenderableManager,
+      EntityId entityId,
+      const float *weights,
+      size_t count,
+      size_t offset,
+      uint32_t requestId,
+      VoidCallback onComplete)
+  {
+    auto *rt = RT(tRenderableManager);
+    std::vector<float> ownedWeights;
+    if (count > 0) {
+      ownedWeights.assign(weights, weights + count);
+    }
+    std::packaged_task<void()> lambda(
+        [=, ownedWeights = std::move(ownedWeights)]() mutable
+        {
+          if (!ownedWeights.empty()) {
+            RenderableManager_setMorphWeights(
+                tRenderableManager, entityId, ownedWeights.data(), ownedWeights.size(), offset);
+          }
           PROXY(onComplete(requestId));
         });
     auto fut = rt->addTask(lambda);

--- a/thermion_dart/native/src/components/MorphAnimationComponentManager.cpp
+++ b/thermion_dart/native/src/components/MorphAnimationComponentManager.cpp
@@ -39,15 +39,18 @@ namespace thermion
 
             TRACE("Component has %d morph animations", animations.size());
 
-            for (int i = (int)animations.size() - 1; i >= 0; i--)
+            // Apply animations in insertion order. If multiple animations
+            // target the same morph, the most recently added animation is
+            // applied last and therefore has priority.
+            for (size_t animationIndex = 0; animationIndex < animations.size();)
             {
-
-                auto &animation = animationComponent.animations[i];
+                auto &animation = animations[animationIndex];
 
                 // Initialize start time on first use
                 if (animation.startTimeInNanos == 0)
                 {
                     animation.startTimeInNanos = frameTimeInNanos;
+                    animationIndex++;
                     continue;
                 }
 
@@ -57,8 +60,8 @@ namespace thermion
 
                 if (!animation.loop && animationTargetTime >= animation.durationInSecs)
                 {
-                    animations.erase(animations.begin() + i);
-                    TRACE("Animation %d completed", i);
+                    animations.erase(animations.begin() + animationIndex);
+                    TRACE("Animation %zu completed", animationIndex);
                     continue;
                 }
 
@@ -71,17 +74,18 @@ namespace thermion
                 }
 
                 auto baseOffset = frameNumber * animation.morphIndices.size();
-                for (int i = 0; i < animation.morphIndices.size(); i++)
+                for (size_t targetIndex = 0; targetIndex < animation.morphIndices.size(); targetIndex++)
                 {
-                    auto morphIndex = animation.morphIndices[i];
+                    auto morphIndex = animation.morphIndices[targetIndex];
                     auto renderableInstance = mRenderableManager.getInstance(entity);
 
                     mRenderableManager.setMorphWeights(
                         renderableInstance,
-                        animation.frameData.data() + baseOffset + i,
+                        animation.frameData.data() + baseOffset + targetIndex,
                         1,
                         morphIndex);
                 }
+                animationIndex++;
             }
         }
     }

--- a/thermion_dart/native/src/components/MorphAnimationComponentManager.cpp
+++ b/thermion_dart/native/src/components/MorphAnimationComponentManager.cpp
@@ -67,7 +67,7 @@ namespace thermion
                 // offset from the end if reverse
                 if (animation.reverse)
                 {
-                    frameNumber = animation.lengthInFrames - frameNumber;
+                    frameNumber = animation.lengthInFrames - 1 - frameNumber;
                 }
 
                 auto baseOffset = frameNumber * animation.morphIndices.size();

--- a/thermion_dart/test/morph_animation_tests.dart
+++ b/thermion_dart/test/morph_animation_tests.dart
@@ -6,27 +6,23 @@ void main() async {
   final testHelper = TestHelper("morph_animation");
   await testHelper.setup();
 
-  test('get morph target names', () async {
+  test('discover morph targets', () async {
     await testHelper.withViewer((viewer) async {
       var cube = await viewer.loadGltf("${testHelper.assetsDir}/cube.glb");
-      var morphTargets = await cube.getMorphTargetNames();
-      expect(morphTargets.length, 0);
+      expect(await cube.getMorphTargetSets(), isEmpty);
 
       var childEntities = await cube.getChildEntities();
       var childEntity = childEntities.first;
 
-      morphTargets = await cube.getMorphTargetNames(entity: childEntity);
-      expect(morphTargets.length, 0);
+      var morphTargets = await cube.getMorphTargets(childEntity);
+      expect(morphTargets.targets, isEmpty);
 
       cube = await viewer.loadGltf("${testHelper.assetsDir}/cube_with_morph_targets.glb");
-      morphTargets = await cube.getMorphTargetNames();
-      expect(morphTargets.length, 0);
-
-      childEntities = await cube.getChildEntities();
-
-      morphTargets = await cube.getMorphTargetNames(entity: childEntities.first);
-      expect(morphTargets.length, 1);
-      expect(morphTargets.first, "Key 1");
+      final morphTargetSets = await cube.getMorphTargetSets();
+      expect(morphTargetSets, hasLength(1));
+      expect(morphTargetSets.single.targets, hasLength(1));
+      expect(morphTargetSets.single.targets.single.index, 0);
+      expect(morphTargetSets.single.targets.single.name, "Key 1");
     });
   });
 
@@ -39,8 +35,16 @@ void main() async {
 
         await testHelper.capture(viewer.view, "cube_no_morph");
 
-        await cube.setMorphTargetWeights((await cube.getChildEntities()).first, [1.0]);
+        final morphTargets = (await cube.getMorphTargetSets()).single;
+        await morphTargets.setWeight("Key 1", 1.0);
         await testHelper.capture(viewer.view, "cube_with_morph");
+
+        await morphTargets.setWeights({"Key 1": 0.5});
+        await morphTargets.setWeightAt(0, 0.25);
+        await morphTargets.setAllWeights([0.0]);
+
+        await expectLater(morphTargets.setWeight("Missing", 1.0), throwsArgumentError);
+        await expectLater(morphTargets.setAllWeights([]), throwsArgumentError);
       },
       bg: kRed,
       cameraPosition: Vector3(3, 2, 6),

--- a/thermion_dart/test/morph_animation_tests.dart
+++ b/thermion_dart/test/morph_animation_tests.dart
@@ -68,4 +68,17 @@ void main() async {
       cameraPosition: Vector3(3, 2, -6),
     );
   });
+
+  test('reject malformed morph animation buffers', () async {
+    await testHelper.withViewer((viewer) async {
+      final cube = await viewer.loadGltf("${testHelper.assetsDir}/cube_with_morph_targets.glb");
+      final renderableManager = FilamentApp.instance!.renderableManager;
+      final entity = (await cube.getChildEntities()).firstWhere(renderableManager.isRenderable);
+      final animationManager = FilamentApp.instance!.animationManager;
+
+      expect(() => animationManager.setMorphAnimation(entity, [0.0], [0], 1, 2, 16.0), throwsArgumentError);
+      expect(() => animationManager.setMorphAnimation(entity, [0.0], [], 1, 1, 16.0), throwsArgumentError);
+      expect(() => animationManager.setMorphAnimation(entity, [0.0], [0], 1, 1, 0.0), throwsArgumentError);
+    });
+  });
 }

--- a/thermion_dart/test/morph_animation_tests.dart
+++ b/thermion_dart/test/morph_animation_tests.dart
@@ -73,6 +73,42 @@ void main() async {
     );
   });
 
+  test('newer overlapping morph animation has priority', () async {
+    await testHelper.withViewer(
+      (viewer) async {
+        final cube = await viewer.loadGltf("${testHelper.assetsDir}/cube_with_morph_targets.glb", addToScene: true);
+        final morphs = (await cube.getMorphTargetSets()).single;
+
+        await morphs.setAllWeights([0.0]);
+        final zeroPose = (await testHelper.capture(viewer.view, null)).values.single;
+        await morphs.setAllWeights([1.0]);
+        final onePose = (await testHelper.capture(viewer.view, null)).values.single;
+        await morphs.setAllWeights([0.0]);
+
+        await cube.setMorphAnimationData(
+          MorphAnimationData(Float32List.fromList([0.0]), ["Key 1"], frameLengthInMs: 1000.0),
+          targetMeshNames: ["Cube"],
+        );
+        await cube.setMorphAnimationData(
+          MorphAnimationData(Float32List.fromList([1.0]), ["Key 1"], frameLengthInMs: 1000.0),
+          targetMeshNames: ["Cube"],
+        );
+
+        final animationManager = FilamentApp.instance!.animationManager;
+        await animationManager.update(1);
+        await animationManager.update(2);
+        final animatedPose = (await testHelper.capture(viewer.view, null)).values.single;
+
+        expect(
+          _meanAbsoluteDifference(animatedPose, onePose),
+          lessThan(_meanAbsoluteDifference(animatedPose, zeroPose)),
+        );
+      },
+      bg: kRed,
+      cameraPosition: Vector3(3, 2, -6),
+    );
+  });
+
   test('reject malformed morph animation buffers', () async {
     await testHelper.withViewer((viewer) async {
       final cube = await viewer.loadGltf("${testHelper.assetsDir}/cube_with_morph_targets.glb");
@@ -85,4 +121,16 @@ void main() async {
       expect(() => animationManager.setMorphAnimation(entity, [0.0], [0], 1, 1, 0.0), throwsArgumentError);
     });
   });
+}
+
+double _meanAbsoluteDifference(Uint8List left, Uint8List right) {
+  final leftValues = Float32List.view(left.buffer, left.offsetInBytes, left.lengthInBytes ~/ 4);
+  final rightValues = Float32List.view(right.buffer, right.offsetInBytes, right.lengthInBytes ~/ 4);
+  expect(leftValues.length, rightValues.length);
+
+  var total = 0.0;
+  for (var i = 0; i < leftValues.length; i++) {
+    total += (leftValues[i] - rightValues[i]).abs();
+  }
+  return total / leftValues.length;
 }

--- a/thermion_dart/test/renderable_manager_tests.dart
+++ b/thermion_dart/test/renderable_manager_tests.dart
@@ -456,13 +456,11 @@ void main() async {
         final morphCount = renderableManager.getMorphTargetCount(cube.entity);
         expect(morphCount, equals(0));
 
-        // Try setting morph weights (should handle gracefully with no morph
-        // targets)
-        await renderableManager.setMorphWeights(cube.entity, [0.5, 0.5], 2);
+        // A complete pose for a renderable with no targets is an empty list.
+        await renderableManager.setMorphWeights(cube.entity, []);
 
-        await expectLater(renderableManager.setMorphWeights(cube.entity, [0.5], 2), throwsRangeError);
-        await expectLater(renderableManager.setMorphWeights(cube.entity, [0.5], -1), throwsRangeError);
-        await expectLater(renderableManager.setMorphWeights(cube.entity, [0.5], 1, offset: -1), throwsRangeError);
+        await expectLater(renderableManager.setMorphWeights(cube.entity, [0.5]), throwsArgumentError);
+        await expectLater(renderableManager.setMorphWeightAt(cube.entity, 0, 0.5), throwsRangeError);
       });
     });
 
@@ -473,7 +471,10 @@ void main() async {
         final meshEntity = (await asset.getChildEntities()).firstWhere(renderableManager.isRenderable);
 
         expect(renderableManager.getMorphTargetCount(meshEntity), equals(1));
-        await renderableManager.setMorphWeights(meshEntity, [1.0], 1);
+        await renderableManager.setMorphWeightAt(meshEntity, 0, 1.0);
+        await renderableManager.setMorphWeights(meshEntity, [0.5]);
+        await expectLater(renderableManager.setMorphWeightAt(meshEntity, 1, 0.5), throwsRangeError);
+        await expectLater(renderableManager.setMorphWeightAt(meshEntity, 0, double.nan), throwsArgumentError);
         await testHelper.capture(viewer.view, "direct_morph_weight");
       });
     });

--- a/thermion_dart/test/renderable_manager_tests.dart
+++ b/thermion_dart/test/renderable_manager_tests.dart
@@ -459,6 +459,22 @@ void main() async {
         // Try setting morph weights (should handle gracefully with no morph
         // targets)
         await renderableManager.setMorphWeights(cube.entity, [0.5, 0.5], 2);
+
+        await expectLater(renderableManager.setMorphWeights(cube.entity, [0.5], 2), throwsRangeError);
+        await expectLater(renderableManager.setMorphWeights(cube.entity, [0.5], -1), throwsRangeError);
+        await expectLater(renderableManager.setMorphWeights(cube.entity, [0.5], 1, offset: -1), throwsRangeError);
+      });
+    });
+
+    test('setMorphWeights updates a morph target on the render thread', () async {
+      await testHelper.withViewer((viewer) async {
+        final asset = await viewer.loadGltf("${testHelper.assetsDir}/cube_with_morph_targets.glb", addToScene: true);
+        final renderableManager = FilamentApp.instance!.renderableManager;
+        final meshEntity = (await asset.getChildEntities()).firstWhere(renderableManager.isRenderable);
+
+        expect(renderableManager.getMorphTargetCount(meshEntity), equals(1));
+        await renderableManager.setMorphWeights(meshEntity, [1.0], 1);
+        await testHelper.capture(viewer.view, "direct_morph_weight");
       });
     });
 


### PR DESCRIPTION
This PR is a breaking change for the morph target API. Previously the API forced the user to use a certain memory layout for morph targets weights/animations. This wasn't documented clearly and is unnecessary/confusing.

The new API adds `MorphTarget`/`MorphTargetSet` classes that handle this internally. The `setMorphTarget` and `setMorphTargetAnimation` methods have been directly removed; use the corresponding methods on  `MorphTargetSet` instead.

This PR also:
-  ensures all this work occurs on the render thread (and fixes a race condition where the Dart-side native memory buffer can be released before the render thread completes).
- documents that active animation overwrites manual weights on its next tick
- make the most recently added custom morph animation win when animations overlap
- fixes the reverse morph-animation frame off-by-one

