### PR TITLE
fix: absolute thermion_dart package URI resolution on Linux

### DIFF
--- a/.github/workflows/run-flutter-builds.yml
+++ b/.github/workflows/run-flutter-builds.yml
@@ -124,6 +124,16 @@ jobs:
           flutter pub get
           flutter test
 
+      # The checked-in example overrides are relative monorepo paths. Real
+      # consumers of a Git or hosted package receive absolute file:/// root
+      # URIs in package_config.json, so exercise that resolution path too.
+      - name: Exercise absolute package URIs (Linux)
+        if: matrix.name == 'Linux'
+        shell: bash
+        run: |
+          sed -i "s|path: ../../../thermion_dart|path: ${GITHUB_WORKSPACE}/thermion_dart|" quickstart/pubspec.yaml
+          sed -i "s|path: ../../../thermion_dart|path: ${GITHUB_WORKSPACE}/thermion_dart|" picking/pubspec.yaml
+
       - name: Build quickstart (Linux)
         if: matrix.name == 'Linux'
         run: cd quickstart && flutter pub get && flutter build linux

--- a/thermion_flutter/thermion_flutter/linux/CMakeLists.txt
+++ b/thermion_flutter/thermion_flutter/linux/CMakeLists.txt
@@ -106,11 +106,10 @@ if(_PKG_CONFIG)
       endforeach()
 
       if(_td_rootUri)
-        # rootUri may be a file:/// URI (e.g. file:///D:/path on Windows,
-        # file:///home on Linux) or a relative path like "../../thermion_dart".
-        # Strip file:/// (3 slashes) first, then file:// (2 slashes) as fallback.
-        string(REGEX REPLACE "^file:///" "" _td_root "${_td_rootUri}")
-        string(REGEX REPLACE "^file://" "" _td_root "${_td_root}")
+        # rootUri may be an absolute file:/// URI or a relative path such as
+        # "../../thermion_dart". Strip only the file:// scheme prefix: the
+        # remaining slash is the root of an absolute Linux path.
+        string(REGEX REPLACE "^file://" "" _td_root "${_td_rootUri}")
         if(NOT IS_ABSOLUTE "${_td_root}")
           get_filename_component(_pkg_dir "${_PKG_CONFIG}" DIRECTORY)
           get_filename_component(_td_root "${_pkg_dir}/${_td_root}" ABSOLUTE)


### PR DESCRIPTION
This PR fixes a build error on Linux by preserving the leading slash when resolving absolute file URI package roots on Linux. We also add a CI workflow to replace the package path in some sample apps to make sure this is detected on Linux CI in future.

