### PR TITLE
CI: pin setup-dart for Linux workflow

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -30,4 +30,6 @@ runs:
         sudo apt-get install -y xvfb
         sudo apt-get install -y libosmesa6-dev
     - name: Set up Dart
-      uses: dart-lang/setup-dart@v1
+      # v1.8.x registers its problem matcher relative to this outer composite
+      # action and fails before Dart tests start. Pin the last known-good v1.7.2.
+      uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260


### PR DESCRIPTION
This PR pins the Linux composite build action to setup-dart v1.7.2 by immutable SHA.
