### PR TITLE
fix: pass camera setModelMatrix through by-value binding

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -19,374 +19,6 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 @ffi.Native<ffi.Uint64>()
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
-@ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TViewport View_getViewport(ffi.Pointer<TView> view);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createLinear(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createACES(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGX(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(ffi.Pointer<TEngine> tEngine, int look);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float, ffi.Float, ffi.Float)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
-  ffi.Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
-);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
-
-@ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
-
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
-external void ColorGradingBuilder_destroy(ffi.Pointer<TColorGradingBuilder> builder);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void ColorGrading_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TColorGrading> colorGrading);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void ColorGradingBuilder_quality(ffi.Pointer<TColorGradingBuilder> builder, int level);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void ColorGradingBuilder_format(ffi.Pointer<TColorGradingBuilder> builder, int format);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(isLeaf: true)
-external void ColorGradingBuilder_dimensions(ffi.Pointer<TColorGradingBuilder> builder, int dim);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ColorGradingBuilder_toneMapper(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  ffi.Pointer<TToneMapper> toneMapper,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_exposure(ffi.Pointer<TColorGradingBuilder> builder, double exposure);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_nightAdaptation(ffi.Pointer<TColorGradingBuilder> builder, double adaptation);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_whiteBalance(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double temperature,
-  double tint,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_contrast(ffi.Pointer<TColorGradingBuilder> builder, double contrast);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_vibrance(ffi.Pointer<TColorGradingBuilder> builder, double vibrance);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_saturation(ffi.Pointer<TColorGradingBuilder> builder, double saturation);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_channelMixer(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double outRedR,
-  double outRedG,
-  double outRedB,
-  double outGreenR,
-  double outGreenG,
-  double outGreenB,
-  double outBlueR,
-  double outBlueG,
-  double outBlueB,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_shadowsMidtonesHighlights(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double shadowsR,
-  double shadowsG,
-  double shadowsB,
-  double shadowsW,
-  double midtonesR,
-  double midtonesG,
-  double midtonesB,
-  double midtonesW,
-  double highlightsR,
-  double highlightsG,
-  double highlightsB,
-  double highlightsW,
-  double rangesX,
-  double rangesY,
-  double rangesZ,
-  double rangesW,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_slopeOffsetPower(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double slopeR,
-  double slopeG,
-  double slopeB,
-  double offsetR,
-  double offsetG,
-  double offsetB,
-  double powerR,
-  double powerG,
-  double powerB,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_curves(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double shadowGammaR,
-  double shadowGammaG,
-  double shadowGammaB,
-  double midPointR,
-  double midPointG,
-  double midPointB,
-  double highlightScaleR,
-  double highlightScaleG,
-  double highlightScaleB,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
-external void ColorGradingBuilder_luminanceScaling(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
-external void ColorGradingBuilder_gamutMapping(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void View_setColorGrading(ffi.Pointer<TView> tView, ffi.Pointer<TColorGrading> tColorGrading);
-
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TColorGrading> View_getColorGrading(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
-external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
-external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external void View_setRenderTarget(ffi.Pointer<TView> view, ffi.Pointer<TRenderTarget> renderTarget);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrustumCullingEnabled(ffi.Pointer<TView> view, bool enabled);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getVisibleRenderableCount(ffi.Pointer<TView> view);
-
-@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TRenderTarget> View_getRenderTarget(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
-external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getShadowType(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(isLeaf: true)
-external void View_setSoftShadowOptions(ffi.Pointer<TView> tView, TSoftShadowOptions options);
-
-@ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(isLeaf: true)
-external void View_setVsmShadowOptions(ffi.Pointer<TView> tView, TVsmShadowOptions options);
-
-@ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(isLeaf: true)
-external void View_setBloom(ffi.Pointer<TView> tView, bool enabled, double strength);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
-external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
-external void View_setAntiAliasing(ffi.Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(isLeaf: true)
-external void View_setLayerEnabled(ffi.Pointer<TView> tView, int layer, bool visible);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(isLeaf: true)
-external void View_setCamera(ffi.Pointer<TView> tView, ffi.Pointer<TCamera> tCamera);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setStencilBufferEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void View_setScene(ffi.Pointer<TView> tView, ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrontFaceWindingInverted(ffi.Pointer<TView> tView, bool inverted);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(isLeaf: true)
-external void View_setAmbientOcclusionOptions(ffi.Pointer<TView> tView, TAmbientOcclusionOptions options);
-
-@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
-external void View_setFogOptions(ffi.Pointer<TView> tView, TFogOptions tFogOptions);
-
-@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setTransparentPickingEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
-external void View_pick(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external void View_setName(ffi.Pointer<TView> tView, ffi.Pointer<ffi.Char> name);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(int t);
-
-@ffi.Native<
-  ffi.Pointer<TGizmo> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TView>,
-    ffi.Pointer<TMaterial>,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGizmo> Gizmo_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> assetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32, GizmoPickCallback)>(isLeaf: true)
-external void Gizmo_pick(ffi.Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
-
 @ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
 external ffi.Pointer<TMaterialInstance> Material_createInstance(ffi.Pointer<TMaterial> tMaterial);
 
@@ -593,279 +225,6 @@ external int MaterialInstance_getTransparencyMode(ffi.Pointer<TMaterialInstance>
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
 external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
-
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external void NameComponentManager_destroy(ffi.Pointer<TNameComponentManager> tNameComponentManager);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    Aabb3,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tVertexBuffer,
-  ffi.Pointer<TIndexBuffer> tIndexBuffer,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  int vertexBufferStorageMode,
-  Aabb3 boundingBox,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  int requiredGeometryCapabilities,
-);
-
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void SceneAsset_addToScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void SceneAsset_removeFromScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getChildEntities(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<EntityId> out);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(ffi.Pointer<TSceneAsset> tSceneAsset, int index);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
-  ffi.Pointer<TSceneAsset> asset,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getGeometryCapabilities(ffi.Pointer<TSceneAsset> asset);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool SceneAsset_supportsFlatShading(ffi.Pointer<TSceneAsset> asset);
-
-@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external int SceneAsset_getVertexBufferStorageMode(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-
-@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int SceneAsset_getPrimitiveOffsetForEntity(ffi.Pointer<TSceneAsset> tSceneAsset, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(ffi.Pointer<TSceneAsset> tSceneAsset, bool flatShading);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getBones(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex, ffi.Pointer<EntityId> out);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void Camera_setExposure(ffi.Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void Camera_getFrustum(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> out);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double, ffi.Bool)>(
-  isLeaf: true,
-)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(isLeaf: true)
-external void Camera_lookAt(ffi.Pointer<TCamera> camera, double3 eye, double3 focus, double3 up);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(ffi.Pointer<TCamera> camera, double focusDistance);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void Camera_setModelMatrix(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> tModelMatrix);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.UnsignedInt,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMeshData>)>(isLeaf: true)
-external void MeshData_dispose(ffi.Pointer<TMeshData> meshData);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Pointer<TMeshData>)>(
-  isLeaf: true,
-)
-external int GltfParser_parseBuffer(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> meshName,
-  ffi.Pointer<TMeshData> outMeshData,
-);
 
 @ffi.Native<
   ffi.Pointer<TTexture> Function(
@@ -1312,6 +671,341 @@ external bool DebugRegistry_getProperty_float(
   ffi.Pointer<ffi.Char> name,
   ffi.Pointer<ffi.Float> outValue,
 );
+
+@ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TViewport View_getViewport(ffi.Pointer<TView> view);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createLinear(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACES(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGX(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(ffi.Pointer<TEngine> tEngine, int look);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float, ffi.Float, ffi.Float)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
+  ffi.Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
+external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
+
+@ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
+
+@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
+external void ColorGradingBuilder_destroy(ffi.Pointer<TColorGradingBuilder> builder);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void ColorGrading_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TColorGrading> colorGrading);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_quality(ffi.Pointer<TColorGradingBuilder> builder, int level);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_format(ffi.Pointer<TColorGradingBuilder> builder, int format);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(isLeaf: true)
+external void ColorGradingBuilder_dimensions(ffi.Pointer<TColorGradingBuilder> builder, int dim);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
+external void ColorGradingBuilder_toneMapper(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  ffi.Pointer<TToneMapper> toneMapper,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_exposure(ffi.Pointer<TColorGradingBuilder> builder, double exposure);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_nightAdaptation(ffi.Pointer<TColorGradingBuilder> builder, double adaptation);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_whiteBalance(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double temperature,
+  double tint,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_contrast(ffi.Pointer<TColorGradingBuilder> builder, double contrast);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_vibrance(ffi.Pointer<TColorGradingBuilder> builder, double vibrance);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_saturation(ffi.Pointer<TColorGradingBuilder> builder, double saturation);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_channelMixer(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double outRedR,
+  double outRedG,
+  double outRedB,
+  double outGreenR,
+  double outGreenG,
+  double outGreenB,
+  double outBlueR,
+  double outBlueG,
+  double outBlueB,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_shadowsMidtonesHighlights(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double shadowsR,
+  double shadowsG,
+  double shadowsB,
+  double shadowsW,
+  double midtonesR,
+  double midtonesG,
+  double midtonesB,
+  double midtonesW,
+  double highlightsR,
+  double highlightsG,
+  double highlightsB,
+  double highlightsW,
+  double rangesX,
+  double rangesY,
+  double rangesZ,
+  double rangesW,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_slopeOffsetPower(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double slopeR,
+  double slopeG,
+  double slopeB,
+  double offsetR,
+  double offsetG,
+  double offsetB,
+  double powerR,
+  double powerG,
+  double powerB,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_curves(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double shadowGammaR,
+  double shadowGammaG,
+  double shadowGammaB,
+  double midPointR,
+  double midPointG,
+  double midPointB,
+  double highlightScaleR,
+  double highlightScaleG,
+  double highlightScaleB,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
+external void ColorGradingBuilder_luminanceScaling(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
+external void ColorGradingBuilder_gamutMapping(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void View_setColorGrading(ffi.Pointer<TView> tView, ffi.Pointer<TColorGrading> tColorGrading);
+
+@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TColorGrading> View_getColorGrading(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
+external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void View_setRenderTarget(ffi.Pointer<TView> view, ffi.Pointer<TRenderTarget> renderTarget);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrustumCullingEnabled(ffi.Pointer<TView> view, bool enabled);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TView>)>(isLeaf: true)
+external int View_getVisibleRenderableCount(ffi.Pointer<TView> view);
+
+@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TRenderTarget> View_getRenderTarget(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
+external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
+external int View_getShadowType(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(isLeaf: true)
+external void View_setSoftShadowOptions(ffi.Pointer<TView> tView, TSoftShadowOptions options);
+
+@ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(isLeaf: true)
+external void View_setVsmShadowOptions(ffi.Pointer<TView> tView, TVsmShadowOptions options);
+
+@ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(isLeaf: true)
+external void View_setBloom(ffi.Pointer<TView> tView, bool enabled, double strength);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
+external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void View_setAntiAliasing(ffi.Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(isLeaf: true)
+external void View_setLayerEnabled(ffi.Pointer<TView> tView, int layer, bool visible);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(isLeaf: true)
+external void View_setCamera(ffi.Pointer<TView> tView, ffi.Pointer<TCamera> tCamera);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setStencilBufferEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void View_setScene(ffi.Pointer<TView> tView, ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrontFaceWindingInverted(ffi.Pointer<TView> tView, bool inverted);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(isLeaf: true)
+external void View_setAmbientOcclusionOptions(ffi.Pointer<TView> tView, TAmbientOcclusionOptions options);
+
+@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
+external void View_setFogOptions(ffi.Pointer<TView> tView, TFogOptions tFogOptions);
+
+@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setTransparentPickingEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
+external void View_pick(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external void View_setName(ffi.Pointer<TView> tView, ffi.Pointer<ffi.Char> name);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
 
 @ffi.Native<
   ffi.Pointer<TMaterialInstance> Function(
@@ -3797,78 +3491,263 @@ external void LightManager_setShadowOptionsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    Aabb3,
   )
 >(isLeaf: true)
-external void Renderer_setClearOptions(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tVertexBuffer,
+  ffi.Pointer<TIndexBuffer> tIndexBuffer,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  int vertexBufferStorageMode,
+  Aabb3 boundingBox,
 );
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)>(isLeaf: true)
-external bool Renderer_beginFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
-external void Renderer_render(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
-external void Renderer_renderStandaloneView(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
     ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<TRenderTarget>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
   )
 >(isLeaf: true)
-external void Renderer_readPixels(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  int requiredGeometryCapabilities,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void Renderer_setFrameInterval(
-  ffi.Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void SceneAsset_addToScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void SceneAsset_removeFromScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getChildEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getChildEntities(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<EntityId> out);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getCameraEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getLightEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(ffi.Pointer<TSceneAsset> tSceneAsset, int index);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
+  ffi.Pointer<TSceneAsset> asset,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getGeometryCapabilities(ffi.Pointer<TSceneAsset> asset);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool SceneAsset_supportsFlatShading(ffi.Pointer<TSceneAsset> asset);
+
+@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external int SceneAsset_getVertexBufferStorageMode(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+
+@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
+external int SceneAsset_getPrimitiveOffsetForEntity(ffi.Pointer<TSceneAsset> tSceneAsset, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_releaseSourceData(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
+external void SceneAsset_setFlatShading(ffi.Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getBones(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex, ffi.Pointer<EntityId> out);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
+external int SceneAsset_getBoneCount(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMeshData>)>(isLeaf: true)
+external void MeshData_dispose(ffi.Pointer<TMeshData> meshData);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Pointer<TMeshData>)>(
+  isLeaf: true,
+)
+external int GltfParser_parseBuffer(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> meshName,
+  ffi.Pointer<TMeshData> outMeshData,
+);
+
+@ffi.Native<
+  ffi.Pointer<TGltfAssetLoader> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Pointer<TNameComponentManager>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external void GltfAssetLoader_destroy(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
+
+@ffi.Native<
+  ffi.Pointer<TFilamentAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+);
+
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, ffi.Pointer<TFilamentAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  ffi.Pointer<TFilamentAsset> tAsset,
+);
+
+@ffi.Native<ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getResourceUriCount(ffi.Pointer<TFilamentAsset> tFilamentAsset);
+
+@ffi.Native<ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(ffi.Pointer<TFilamentAsset> tFilamentAsset);
+
+@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+
+@ffi.Native<ffi.Void Function()>()
+external void FrameScheduler_stop();
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(int port, int targetFps);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_setTargetFps(int fps);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
+
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(int t);
+
+@ffi.Native<
+  ffi.Pointer<TGizmo> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TView>,
+    ffi.Pointer<TMaterial>,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TGizmo> Gizmo_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> assetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32, GizmoPickCallback)>(isLeaf: true)
+external void Gizmo_pick(ffi.Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
+external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
+
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external void NameComponentManager_destroy(ffi.Pointer<TNameComponentManager> tNameComponentManager);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
 );
 
 @ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(
@@ -3883,24 +3762,228 @@ external ffi.Pointer<TRenderTarget> RenderTarget_create(
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
 external void RenderTarget_destroy(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderTarget> tRenderTarget);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Skybox_setColor(ffi.Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+@ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TAnimationManager> AnimationManager_create(ffi.Pointer<TEngine> tEngine);
 
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void Skybox_setLayerMask(ffi.Pointer<TSkybox> tSkybox, int select, int values);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void AnimationManager_destroy(ffi.Pointer<TAnimationManager> tAnimationManager);
 
-/// Returns the visibility mask bits.
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external int Skybox_getLayerMask(ffi.Pointer<TSkybox> tSkybox);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(isLeaf: true)
+external void AnimationManager_update(ffi.Pointer<TAnimationManager> tAnimationManager, int frameTimeInNanos);
 
-/// Returns the skybox intensity in lux.
-@ffi.Native<ffi.Float Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external double Skybox_getIntensity(ffi.Pointer<TSkybox> tSkybox);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_addGltfAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
-/// Returns the environment texture, or nullptr for a color-only skybox.
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external ffi.Pointer<TTexture> Skybox_getTexture(ffi.Pointer<TSkybox> tSkybox);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_removeGltfAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+external void AnimationManager_addMorphAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+external void AnimationManager_removeMorphAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_addBoneAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_removeBoneAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Pointer<ffi.Uint32>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external bool AnimationManager_setMorphAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> morphData,
+  ffi.Pointer<ffi.Uint32> morphIndices,
+  int numMorphTargets,
+  int numFrames,
+  double frameLengthInMs,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+external bool AnimationManager_clearMorphAnimation(ffi.Pointer<TAnimationManager> tAnimationManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void AnimationManager_resetToRestPose(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external bool AnimationManager_addBoneAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+  ffi.Pointer<ffi.Float> frameData,
+  int numFrames,
+  double frameLengthInMs,
+  double fadeOutInSecs,
+  double fadeInInSecs,
+  double maxDelta,
+  bool loop,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)
+>(isLeaf: true)
+external void AnimationManager_getRestLocalTransforms(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int skinIndex,
+  ffi.Pointer<ffi.Float> out,
+  int numBones,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)
+>(isLeaf: true)
+external void AnimationManager_getInverseBindMatrix(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int skinIndex,
+  int boneIndex,
+  ffi.Pointer<ffi.Float> out,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external bool AnimationManager_playGltfAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int index,
+  bool loop,
+  bool reverse,
+  bool replaceActive,
+  double crossfade,
+  double startOffset,
+  double speed,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external bool AnimationManager_stopGltfAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int index,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external double AnimationManager_getGltfAnimationDuration(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int animationIndex,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int AnimationManager_getGltfAnimationCount(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Char>, ffi.Int)
+>(isLeaf: true)
+external void AnimationManager_getGltfAnimationName(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  ffi.Pointer<ffi.Char> outPtr,
+  int index,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
+external int AnimationManager_getMorphTargetNameCount(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int childEntity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId, ffi.Pointer<ffi.Char>, ffi.Int)
+>(isLeaf: true)
+external void AnimationManager_getMorphTargetName(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int childEntity,
+  ffi.Pointer<ffi.Char> outPtr,
+  int index,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_updateBoneMatrices(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
+external bool AnimationManager_setMorphTargetWeights(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> morphData,
+  int numWeights,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Float)>(
+  isLeaf: true,
+)
+external bool AnimationManager_setGltfAnimationTime(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int animationIndex,
+  double timeInSeconds,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
 external void RenderableManager_destroyEntity(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
@@ -4260,8 +4343,332 @@ external void RenderableBuilder_boneIndicesAndWeights(
 @ffi.Native<ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
 external int RenderableBuilder_build(ffi.Pointer<TRenderableBuilder> builder, ffi.Pointer<TEngine> engine, int entity);
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void Camera_setExposure(ffi.Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void Camera_getFrustum(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> out);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double, ffi.Bool)>(
+  isLeaf: true,
+)
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(isLeaf: true)
+external void Camera_lookAt(ffi.Pointer<TCamera> camera, double3 eye, double3 focus, double3 up);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(ffi.Pointer<TCamera> camera, double focusDistance);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void Camera_setModelMatrix(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> tModelMatrix);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.UnsignedInt,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(isLeaf: true)
+external void Scene_setSkybox(ffi.Pointer<TScene> tScene, ffi.Pointer<TSkybox> skybox);
+
+@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TScene>)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Scene_getSkybox(ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Scene_setIndirectLight(ffi.Pointer<TScene> tScene, ffi.Pointer<TIndirectLight> tIndirectLight);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external void Scene_addFilamentAsset(ffi.Pointer<TScene> tScene, ffi.Pointer<TFilamentAsset> asset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Skybox_setColor(ffi.Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void Skybox_setLayerMask(ffi.Pointer<TSkybox> tSkybox, int select, int values);
+
+/// Returns the visibility mask bits.
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external int Skybox_getLayerMask(ffi.Pointer<TSkybox> tSkybox);
+
+/// Returns the skybox intensity in lux.
+@ffi.Native<ffi.Float Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external double Skybox_getIntensity(ffi.Pointer<TSkybox> tSkybox);
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external ffi.Pointer<TTexture> Skybox_getTexture(ffi.Pointer<TSkybox> tSkybox);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void Renderer_setClearOptions(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)>(isLeaf: true)
+external bool Renderer_beginFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
+external void Renderer_render(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
+external void Renderer_renderStandaloneView(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<TRenderTarget>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void Renderer_readPixels(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void Renderer_setFrameInterval(
+  ffi.Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
 external void IndirectLight_setRotation(ffi.Pointer<TIndirectLight> tIndirectLight, ffi.Pointer<ffi.Double> rotation);
+
+@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_asyncBeginLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_asyncUpdateLoad(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external double GltfResourceLoader_asyncGetLoadProgress(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Uint8>, ffi.Size)
+>(isLeaf: true)
+external void GltfResourceLoader_addResourceData(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.Char> uri,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_loadResources(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void FilamentAsset_getEntities(ffi.Pointer<TFilamentAsset> filamentAsset, ffi.Pointer<EntityId> out);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<ffi.Pointer<TRenderManager> Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(isLeaf: true)
+external void RenderManager_render(ffi.Pointer<TRenderManager> tRenderer, int frameTimeInNanos);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)
+>(isLeaf: true)
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void RenderManager_removeSwapChain(ffi.Pointer<TRenderManager> tRenderer, ffi.Pointer<TSwapChain> swapChain);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_detachFromRenderThread(ffi.Pointer<TRenderManager> tRenderManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(isLeaf: true)
+external void RenderManager_setPaused(ffi.Pointer<TRenderManager> tRenderer, bool paused);
 
 @ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create();
@@ -4355,413 +4762,6 @@ external void SurfaceOrientation_getQuats_half4(
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
 external void SurfaceOrientation_destroy(ffi.Pointer<TSurfaceOrientation> orientation);
-
-@ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TAnimationManager> AnimationManager_create(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void AnimationManager_destroy(ffi.Pointer<TAnimationManager> tAnimationManager);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(isLeaf: true)
-external void AnimationManager_update(ffi.Pointer<TAnimationManager> tAnimationManager, int frameTimeInNanos);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_addGltfAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_removeGltfAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
-external void AnimationManager_addMorphAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
-external void AnimationManager_removeMorphAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_addBoneAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_removeBoneAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Pointer<ffi.Uint32>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Float,
-  )
->(isLeaf: true)
-external bool AnimationManager_setMorphAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> morphData,
-  ffi.Pointer<ffi.Uint32> morphIndices,
-  int numMorphTargets,
-  int numFrames,
-  double frameLengthInMs,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
-external bool AnimationManager_clearMorphAnimation(ffi.Pointer<TAnimationManager> tAnimationManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void AnimationManager_resetToRestPose(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external bool AnimationManager_addBoneAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-  ffi.Pointer<ffi.Float> frameData,
-  int numFrames,
-  double frameLengthInMs,
-  double fadeOutInSecs,
-  double fadeInInSecs,
-  double maxDelta,
-  bool loop,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)
->(isLeaf: true)
-external void AnimationManager_getRestLocalTransforms(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int skinIndex,
-  ffi.Pointer<ffi.Float> out,
-  int numBones,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)
->(isLeaf: true)
-external void AnimationManager_getInverseBindMatrix(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int skinIndex,
-  int boneIndex,
-  ffi.Pointer<ffi.Float> out,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external bool AnimationManager_playGltfAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int index,
-  bool loop,
-  bool reverse,
-  bool replaceActive,
-  double crossfade,
-  double startOffset,
-  double speed,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external bool AnimationManager_stopGltfAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int index,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external double AnimationManager_getGltfAnimationDuration(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int animationIndex,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int AnimationManager_getGltfAnimationCount(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Char>, ffi.Int)
->(isLeaf: true)
-external void AnimationManager_getGltfAnimationName(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  ffi.Pointer<ffi.Char> outPtr,
-  int index,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int AnimationManager_getMorphTargetNameCount(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int childEntity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId, ffi.Pointer<ffi.Char>, ffi.Int)
->(isLeaf: true)
-external void AnimationManager_getMorphTargetName(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int childEntity,
-  ffi.Pointer<ffi.Char> outPtr,
-  int index,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_updateBoneMatrices(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
-external bool AnimationManager_setMorphTargetWeights(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> morphData,
-  int numWeights,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Float)>(
-  isLeaf: true,
-)
-external bool AnimationManager_setGltfAnimationTime(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int animationIndex,
-  double timeInSeconds,
-);
-
-@ffi.Native<
-  ffi.Pointer<TGltfAssetLoader> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Pointer<TNameComponentManager>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external void GltfAssetLoader_destroy(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
-
-@ffi.Native<
-  ffi.Pointer<TFilamentAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int numInstances,
-);
-
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, ffi.Pointer<TFilamentAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  ffi.Pointer<TFilamentAsset> tAsset,
-);
-
-@ffi.Native<ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getResourceUriCount(ffi.Pointer<TFilamentAsset> tFilamentAsset);
-
-@ffi.Native<ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(ffi.Pointer<TFilamentAsset> tFilamentAsset);
-
-@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external bool GltfResourceLoader_asyncBeginLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoad(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external double GltfResourceLoader_asyncGetLoadProgress(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Uint8>, ffi.Size)
->(isLeaf: true)
-external void GltfResourceLoader_addResourceData(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.Char> uri,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external bool GltfResourceLoader_loadResources(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<TRenderManager> Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(isLeaf: true)
-external void RenderManager_render(ffi.Pointer<TRenderManager> tRenderer, int frameTimeInNanos);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)
->(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
-external void RenderManager_removeSwapChain(ffi.Pointer<TRenderManager> tRenderer, ffi.Pointer<TSwapChain> swapChain);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_detachFromRenderThread(ffi.Pointer<TRenderManager> tRenderManager);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(isLeaf: true)
-external void RenderManager_setPaused(ffi.Pointer<TRenderManager> tRenderer, bool paused);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(ffi.Pointer<TFilamentAsset> filamentAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void FilamentAsset_getEntities(ffi.Pointer<TFilamentAsset> filamentAsset, ffi.Pointer<EntityId> out);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(ffi.Pointer<TFilamentAsset> filamentAsset);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(ffi.Pointer<TFilamentAsset> filamentAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(isLeaf: true)
-external void Scene_setSkybox(ffi.Pointer<TScene> tScene, ffi.Pointer<TSkybox> skybox);
-
-@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TScene>)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Scene_getSkybox(ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Scene_setIndirectLight(ffi.Pointer<TScene> tScene, ffi.Pointer<TIndirectLight> tIndirectLight);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external void Scene_addFilamentAsset(ffi.Pointer<TScene> tScene, ffi.Pointer<TFilamentAsset> asset);
-
-@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-
-@ffi.Native<ffi.Void Function()>()
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(int port, int targetFps);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_setTargetFps(int fps);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
 external void MovementIntentExecutor_destroy(ffi.Pointer<TMovementIntentExecutor> executor);
@@ -5115,296 +5115,6 @@ sealed class TIndexType {
   static const TINDEX_TYPE_UINT = 1;
 }
 
-final class TViewport extends ffi.Struct {
-  @ffi.Int32()
-  external int left;
-
-  @ffi.Int32()
-  external int bottom;
-
-  @ffi.Uint32()
-  external int width;
-
-  @ffi.Uint32()
-  external int height;
-}
-
-/// Copied from FogOptions in View.h
-final class TFogOptions extends ffi.Struct {
-  @ffi.Float()
-  external double distance;
-
-  @ffi.Float()
-  external double cutOffDistance;
-
-  @ffi.Float()
-  external double maximumOpacity;
-
-  @ffi.Float()
-  external double height;
-
-  @ffi.Float()
-  external double heightFalloff;
-
-  @ffi.Float()
-  external double density;
-
-  @ffi.Float()
-  external double inScatteringStart;
-
-  @ffi.Float()
-  external double inScatteringSize;
-
-  external ffi.Pointer<TTexture> skyColor;
-
-  @ffi.Float()
-  external double linearColorR;
-
-  @ffi.Float()
-  external double linearColorG;
-
-  @ffi.Float()
-  external double linearColorB;
-
-  @ffi.Bool()
-  external bool fogColorFromIbl;
-
-  @ffi.Bool()
-  external bool enabled;
-}
-
-final class TToneMapper extends ffi.Opaque {}
-
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
-}
-
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
-}
-
-sealed class TLutFormat {
-  static const INTEGER = 0;
-  static const FLOAT = 1;
-}
-
-final class TColorGradingBuilder extends ffi.Opaque {}
-
-/// Options for DPCF and PCSS Shadowing.
-final class TSoftShadowOptions extends ffi.Struct {
-  @ffi.Float()
-  external double penumbraScale;
-
-  @ffi.Float()
-  external double penumbraRatioScale;
-
-  @ffi.Float()
-  external double maxPenumbraRatio;
-
-  @ffi.Float()
-  external double maxSearchRadius;
-}
-
-/// Options for VSM Shadowing.
-final class TVsmShadowOptions extends ffi.Struct {
-  @ffi.Uint8()
-  external int anisotropy;
-
-  @ffi.Bool()
-  external bool mipmapping;
-
-  @ffi.Uint8()
-  external int msaaSamples;
-
-  @ffi.Bool()
-  external bool highPrecision;
-
-  @ffi.Float()
-  external double minVarianceScale;
-
-  @ffi.Float()
-  external double lightBleedReduction;
-}
-
-/// Screen Space Cone Tracing (SSCT) options
-/// Ambient shadows from dominant light
-final class TSsct extends ffi.Struct {
-  /// !< full cone angle in radian, between 0 and pi/2
-  @ffi.Float()
-  external double lightConeRad;
-
-  /// !< how far shadows can be cast
-  @ffi.Float()
-  external double shadowDistance;
-
-  /// !< max distance for contact
-  @ffi.Float()
-  external double contactDistanceMax;
-
-  /// !< intensity
-  @ffi.Float()
-  external double intensity;
-
-  /// !< light direction X
-  @ffi.Float()
-  external double lightDirectionX;
-
-  /// !< light direction Y
-  @ffi.Float()
-  external double lightDirectionY;
-
-  /// !< light direction Z
-  @ffi.Float()
-  external double lightDirectionZ;
-
-  /// !< depth bias in world units (mitigate self shadowing)
-  @ffi.Float()
-  external double depthBias;
-
-  /// !< depth slope bias (mitigate self shadowing)
-  @ffi.Float()
-  external double depthSlopeBias;
-
-  /// !< tracing sample count, between 1 and 255
-  @ffi.Uint8()
-  external int sampleCount;
-
-  /// !< # of rays to trace, between 1 and 255
-  @ffi.Uint8()
-  external int rayCount;
-
-  /// !< enables or disables SSCT
-  @ffi.Bool()
-  external bool enabled;
-}
-
-sealed class TAmbientOcclusionType {
-  static const SAO = 0;
-  static const GTAO = 1;
-}
-
-/// Ground Truth-based Ambient Occlusion (GTAO) options
-final class TGtao extends ffi.Struct {
-  /// !< number of slices; higher values reduce noise
-  @ffi.Uint8()
-  external int sampleSliceCount;
-
-  /// !< integration steps per slice; higher values reduce bias
-  @ffi.Uint8()
-  external int sampleStepsPerSlice;
-
-  /// !< ignored when visibility bitmasks are enabled
-  @ffi.Float()
-  external double thicknessHeuristic;
-
-  /// !< enables visibility bitmasks mode
-  @ffi.Bool()
-  external bool useVisibilityBitmasks;
-
-  /// !< world-space thickness used by visibility bitmasks
-  @ffi.Float()
-  external double constThickness;
-
-  /// !< increases thickness with distance
-  @ffi.Bool()
-  external bool linearThickness;
-}
-
-/// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
-final class TAmbientOcclusionOptions extends ffi.Struct {
-  /// !< Ambient Occlusion radius in meters, between 0 and ~10
-  @ffi.Float()
-  external double radius;
-
-  /// !< Controls ambient occlusion's contrast. Must be positive
-  @ffi.Float()
-  external double power;
-
-  /// !< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm
-  @ffi.Float()
-  external double bias;
-
-  /// !< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0
-  @ffi.Float()
-  external double resolution;
-
-  /// !< Strength of the Ambient Occlusion effect
-  @ffi.Float()
-  external double intensity;
-
-  /// !< depth distance that constitute an edge for filtering
-  @ffi.Float()
-  external double bilateralThreshold;
-
-  /// !< affects # of samples used for AO
-  @ffi.UnsignedInt()
-  external int quality;
-
-  /// !< affects AO smoothness
-  @ffi.UnsignedInt()
-  external int lowPassFilter;
-
-  /// !< affects AO buffer upsampling quality
-  @ffi.UnsignedInt()
-  external int upsampling;
-
-  /// !< enables or disables screen-space ambient occlusion
-  @ffi.Bool()
-  external bool enabled;
-
-  /// !< enables bent normals computation from AO, and specular AO
-  @ffi.Bool()
-  external bool bentNormals;
-
-  /// !< min angle in radian to consider
-  @ffi.Float()
-  external double minHorizonAngleRad;
-
-  external TSsct ssct;
-
-  external TGtao gtao;
-
-  /// !< ambient occlusion algorithm
-  @ffi.UnsignedInt()
-  external int aoType;
-}
-
-typedef PickCallbackFunction =
-    ffi.Void Function(
-      ffi.Uint32 requestId,
-      EntityId entityId,
-      ffi.Float depth,
-      ffi.Float fragX,
-      ffi.Float fragY,
-      ffi.Float fragZ,
-    );
-typedef DartPickCallbackFunction =
-    void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
-typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-typedef GizmoPickCallbackFunction =
-    ffi.Void Function(ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef GizmoPickCallback = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
-
 sealed class TSamplerCompareFunc {
   /// !< Less or equal
   static const LE = 0;
@@ -5478,40 +5188,6 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_MULTIPLY = 5;
   static const BLENDING_MODE_SCREEN = 6;
   static const BLENDING_MODE_CUSTOM = 7;
-}
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-final class TMeshData extends ffi.Struct {
-  external ffi.Pointer<ffi.Char> name;
-
-  external ffi.Pointer<ffi.Char> materialName;
-
-  external ffi.Pointer<ffi.Float> vertices;
-
-  @ffi.Int()
-  external int vertexCount;
-
-  external ffi.Pointer<ffi.Float> normals;
-
-  @ffi.Int()
-  external int normalCount;
-
-  external ffi.Pointer<ffi.Float> uvs;
-
-  @ffi.Int()
-  external int uvCount;
-
-  external ffi.Pointer<ffi.Uint32> indices;
-
-  @ffi.Int()
-  external int indexCount;
-
-  @ffi.UnsignedInt()
-  external int primitiveType;
 }
 
 sealed class TTextureSamplerType {
@@ -5787,6 +5463,277 @@ sealed class TBackend {
   static const BACKEND_NOOP = 4;
 }
 
+final class TViewport extends ffi.Struct {
+  @ffi.Int32()
+  external int left;
+
+  @ffi.Int32()
+  external int bottom;
+
+  @ffi.Uint32()
+  external int width;
+
+  @ffi.Uint32()
+  external int height;
+}
+
+/// Copied from FogOptions in View.h
+final class TFogOptions extends ffi.Struct {
+  @ffi.Float()
+  external double distance;
+
+  @ffi.Float()
+  external double cutOffDistance;
+
+  @ffi.Float()
+  external double maximumOpacity;
+
+  @ffi.Float()
+  external double height;
+
+  @ffi.Float()
+  external double heightFalloff;
+
+  @ffi.Float()
+  external double density;
+
+  @ffi.Float()
+  external double inScatteringStart;
+
+  @ffi.Float()
+  external double inScatteringSize;
+
+  external ffi.Pointer<TTexture> skyColor;
+
+  @ffi.Float()
+  external double linearColorR;
+
+  @ffi.Float()
+  external double linearColorG;
+
+  @ffi.Float()
+  external double linearColorB;
+
+  @ffi.Bool()
+  external bool fogColorFromIbl;
+
+  @ffi.Bool()
+  external bool enabled;
+}
+
+final class TToneMapper extends ffi.Opaque {}
+
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
+}
+
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
+}
+
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
+}
+
+final class TColorGradingBuilder extends ffi.Opaque {}
+
+/// Options for DPCF and PCSS Shadowing.
+final class TSoftShadowOptions extends ffi.Struct {
+  @ffi.Float()
+  external double penumbraScale;
+
+  @ffi.Float()
+  external double penumbraRatioScale;
+
+  @ffi.Float()
+  external double maxPenumbraRatio;
+
+  @ffi.Float()
+  external double maxSearchRadius;
+}
+
+/// Options for VSM Shadowing.
+final class TVsmShadowOptions extends ffi.Struct {
+  @ffi.Uint8()
+  external int anisotropy;
+
+  @ffi.Bool()
+  external bool mipmapping;
+
+  @ffi.Uint8()
+  external int msaaSamples;
+
+  @ffi.Bool()
+  external bool highPrecision;
+
+  @ffi.Float()
+  external double minVarianceScale;
+
+  @ffi.Float()
+  external double lightBleedReduction;
+}
+
+/// Screen Space Cone Tracing (SSCT) options
+/// Ambient shadows from dominant light
+final class TSsct extends ffi.Struct {
+  /// !< full cone angle in radian, between 0 and pi/2
+  @ffi.Float()
+  external double lightConeRad;
+
+  /// !< how far shadows can be cast
+  @ffi.Float()
+  external double shadowDistance;
+
+  /// !< max distance for contact
+  @ffi.Float()
+  external double contactDistanceMax;
+
+  /// !< intensity
+  @ffi.Float()
+  external double intensity;
+
+  /// !< light direction X
+  @ffi.Float()
+  external double lightDirectionX;
+
+  /// !< light direction Y
+  @ffi.Float()
+  external double lightDirectionY;
+
+  /// !< light direction Z
+  @ffi.Float()
+  external double lightDirectionZ;
+
+  /// !< depth bias in world units (mitigate self shadowing)
+  @ffi.Float()
+  external double depthBias;
+
+  /// !< depth slope bias (mitigate self shadowing)
+  @ffi.Float()
+  external double depthSlopeBias;
+
+  /// !< tracing sample count, between 1 and 255
+  @ffi.Uint8()
+  external int sampleCount;
+
+  /// !< # of rays to trace, between 1 and 255
+  @ffi.Uint8()
+  external int rayCount;
+
+  /// !< enables or disables SSCT
+  @ffi.Bool()
+  external bool enabled;
+}
+
+sealed class TAmbientOcclusionType {
+  static const SAO = 0;
+  static const GTAO = 1;
+}
+
+/// Ground Truth-based Ambient Occlusion (GTAO) options
+final class TGtao extends ffi.Struct {
+  /// !< number of slices; higher values reduce noise
+  @ffi.Uint8()
+  external int sampleSliceCount;
+
+  /// !< integration steps per slice; higher values reduce bias
+  @ffi.Uint8()
+  external int sampleStepsPerSlice;
+
+  /// !< ignored when visibility bitmasks are enabled
+  @ffi.Float()
+  external double thicknessHeuristic;
+
+  /// !< enables visibility bitmasks mode
+  @ffi.Bool()
+  external bool useVisibilityBitmasks;
+
+  /// !< world-space thickness used by visibility bitmasks
+  @ffi.Float()
+  external double constThickness;
+
+  /// !< increases thickness with distance
+  @ffi.Bool()
+  external bool linearThickness;
+}
+
+/// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
+final class TAmbientOcclusionOptions extends ffi.Struct {
+  /// !< Ambient Occlusion radius in meters, between 0 and ~10
+  @ffi.Float()
+  external double radius;
+
+  /// !< Controls ambient occlusion's contrast. Must be positive
+  @ffi.Float()
+  external double power;
+
+  /// !< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm
+  @ffi.Float()
+  external double bias;
+
+  /// !< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0
+  @ffi.Float()
+  external double resolution;
+
+  /// !< Strength of the Ambient Occlusion effect
+  @ffi.Float()
+  external double intensity;
+
+  /// !< depth distance that constitute an edge for filtering
+  @ffi.Float()
+  external double bilateralThreshold;
+
+  /// !< affects # of samples used for AO
+  @ffi.UnsignedInt()
+  external int quality;
+
+  /// !< affects AO smoothness
+  @ffi.UnsignedInt()
+  external int lowPassFilter;
+
+  /// !< affects AO buffer upsampling quality
+  @ffi.UnsignedInt()
+  external int upsampling;
+
+  /// !< enables or disables screen-space ambient occlusion
+  @ffi.Bool()
+  external bool enabled;
+
+  /// !< enables bent normals computation from AO, and specular AO
+  @ffi.Bool()
+  external bool bentNormals;
+
+  /// !< min angle in radian to consider
+  @ffi.Float()
+  external double minHorizonAngleRad;
+
+  external TSsct ssct;
+
+  external TGtao gtao;
+
+  /// !< ambient occlusion algorithm
+  @ffi.UnsignedInt()
+  external int aoType;
+}
+
+typedef PickCallbackFunction =
+    ffi.Void Function(
+      ffi.Uint32 requestId,
+      EntityId entityId,
+      ffi.Float depth,
+      ffi.Float fragX,
+      ffi.Float fragY,
+      ffi.Float fragZ,
+    );
+typedef DartPickCallbackFunction =
+    void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
+typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
+
 sealed class TLightType {
   static const LIGHT_TYPE_SUN = 0;
   static const LIGHT_TYPE_DIRECTIONAL = 1;
@@ -5878,9 +5825,63 @@ final class TShadowOptions extends ffi.Struct {
 typedef FilamentRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> owner);
 typedef DartFilamentRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> owner);
 typedef FilamentRenderCallback = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+
+final class TMeshData extends ffi.Struct {
+  external ffi.Pointer<ffi.Char> name;
+
+  external ffi.Pointer<ffi.Char> materialName;
+
+  external ffi.Pointer<ffi.Float> vertices;
+
+  @ffi.Int()
+  external int vertexCount;
+
+  external ffi.Pointer<ffi.Float> normals;
+
+  @ffi.Int()
+  external int normalCount;
+
+  external ffi.Pointer<ffi.Float> uvs;
+
+  @ffi.Int()
+  external int uvCount;
+
+  external ffi.Pointer<ffi.Uint32> indices;
+
+  @ffi.Int()
+  external int indexCount;
+
+  @ffi.UnsignedInt()
+  external int primitiveType;
+}
+
 typedef FrameTickCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
 typedef DartFrameTickCallbackFunction = void Function(int frameTimeNanos);
 typedef FrameTickCallback = ffi.Pointer<ffi.NativeFunction<FrameTickCallbackFunction>>;
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+typedef GizmoPickCallbackFunction =
+    ffi.Void Function(ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+typedef GizmoPickCallback = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
 
 final class TMovementIntentCalculator extends ffi.Opaque {}
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -19,116 +19,67 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 @ffi.Native<ffi.Uint64>()
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
-    isLeaf: true)
-external ffi.Pointer<TMaterialInstance> Material_createInstance(
-  ffi.Pointer<TMaterial> tMaterial,
-);
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> Material_createInstance(ffi.Pointer<TMaterial> tMaterial);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getFeatureLevel(
-  ffi.Pointer<TMaterial> tMaterial,
-);
+external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createImageMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TMaterial> Material_createImageMaterial(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createGridMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TMaterial> Material_createGridMaterial(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createGizmoMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TMaterial> Material_createGizmoMaterial(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createSilhouetteMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TMaterial> Material_createSilhouetteMaterial(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createEdgeOutlineMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TMaterial> Material_createEdgeOutlineMaterial(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createWireframeMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TMaterial> Material_createWireframeMaterial(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createTranslationAxisMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TMaterial> Material_createTranslationAxisMaterial(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(
-  ffi.Pointer<TEngine> tEngine,
-);
+external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(
-    isLeaf: true)
-external bool Material_hasParameter(
-  ffi.Pointer<TMaterial> tMaterial,
-  ffi.Pointer<ffi.Char> propertyName,
-);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external bool Material_hasParameter(ffi.Pointer<TMaterial> tMaterial, ffi.Pointer<ffi.Char> propertyName);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external bool MaterialInstance_isStencilWriteEnabled(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-);
+external bool MaterialInstance_isStencilWriteEnabled(ffi.Pointer<TMaterialInstance> materialInstance);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-    isLeaf: true)
-external void MaterialInstance_setStencilWrite(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
+external void MaterialInstance_setStencilWrite(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void MaterialInstance_setCullingMode(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int culling,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
+external void MaterialInstance_setCullingMode(ffi.Pointer<TMaterialInstance> materialInstance, int culling);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-    isLeaf: true)
-external void MaterialInstance_setDoubleSided(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  bool doubleSided,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
+external void MaterialInstance_setDoubleSided(ffi.Pointer<TMaterialInstance> materialInstance, bool doubleSided);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-    isLeaf: true)
-external void MaterialInstance_setDepthWrite(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
+external void MaterialInstance_setDepthWrite(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
-    isLeaf: true)
-external void MaterialInstance_setDepthCulling(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  bool enabled,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
+external void MaterialInstance_setDepthCulling(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Double)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
   double value,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Double, ffi.Double)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Double, ffi.Double)>(
+  isLeaf: true,
+)
 external void MaterialInstance_setParameterFloat2(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -137,8 +88,8 @@ external void MaterialInstance_setParameterFloat2(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Double, ffi.Double, ffi.Double)
+>(isLeaf: true)
 external void MaterialInstance_setParameterFloat3(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -148,8 +99,8 @@ external void MaterialInstance_setParameterFloat3(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Double>, ffi.Uint32)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Double>, ffi.Uint32)
+>(isLeaf: true)
 external void MaterialInstance_setParameterFloat3Array(
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -158,8 +109,15 @@ external void MaterialInstance_setParameterFloat3Array(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterFloat4(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -169,36 +127,32 @@ external void MaterialInstance_setParameterFloat4(
   double z,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Double>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Double>)>(
+  isLeaf: true,
+)
 external void MaterialInstance_setParameterMat3(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
   ffi.Pointer<ffi.Double> matrix,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Double>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Double>)>(
+  isLeaf: true,
+)
 external void MaterialInstance_setParameterMat4(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
   ffi.Pointer<ffi.Double> matrix,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Int)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
 external void MaterialInstance_setParameterInt(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
   int value,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Bool)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
 external void MaterialInstance_setParameterBool(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -206,8 +160,13 @@ external void MaterialInstance_setParameterBool(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTextureSampler>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTextureSampler>,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterTexture(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -215,542 +174,531 @@ external void MaterialInstance_setParameterTexture(
   ffi.Pointer<TTextureSampler> sampler,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void MaterialInstance_setDepthFunc(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int depthFunc,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
+external void MaterialInstance_setDepthFunc(ffi.Pointer<TMaterialInstance> materialInstance, int depthFunc);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilOpStencilFail(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
   int face,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
-external void MaterialInstance_setStencilOpDepthFail(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int op,
-  int face,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external void MaterialInstance_setStencilOpDepthFail(ffi.Pointer<TMaterialInstance> materialInstance, int op, int face);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilOpDepthStencilPass(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
   int face,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilCompareFunction(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int func,
   int face,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8,
-        ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8, ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilReferenceValue(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int value,
   int face,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
-    isLeaf: true)
-external void MaterialInstance_setStencilReadMask(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int mask,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(isLeaf: true)
+external void MaterialInstance_setStencilReadMask(ffi.Pointer<TMaterialInstance> materialInstance, int mask);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
-    isLeaf: true)
-external void MaterialInstance_setStencilWriteMask(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  int mask,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(isLeaf: true)
+external void MaterialInstance_setStencilWriteMask(ffi.Pointer<TMaterialInstance> materialInstance, int mask);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
-    isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setTransparencyMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int transparencyMode,
 );
 
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(
-    isLeaf: true)
-external int MaterialInstance_getTransparencyMode(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-);
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external int MaterialInstance_getTransparencyMode(ffi.Pointer<TMaterialInstance> materialInstance);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getBlendingMode(
-  ffi.Pointer<TMaterial> material,
-);
+external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
 
 @ffi.Native<
-    ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>,
-        ffi.UnsignedInt)>(isLeaf: true)
-external int LightManager_createLight(
+  ffi.Pointer<TTexture> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint8,
+    ffi.Uint16,
+    ffi.IntPtr,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TTexture> Texture_build(
+  ffi.Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import$,
+  int sampler,
+  int format,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void Texture_setExternalImage(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<ffi.Void> externalImage,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external void LightManager_destroyLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_hasComponent(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external int LightManager_getType(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isDirectional(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isPointLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isSpotLight(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
+@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
+external int Texture_getLevels(ffi.Pointer<TTexture> tTexture);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double3 LightManager_getColor(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityCandela(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getIntensity(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double falloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSpotLightOuterCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSpotLightInnerCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloSize,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunHaloSize(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
-    isLeaf: true)
-external void LightManager_setSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double haloFalloff,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external double LightManager_getSunHaloFalloff(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
-    isLeaf: true)
-external void LightManager_setShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external bool LightManager_isShadowCaster(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-);
-
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
-    isLeaf: true)
-external TShadowOptions LightManager_getShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt,
-        ffi.Bool)>(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
-external bool LightManager_getLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float,
-        ffi.Float)>(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
-    isLeaf: true)
-external double LightManager_rgbToColorTemperature(
-  double r,
-  double g,
-  double b,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void FilamentAsset_getEntities(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-  ffi.Pointer<EntityId> out,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
-  ffi.Pointer<TFilamentAsset> filamentAsset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TGltfAssetLoader> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Bool Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TLinearImage>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Int,
+  )
+>(isLeaf: true)
+external bool Texture_loadImage(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external void GltfAssetLoader_destroy(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
 );
 
 @ffi.Native<
-    ffi.Pointer<TFilamentAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32)>(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Bool Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Uint32,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external bool Texture_setImage(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
+external int Texture_getWidth(ffi.Pointer<TTexture> tTexture, int level);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
+external int Texture_getHeight(ffi.Pointer<TTexture> tTexture, int level);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
+external int Texture_getDepth(ffi.Pointer<TTexture> tTexture, int level);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>)>(isLeaf: true)
+external int Texture_getFormat(ffi.Pointer<TTexture> tTexture);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
+external int Texture_getUsage(ffi.Pointer<TTexture> tTexture, int level);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Texture_generateMipMaps(ffi.Pointer<TTexture> tTexture, ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TKtx1Bundle> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(ffi.Pointer<ffi.Uint8> ktxData, int length);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void Ktx1Bundle_getSphericalHarmonics(ffi.Pointer<TKtx1Bundle> tBundle, ffi.Pointer<ffi.Float> harmonics);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external bool Ktx1Bundle_isCubemap(ffi.Pointer<TKtx1Bundle> tBundle);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external void Ktx1Bundle_destroy(ffi.Pointer<TKtx1Bundle> tBundle);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>, ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  VoidCallback onTextureUploadComplete,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+);
+
+@ffi.Native<ffi.Pointer<TLinearImage> Function(ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+external ffi.Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel);
+
+@ffi.Native<ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Bool)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TLinearImage> Image_decode(
   ffi.Pointer<ffi.Uint8> data,
   int length,
-  int numInstances,
+  ffi.Pointer<ffi.Char> name,
+  bool alpha,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external ffi.Pointer<ffi.Float> Image_getBytes(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external void Image_destroy(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getWidth(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getHeight(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getChannels(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getColorTexture(ffi.Pointer<TRenderTarget> tRenderTarget);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(ffi.Pointer<TRenderTarget> tRenderTarget);
+
+@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_create();
+
+@ffi.Native<
+  ffi.Pointer<TTextureSampler> Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+);
+
+@ffi.Native<ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setMinFilter(ffi.Pointer<TTextureSampler> sampler, int filter);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setMagFilter(ffi.Pointer<TTextureSampler> sampler, int filter);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setWrapModeS(ffi.Pointer<TTextureSampler> sampler, int mode);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setWrapModeT(ffi.Pointer<TTextureSampler> sampler, int mode);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setWrapModeR(ffi.Pointer<TTextureSampler> sampler, int mode);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(isLeaf: true)
+external void TextureSampler_setAnisotropy(ffi.Pointer<TTextureSampler> sampler, double anisotropy);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setCompareMode(ffi.Pointer<TTextureSampler> sampler, int mode, int func);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
+external void TextureSampler_destroy(ffi.Pointer<TTextureSampler> sampler);
+
+@ffi.Native<
+  ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)
+>(isLeaf: true)
+external ffi.Pointer<TEngine> Engine_create(
+  int backend,
+  ffi.Pointer<ffi.Void> platform,
+  ffi.Pointer<ffi.Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getSupportedFeatureLevel(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_destroy(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TRenderer> Engine_createRenderer(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Engine_destroyRenderer(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderer> tRenderer);
+
+@ffi.Native<ffi.Pointer<TSwapChain> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Void> window,
+  int flags,
+);
+
+@ffi.Native<ffi.Pointer<TSwapChain> Function(ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  int flags,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void Engine_destroySwapChain(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TSwapChain> tSwapChain);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(isLeaf: true)
+external void Engine_destroyView(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void Engine_destroyScene(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void Engine_destroyColorGrading(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TColorGrading> tColorGrading);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
+external ffi.Pointer<TCamera> Engine_createCamera(ffi.Pointer<TEngine> tEngine, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(isLeaf: true)
+external void Engine_destroyCamera(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TCamera> tCamera);
+
+@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TView> Engine_createView(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
+external ffi.Pointer<TCamera> Engine_getCameraComponent(ffi.Pointer<TEngine> tEngine, int entityId);
+
+@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TTransformManager> Engine_getTransformManager(ffi.Pointer<TEngine> engine);
+
+@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(ffi.Pointer<TEngine> engine);
+
+@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TLightManager> Engine_getLightManager(ffi.Pointer<TEngine> engine);
+
+@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TEntityManager> Engine_getEntityManager(ffi.Pointer<TEngine> engine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
+external void Engine_setAutomaticInstancingEnabled(ffi.Pointer<TEngine> tEngine, bool enabled);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getMaxAutomaticInstances(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external void Engine_destroyTexture(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TTexture> tTexture);
+
+@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TFence> Engine_createFence(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(isLeaf: true)
+external void Engine_destroyFence(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TFence> tFence);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_flushAndWait(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_execute(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Engine_buildMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> materialData,
+  int length,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(isLeaf: true)
+external void Engine_destroyMaterial(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TMaterial> tMaterial);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void Engine_destroyMaterialInstance(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TScene> Engine_createScene(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Bool, ffi.Float, ffi.Uint8)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TSkybox> Engine_buildSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
 );
 
 @ffi.Native<
-    ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>,
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  ffi.Pointer<TFilamentAsset> tAsset,
+  ffi.Pointer<TSkybox> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
 );
 
 @ffi.Native<
-    ffi.Pointer<TMaterialProvider> Function(
-        ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getResourceUriCount(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)
+>(isLeaf: true)
+external ffi.Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<TTexture> tIrradianceTexture,
+  double intensity,
 );
 
 @ffi.Native<
-    ffi.Pointer<ffi.Pointer<ffi.Char>> Function(
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)
+>(isLeaf: true)
+external ffi.Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<ffi.Float> irradianceHarmonics,
+  double intensity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(isLeaf: true)
+external void Engine_destroySkybox(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TSkybox> tSkybox);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Engine_destroyIndirectLight(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TIndirectLight> tIndirectLight);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
+external int EntityManager_createEntity(ffi.Pointer<TEntityManager> tEntityManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(isLeaf: true)
+external void EntityManager_destroyEntity(ffi.Pointer<TEntityManager> tEntityManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
+external void Fence_waitAndDestroy(ffi.Pointer<TFence> tFence);
+
+@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external bool DebugRegistry_hasProperty(ffi.Pointer<TDebugRegistry> tDebugRegistry, ffi.Pointer<ffi.Char> name);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
+external bool DebugRegistry_setProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  bool value,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
+external bool DebugRegistry_setProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  int value,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Float)>(isLeaf: true)
+external bool DebugRegistry_setProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  double value,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Bool>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Bool> outValue,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Int> outValue,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Float> outValue,
 );
 
 @ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TViewport View_getViewport(
-  ffi.Pointer<TView> view,
-);
+external TViewport View_getViewport(ffi.Pointer<TView> view);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createLinear(
-  ffi.Pointer<TEngine> tEngine,
-);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createLinear(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createACES(
-  ffi.Pointer<TEngine> tEngine,
-);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACES(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(
-  ffi.Pointer<TEngine> tEngine,
-);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(
-  ffi.Pointer<TEngine> tEngine,
-);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(
-  ffi.Pointer<TEngine> tEngine,
-);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGX(
-  ffi.Pointer<TEngine> tEngine,
-);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGX(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(
-    isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(
-  ffi.Pointer<TEngine> tEngine,
-  int look,
-);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(ffi.Pointer<TEngine> tEngine, int look);
 
-@ffi.Native<
-    ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float,
-        ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float, ffi.Float, ffi.Float)>(
+  isLeaf: true,
+)
 external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
   ffi.Pointer<TEngine> tEngine,
   double contrast,
@@ -759,128 +707,78 @@ external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
   double hdrMax,
 );
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(
-  ffi.Pointer<TEngine> tEngine,
-);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ToneMapper_destroy(
-  ffi.Pointer<TToneMapper> toneMapper,
-);
+external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
 
 @ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
 
-@ffi.Native<
-    ffi.Pointer<TColorGrading> Function(
-        ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
   ffi.Pointer<TColorGradingBuilder> builder,
   ffi.Pointer<TEngine> engine,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
-external void ColorGradingBuilder_destroy(
-  ffi.Pointer<TColorGradingBuilder> builder,
-);
+external void ColorGradingBuilder_destroy(ffi.Pointer<TColorGradingBuilder> builder);
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void ColorGrading_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TColorGrading> colorGrading,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void ColorGrading_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TColorGrading> colorGrading);
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void ColorGradingBuilder_quality(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int level,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_quality(ffi.Pointer<TColorGradingBuilder> builder, int level);
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void ColorGradingBuilder_format(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int format,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_format(ffi.Pointer<TColorGradingBuilder> builder, int format);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(
-    isLeaf: true)
-external void ColorGradingBuilder_dimensions(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  int dim,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(isLeaf: true)
+external void ColorGradingBuilder_dimensions(ffi.Pointer<TColorGradingBuilder> builder, int dim);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TColorGradingBuilder>,
-        ffi.Pointer<TToneMapper>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
 external void ColorGradingBuilder_toneMapper(
   ffi.Pointer<TColorGradingBuilder> builder,
   ffi.Pointer<TToneMapper> toneMapper,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
-external void ColorGradingBuilder_exposure(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double exposure,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_exposure(ffi.Pointer<TColorGradingBuilder> builder, double exposure);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
-external void ColorGradingBuilder_nightAdaptation(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double adaptation,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_nightAdaptation(ffi.Pointer<TColorGradingBuilder> builder, double adaptation);
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
 external void ColorGradingBuilder_whiteBalance(
   ffi.Pointer<TColorGradingBuilder> builder,
   double temperature,
   double tint,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
-external void ColorGradingBuilder_contrast(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double contrast,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_contrast(ffi.Pointer<TColorGradingBuilder> builder, double contrast);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
-external void ColorGradingBuilder_vibrance(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double vibrance,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_vibrance(ffi.Pointer<TColorGradingBuilder> builder, double vibrance);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
-    isLeaf: true)
-external void ColorGradingBuilder_saturation(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double saturation,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_saturation(ffi.Pointer<TColorGradingBuilder> builder, double saturation);
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_channelMixer(
   ffi.Pointer<TColorGradingBuilder> builder,
   double outRedR,
@@ -895,24 +793,26 @@ external void ColorGradingBuilder_channelMixer(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_shadowsMidtonesHighlights(
   ffi.Pointer<TColorGradingBuilder> builder,
   double shadowsR,
@@ -934,17 +834,19 @@ external void ColorGradingBuilder_shadowsMidtonesHighlights(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_slopeOffsetPower(
   ffi.Pointer<TColorGradingBuilder> builder,
   double slopeR,
@@ -959,17 +861,19 @@ external void ColorGradingBuilder_slopeOffsetPower(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_curves(
   ffi.Pointer<TColorGradingBuilder> builder,
   double shadowGammaR,
@@ -983,830 +887,169 @@ external void ColorGradingBuilder_curves(
   double highlightScaleB,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void ColorGradingBuilder_luminanceScaling(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  bool enabled,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
+external void ColorGradingBuilder_luminanceScaling(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void ColorGradingBuilder_gamutMapping(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  bool enabled,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
+external void ColorGradingBuilder_gamutMapping(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(
-    isLeaf: true)
-external void View_setColorGrading(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TColorGrading> tColorGrading,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void View_setColorGrading(ffi.Pointer<TView> tView, ffi.Pointer<TColorGrading> tColorGrading);
 
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(
-    isLeaf: true)
-external ffi.Pointer<TColorGrading> View_getColorGrading(
-  ffi.Pointer<TView> tView,
-);
+@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TColorGrading> View_getColorGrading(ffi.Pointer<TView> tView);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void View_setBlendMode(
-  ffi.Pointer<TView> view,
-  int blendMode,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
+external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(
-    isLeaf: true)
-external void View_setViewport(
-  ffi.Pointer<TView> view,
-  int width,
-  int height,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
-external void View_setRenderTarget(
-  ffi.Pointer<TView> view,
-  ffi.Pointer<TRenderTarget> renderTarget,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void View_setRenderTarget(ffi.Pointer<TView> view, ffi.Pointer<TRenderTarget> renderTarget);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrustumCullingEnabled(
-  ffi.Pointer<TView> view,
-  bool enabled,
-);
+external void View_setFrustumCullingEnabled(ffi.Pointer<TView> view, bool enabled);
 
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getVisibleRenderableCount(
-  ffi.Pointer<TView> view,
-);
+external int View_getVisibleRenderableCount(ffi.Pointer<TView> view);
 
-@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(
-    isLeaf: true)
-external ffi.Pointer<TRenderTarget> View_getRenderTarget(
-  ffi.Pointer<TView> tView,
-);
+@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TRenderTarget> View_getRenderTarget(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setPostProcessing(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
+external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setShadowsEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
+external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
-external void View_setShadowType(
-  ffi.Pointer<TView> tView,
-  int shadowType,
-);
+external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getShadowType(
-  ffi.Pointer<TView> tView,
-);
+external int View_getShadowType(ffi.Pointer<TView> tView);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(
-    isLeaf: true)
-external void View_setSoftShadowOptions(
-  ffi.Pointer<TView> tView,
-  TSoftShadowOptions options,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(isLeaf: true)
+external void View_setSoftShadowOptions(ffi.Pointer<TView> tView, TSoftShadowOptions options);
 
 @ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TSoftShadowOptions View_getSoftShadowOptions(
-  ffi.Pointer<TView> tView,
-);
+external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(
-    isLeaf: true)
-external void View_setVsmShadowOptions(
-  ffi.Pointer<TView> tView,
-  TVsmShadowOptions options,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(isLeaf: true)
+external void View_setVsmShadowOptions(ffi.Pointer<TView> tView, TVsmShadowOptions options);
 
 @ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TVsmShadowOptions View_getVsmShadowOptions(
-  ffi.Pointer<TView> tView,
-);
+external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(
-    isLeaf: true)
-external void View_setBloom(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  double strength,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(isLeaf: true)
+external void View_setBloom(ffi.Pointer<TView> tView, bool enabled, double strength);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void View_setRenderQuality(
-  ffi.Pointer<TView> tView,
-  int qualityLevel,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
+external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
-external void View_setAntiAliasing(
-  ffi.Pointer<TView> tView,
-  bool msaa,
-  bool fxaa,
-  bool taa,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void View_setAntiAliasing(ffi.Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(
-    isLeaf: true)
-external void View_setLayerEnabled(
-  ffi.Pointer<TView> tView,
-  int layer,
-  bool visible,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(isLeaf: true)
+external void View_setLayerEnabled(ffi.Pointer<TView> tView, int layer, bool visible);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(
-    isLeaf: true)
-external void View_setCamera(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TCamera> tCamera,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(isLeaf: true)
+external void View_setCamera(ffi.Pointer<TView> tView, ffi.Pointer<TCamera> tCamera);
 
 @ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TScene> View_getScene(
-  ffi.Pointer<TView> tView,
-);
+external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TCamera> View_getCamera(
-  ffi.Pointer<TView> tView,
-);
+external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setStencilBufferEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
+external void View_setStencilBufferEnabled(ffi.Pointer<TView> tView, bool enabled);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isStencilBufferEnabled(
-  ffi.Pointer<TView> tView,
-);
+external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setDitheringEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
+external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isDitheringEnabled(
-  ffi.Pointer<TView> tView,
-);
+external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void View_setScene(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TScene> tScene,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void View_setScene(ffi.Pointer<TView> tView, ffi.Pointer<TScene> tScene);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrontFaceWindingInverted(
-  ffi.Pointer<TView> tView,
-  bool inverted,
-);
+external void View_setFrontFaceWindingInverted(ffi.Pointer<TView> tView, bool inverted);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(
-    isLeaf: true)
-external void View_setAmbientOcclusionOptions(
-  ffi.Pointer<TView> tView,
-  TAmbientOcclusionOptions options,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(isLeaf: true)
+external void View_setAmbientOcclusionOptions(ffi.Pointer<TView> tView, TAmbientOcclusionOptions options);
 
 @ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(
-  ffi.Pointer<TView> tView,
-);
+external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
-external void View_setFogOptions(
-  ffi.Pointer<TView> tView,
-  TFogOptions tFogOptions,
-);
+external void View_setFogOptions(ffi.Pointer<TView> tView, TFogOptions tFogOptions);
 
 @ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TFogOptions View_getFogOptions(
-  ffi.Pointer<TView> tView,
-);
+external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setTransparentPickingEnabled(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-);
+external void View_setTransparentPickingEnabled(ffi.Pointer<TView> tView, bool enabled);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isTransparentPickingEnabled(
-  ffi.Pointer<TView> tView,
-);
+external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
-        PickCallback)>(isLeaf: true)
-external void View_pick(
-  ffi.Pointer<TView> tView,
-  int requestId,
-  int x,
-  int y,
-  PickCallback callback,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
+external void View_pick(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(
-    isLeaf: true)
-external void View_setName(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<ffi.Char> name,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external void View_setName(ffi.Pointer<TView> tView, ffi.Pointer<ffi.Char> name);
 
 @ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> View_getName(
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external void NameComponentManager_destroy(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-);
+external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
 
 @ffi.Native<
-    ffi.Pointer<ffi.Char> Function(
-        ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientationBuilder>
-    SurfaceOrientationBuilder_create();
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_vertexCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_normals(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> normals,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_tangents(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> tangents,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_uvs(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> uvs,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_positions(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> positions,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangleCount(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_uint(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint32> triangles,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
-        ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_ushort(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint16> triangles,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSurfaceOrientation> Function(
-        ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
-    isLeaf: true)
-external void SurfaceOrientationBuilder_destroy(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external int SurfaceOrientation_getVertexCount(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_float4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Float> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_short4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Int16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>,
-        ffi.Size, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientation_getQuats_half4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Uint16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external void SurfaceOrientation_destroy(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void IndirectLight_setRotation(
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-  ffi.Pointer<ffi.Double> rotation,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTexture> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint8,
-        ffi.Uint16,
-        ffi.IntPtr,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTexture> Texture_build(
-  ffi.Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import$,
-  int sampler,
-  int format,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
-        ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void Texture_setExternalImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<ffi.Void> externalImage,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getLevels(
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TLinearImage>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Int)>(isLeaf: true)
-external bool Texture_loadImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Uint32,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32)>(isLeaf: true)
-external bool Texture_setImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getWidth(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getHeight(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getDepth(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getFormat(
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
-    isLeaf: true)
-external int Texture_getUsage(
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external void Texture_generateMipMaps(
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TKtx1Bundle> Function(
-        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(
-  ffi.Pointer<ffi.Uint8> ktxData,
-  int length,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void Ktx1Bundle_getSphericalHarmonics(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  ffi.Pointer<ffi.Float> harmonics,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external bool Ktx1Bundle_isCubemap(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external void Ktx1Bundle_destroy(
-  ffi.Pointer<TKtx1Bundle> tBundle,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  VoidCallback onTextureUploadComplete,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTexture> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-);
-
-@ffi.Native<
-    ffi.Pointer<TLinearImage> Function(
-        ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
-external ffi.Pointer<TLinearImage> Image_createEmpty(
-  int width,
-  int height,
-  int channel,
-);
-
-@ffi.Native<
-    ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
-        ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
-external ffi.Pointer<TLinearImage> Image_decode(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> name,
-  bool alpha,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(
-    isLeaf: true)
-external ffi.Pointer<ffi.Float> Image_getBytes(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external void Image_destroy(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getWidth(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getHeight(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getChannels(
-  ffi.Pointer<TLinearImage> tLinearImage,
-);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getColorTexture(
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
-    isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
-
-@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_create();
-
-@ffi.Native<
-    ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt,
-        ffi.UnsignedInt, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-);
-
-@ffi.Native<
-    ffi.Pointer<TTextureSampler> Function(
-        ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(
-  int compareMode,
-  int compareFunc,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setMinFilter(
-  ffi.Pointer<TTextureSampler> sampler,
-  int filter,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setMagFilter(
-  ffi.Pointer<TTextureSampler> sampler,
-  int filter,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeS(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeT(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void TextureSampler_setWrapModeR(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(
-    isLeaf: true)
-external void TextureSampler_setAnisotropy(
-  ffi.Pointer<TTextureSampler> sampler,
-  double anisotropy,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
-        ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setCompareMode(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-  int func,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
-external void TextureSampler_destroy(
-  ffi.Pointer<TTextureSampler> sampler,
-);
-
-@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithCallback(
-  FrameTickCallback tickCallback,
-  int targetFps,
-);
-
-@ffi.Native<ffi.Void Function()>()
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(
-  ffi.Pointer<ffi.Void> data,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(
-  int port,
-  int targetFps,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_setTargetFps(
-  int fps,
-);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
-
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(
-  int t,
-);
-
-@ffi.Native<
-    ffi.Pointer<TGizmo> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<TView>,
-        ffi.Pointer<TMaterial>,
-        ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TGizmo> Gizmo_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> assetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32,
-        GizmoPickCallback)>(isLeaf: true)
-external void Gizmo_pick(
-  ffi.Pointer<TGizmo> tGizmo,
-  int x,
-  int y,
-  GizmoPickCallback callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
-    isLeaf: true)
-external void Gizmo_highlight(
-  ffi.Pointer<TGizmo> tGizmo,
-  int axis,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(
-  ffi.Pointer<TGizmo> tGizmo,
-);
-
-@ffi.Native<
-    ffi.Pointer<TMaterialInstance> Function(
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Int,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Pointer<TMaterialInstance> Function(
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   ffi.Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -1849,93 +1092,31 @@ external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   bool hasVolume,
 );
 
-@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
-    isLeaf: true)
-external void IndexBufferBuilder_indexCount(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void IndexBufferBuilder_bufferType(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  int indexType,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndexBuffer> Function(
-        ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
-external void IndexBufferBuilder_destroy(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(
-  ffi.Pointer<TIndexBuffer> buffer,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
-external void IndexBuffer_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
-    isLeaf: true)
-external void IndexBuffer_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-);
-
 @ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(
-    isLeaf: true)
-external void VertexBufferBuilder_bufferCount(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  int count,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(isLeaf: true)
+external void VertexBufferBuilder_bufferCount(ffi.Pointer<TVertexBufferBuilder> builder, int count);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(
-    isLeaf: true)
-external void VertexBufferBuilder_vertexCount(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  int count,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(isLeaf: true)
+external void VertexBufferBuilder_vertexCount(ffi.Pointer<TVertexBufferBuilder> builder, int count);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void VertexBufferBuilder_enableBufferObjects(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  bool enabled,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Bool)>(isLeaf: true)
+external void VertexBufferBuilder_enableBufferObjects(ffi.Pointer<TVertexBufferBuilder> builder, bool enabled);
 
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TVertexBufferBuilder>)>(
-    isLeaf: true)
-external int VertexBufferBuilder_getStorageMode(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-);
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
+external int VertexBufferBuilder_getStorageMode(ffi.Pointer<TVertexBufferBuilder> builder);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt,
-        ffi.Uint8, ffi.UnsignedInt, ffi.Uint32, ffi.Uint8)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.UnsignedInt,
+    ffi.Uint8,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
 external void VertexBufferBuilder_attribute(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int attribute,
@@ -1945,36 +1126,31 @@ external void VertexBufferBuilder_attribute(
   int byteStride,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt,
-        ffi.Bool)>(isLeaf: true)
-external void VertexBufferBuilder_normalized(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  bool normalize,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void VertexBufferBuilder_normalized(ffi.Pointer<TVertexBufferBuilder> builder, int attribute, bool normalize);
 
-@ffi.Native<
-    ffi.Pointer<TVertexBuffer> Function(
-        ffi.Pointer<TVertexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TVertexBuffer> VertexBufferBuilder_build(
   ffi.Pointer<TVertexBufferBuilder> builder,
   ffi.Pointer<TEngine> engine,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
-external void VertexBufferBuilder_destroy(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-);
+external void VertexBufferBuilder_destroy(ffi.Pointer<TVertexBufferBuilder> builder);
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external int VertexBuffer_getVertexCount(
-  ffi.Pointer<TVertexBuffer> buffer,
-);
+external int VertexBuffer_getVertexCount(ffi.Pointer<TVertexBuffer> buffer);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
-        ffi.Uint8, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
 external void VertexBuffer_setBufferAt(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
@@ -1984,9 +1160,9 @@ external void VertexBuffer_setBufferAt(
   int byteOffset,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
-        ffi.Uint8, ffi.Pointer<TBufferObject>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>, ffi.Uint8, ffi.Pointer<TBufferObject>)>(
+  isLeaf: true,
+)
 external void VertexBuffer_setBufferObjectAt(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
@@ -1994,879 +1170,62 @@ external void VertexBuffer_setBufferObjectAt(
   ffi.Pointer<TBufferObject> bufferObject,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external void VertexBuffer_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TVertexBuffer> buffer,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
+external void VertexBuffer_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TVertexBuffer> buffer);
 
-@ffi.Native<
-    ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(isLeaf: true)
-external ffi.Pointer<TRenderTarget> RenderTarget_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> color,
-  ffi.Pointer<TTexture> depth,
-);
+@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external void RenderTarget_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(isLeaf: true)
+external void IndexBufferBuilder_indexCount(ffi.Pointer<TIndexBufferBuilder> builder, int count);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void IndexBufferBuilder_bufferType(ffi.Pointer<TIndexBufferBuilder> builder, int indexType);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
-    isLeaf: true)
-external void Scene_setSkybox(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TSkybox> skybox,
-);
-
-@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TScene>)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Scene_getSkybox(
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Scene_setIndirectLight(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external void Scene_addFilamentAsset(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TFilamentAsset> asset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TRenderManager> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
-    isLeaf: true)
-external void RenderManager_render(
-  ffi.Pointer<TRenderManager> tRenderer,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
-        ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)>(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
-external void RenderManager_removeSwapChain(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(
-  ffi.Pointer<TRenderManager> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_detachFromRenderThread(
-  ffi.Pointer<TRenderManager> tRenderManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
-    isLeaf: true)
-external void RenderManager_setPaused(
-  ffi.Pointer<TRenderManager> tRenderer,
-  bool paused,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void Camera_setExposure(
-  ffi.Pointer<TCamera> camera,
-  double aperture,
-  double shutterSpeed,
-  double sensitivity,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
-    isLeaf: true)
-external void Camera_getFrustum(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> out,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double, ffi.Bool)>(isLeaf: true)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
-    isLeaf: true)
-external void Camera_lookAt(
-  ffi.Pointer<TCamera> camera,
-  double3 eye,
-  double3 focus,
-  double3 up,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(
-  ffi.Pointer<TCamera> camera,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(
-  ffi.Pointer<TCamera> camera,
-  double focusDistance,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4)>(isLeaf: true)
-external void Camera_setModelMatrix(
-  ffi.Pointer<TCamera> camera,
-  double4x4 tModelMatrix,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(
-  ffi.Pointer<TCamera> camera,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TCamera>,
-        ffi.UnsignedInt,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
-external double4x4 TransformManager_getLocalTransform(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
-external double4x4 TransformManager_getWorldTransform(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TTransformManager>, EntityId, double4x4)>(isLeaf: true)
-external void TransformManager_setTransform(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  double4x4 transform,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(
-    isLeaf: true)
-external bool TransformManager_transformToUnitCube(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  Aabb3 boundingBox,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId,
-        ffi.Bool)>(isLeaf: true)
-external void TransformManager_setParent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int child,
-  int parent,
-  bool preserveScaling,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
-external int TransformManager_getParent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int child,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
-external int TransformManager_getAncestor(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int childEntityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
-external void TransformManager_createComponent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
-external void TransformManager_removeComponent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
-external bool TransformManager_hasComponent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external bool TransformManager_empty(
-  ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external int TransformManager_getComponentCount(
-  ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(
-    isLeaf: true)
-external int TransformManager_getChildCount(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId,
-        ffi.Pointer<EntityId>, ffi.Int)>(isLeaf: true)
-external void TransformManager_getChildren(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  ffi.Pointer<EntityId> children,
-  int count,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external void TransformManager_openLocalTransformTransaction(
-  ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external void TransformManager_commitLocalTransformTransaction(
-  ffi.Pointer<TTransformManager> tTransformManager,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Double, ffi.Double,
-        ffi.Double, ffi.Double, ffi.Uint8, ffi.Bool, ffi.Bool)>(isLeaf: true)
-external void Renderer_setClearOptions(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>,
-        ffi.Uint64)>(isLeaf: true)
-external bool Renderer_beginFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Renderer_render(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Renderer_renderStandaloneView(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Pointer<TRenderTarget>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size)>(isLeaf: true)
-external void Renderer_readPixels(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8,
-        ffi.Uint8)>(isLeaf: true)
-external void Renderer_setFrameInterval(
-  ffi.Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-);
-
-@ffi.Native<
-    ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>,
-        ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)>(isLeaf: true)
-external ffi.Pointer<TEngine> Engine_create(
-  int backend,
-  ffi.Pointer<ffi.Void> platform,
-  ffi.Pointer<ffi.Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getSupportedFeatureLevel(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_destroy(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TRenderer> Engine_createRenderer(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(
-    isLeaf: true)
-external void Engine_destroyRenderer(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSwapChain> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Void> window,
-  int flags,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSwapChain> Function(
-        ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  int flags,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
-    isLeaf: true)
-external void Engine_destroySwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSwapChain> tSwapChain,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
-    isLeaf: true)
-external void Engine_destroyView(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TView> tView,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void Engine_destroyScene(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TScene> tScene,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void Engine_destroyColorGrading(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TColorGrading> tColorGrading,
-);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-    isLeaf: true)
-external ffi.Pointer<TCamera> Engine_createCamera(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
-    isLeaf: true)
-external void Engine_destroyCamera(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TCamera> tCamera,
-);
-
-@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TView> Engine_createView(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
-    isLeaf: true)
-external ffi.Pointer<TCamera> Engine_getCameraComponent(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-);
-
-@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TTransformManager> Engine_getTransformManager(
+@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  ffi.Pointer<TIndexBufferBuilder> builder,
   ffi.Pointer<TEngine> engine,
 );
 
-@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
+external void IndexBufferBuilder_destroy(ffi.Pointer<TIndexBufferBuilder> builder);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)
+>(isLeaf: true)
+external void IndexBuffer_setBuffer(
   ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
 );
 
-@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TLightManager> Engine_getLightManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TEntityManager> Engine_getEntityManager(
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
-external void Engine_setAutomaticInstancingEnabled(
-  ffi.Pointer<TEngine> tEngine,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getMaxAutomaticInstances(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
-    isLeaf: true)
-external void Engine_destroyTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-);
-
-@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TFence> Engine_createFence(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
-    isLeaf: true)
-external void Engine_destroyFence(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TFence> tFence,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_flushAndWait(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_execute(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TMaterial> Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Engine_buildMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> materialData,
-  int length,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
-    isLeaf: true)
-external void Engine_destroyMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterial> tMaterial,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external void Engine_destroyMaterialInstance(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TScene> Engine_createScene(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
-        ffi.Bool, ffi.Float, ffi.Uint8)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float,
-        ffi.Float, ffi.Float, ffi.Bool, ffi.Float, ffi.Uint8)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)>(isLeaf: true)
-external ffi.Pointer<TIndirectLight>
-    Engine_buildIndirectLightFromIrradianceTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-);
-
-@ffi.Native<
-    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)>(isLeaf: true)
-external ffi.Pointer<TIndirectLight>
-    Engine_buildIndirectLightFromIrradianceHarmonics(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<ffi.Float> irradianceHarmonics,
-  double intensity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
-    isLeaf: true)
-external void Engine_destroySkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSkybox> tSkybox,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Engine_destroyIndirectLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
-external int EntityManager_createEntity(
-  ffi.Pointer<TEntityManager> tEntityManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
-    isLeaf: true)
-external void EntityManager_destroyEntity(
-  ffi.Pointer<TEntityManager> tEntityManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
-external void Fence_waitAndDestroy(
-  ffi.Pointer<TFence> tFence,
-);
-
-@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
-  ffi.Pointer<TEngine> tEngine,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external bool DebugRegistry_hasProperty(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Bool)>(isLeaf: true)
-external bool DebugRegistry_setProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  bool value,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Int)>(isLeaf: true)
-external bool DebugRegistry_setProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  int value,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Float)>(isLeaf: true)
-external bool DebugRegistry_setProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  double value,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Bool>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Bool> outValue,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Int>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Int> outValue,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Float> outValue,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external void IndexBuffer_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TIndexBuffer> buffer);
 
 @ffi.Native<ffi.Pointer<TBufferObjectBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TBufferObjectBuilder> BufferObjectBuilder_create();
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Uint32)>(
-    isLeaf: true)
-external void BufferObjectBuilder_size(
-  ffi.Pointer<TBufferObjectBuilder> builder,
-  int sizeInBytes,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Uint32)>(isLeaf: true)
+external void BufferObjectBuilder_size(ffi.Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
 
-@ffi.Native<
-    ffi.Pointer<TBufferObject> Function(
-        ffi.Pointer<TBufferObjectBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+@ffi.Native<ffi.Pointer<TBufferObject> Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TBufferObject> BufferObjectBuilder_build(
   ffi.Pointer<TBufferObjectBuilder> builder,
   ffi.Pointer<TEngine> engine,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>)>(isLeaf: true)
-external void BufferObjectBuilder_destroy(
-  ffi.Pointer<TBufferObjectBuilder> builder,
-);
+external void BufferObjectBuilder_destroy(ffi.Pointer<TBufferObjectBuilder> builder);
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>,
-        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)
+>(isLeaf: true)
 external void BufferObject_setBuffer(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TBufferObject> buffer,
@@ -2875,42 +1234,268 @@ external void BufferObject_setBuffer(
   int byteOffset,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>)>(isLeaf: true)
-external void BufferObject_destroy(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TBufferObject> buffer,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>)>(isLeaf: true)
+external void BufferObject_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TBufferObject> buffer);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external double4x4 TransformManager_getLocalTransform(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external double4x4 TransformManager_getWorldTransform(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4)>(isLeaf: true)
+external void TransformManager_setTransform(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  double4x4 transform,
 );
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(isLeaf: true)
+external bool TransformManager_transformToUnitCube(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  Aabb3 boundingBox,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId, ffi.Bool)>(isLeaf: true)
+external void TransformManager_setParent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int child,
+  int parent,
+  bool preserveScaling,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external int TransformManager_getParent(ffi.Pointer<TTransformManager> tTransformManager, int child);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external int TransformManager_getAncestor(ffi.Pointer<TTransformManager> tTransformManager, int childEntityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external void TransformManager_createComponent(ffi.Pointer<TTransformManager> tTransformManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external void TransformManager_removeComponent(ffi.Pointer<TTransformManager> tTransformManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external bool TransformManager_hasComponent(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external bool TransformManager_empty(ffi.Pointer<TTransformManager> tTransformManager);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external int TransformManager_getComponentCount(ffi.Pointer<TTransformManager> tTransformManager);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external int TransformManager_getChildCount(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Pointer<EntityId>, ffi.Int)>(isLeaf: true)
+external void TransformManager_getChildren(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  ffi.Pointer<EntityId> children,
+  int count,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external void TransformManager_openLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external void TransformManager_commitLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>, ffi.UnsignedInt)>(isLeaf: true)
+external int LightManager_createLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external void LightManager_destroyLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_hasComponent(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external int LightManager_getType(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isDirectional(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isPointLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isSpotLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getPosition(ffi.Pointer<TLightManager> tLightManager, int light);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getDirection(ffi.Pointer<TLightManager> tLightManager, int light);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setColor(ffi.Pointer<TLightManager> tLightManager, int entity, double r, double g, double b);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getColor(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensity(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityCandela(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getIntensity(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double falloff);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSpotLightOuterCone(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSpotLightInnerCone(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunAngularRadius(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity, double haloSize);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double haloFalloff);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void LightManager_setShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity, bool enabled);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external TShadowOptions LightManager_getShadowOptions(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool LightManager_getLightChannel(ffi.Pointer<TLightManager> tLightManager, int entity, int channel);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(ffi.Pointer<ffi.Float> splitPositions, int cascades);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external double LightManager_rgbToColorTemperature(double r, double g, double b);
 
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
 external ffi.Pointer<ffi.Void> RenderThread_create();
 
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(
-  ffi.Pointer<ffi.Char> canvasSelector,
-);
+external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(ffi.Pointer<ffi.Char> canvasSelector);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void RenderThread_destroy(
-  ffi.Pointer<ffi.Void> renderThread,
-);
+external void RenderThread_destroy(ffi.Pointer<ffi.Void> renderThread);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)>(isLeaf: true)
+external void RenderThread_addTask(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> task);
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)>(isLeaf: true)
-external void RenderThread_addTask(
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> task,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TSwapChain>,
-        ffi.Pointer<ffi.Pointer<TView>>,
-        ffi.Uint8,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Pointer<ffi.Pointer<TView>>,
+    ffi.Uint8,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderManager_setRenderableRenderThread(
   ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -2920,9 +1505,7 @@ external void RenderManager_setRenderableRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderManager_renderRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   int frameTimeInNanos,
@@ -2930,9 +1513,9 @@ external void RenderManager_renderRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void RenderManager_addAnimationManagerRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TAnimationManager> tAnimationManager,
@@ -2940,9 +1523,9 @@ external void RenderManager_addAnimationManagerRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>,
-        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void RenderManager_removeAnimationManagerRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TAnimationManager> tAnimationManager,
@@ -2950,9 +1533,9 @@ external void RenderManager_removeAnimationManagerRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void RenderManager_removeSwapChainRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -2961,22 +1544,17 @@ external void RenderManager_removeSwapChainRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TAnimationManager>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>>,
+  )
+>(isLeaf: true)
 external void AnimationManager_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void AnimationManager_destroyRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int requestId,
@@ -2984,41 +1562,33 @@ external void AnimationManager_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.UnsignedInt,
-            ffi.Pointer<ffi.Void>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Uint8,
-            ffi.Bool,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Void>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createRenderThread(
   int backend,
   ffi.Pointer<ffi.Void> platform,
   ffi.Pointer<ffi.Void> sharedContext,
   int stereoscopicEyeCount,
   bool disableHandleUseAfterFreeCheck,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>)
+>(isLeaf: true)
 external void Engine_createRendererRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyRendererRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderer> tRenderer,
@@ -3027,58 +1597,51 @@ external void Engine_destroyRendererRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<ffi.Void>,
-            ffi.Uint64,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createSwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Void> window,
   int flags,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint64,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createHeadlessSwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int width,
   int height,
   int flags,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            EntityId,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    EntityId,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>,
+  )
+>(isLeaf: true)
 external void Engine_createCameraRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int entityId,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyCameraRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TCamera> tCamera,
@@ -3087,45 +1650,32 @@ external void Engine_destroyCameraRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>)
+>(isLeaf: true)
 external void Engine_createViewRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<ffi.Uint8>,
-            ffi.Size,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
 external void Engine_buildMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> materialData,
   int length,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-    isLeaf: true)
-external void Engine_destroyRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  int requestId,
-  VoidCallback onComplete,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroySwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -3133,9 +1683,7 @@ external void Engine_destroySwapChainRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyViewRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TView> tView,
@@ -3143,9 +1691,7 @@ external void Engine_destroyViewRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroySceneRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TScene> tScene,
@@ -3153,9 +1699,7 @@ external void Engine_destroySceneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyColorGradingRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TColorGrading> tColorGrading,
@@ -3163,9 +1707,7 @@ external void Engine_destroyColorGradingRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterial> tMaterial,
@@ -3173,9 +1715,9 @@ external void Engine_destroyMaterialRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void Engine_destroyMaterialInstanceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
@@ -3183,9 +1725,7 @@ external void Engine_destroyMaterialInstanceRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroySkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSkybox> tSkybox,
@@ -3193,9 +1733,9 @@ external void Engine_destroySkyboxRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void Engine_destroyIndirectLightRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -3204,19 +1744,19 @@ external void Engine_destroyIndirectLightRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint8,
-            ffi.Uint16,
-            ffi.IntPtr,
-            ffi.UnsignedInt,
-            ffi.UnsignedInt,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint8,
+    ffi.Uint16,
+    ffi.IntPtr,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
 external void Texture_buildRenderThread(
   ffi.Pointer<TEngine> engine,
   int width,
@@ -3227,13 +1767,12 @@ external void Texture_buildRenderThread(
   int import$,
   int sampler,
   int format,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
-        ffi.Pointer<ffi.Void>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Void>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void Texture_setExternalImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -3242,9 +1781,7 @@ external void Texture_setExternalImageRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Texture_generateMipMapsRenderThread(
   ffi.Pointer<TTexture> tTexture,
   ffi.Pointer<TEngine> tEngine,
@@ -3253,42 +1790,38 @@ external void Texture_generateMipMapsRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TKtx1Bundle>,
-            ffi.Uint32,
-            VoidCallback,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TKtx1Bundle>,
+    ffi.Uint32,
+    VoidCallback,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
 external void Ktx1Reader_createTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TKtx1Bundle> tBundle,
   int requestId,
   VoidCallback onTextureUploadComplete,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<ffi.Uint8>,
-            ffi.Size,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
 external void Ktx2Reader_createTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> data,
   int size,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyTextureRenderThread(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TTexture> tTexture,
@@ -3297,28 +1830,17 @@ external void Engine_destroyTextureRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>)
+>(isLeaf: true)
 external void Engine_createFenceRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>> onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(
-    isLeaf: true)
-external void Fence_waitAndDestroyRenderThread(
-  ffi.Pointer<TFence> tFence,
-  int requestId,
-  VoidCallback onComplete,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Fence_waitAndDestroyRenderThread(ffi.Pointer<TFence> tFence, int requestId, VoidCallback onComplete);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyFenceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TFence> tFence,
@@ -3326,55 +1848,44 @@ external void Engine_destroyFenceRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-    isLeaf: true)
-external void Engine_flushAndWaitRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  int requestId,
-  VoidCallback onComplete,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_flushAndWaitRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
-    isLeaf: true)
-external void Engine_executeRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  int requestId,
-  VoidCallback onComplete,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_executeRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TTexture>,
-            ffi.Bool,
-            ffi.Float,
-            ffi.Uint8,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Uint8,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
+  )
+>(isLeaf: true)
 external void Engine_buildSkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
   bool showSun,
   double intensity,
   int priority,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Float,
-            ffi.Float,
-            ffi.Float,
-            ffi.Float,
-            ffi.Bool,
-            ffi.Float,
-            ffi.Uint8,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Uint8,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
+  )
+>(isLeaf: true)
 external void Engine_buildColoredSkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   double r,
@@ -3384,60 +1895,57 @@ external void Engine_buildColoredSkyboxRenderThread(
   bool showSun,
   double intensity,
   int priority,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TTexture>,
-        ffi.Float,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TIndirectLight>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
+    ffi.Float,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>,
+  )
+>(isLeaf: true)
 external void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<TTexture> tIrradianceTexture,
   double intensity,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<ffi.Float>,
-        ffi.Float,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TIndirectLight>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Float,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>,
+  )
+>(isLeaf: true)
 external void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<ffi.Float> harmonics,
   double intensity,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Double,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Renderer_setClearOptionsRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   double clearR,
@@ -3452,12 +1960,13 @@ external void Renderer_setClearOptionsRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TRenderer>,
-            ffi.Pointer<TSwapChain>,
-            ffi.Uint64,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void Renderer_beginFrameRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -3465,18 +1974,10 @@ external void Renderer_beginFrameRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Renderer_endFrameRenderThread(
-  ffi.Pointer<TRenderer> tRenderer,
-  int requestId,
-  VoidCallback onComplete,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Renderer_endFrameRenderThread(ffi.Pointer<TRenderer> tRenderer, int requestId, VoidCallback onComplete);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Renderer_renderRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
@@ -3484,9 +1985,7 @@ external void Renderer_renderRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Renderer_renderStandaloneViewRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
@@ -3495,19 +1994,21 @@ external void Renderer_renderStandaloneViewRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderer>,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Pointer<TRenderTarget>,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<TRenderTarget>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void Renderer_readPixelsRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   int width,
@@ -3524,27 +2025,26 @@ external void Renderer_readPixelsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TMaterial>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TMaterialInstance>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterial>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>,
+  )
+>(isLeaf: true)
 external void Material_createInstanceRenderThread(
   ffi.Pointer<TMaterial> tMaterial,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TMaterialInstance>,
-        ffi.Pointer<ffi.Char>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TTextureSampler>,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTextureSampler>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void MaterialInstance_setParameterTextureRenderThread(
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -3555,126 +2055,82 @@ external void MaterialInstance_setParameterTextureRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
 external void Material_createImageMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
 external void Material_createGizmoMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
 external void Material_createBoneOverlayMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
 external void Material_createSilhouetteMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
 external void Material_createEdgeOutlineMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
 external void Material_createWireframeMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
 external void Material_createTranslationAxisMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TColorGradingBuilder>)>>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>)>(
+  isLeaf: true,
+)
 external void ColorGradingBuilder_createRenderThread(
-  ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TColorGradingBuilder>,
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TColorGrading>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>,
+  )
+>(isLeaf: true)
 external void ColorGradingBuilder_buildRenderThread(
   ffi.Pointer<TColorGradingBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void ColorGradingBuilder_destroyRenderThread(
   ffi.Pointer<TColorGradingBuilder> tBuilder,
   int requestId,
@@ -3682,155 +2138,104 @@ external void ColorGradingBuilder_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
 external void ToneMapper_createLinearRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
 external void ToneMapper_createACESRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
 external void ToneMapper_createACESLegacyRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
 external void ToneMapper_createFilmicRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
 external void ToneMapper_createPBRNeutralRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
 external void ToneMapper_createAGXRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Int,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>,
+  )
+>(isLeaf: true)
 external void ToneMapper_createAGXWithLookRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int look,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Float,
-            ffi.Float,
-            ffi.Float,
-            ffi.Float,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>,
+  )
+>(isLeaf: true)
 external void ToneMapper_createGenericRenderThread(
   ffi.Pointer<TEngine> tEngine,
   double contrast,
   double midGrayIn,
   double midGrayOut,
   double hdrMax,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
 external void ToneMapper_createDisplayRangeRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void ToneMapper_destroyRenderThread(
   ffi.Pointer<TToneMapper> tToneMapper,
   int requestId,
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
-        PickCallback)>(isLeaf: true)
-external void View_pickRenderThread(
-  ffi.Pointer<TView> tView,
-  int requestId,
-  int x,
-  int y,
-  PickCallback callback,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
+external void View_pickRenderThread(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setColorGradingRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TColorGrading> tColorGrading,
@@ -3838,9 +2243,7 @@ external void View_setColorGradingRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Double, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Double, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setBloomRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3849,9 +2252,7 @@ external void View_setBloomRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setCameraRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TCamera> tCamera,
@@ -3860,20 +2261,14 @@ external void View_setCameraRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TView>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>)
+>(isLeaf: true)
 external void View_getNameRenderThread(
   ffi.Pointer<TView> tView,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setNameRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<ffi.Char> name,
@@ -3881,9 +2276,7 @@ external void View_setNameRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setViewportRenderThread(
   ffi.Pointer<TView> tView,
   int width,
@@ -3892,9 +2285,7 @@ external void View_setViewportRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setRenderTargetRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TRenderTarget> tRenderTarget,
@@ -3902,9 +2293,7 @@ external void View_setRenderTargetRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setAntiAliasingRenderThread(
   ffi.Pointer<TView> tView,
   bool msaa,
@@ -3914,9 +2303,7 @@ external void View_setAntiAliasingRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setPostProcessingRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3924,9 +2311,7 @@ external void View_setPostProcessingRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setFrustumCullingEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3934,9 +2319,7 @@ external void View_setFrustumCullingEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setStencilBufferEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3944,9 +2327,7 @@ external void View_setStencilBufferEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setDitheringEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -3954,9 +2335,7 @@ external void View_setDitheringEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setRenderQualityRenderThread(
   ffi.Pointer<TView> tView,
   int qualityLevel,
@@ -3964,9 +2343,7 @@ external void View_setRenderQualityRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setSceneRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TScene> tScene,
@@ -3974,9 +2351,7 @@ external void View_setSceneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setLayerEnabledRenderThread(
   ffi.Pointer<TView> tView,
   int layer,
@@ -3985,9 +2360,7 @@ external void View_setLayerEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setBlendModeRenderThread(
   ffi.Pointer<TView> tView,
   int blendMode,
@@ -3995,9 +2368,7 @@ external void View_setBlendModeRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setFogOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TFogOptions tFogOptions,
@@ -4005,9 +2376,7 @@ external void View_setFogOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setAmbientOcclusionOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TAmbientOcclusionOptions options,
@@ -4015,9 +2384,7 @@ external void View_setAmbientOcclusionOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setFrontFaceWindingInvertedRenderThread(
   ffi.Pointer<TView> tView,
   bool inverted,
@@ -4025,9 +2392,7 @@ external void View_setFrontFaceWindingInvertedRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setShadowsEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -4035,9 +2400,7 @@ external void View_setShadowsEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setShadowTypeRenderThread(
   ffi.Pointer<TView> tView,
   int shadowType,
@@ -4045,9 +2408,7 @@ external void View_setShadowTypeRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setSoftShadowOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TSoftShadowOptions options,
@@ -4055,9 +2416,7 @@ external void View_setSoftShadowOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setVsmShadowOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TVsmShadowOptions options,
@@ -4065,9 +2424,7 @@ external void View_setVsmShadowOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setTransparentPickingEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -4075,9 +2432,7 @@ external void View_setTransparentPickingEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_destroyRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int requestId,
@@ -4085,40 +2440,37 @@ external void SceneAsset_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TGltfAssetLoader>,
-            ffi.Pointer<TNameComponentManager>,
-            ffi.Pointer<TFilamentAsset>,
-            ffi.Uint32,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
+  )
+>(isLeaf: true)
 external void SceneAsset_createFromFilamentAssetRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
   int requiredGeometryCapabilities,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TVertexBuffer>,
-            ffi.Pointer<TIndexBuffer>,
-            ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-            ffi.Int,
-            ffi.UnsignedInt,
-            ffi.UnsignedInt,
-            Aabb3,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    Aabb3,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
+  )
+>(isLeaf: true)
 external void SceneAsset_createFromBuffersRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tVertexBuffer,
@@ -4128,39 +2480,32 @@ external void SceneAsset_createFromBuffersRenderThread(
   int tPrimitiveType,
   int vertexBufferStorageMode,
   Aabb3 boundingBox,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-      callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> callback,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TSceneAsset>,
-            ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-            ffi.Int,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
+  )
+>(isLeaf: true)
 external void SceneAsset_createInstanceRenderThread(
   ffi.Pointer<TSceneAsset> asset,
   ffi.Pointer<ffi.Pointer<TMaterialInstance>> tMaterialInstances,
   int materialInstanceCount,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
-      callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> callback,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_releaseSourceDataRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int requestId,
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_setFlatShadingRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   bool flatShading,
@@ -4169,50 +2514,49 @@ external void SceneAsset_setFlatShadingRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Int,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Uint8,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TMaterialInstance>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>,
+  )
+>(isLeaf: true)
 external void MaterialProvider_createMaterialInstanceRenderThread(
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
   bool doubleSided,
@@ -4253,14 +2597,10 @@ external void MaterialProvider_createMaterialInstanceRenderThread(
   bool hasSheen,
   bool hasIOR,
   bool hasVolume,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>
-      callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>> callback,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void AnimationManager_updateRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int frameTimeInNanos,
@@ -4269,8 +2609,15 @@ external void AnimationManager_updateRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int, ffi.Float, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Float,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void AnimationManager_setGltfAnimationTimeRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -4281,11 +2628,12 @@ external void AnimationManager_setGltfAnimationTimeRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TAnimationManager>,
-            ffi.Pointer<TSceneAsset>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void AnimationManager_updateBoneMatricesRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -4293,13 +2641,14 @@ external void AnimationManager_updateBoneMatricesRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TAnimationManager>,
-            EntityId,
-            ffi.Pointer<ffi.Float>,
-            ffi.Int,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void AnimationManager_setMorphTargetWeightsRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -4309,98 +2658,86 @@ external void AnimationManager_setMorphTargetWeightsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Uint32,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TLinearImage>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>,
+  )
+>(isLeaf: true)
 external void Image_createEmptyRenderThread(
   int width,
   int height,
   int channel,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Pointer<ffi.Char>,
-        ffi.Bool,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TLinearImage>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.Char>,
+    ffi.Bool,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>,
+  )
+>(isLeaf: true)
 external void Image_decodeRenderThread(
   ffi.Pointer<ffi.Uint8> data,
   int length,
   ffi.Pointer<ffi.Char> name,
   bool alpha,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TLinearImage>,
-            ffi.Pointer<
-                ffi
-                .NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TLinearImage>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>,
+  )
+>(isLeaf: true)
 external void Image_getBytesRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Image_destroyRenderThread(
-  ffi.Pointer<TLinearImage> tLinearImage,
-  int requestId,
-  VoidCallback onComplete,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Image_destroyRenderThread(ffi.Pointer<TLinearImage> tLinearImage, int requestId, VoidCallback onComplete);
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TLinearImage>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
+>(isLeaf: true)
 external void Image_getWidthRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TLinearImage>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
+>(isLeaf: true)
 external void Image_getHeightRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TLinearImage>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
+>(isLeaf: true)
 external void Image_getChannelsRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TTexture>,
-            ffi.Pointer<TLinearImage>,
-            ffi.UnsignedInt,
-            ffi.UnsignedInt,
-            ffi.Int,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TLinearImage>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void Texture_loadImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -4412,22 +2749,23 @@ external void Texture_loadImageRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TTexture>,
-            ffi.Uint32,
-            ffi.Pointer<ffi.Uint8>,
-            ffi.Size,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Uint32,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Uint32,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void Texture_setImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -4446,36 +2784,32 @@ external void Texture_setImageRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TRenderTarget>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderTarget>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
 external void RenderTarget_getColorTextureRenderThread(
   ffi.Pointer<TRenderTarget> tRenderTarget,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<TTexture>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TRenderTarget>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>>,
+  )
+>(isLeaf: true)
 external void RenderTarget_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> color,
   ffi.Pointer<TTexture> depth,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderTarget_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderTarget> tRenderTarget,
@@ -4483,59 +2817,46 @@ external void RenderTarget_destroyRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>)>(
+  isLeaf: true,
+)
 external void TextureSampler_createRenderThread(
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>,
+  )
+>(isLeaf: true)
 external void TextureSampler_createWithFilteringRenderThread(
   int minFilter,
   int magFilter,
   int wrapS,
   int wrapT,
   int wrapR,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>,
+  )
+>(isLeaf: true)
 external void TextureSampler_createWithComparisonRenderThread(
   int compareMode,
   int compareFunc,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_setMinFilterRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
@@ -4543,9 +2864,7 @@ external void TextureSampler_setMinFilterRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_setMagFilterRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
@@ -4553,9 +2872,7 @@ external void TextureSampler_setMagFilterRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeSRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4563,9 +2880,7 @@ external void TextureSampler_setWrapModeSRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeTRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4573,9 +2888,7 @@ external void TextureSampler_setWrapModeTRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeRRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4583,9 +2896,7 @@ external void TextureSampler_setWrapModeRRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_setAnisotropyRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   double anisotropy,
@@ -4594,8 +2905,8 @@ external void TextureSampler_setAnisotropyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
-        ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.UnsignedInt, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
 external void TextureSampler_setCompareModeRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -4604,18 +2915,16 @@ external void TextureSampler_setCompareModeRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_destroyRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int requestId,
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void AnimationManager_resetToRestPoseRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -4624,26 +2933,21 @@ external void AnimationManager_resetToRestPoseRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TMaterialProvider>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TGltfAssetLoader>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>>,
+  )
+>(isLeaf: true)
 external void GltfAssetLoader_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>>
-      callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>> callback,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void GltfAssetLoader_destroyRenderThread(
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   int requestId,
@@ -4651,23 +2955,19 @@ external void GltfAssetLoader_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(
-                    ffi.Pointer<TGltfResourceLoader>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>>,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>>
-      callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>> callback,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void GltfResourceLoader_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfResourceLoader> tResourceLoader,
@@ -4676,11 +2976,12 @@ external void GltfResourceLoader_destroyRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TGltfResourceLoader>,
-            ffi.Pointer<TFilamentAsset>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_loadResourcesRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -4688,13 +2989,15 @@ external void GltfResourceLoader_loadResourcesRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_addResourceDataRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.Char> uri,
@@ -4705,11 +3008,12 @@ external void GltfResourceLoader_addResourceDataRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TGltfResourceLoader>,
-            ffi.Pointer<TFilamentAsset>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void GltfResourceLoader_asyncBeginLoadRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -4717,43 +3021,36 @@ external void GltfResourceLoader_asyncBeginLoadRenderThread(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoadRenderThread(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
+external void GltfResourceLoader_asyncUpdateLoadRenderThread(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TGltfResourceLoader>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>)
+>(isLeaf: true)
 external void GltfResourceLoader_asyncGetLoadProgressRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>> callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<ffi.Uint8>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>,
+  )
+>(isLeaf: true)
 external void GltfAssetLoader_loadRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   ffi.Pointer<ffi.Uint8> data,
   int length,
   int numInstances,
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>
-      callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>> callback,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_addFilamentAssetRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TFilamentAsset> tAsset,
@@ -4762,17 +3059,14 @@ external void Scene_addFilamentAssetRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TFilamentAsset>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)
+>(isLeaf: true)
 external void FilamentAsset_getWireframeRenderThread(
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_addEntityRenderThread(
   ffi.Pointer<TScene> tScene,
   int entityId,
@@ -4780,9 +3074,7 @@ external void Scene_addEntityRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_removeEntityRenderThread(
   ffi.Pointer<TScene> tScene,
   int entityId,
@@ -4790,9 +3082,7 @@ external void Scene_removeEntityRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_addToSceneRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
@@ -4800,9 +3090,7 @@ external void SceneAsset_addToSceneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_removeFromSceneRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
@@ -4810,9 +3098,7 @@ external void SceneAsset_removeFromSceneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_setSkyboxRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TSkybox> tSkybox,
@@ -4820,9 +3106,7 @@ external void Scene_setSkyboxRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_setIndirectLightRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -4831,17 +3115,17 @@ external void Scene_setIndirectLightRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TEngine>,
-            ffi.Pointer<TGltfAssetLoader>,
-            ffi.Pointer<TGltfResourceLoader>,
-            ffi.Pointer<TNameComponentManager>,
-            ffi.Pointer<TView>,
-            ffi.Pointer<TMaterial>,
-            ffi.UnsignedInt,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TView>,
+    ffi.Pointer<TMaterial>,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>,
+  )
+>(isLeaf: true)
 external void Gizmo_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -4850,27 +3134,23 @@ external void Gizmo_createRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TMaterial> tMaterial,
   int tGizmoType,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>
-      callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>> callback,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TVertexBufferBuilder>,
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>,
+  )
+>(isLeaf: true)
 external void VertexBufferBuilder_buildRenderThread(
   ffi.Pointer<TVertexBufferBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void VertexBuffer_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -4879,15 +3159,17 @@ external void VertexBuffer_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Uint8,
-        ffi.Pointer<ffi.Void>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void VertexBuffer_setBufferAtRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -4900,13 +3182,15 @@ external void VertexBuffer_setBufferAtRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Uint8,
-        ffi.Pointer<TBufferObject>,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<TBufferObject>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void VertexBuffer_setBufferObjectAtRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -4917,28 +3201,29 @@ external void VertexBuffer_setBufferObjectAtRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TBufferObjectBuilder>,
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TBufferObject>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TBufferObjectBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>>,
+  )
+>(isLeaf: true)
 external void BufferObjectBuilder_buildRenderThread(
   ffi.Pointer<TBufferObjectBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>> onComplete,
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TBufferObject>,
-        ffi.Pointer<ffi.Void>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TBufferObject>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void BufferObject_setBufferRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TBufferObject> tBuffer,
@@ -4949,9 +3234,7 @@ external void BufferObject_setBufferRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void BufferObject_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TBufferObject> tBuffer,
@@ -4960,22 +3243,19 @@ external void BufferObject_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TIndexBufferBuilder>,
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<
-            ffi.NativeFunction<
-                ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TIndexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>,
+  )
+>(isLeaf: true)
 external void IndexBufferBuilder_buildRenderThread(
   ffi.Pointer<TIndexBufferBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>
-      onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void IndexBuffer_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndexBuffer> tBuffer,
@@ -4984,14 +3264,16 @@ external void IndexBuffer_destroyRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Void>,
-        ffi.Size,
-        ffi.Uint32,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void IndexBuffer_setBufferRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndexBuffer> tBuffer,
@@ -5003,12 +3285,13 @@ external void IndexBuffer_setBufferRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TRenderableBuilder>,
-            ffi.Pointer<TEngine>,
-            EntityId,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Pointer<TEngine>,
+    EntityId,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>,
+  )
+>(isLeaf: true)
 external void RenderableBuilder_buildRenderThread(
   ffi.Pointer<TRenderableBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
@@ -5017,17 +3300,14 @@ external void RenderableBuilder_buildRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(ffi.Pointer<TEntityManager>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)>(
-    isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TEntityManager>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)
+>(isLeaf: true)
 external void EntityManager_createEntityRenderThread(
   ffi.Pointer<TEntityManager> tEntityManager,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void EntityManager_destroyEntityRenderThread(
   ffi.Pointer<TEntityManager> tEntityManager,
   int entityId,
@@ -5035,9 +3315,9 @@ external void EntityManager_destroyEntityRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void TransformManager_setTransformRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -5046,9 +3326,9 @@ external void TransformManager_setTransformRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId,
-        ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void TransformManager_setParentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
@@ -5058,9 +3338,7 @@ external void TransformManager_setParentRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TransformManager_createComponentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -5068,9 +3346,7 @@ external void TransformManager_createComponentRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TransformManager_removeComponentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -5078,9 +3354,7 @@ external void TransformManager_removeComponentRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderableManager_destroyEntityRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5089,14 +3363,16 @@ external void RenderableManager_destroyEntityRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>,
-        EntityId,
-        ffi.Pointer<ffi.Float>,
-        ffi.Size,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderableManager_setMorphWeightsRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5108,14 +3384,16 @@ external void RenderableManager_setMorphWeightsRenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>,
-        EntityId,
-        ffi.Pointer<ffi.Float>,
-        ffi.Size,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderableManager_setBonesFromMat4RenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5127,14 +3405,16 @@ external void RenderableManager_setBonesFromMat4RenderThread(
 );
 
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>,
-        EntityId,
-        ffi.Pointer<ffi.Float>,
-        ffi.Size,
-        ffi.Size,
-        ffi.Uint32,
-        VoidCallback)>(isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
 external void RenderableManager_setBonesFromBoneRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5146,16 +3426,17 @@ external void RenderableManager_setBonesFromBoneRenderThread(
 );
 
 @ffi.Native<
-        ffi.Void Function(
-            ffi.Pointer<TRenderableManager>,
-            EntityId,
-            ffi.Int,
-            ffi.Uint8,
-            ffi.Pointer<TVertexBuffer>,
-            ffi.Size,
-            ffi.Size,
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
-    isLeaf: true)
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Int,
+    ffi.Uint8,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
 external void RenderableManager_setGeometryAtNonIndexedRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5167,9 +3448,9 @@ external void RenderableManager_setGeometryAtNonIndexedRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void RenderableManager_setCastShadowsRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5178,9 +3459,9 @@ external void RenderableManager_setCastShadowsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void RenderableManager_setReceiveShadowsRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -5189,9 +3470,7 @@ external void RenderableManager_setReceiveShadowsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void LightManager_setShadowCasterRenderThread(
   ffi.Pointer<TLightManager> tLightManager,
   int entityId,
@@ -5200,9 +3479,9 @@ external void LightManager_setShadowCasterRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions,
-        ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
 external void LightManager_setShadowOptionsRenderThread(
   ffi.Pointer<TLightManager> tLightManager,
   int entityId,
@@ -5211,631 +3490,18 @@ external void LightManager_setShadowOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
-  ffi.Pointer<TEngine> tEngine,
-);
-
 @ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external bool GltfResourceLoader_asyncBeginLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external double GltfResourceLoader_asyncGetLoadProgress(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external void GltfResourceLoader_addResourceData(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.Char> uri,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>,
-        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external bool GltfResourceLoader_loadResources(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double)>(isLeaf: true)
-external void Skybox_setColor(
-  ffi.Pointer<TSkybox> tSkybox,
-  double r,
-  double g,
-  double b,
-  double a,
-);
-
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Uint8, ffi.Uint8)>(
-    isLeaf: true)
-external void Skybox_setLayerMask(
-  ffi.Pointer<TSkybox> tSkybox,
-  int select,
-  int values,
-);
-
-/// Returns the visibility mask bits.
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external int Skybox_getLayerMask(
-  ffi.Pointer<TSkybox> tSkybox,
-);
-
-/// Returns the skybox intensity in lux.
-@ffi.Native<ffi.Float Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external double Skybox_getIntensity(
-  ffi.Pointer<TSkybox> tSkybox,
-);
-
-/// Returns the environment texture, or nullptr for a color-only skybox.
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external ffi.Pointer<TTexture> Skybox_getTexture(
-  ffi.Pointer<TSkybox> tSkybox,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMeshData>)>(isLeaf: true)
-external void MeshData_dispose(
-  ffi.Pointer<TMeshData> meshData,
-);
-
-@ffi.Native<
-    ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>,
-        ffi.Pointer<TMeshData>)>(isLeaf: true)
-external int GltfParser_parseBuffer(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> meshName,
-  ffi.Pointer<TMeshData> outMeshData,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external void RenderableManager_destroyEntity(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external bool RenderableManager_hasComponent(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
-external bool RenderableManager_empty(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external bool RenderableManager_isRenderable(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
-external int RenderableManager_getComponentCount(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int,
-        ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external bool RenderableManager_setMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-);
-
-@ffi.Native<
-    ffi.Pointer<TMaterialInstance> Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
-external void RenderableManager_clearMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-);
-
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TRenderableManager>,
-        EntityId,
-        ffi.Int,
-        ffi.Uint8,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Size,
-        ffi.Size)>(isLeaf: true)
-external bool RenderableManager_setGeometryAtNonIndexed(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  int type,
-  ffi.Pointer<TVertexBuffer> vertices,
-  int offset,
-  int count,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external int RenderableManager_getPrimitiveCount(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external Aabb3 RenderableManager_getAxisAlignedBoundingBox(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, Aabb3)>(isLeaf: true)
-external void RenderableManager_setAxisAlignedBoundingBox(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  Aabb3 aabb,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external Aabb3 RenderableManager_getAabb(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external Aabb3 RenderableManager_getBoundingBox(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8,
-        ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setLayerMask(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int select,
-  int values,
-);
-
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external int RenderableManager_getLayerMask(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setVisibilityLayer(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int layer,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setPriority(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int priority,
-);
-
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external int RenderableManager_getPriority(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setCulling(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external bool RenderableManager_getCulling(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setFogEnabled(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external bool RenderableManager_getFogEnabled(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setLightChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.UnsignedInt)>(isLeaf: true)
-external bool RenderableManager_getLightChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setCastShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool castShadows,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external bool RenderableManager_isShadowCaster(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setReceiveShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool receiveShadows,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external bool RenderableManager_isShadowReceiver(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setScreenSpaceContactShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size,
-        ffi.Uint16)>(isLeaf: true)
-external void RenderableManager_setBlendOrderAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  int order,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size,
-        ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setGlobalBlendOrderEnabledAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  bool enabled,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
-external void RenderableManager_setMorphWeights(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> weights,
-  int count,
-  int offset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(
-    isLeaf: true)
-external int RenderableManager_getMorphTargetCount(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
-external void RenderableManager_setBonesFromMat4(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> transforms,
-  int boneCount,
-  int offset,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
-        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
-external void RenderableManager_setBonesFromBone(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> bones,
-  int boneCount,
-  int offset,
-);
-
-@ffi.Native<ffi.Pointer<TRenderableBuilder> Function(ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TRenderableBuilder> RenderableBuilder_create(
-  int primitiveCount,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>)>(isLeaf: true)
-external void RenderableBuilder_destroy(
-  ffi.Pointer<TRenderableBuilder> builder,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, Aabb3)>(
-    isLeaf: true)
-external void RenderableBuilder_boundingBox(
-  ffi.Pointer<TRenderableBuilder> builder,
-  Aabb3 aabb,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
-        ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external void RenderableBuilder_material(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  ffi.Pointer<TMaterialInstance> materialInstance,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableBuilder>,
-        ffi.Size,
-        ffi.Uint8,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Pointer<TIndexBuffer>,
-        ffi.Size,
-        ffi.Size)>(isLeaf: true)
-external void RenderableBuilder_geometry(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  int type,
-  ffi.Pointer<TVertexBuffer> vertices,
-  ffi.Pointer<TIndexBuffer> indices,
-  int offset,
-  int count,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint8,
-        ffi.Pointer<TVertexBuffer>, ffi.Size, ffi.Size)>(isLeaf: true)
-external void RenderableBuilder_geometryNonIndexed(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  int type,
-  ffi.Pointer<TVertexBuffer> vertices,
-  int offset,
-  int count,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(
-    isLeaf: true)
-external void RenderableBuilder_priority(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int priority,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(
-    isLeaf: true)
-external void RenderableBuilder_channel(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void RenderableBuilder_culling(
-  ffi.Pointer<TRenderableBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void RenderableBuilder_castShadows(
-  ffi.Pointer<TRenderableBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void RenderableBuilder_receiveShadows(
-  ffi.Pointer<TRenderableBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void RenderableBuilder_fog(
-  ffi.Pointer<TRenderableBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt,
-        ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_lightChannel(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int channel,
-  bool enabled,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void RenderableBuilder_layerMask(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int select,
-  int values,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void RenderableBuilder_screenSpaceContactShadows(
-  ffi.Pointer<TRenderableBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
-external void RenderableBuilder_blendOrder(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  int order,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_globalBlendOrderEnabled(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size)>(
-    isLeaf: true)
-external void RenderableBuilder_instances(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int instanceCount,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
-        ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void RenderableBuilder_skinningFromMat4(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int boneCount,
-  ffi.Pointer<ffi.Float> transforms,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
-        ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void RenderableBuilder_skinningFromBone(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int boneCount,
-  ffi.Pointer<ffi.Float> bones,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
-    isLeaf: true)
-external void RenderableBuilder_enableSkinningBuffers(
-  ffi.Pointer<TRenderableBuilder> builder,
-  bool enabled,
-);
-
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
-        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
-external void RenderableBuilder_boneIndicesAndWeights(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  ffi.Pointer<ffi.Float> indicesAndWeights,
-  int count,
-  int bonesPerVertex,
-);
-
-@ffi.Native<
-    ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>,
-        EntityId)>(isLeaf: true)
-external int RenderableBuilder_build(
-  ffi.Pointer<TRenderableBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-  int entity,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TVertexBuffer>,
-        ffi.Pointer<TIndexBuffer>,
-        ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-        ffi.Int,
-        ffi.UnsignedInt,
-        ffi.UnsignedInt,
-        Aabb3)>(isLeaf: true)
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    Aabb3,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tVertexBuffer,
@@ -5848,12 +3514,14 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
 );
 
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TEngine>,
-        ffi.Pointer<TGltfAssetLoader>,
-        ffi.Pointer<TNameComponentManager>,
-        ffi.Pointer<TFilamentAsset>,
-        ffi.Uint32)>(isLeaf: true)
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -5862,91 +3530,51 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
   int requiredGeometryCapabilities,
 );
 
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void SceneAsset_addToScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void SceneAsset_addToScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
-    isLeaf: true)
-external void SceneAsset_removeFromScene(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void SceneAsset_removeFromScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
 
 @ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external int SceneAsset_getChildEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
-    isLeaf: true)
-external void SceneAsset_getChildEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<EntityId> out,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getChildEntities(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<EntityId> out);
 
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external int SceneAsset_getCameraEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
 
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
-    isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external int SceneAsset_getLightEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(ffi.Pointer<TSceneAsset> tSceneAsset, int index);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int index,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<
-    ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>,
-        ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)>(isLeaf: true)
+  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)
+>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
   ffi.Pointer<TSceneAsset> asset,
   ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
@@ -5954,157 +3582,242 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(
-  ffi.Pointer<TSceneAsset> asset,
-);
+external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getGeometryCapabilities(
-  ffi.Pointer<TSceneAsset> asset,
-);
+external int SceneAsset_getGeometryCapabilities(ffi.Pointer<TSceneAsset> asset);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool SceneAsset_supportsFlatShading(
-  ffi.Pointer<TSceneAsset> asset,
-);
+external bool SceneAsset_supportsFlatShading(ffi.Pointer<TSceneAsset> asset);
 
-@ffi.Native<
-    ffi.Pointer<TVertexBuffer> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
 external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int primitiveIndex,
 );
 
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(
-    isLeaf: true)
-external int SceneAsset_getVertexBufferStorageMode(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external int SceneAsset_getVertexBufferStorageMode(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
 
-@ffi.Native<
-    ffi.Pointer<TIndexBuffer> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
+@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int SceneAsset_getPrimitiveOffsetForEntity(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int entity,
-);
+external int SceneAsset_getPrimitiveOffsetForEntity(ffi.Pointer<TSceneAsset> tSceneAsset, int entity);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
+external void SceneAsset_releaseSourceData(ffi.Pointer<TSceneAsset> tSceneAsset);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
-);
+external void SceneAsset_setFlatShading(ffi.Pointer<TSceneAsset> tSceneAsset, bool flatShading);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size,
-        ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getBones(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  ffi.Pointer<EntityId> out,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getBones(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex, ffi.Pointer<EntityId> out);
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-);
+external int SceneAsset_getBoneCount(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex);
 
-@ffi.Native<
-    ffi.Pointer<ffi.Char> Function(
-        ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
 external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int skinIndex,
   int boneIndex,
 );
 
-@ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(
-    isLeaf: true)
-external ffi.Pointer<TAnimationManager> AnimationManager_create(
-  ffi.Pointer<TEngine> tEngine,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMeshData>)>(isLeaf: true)
+external void MeshData_dispose(ffi.Pointer<TMeshData> meshData);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void AnimationManager_destroy(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(
-    isLeaf: true)
-external void AnimationManager_update(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int frameTimeInNanos,
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Pointer<TMeshData>)>(
+  isLeaf: true,
+)
+external int GltfParser_parseBuffer(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> meshName,
+  ffi.Pointer<TMeshData> outMeshData,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+  ffi.Pointer<TGltfAssetLoader> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Pointer<TNameComponentManager>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external void GltfAssetLoader_destroy(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
+
+@ffi.Native<
+  ffi.Pointer<TFilamentAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+);
+
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, ffi.Pointer<TFilamentAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  ffi.Pointer<TFilamentAsset> tAsset,
+);
+
+@ffi.Native<ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getResourceUriCount(ffi.Pointer<TFilamentAsset> tFilamentAsset);
+
+@ffi.Native<ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(ffi.Pointer<TFilamentAsset> tFilamentAsset);
+
+@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+
+@ffi.Native<ffi.Void Function()>()
+external void FrameScheduler_stop();
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(int port, int targetFps);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_setTargetFps(int fps);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
+
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(int t);
+
+@ffi.Native<
+  ffi.Pointer<TGizmo> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TView>,
+    ffi.Pointer<TMaterial>,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TGizmo> Gizmo_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> assetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32, GizmoPickCallback)>(isLeaf: true)
+external void Gizmo_pick(ffi.Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
+external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
+
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external void NameComponentManager_destroy(ffi.Pointer<TNameComponentManager> tNameComponentManager);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TRenderTarget> RenderTarget_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> color,
+  ffi.Pointer<TTexture> depth,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void RenderTarget_destroy(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderTarget> tRenderTarget);
+
+@ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TAnimationManager> AnimationManager_create(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void AnimationManager_destroy(ffi.Pointer<TAnimationManager> tAnimationManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(isLeaf: true)
+external void AnimationManager_update(ffi.Pointer<TAnimationManager> tAnimationManager, int frameTimeInNanos);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_addGltfAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_removeGltfAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-    isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
 external void AnimationManager_addMorphAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-    isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
 external void AnimationManager_removeMorphAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_addBoneAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_removeBoneAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>,
-        EntityId,
-        ffi.Pointer<ffi.Float>,
-        ffi.Pointer<ffi.Uint32>,
-        ffi.Int,
-        ffi.Int,
-        ffi.Float)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Pointer<ffi.Uint32>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external bool AnimationManager_setMorphAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -6115,34 +3828,30 @@ external bool AnimationManager_setMorphAnimation(
   double frameLengthInMs,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(
-    isLeaf: true)
-external bool AnimationManager_clearMorphAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+external bool AnimationManager_clearMorphAnimation(ffi.Pointer<TAnimationManager> tAnimationManager, int entityId);
 
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external void AnimationManager_resetToRestPose(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>,
-        ffi.Pointer<TSceneAsset>,
-        ffi.Int,
-        ffi.Int,
-        ffi.Pointer<ffi.Float>,
-        ffi.Int,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float,
-        ffi.Bool)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Bool,
+  )
+>(isLeaf: true)
 external bool AnimationManager_addBoneAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -6158,8 +3867,8 @@ external bool AnimationManager_addBoneAnimation(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)
+>(isLeaf: true)
 external void AnimationManager_getRestLocalTransforms(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6169,8 +3878,8 @@ external void AnimationManager_getRestLocalTransforms(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)
+>(isLeaf: true)
 external void AnimationManager_getInverseBindMatrix(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6180,16 +3889,18 @@ external void AnimationManager_getInverseBindMatrix(
 );
 
 @ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>,
-        ffi.Pointer<TSceneAsset>,
-        ffi.Int,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Bool,
-        ffi.Float,
-        ffi.Float,
-        ffi.Float)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
 external bool AnimationManager_playGltfAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -6202,35 +3913,29 @@ external bool AnimationManager_playGltfAnimation(
   double speed,
 );
 
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
 external bool AnimationManager_stopGltfAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
   int index,
 );
 
-@ffi.Native<
-    ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int)>(isLeaf: true)
+@ffi.Native<ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
 external double AnimationManager_getGltfAnimationDuration(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
   int animationIndex,
 );
 
-@ffi.Native<
-    ffi.Int Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external int AnimationManager_getGltfAnimationCount(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Char>, ffi.Int)
+>(isLeaf: true)
 external void AnimationManager_getGltfAnimationName(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6238,9 +3943,7 @@ external void AnimationManager_getGltfAnimationName(
   int index,
 );
 
-@ffi.Native<
-    ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        EntityId)>(isLeaf: true)
+@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
 external int AnimationManager_getMorphTargetNameCount(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6248,8 +3951,8 @@ external int AnimationManager_getMorphTargetNameCount(
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        EntityId, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId, ffi.Pointer<ffi.Char>, ffi.Int)
+>(isLeaf: true)
 external void AnimationManager_getMorphTargetName(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -6258,17 +3961,13 @@ external void AnimationManager_getMorphTargetName(
   int index,
 );
 
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_updateBoneMatrices(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId,
-        ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
 external bool AnimationManager_setMorphTargetWeights(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -6276,9 +3975,9 @@ external bool AnimationManager_setMorphTargetWeights(
   int numWeights,
 );
 
-@ffi.Native<
-    ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
-        ffi.Int, ffi.Float)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Float)>(
+  isLeaf: true,
+)
 external bool AnimationManager_setGltfAnimationTime(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -6286,35 +3985,803 @@ external bool AnimationManager_setGltfAnimationTime(
   double timeInSeconds,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
-    isLeaf: true)
-external void MovementIntentExecutor_destroy(
-  ffi.Pointer<TMovementIntentExecutor> executor,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external void RenderableManager_destroyEntity(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_hasComponent(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
+external bool RenderableManager_empty(ffi.Pointer<TRenderableManager> tRenderableManager);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_isRenderable(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
+external int RenderableManager_getComponentCount(ffi.Pointer<TRenderableManager> tRenderableManager);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int, ffi.Pointer<TMaterialInstance>)>(
+  isLeaf: true,
+)
+external bool RenderableManager_setMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
+external void RenderableManager_clearMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
 );
 
 @ffi.Native<
-    ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>,
-        ffi.Pointer<TMovementIntent>, ffi.Uint64)>(isLeaf: true)
+  ffi.Bool Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Int,
+    ffi.Uint8,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external bool RenderableManager_setGeometryAtNonIndexed(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  int type,
+  ffi.Pointer<TVertexBuffer> vertices,
+  int offset,
+  int count,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external int RenderableManager_getPrimitiveCount(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external Aabb3 RenderableManager_getAxisAlignedBoundingBox(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, Aabb3)>(isLeaf: true)
+external void RenderableManager_setAxisAlignedBoundingBox(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  Aabb3 aabb,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external Aabb3 RenderableManager_getAabb(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external Aabb3 RenderableManager_getBoundingBox(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setLayerMask(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int select,
+  int values,
+);
+
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external int RenderableManager_getLayerMask(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setVisibilityLayer(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int layer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setPriority(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int priority,
+);
+
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external int RenderableManager_getPriority(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setCulling(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_getCulling(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setFogEnabled(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_getFogEnabled(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setLightChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool RenderableManager_getLightChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setCastShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool castShadows,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_isShadowCaster(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setReceiveShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool receiveShadows,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_isShadowReceiver(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setScreenSpaceContactShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size, ffi.Uint16)>(isLeaf: true)
+external void RenderableManager_setBlendOrderAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  int order,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setGlobalBlendOrderEnabledAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void RenderableManager_setMorphWeights(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> weights,
+  int count,
+  int offset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external int RenderableManager_getMorphTargetCount(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void RenderableManager_setBonesFromMat4(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> transforms,
+  int boneCount,
+  int offset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void RenderableManager_setBonesFromBone(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> bones,
+  int boneCount,
+  int offset,
+);
+
+@ffi.Native<ffi.Pointer<TRenderableBuilder> Function(ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TRenderableBuilder> RenderableBuilder_create(int primitiveCount);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>)>(isLeaf: true)
+external void RenderableBuilder_destroy(ffi.Pointer<TRenderableBuilder> builder);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, Aabb3)>(isLeaf: true)
+external void RenderableBuilder_boundingBox(ffi.Pointer<TRenderableBuilder> builder, Aabb3 aabb);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void RenderableBuilder_material(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  ffi.Pointer<TMaterialInstance> materialInstance,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Size,
+    ffi.Uint8,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void RenderableBuilder_geometry(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  int type,
+  ffi.Pointer<TVertexBuffer> vertices,
+  ffi.Pointer<TIndexBuffer> indices,
+  int offset,
+  int count,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Size,
+    ffi.Uint8,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void RenderableBuilder_geometryNonIndexed(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  int type,
+  ffi.Pointer<TVertexBuffer> vertices,
+  int offset,
+  int count,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(isLeaf: true)
+external void RenderableBuilder_priority(ffi.Pointer<TRenderableBuilder> builder, int priority);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(isLeaf: true)
+external void RenderableBuilder_channel(ffi.Pointer<TRenderableBuilder> builder, int channel);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_culling(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_castShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_receiveShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_fog(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_lightChannel(ffi.Pointer<TRenderableBuilder> builder, int channel, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void RenderableBuilder_layerMask(ffi.Pointer<TRenderableBuilder> builder, int select, int values);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_screenSpaceContactShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
+external void RenderableBuilder_blendOrder(ffi.Pointer<TRenderableBuilder> builder, int primitiveIndex, int order);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_globalBlendOrderEnabled(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size)>(isLeaf: true)
+external void RenderableBuilder_instances(ffi.Pointer<TRenderableBuilder> builder, int instanceCount);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void RenderableBuilder_skinningFromMat4(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int boneCount,
+  ffi.Pointer<ffi.Float> transforms,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void RenderableBuilder_skinningFromBone(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int boneCount,
+  ffi.Pointer<ffi.Float> bones,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_enableSkinningBuffers(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void RenderableBuilder_boneIndicesAndWeights(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  ffi.Pointer<ffi.Float> indicesAndWeights,
+  int count,
+  int bonesPerVertex,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
+external int RenderableBuilder_build(ffi.Pointer<TRenderableBuilder> builder, ffi.Pointer<TEngine> engine, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void Camera_setExposure(ffi.Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void Camera_getFrustum(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> out);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double, ffi.Bool)>(
+  isLeaf: true,
+)
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(isLeaf: true)
+external void Camera_lookAt(ffi.Pointer<TCamera> camera, double3 eye, double3 focus, double3 up);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(ffi.Pointer<TCamera> camera, double focusDistance);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4)>(isLeaf: true)
+external void Camera_setModelMatrix(ffi.Pointer<TCamera> camera, double4x4 tModelMatrix);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.UnsignedInt,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(isLeaf: true)
+external void Scene_setSkybox(ffi.Pointer<TScene> tScene, ffi.Pointer<TSkybox> skybox);
+
+@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TScene>)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Scene_getSkybox(ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Scene_setIndirectLight(ffi.Pointer<TScene> tScene, ffi.Pointer<TIndirectLight> tIndirectLight);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external void Scene_addFilamentAsset(ffi.Pointer<TScene> tScene, ffi.Pointer<TFilamentAsset> asset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Skybox_setColor(ffi.Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void Skybox_setLayerMask(ffi.Pointer<TSkybox> tSkybox, int select, int values);
+
+/// Returns the visibility mask bits.
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external int Skybox_getLayerMask(ffi.Pointer<TSkybox> tSkybox);
+
+/// Returns the skybox intensity in lux.
+@ffi.Native<ffi.Float Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external double Skybox_getIntensity(ffi.Pointer<TSkybox> tSkybox);
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external ffi.Pointer<TTexture> Skybox_getTexture(ffi.Pointer<TSkybox> tSkybox);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void Renderer_setClearOptions(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)>(isLeaf: true)
+external bool Renderer_beginFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
+external void Renderer_render(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
+external void Renderer_renderStandaloneView(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<TRenderTarget>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void Renderer_readPixels(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void Renderer_setFrameInterval(
+  ffi.Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void IndirectLight_setRotation(ffi.Pointer<TIndirectLight> tIndirectLight, ffi.Pointer<ffi.Double> rotation);
+
+@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_asyncBeginLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_asyncUpdateLoad(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external double GltfResourceLoader_asyncGetLoadProgress(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Uint8>, ffi.Size)
+>(isLeaf: true)
+external void GltfResourceLoader_addResourceData(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.Char> uri,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_loadResources(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void FilamentAsset_getEntities(ffi.Pointer<TFilamentAsset> filamentAsset, ffi.Pointer<EntityId> out);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<ffi.Pointer<TRenderManager> Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(isLeaf: true)
+external void RenderManager_render(ffi.Pointer<TRenderManager> tRenderer, int frameTimeInNanos);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)
+>(isLeaf: true)
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void RenderManager_removeSwapChain(ffi.Pointer<TRenderManager> tRenderer, ffi.Pointer<TSwapChain> swapChain);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_detachFromRenderThread(ffi.Pointer<TRenderManager> tRenderManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(isLeaf: true)
+external void RenderManager_setPaused(ffi.Pointer<TRenderManager> tRenderer, bool paused);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_vertexCount(ffi.Pointer<TSurfaceOrientationBuilder> builder, int count);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_normals(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> normals,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_tangents(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> tangents,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_uvs(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> uvs,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_positions(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> positions,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangleCount(ffi.Pointer<TSurfaceOrientationBuilder> builder, int count);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_uint(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint32> triangles,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_ushort(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint16> triangles,
+);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientation> Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_destroy(ffi.Pointer<TSurfaceOrientationBuilder> builder);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external int SurfaceOrientation_getVertexCount(ffi.Pointer<TSurfaceOrientation> orientation);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void SurfaceOrientation_getQuats_float4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Float> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void SurfaceOrientation_getQuats_short4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Int16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void SurfaceOrientation_getQuats_half4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Uint16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external void SurfaceOrientation_destroy(ffi.Pointer<TSurfaceOrientation> orientation);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
+external void MovementIntentExecutor_destroy(ffi.Pointer<TMovementIntentExecutor> executor);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>, ffi.Pointer<TMovementIntent>, ffi.Uint64)>(
+  isLeaf: true,
+)
 external void MovementIntentExecutor_process(
   ffi.Pointer<TMovementIntentExecutor> executor,
   ffi.Pointer<TMovementIntent> intent,
   int deltaTimeInNanos,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
-    isLeaf: true)
-external void Pipeline_registerMovementIntentExecutor(
-  ffi.Pointer<TMovementIntentExecutor> executor,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
+external void Pipeline_registerMovementIntentExecutor(ffi.Pointer<TMovementIntentExecutor> executor);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void TransformPipeline_setEngine(
-  ffi.Pointer<ffi.Void> enginePtr,
-);
+external void TransformPipeline_setEngine(ffi.Pointer<ffi.Void> enginePtr);
 
-@ffi.Native<
-    ffi.Void Function(ffi.Int, ffi.Int, ffi.Double, ffi.Double, ffi.Double,
-        ffi.Double)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
 external void TransformPipeline_onMouseEvent(
   int eventType,
   int button,
@@ -6325,81 +4792,49 @@ external void TransformPipeline_onMouseEvent(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Int, ffi.Int)>(isLeaf: true)
-external void TransformPipeline_onKeyEvent(
-  int eventType,
-  int logicalKey,
-  int physicalKey,
-  int synthesized,
-);
+external void TransformPipeline_onKeyEvent(int eventType, int logicalKey, int physicalKey, int synthesized);
 
 @ffi.Native<ffi.Void Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void TransformPipeline_onScrollEvent(
-  double localX,
-  double localY,
-  double delta,
-);
+external void TransformPipeline_onScrollEvent(double localX, double localY, double delta);
 
 @ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_update(
-  double deltaTime,
-);
+external void TransformPipeline_update(double deltaTime);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>(
-    isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
 external void TransformPipeline_registerPipelineStage(
   ffi.Pointer<ffi.Void> pipelineStageHandle,
   ffi.Pointer<ffi.Char> name,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void TransformPipeline_unregisterPipelineStage(
-  ffi.Pointer<ffi.Void> pipelineStageHandle,
-);
+external void TransformPipeline_unregisterPipelineStage(ffi.Pointer<ffi.Void> pipelineStageHandle);
 
 @ffi.Native<ffi.Void Function()>(isLeaf: true)
 external void TransformPipeline_cleanup();
 
 @ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Float)>(isLeaf: true)
-external void TransformPipeline_addKeyBinding(
-  int logicalKey,
-  int intentAction,
-  double value,
-);
+external void TransformPipeline_addKeyBinding(int logicalKey, int intentAction, double value);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForKey(
-  int logicalKey,
-);
+external void TransformPipeline_removeKeyBindingsForKey(int logicalKey);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForAction(
-  int intentAction,
-);
+external void TransformPipeline_removeKeyBindingsForAction(int intentAction);
 
 @ffi.Native<ffi.Void Function()>(isLeaf: true)
 external void TransformPipeline_clearKeyBindings();
 
 @ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Float)>(isLeaf: true)
-external void TransformPipeline_addMouseButtonBinding(
-  int mouseButton,
-  int intentAction,
-  double value,
-);
+external void TransformPipeline_addMouseButtonBinding(int mouseButton, int intentAction, double value);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeMouseButtonBindings(
-  int mouseButton,
-);
+external void TransformPipeline_removeMouseButtonBindings(int mouseButton);
 
 @ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_setMouseSensitivity(
-  double sensitivity,
-);
+external void TransformPipeline_setMouseSensitivity(double sensitivity);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_setInvertMouseY(
-  int invert,
-);
+external void TransformPipeline_setInvertMouseY(int invert);
 
 typedef VoidCallbackFunction = ffi.Void Function(ffi.Int32 requestId);
 typedef DartVoidCallbackFunction = void Function(int requestId);
@@ -6755,92 +5190,277 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
 }
 
-final class TShadowOptions extends ffi.Struct {
-  @ffi.Uint32()
-  external int mapSize;
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
 
-  @ffi.Uint8()
-  external int shadowCascades;
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
 
-  @ffi.Array.multi([3])
-  external ffi.Array<ffi.Float> cascadeSplitPositions;
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
 
-  @ffi.Float()
-  external double constantBias;
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
 
-  @ffi.Float()
-  external double normalBias;
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
 
-  @ffi.Float()
-  external double shadowFar;
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
 
-  @ffi.Float()
-  external double shadowNearHint;
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
 
-  @ffi.Float()
-  external double shadowFarHint;
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
 
-  @ffi.Bool()
-  external bool stable;
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
 
-  @ffi.Bool()
-  external bool lispsm;
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
 
-  @ffi.Float()
-  external double polygonOffsetConstant;
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
 
-  @ffi.Float()
-  external double polygonOffsetSlope;
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
 
-  @ffi.Bool()
-  external bool screenSpaceContactShadows;
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
 
-  @ffi.Uint8()
-  external int stepCount;
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
 
-  @ffi.Float()
-  external double maxShadowDistance;
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
 
-  @ffi.Bool()
-  external bool vsmElvsm;
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
 
-  @ffi.Float()
-  external double vsmBlurWidth;
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
 
-  @ffi.Float()
-  external double shadowBulbRadius;
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
 
-  @ffi.Float()
-  external double penumbraScale;
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
 
-  @ffi.Float()
-  external double penumbraRatioScale;
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
 
-  @ffi.Float()
-  external double maxPenumbraRatio;
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
 
-  @ffi.Float()
-  external double maxSearchRadius;
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
 
-  @ffi.Float()
-  external double transformX;
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
 
-  @ffi.Float()
-  external double transformY;
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
 
-  @ffi.Float()
-  external double transformZ;
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
 
-  @ffi.Float()
-  external double transformW;
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
 }
 
 final class TViewport extends ffi.Struct {
@@ -7101,333 +5721,110 @@ final class TAmbientOcclusionOptions extends ffi.Struct {
   external int aoType;
 }
 
-typedef PickCallbackFunction = ffi.Void Function(
-    ffi.Uint32 requestId,
-    EntityId entityId,
-    ffi.Float depth,
-    ffi.Float fragX,
-    ffi.Float fragY,
-    ffi.Float fragZ);
-typedef DartPickCallbackFunction = void Function(
-    int requestId,
-    DartEntityId entityId,
-    double depth,
-    double fragX,
-    double fragY,
-    double fragZ);
+typedef PickCallbackFunction =
+    ffi.Void Function(
+      ffi.Uint32 requestId,
+      EntityId entityId,
+      ffi.Float depth,
+      ffi.Float fragX,
+      ffi.Float fragY,
+      ffi.Float fragZ,
+    );
+typedef DartPickCallbackFunction =
+    void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
 typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
 
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
 }
 
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+final class TShadowOptions extends ffi.Struct {
+  @ffi.Uint32()
+  external int mapSize;
+
+  @ffi.Uint8()
+  external int shadowCascades;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.Float> cascadeSplitPositions;
+
+  @ffi.Float()
+  external double constantBias;
+
+  @ffi.Float()
+  external double normalBias;
+
+  @ffi.Float()
+  external double shadowFar;
+
+  @ffi.Float()
+  external double shadowNearHint;
+
+  @ffi.Float()
+  external double shadowFarHint;
+
+  @ffi.Bool()
+  external bool stable;
+
+  @ffi.Bool()
+  external bool lispsm;
+
+  @ffi.Float()
+  external double polygonOffsetConstant;
+
+  @ffi.Float()
+  external double polygonOffsetSlope;
+
+  @ffi.Bool()
+  external bool screenSpaceContactShadows;
+
+  @ffi.Uint8()
+  external int stepCount;
+
+  @ffi.Float()
+  external double maxShadowDistance;
+
+  @ffi.Bool()
+  external bool vsmElvsm;
+
+  @ffi.Float()
+  external double vsmBlurWidth;
+
+  @ffi.Float()
+  external double shadowBulbRadius;
+
+  @ffi.Float()
+  external double penumbraScale;
+
+  @ffi.Float()
+  external double penumbraRatioScale;
+
+  @ffi.Float()
+  external double maxPenumbraRatio;
+
+  @ffi.Float()
+  external double maxSearchRadius;
+
+  @ffi.Float()
+  external double transformX;
+
+  @ffi.Float()
+  external double transformY;
+
+  @ffi.Float()
+  external double transformZ;
+
+  @ffi.Float()
+  external double transformW;
 }
 
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-typedef FrameTickCallbackFunction = ffi.Void Function(
-    ffi.Uint64 frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameTickCallback
-    = ffi.Pointer<ffi.NativeFunction<FrameTickCallbackFunction>>;
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-typedef GizmoPickCallbackFunction = ffi.Void Function(
-    ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
-typedef DartGizmoPickCallbackFunction = void Function(
-    int resultType, double x, double y, double z);
-typedef GizmoPickCallback
-    = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-typedef FilamentRenderCallbackFunction = ffi.Void Function(
-    ffi.Pointer<ffi.Void> owner);
-typedef DartFilamentRenderCallbackFunction = void Function(
-    ffi.Pointer<ffi.Void> owner);
-typedef FilamentRenderCallback
-    = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+typedef FilamentRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> owner);
+typedef DartFilamentRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> owner);
+typedef FilamentRenderCallback = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
 
 final class TMeshData extends ffi.Struct {
   external ffi.Pointer<ffi.Char> name;
@@ -7456,6 +5853,34 @@ final class TMeshData extends ffi.Struct {
 
   @ffi.UnsignedInt()
   external int primitiveType;
+}
+
+typedef FrameTickCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(int frameTimeNanos);
+typedef FrameTickCallback = ffi.Pointer<ffi.NativeFunction<FrameTickCallbackFunction>>;
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+typedef GizmoPickCallbackFunction =
+    ffi.Void Function(ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+typedef GizmoPickCallback = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
 }
 
 final class TMovementIntentCalculator extends ffi.Opaque {}

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -19,67 +19,116 @@ external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 @ffi.Native<ffi.Uint64>()
 external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
 
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> Material_createInstance(ffi.Pointer<TMaterial> tMaterial);
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(
+    isLeaf: true)
+external ffi.Pointer<TMaterialInstance> Material_createInstance(
+  ffi.Pointer<TMaterial> tMaterial,
+);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
+external int Material_getFeatureLevel(
+  ffi.Pointer<TMaterial> tMaterial,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createImageMaterial(ffi.Pointer<TEngine> tEngine);
+external ffi.Pointer<TMaterial> Material_createImageMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createGridMaterial(ffi.Pointer<TEngine> tEngine);
+external ffi.Pointer<TMaterial> Material_createGridMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createGizmoMaterial(ffi.Pointer<TEngine> tEngine);
+external ffi.Pointer<TMaterial> Material_createGizmoMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createSilhouetteMaterial(ffi.Pointer<TEngine> tEngine);
+external ffi.Pointer<TMaterial> Material_createSilhouetteMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createEdgeOutlineMaterial(ffi.Pointer<TEngine> tEngine);
+external ffi.Pointer<TMaterial> Material_createEdgeOutlineMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createWireframeMaterial(ffi.Pointer<TEngine> tEngine);
+external ffi.Pointer<TMaterial> Material_createWireframeMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createTranslationAxisMaterial(ffi.Pointer<TEngine> tEngine);
+external ffi.Pointer<TMaterial> Material_createTranslationAxisMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(ffi.Pointer<TEngine> tEngine);
+external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(
+  ffi.Pointer<TEngine> tEngine,
+);
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external bool Material_hasParameter(ffi.Pointer<TMaterial> tMaterial, ffi.Pointer<ffi.Char> propertyName);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(
+    isLeaf: true)
+external bool Material_hasParameter(
+  ffi.Pointer<TMaterial> tMaterial,
+  ffi.Pointer<ffi.Char> propertyName,
+);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external bool MaterialInstance_isStencilWriteEnabled(ffi.Pointer<TMaterialInstance> materialInstance);
+external bool MaterialInstance_isStencilWriteEnabled(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
-external void MaterialInstance_setStencilWrite(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
+    isLeaf: true)
+external void MaterialInstance_setStencilWrite(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
-external void MaterialInstance_setCullingMode(ffi.Pointer<TMaterialInstance> materialInstance, int culling);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void MaterialInstance_setCullingMode(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int culling,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
-external void MaterialInstance_setDoubleSided(ffi.Pointer<TMaterialInstance> materialInstance, bool doubleSided);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
+    isLeaf: true)
+external void MaterialInstance_setDoubleSided(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  bool doubleSided,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
-external void MaterialInstance_setDepthWrite(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
+    isLeaf: true)
+external void MaterialInstance_setDepthWrite(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
-external void MaterialInstance_setDepthCulling(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(
+    isLeaf: true)
+external void MaterialInstance_setDepthCulling(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  bool enabled,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Double)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
   double value,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Double, ffi.Double)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Double, ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat2(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -88,8 +137,8 @@ external void MaterialInstance_setParameterFloat2(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Double, ffi.Double, ffi.Double)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat3(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -99,8 +148,8 @@ external void MaterialInstance_setParameterFloat3(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Double>, ffi.Uint32)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Double>, ffi.Uint32)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat3Array(
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -109,15 +158,8 @@ external void MaterialInstance_setParameterFloat3Array(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat4(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -127,32 +169,36 @@ external void MaterialInstance_setParameterFloat4(
   double z,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Double>)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Double>)>(isLeaf: true)
 external void MaterialInstance_setParameterMat3(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
   ffi.Pointer<ffi.Double> matrix,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Double>)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Double>)>(isLeaf: true)
 external void MaterialInstance_setParameterMat4(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
   ffi.Pointer<ffi.Double> matrix,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Int)>(isLeaf: true)
 external void MaterialInstance_setParameterInt(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
   int value,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Bool)>(isLeaf: true)
 external void MaterialInstance_setParameterBool(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -160,13 +206,8 @@ external void MaterialInstance_setParameterBool(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTextureSampler>,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTextureSampler>)>(isLeaf: true)
 external void MaterialInstance_setParameterTexture(
   ffi.Pointer<TMaterialInstance> materialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -174,531 +215,542 @@ external void MaterialInstance_setParameterTexture(
   ffi.Pointer<TTextureSampler> sampler,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
-external void MaterialInstance_setDepthFunc(ffi.Pointer<TMaterialInstance> materialInstance, int depthFunc);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void MaterialInstance_setDepthFunc(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int depthFunc,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilOpStencilFail(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
   int face,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external void MaterialInstance_setStencilOpDepthFail(ffi.Pointer<TMaterialInstance> materialInstance, int op, int face);
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
+external void MaterialInstance_setStencilOpDepthFail(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int op,
+  int face,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilOpDepthStencilPass(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int op,
   int face,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilCompareFunction(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int func,
   int face,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8, ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8,
+        ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilReferenceValue(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int value,
   int face,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(isLeaf: true)
-external void MaterialInstance_setStencilReadMask(ffi.Pointer<TMaterialInstance> materialInstance, int mask);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
+    isLeaf: true)
+external void MaterialInstance_setStencilReadMask(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int mask,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(isLeaf: true)
-external void MaterialInstance_setStencilWriteMask(ffi.Pointer<TMaterialInstance> materialInstance, int mask);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(
+    isLeaf: true)
+external void MaterialInstance_setStencilWriteMask(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  int mask,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(
+    isLeaf: true)
 external void MaterialInstance_setTransparencyMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int transparencyMode,
 );
 
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external int MaterialInstance_getTransparencyMode(ffi.Pointer<TMaterialInstance> materialInstance);
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(
+    isLeaf: true)
+external int MaterialInstance_getTransparencyMode(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
-
-@ffi.Native<
-  ffi.Pointer<TTexture> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint8,
-    ffi.Uint16,
-    ffi.IntPtr,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TTexture> Texture_build(
-  ffi.Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import$,
-  int sampler,
-  int format,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void Texture_setExternalImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<ffi.Void> externalImage,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getLevels(ffi.Pointer<TTexture> tTexture);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TLinearImage>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Int,
-  )
->(isLeaf: true)
-external bool Texture_loadImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
+external int Material_getBlendingMode(
+  ffi.Pointer<TMaterial> material,
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Uint32,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external bool Texture_setImage(
+    ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>,
+        ffi.UnsignedInt)>(isLeaf: true)
+external int LightManager_createLight(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
 );
 
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
-external int Texture_getWidth(ffi.Pointer<TTexture> tTexture, int level);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
-external int Texture_getHeight(ffi.Pointer<TTexture> tTexture, int level);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
-external int Texture_getDepth(ffi.Pointer<TTexture> tTexture, int level);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getFormat(ffi.Pointer<TTexture> tTexture);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
-external int Texture_getUsage(ffi.Pointer<TTexture> tTexture, int level);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Texture_generateMipMaps(ffi.Pointer<TTexture> tTexture, ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TKtx1Bundle> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(ffi.Pointer<ffi.Uint8> ktxData, int length);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void Ktx1Bundle_getSphericalHarmonics(ffi.Pointer<TKtx1Bundle> tBundle, ffi.Pointer<ffi.Float> harmonics);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external bool Ktx1Bundle_isCubemap(ffi.Pointer<TKtx1Bundle> tBundle);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external void Ktx1Bundle_destroy(ffi.Pointer<TKtx1Bundle> tBundle);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>, ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  VoidCallback onTextureUploadComplete,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external void LightManager_destroyLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_hasComponent(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.Pointer<TLinearImage> Function(ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
-external ffi.Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel);
-
-@ffi.Native<ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Bool)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TLinearImage> Image_decode(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> name,
-  bool alpha,
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external int LightManager_getType(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external ffi.Pointer<ffi.Float> Image_getBytes(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external void Image_destroy(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getWidth(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getHeight(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getChannels(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getColorTexture(ffi.Pointer<TRenderTarget> tRenderTarget);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(ffi.Pointer<TRenderTarget> tRenderTarget);
-
-@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_create();
-
-@ffi.Native<
-  ffi.Pointer<TTextureSampler> Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isDirectional(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setMinFilter(ffi.Pointer<TTextureSampler> sampler, int filter);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setMagFilter(ffi.Pointer<TTextureSampler> sampler, int filter);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setWrapModeS(ffi.Pointer<TTextureSampler> sampler, int mode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setWrapModeT(ffi.Pointer<TTextureSampler> sampler, int mode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setWrapModeR(ffi.Pointer<TTextureSampler> sampler, int mode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(isLeaf: true)
-external void TextureSampler_setAnisotropy(ffi.Pointer<TTextureSampler> sampler, double anisotropy);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setCompareMode(ffi.Pointer<TTextureSampler> sampler, int mode, int func);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
-external void TextureSampler_destroy(ffi.Pointer<TTextureSampler> sampler);
-
-@ffi.Native<
-  ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)
->(isLeaf: true)
-external ffi.Pointer<TEngine> Engine_create(
-  int backend,
-  ffi.Pointer<ffi.Void> platform,
-  ffi.Pointer<ffi.Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isPointLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getSupportedFeatureLevel(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_destroy(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TRenderer> Engine_createRenderer(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Engine_destroyRenderer(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderer> tRenderer);
-
-@ffi.Native<ffi.Pointer<TSwapChain> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Void> window,
-  int flags,
-);
-
-@ffi.Native<ffi.Pointer<TSwapChain> Function(ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  int flags,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
-external void Engine_destroySwapChain(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TSwapChain> tSwapChain);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(isLeaf: true)
-external void Engine_destroyView(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void Engine_destroyScene(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void Engine_destroyColorGrading(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TColorGrading> tColorGrading);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
-external ffi.Pointer<TCamera> Engine_createCamera(ffi.Pointer<TEngine> tEngine, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(isLeaf: true)
-external void Engine_destroyCamera(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TCamera> tCamera);
-
-@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TView> Engine_createView(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
-external ffi.Pointer<TCamera> Engine_getCameraComponent(ffi.Pointer<TEngine> tEngine, int entityId);
-
-@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TTransformManager> Engine_getTransformManager(ffi.Pointer<TEngine> engine);
-
-@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(ffi.Pointer<TEngine> engine);
-
-@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TLightManager> Engine_getLightManager(ffi.Pointer<TEngine> engine);
-
-@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TEntityManager> Engine_getEntityManager(ffi.Pointer<TEngine> engine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
-external void Engine_setAutomaticInstancingEnabled(ffi.Pointer<TEngine> tEngine, bool enabled);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getMaxAutomaticInstances(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
-external void Engine_destroyTexture(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TTexture> tTexture);
-
-@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TFence> Engine_createFence(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(isLeaf: true)
-external void Engine_destroyFence(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TFence> tFence);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_flushAndWait(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_execute(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Engine_buildMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> materialData,
-  int length,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(isLeaf: true)
-external void Engine_destroyMaterial(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TMaterial> tMaterial);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external void Engine_destroyMaterialInstance(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TScene> Engine_createScene(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Bool, ffi.Float, ffi.Uint8)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TSkybox> Engine_buildSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isSpotLight(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
 @ffi.Native<
-  ffi.Pointer<TSkybox> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Uint8,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
-  ffi.Pointer<TEngine> tEngine,
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
   double r,
   double g,
   double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
 );
 
 @ffi.Native<
-  ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)
->(isLeaf: true)
-external ffi.Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<TTexture> tIrradianceTexture,
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
+);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double3 LightManager_getColor(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
   double intensity,
 );
 
 @ffi.Native<
-  ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)
->(isLeaf: true)
-external ffi.Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<ffi.Float> irradianceHarmonics,
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityCandela(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
   double intensity,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(isLeaf: true)
-external void Engine_destroySkybox(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TSkybox> tSkybox);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Engine_destroyIndirectLight(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TIndirectLight> tIndirectLight);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
-external int EntityManager_createEntity(ffi.Pointer<TEntityManager> tEntityManager);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(isLeaf: true)
-external void EntityManager_destroyEntity(ffi.Pointer<TEntityManager> tEntityManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
-external void Fence_waitAndDestroy(ffi.Pointer<TFence> tFence);
-
-@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external bool DebugRegistry_hasProperty(ffi.Pointer<TDebugRegistry> tDebugRegistry, ffi.Pointer<ffi.Char> name);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
-external bool DebugRegistry_setProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  bool value,
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
-external bool DebugRegistry_setProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  int value,
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getIntensity(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Float)>(isLeaf: true)
-external bool DebugRegistry_setProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  double value,
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double falloff,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Bool>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Bool> outValue,
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Int> outValue,
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Float> outValue,
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSpotLightOuterCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSpotLightInnerCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloSize,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunHaloSize(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(
+    isLeaf: true)
+external void LightManager_setSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double haloFalloff,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external double LightManager_getSunHaloFalloff(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(
+    isLeaf: true)
+external void LightManager_setShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external bool LightManager_isShadowCaster(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(
+    isLeaf: true)
+external TShadowOptions LightManager_getShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt,
+        ffi.Bool)>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool LightManager_getLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float,
+        ffi.Float)>(isLeaf: true)
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(
+    isLeaf: true)
+external double LightManager_rgbToColorTemperature(
+  double r,
+  double g,
+  double b,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void FilamentAsset_getEntities(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+  ffi.Pointer<EntityId> out,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(
+  ffi.Pointer<TFilamentAsset> filamentAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TGltfAssetLoader> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external void GltfAssetLoader_destroy(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+);
+
+@ffi.Native<
+    ffi.Pointer<TFilamentAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32)>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>,
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  ffi.Pointer<TFilamentAsset> tAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialProvider> Function(
+        ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getResourceUriCount(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<ffi.Pointer<ffi.Char>> Function(
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
 );
 
 @ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TViewport View_getViewport(ffi.Pointer<TView> view);
+external TViewport View_getViewport(
+  ffi.Pointer<TView> view,
+);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createLinear(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createLinear(
+  ffi.Pointer<TEngine> tEngine,
+);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createACES(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACES(
+  ffi.Pointer<TEngine> tEngine,
+);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(
+  ffi.Pointer<TEngine> tEngine,
+);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(
+  ffi.Pointer<TEngine> tEngine,
+);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(
+  ffi.Pointer<TEngine> tEngine,
+);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGX(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGX(
+  ffi.Pointer<TEngine> tEngine,
+);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(ffi.Pointer<TEngine> tEngine, int look);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(
+  ffi.Pointer<TEngine> tEngine,
+  int look,
+);
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float, ffi.Float, ffi.Float)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float,
+        ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
 external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
   ffi.Pointer<TEngine> tEngine,
   double contrast,
@@ -707,78 +759,128 @@ external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
   double hdrMax,
 );
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(
+  ffi.Pointer<TEngine> tEngine,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
+external void ToneMapper_destroy(
+  ffi.Pointer<TToneMapper> toneMapper,
+);
 
 @ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
 
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Pointer<TColorGrading> Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
   ffi.Pointer<TColorGradingBuilder> builder,
   ffi.Pointer<TEngine> engine,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
-external void ColorGradingBuilder_destroy(ffi.Pointer<TColorGradingBuilder> builder);
+external void ColorGradingBuilder_destroy(
+  ffi.Pointer<TColorGradingBuilder> builder,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void ColorGrading_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TColorGrading> colorGrading);
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void ColorGrading_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TColorGrading> colorGrading,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void ColorGradingBuilder_quality(ffi.Pointer<TColorGradingBuilder> builder, int level);
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_quality(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int level,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void ColorGradingBuilder_format(ffi.Pointer<TColorGradingBuilder> builder, int format);
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_format(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int format,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(isLeaf: true)
-external void ColorGradingBuilder_dimensions(ffi.Pointer<TColorGradingBuilder> builder, int dim);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(
+    isLeaf: true)
+external void ColorGradingBuilder_dimensions(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  int dim,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TColorGradingBuilder>,
+        ffi.Pointer<TToneMapper>)>(isLeaf: true)
 external void ColorGradingBuilder_toneMapper(
   ffi.Pointer<TColorGradingBuilder> builder,
   ffi.Pointer<TToneMapper> toneMapper,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_exposure(ffi.Pointer<TColorGradingBuilder> builder, double exposure);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_exposure(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double exposure,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_nightAdaptation(ffi.Pointer<TColorGradingBuilder> builder, double adaptation);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_nightAdaptation(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double adaptation,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
 external void ColorGradingBuilder_whiteBalance(
   ffi.Pointer<TColorGradingBuilder> builder,
   double temperature,
   double tint,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_contrast(ffi.Pointer<TColorGradingBuilder> builder, double contrast);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_contrast(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double contrast,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_vibrance(ffi.Pointer<TColorGradingBuilder> builder, double vibrance);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_vibrance(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double vibrance,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_saturation(ffi.Pointer<TColorGradingBuilder> builder, double saturation);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(
+    isLeaf: true)
+external void ColorGradingBuilder_saturation(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double saturation,
+);
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
 external void ColorGradingBuilder_channelMixer(
   ffi.Pointer<TColorGradingBuilder> builder,
   double outRedR,
@@ -793,26 +895,24 @@ external void ColorGradingBuilder_channelMixer(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
 external void ColorGradingBuilder_shadowsMidtonesHighlights(
   ffi.Pointer<TColorGradingBuilder> builder,
   double shadowsR,
@@ -834,19 +934,17 @@ external void ColorGradingBuilder_shadowsMidtonesHighlights(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
 external void ColorGradingBuilder_slopeOffsetPower(
   ffi.Pointer<TColorGradingBuilder> builder,
   double slopeR,
@@ -861,19 +959,17 @@ external void ColorGradingBuilder_slopeOffsetPower(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
 external void ColorGradingBuilder_curves(
   ffi.Pointer<TColorGradingBuilder> builder,
   double shadowGammaR,
@@ -887,169 +983,830 @@ external void ColorGradingBuilder_curves(
   double highlightScaleB,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
-external void ColorGradingBuilder_luminanceScaling(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void ColorGradingBuilder_luminanceScaling(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  bool enabled,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
-external void ColorGradingBuilder_gamutMapping(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void ColorGradingBuilder_gamutMapping(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  bool enabled,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void View_setColorGrading(ffi.Pointer<TView> tView, ffi.Pointer<TColorGrading> tColorGrading);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(
+    isLeaf: true)
+external void View_setColorGrading(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TColorGrading> tColorGrading,
+);
 
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TColorGrading> View_getColorGrading(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(
+    isLeaf: true)
+external ffi.Pointer<TColorGrading> View_getColorGrading(
+  ffi.Pointer<TView> tView,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
-external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void View_setBlendMode(
+  ffi.Pointer<TView> view,
+  int blendMode,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
-external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(
+    isLeaf: true)
+external void View_setViewport(
+  ffi.Pointer<TView> view,
+  int width,
+  int height,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external void View_setRenderTarget(ffi.Pointer<TView> view, ffi.Pointer<TRenderTarget> renderTarget);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(
+    isLeaf: true)
+external void View_setRenderTarget(
+  ffi.Pointer<TView> view,
+  ffi.Pointer<TRenderTarget> renderTarget,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrustumCullingEnabled(ffi.Pointer<TView> view, bool enabled);
+external void View_setFrustumCullingEnabled(
+  ffi.Pointer<TView> view,
+  bool enabled,
+);
 
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getVisibleRenderableCount(ffi.Pointer<TView> view);
+external int View_getVisibleRenderableCount(
+  ffi.Pointer<TView> view,
+);
 
-@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TRenderTarget> View_getRenderTarget(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(
+    isLeaf: true)
+external ffi.Pointer<TRenderTarget> View_getRenderTarget(
+  ffi.Pointer<TView> tView,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
+external void View_setPostProcessing(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
+external void View_setShadowsEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
-external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
+external void View_setShadowType(
+  ffi.Pointer<TView> tView,
+  int shadowType,
+);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getShadowType(ffi.Pointer<TView> tView);
+external int View_getShadowType(
+  ffi.Pointer<TView> tView,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(isLeaf: true)
-external void View_setSoftShadowOptions(ffi.Pointer<TView> tView, TSoftShadowOptions options);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(
+    isLeaf: true)
+external void View_setSoftShadowOptions(
+  ffi.Pointer<TView> tView,
+  TSoftShadowOptions options,
+);
 
 @ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
+external TSoftShadowOptions View_getSoftShadowOptions(
+  ffi.Pointer<TView> tView,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(isLeaf: true)
-external void View_setVsmShadowOptions(ffi.Pointer<TView> tView, TVsmShadowOptions options);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(
+    isLeaf: true)
+external void View_setVsmShadowOptions(
+  ffi.Pointer<TView> tView,
+  TVsmShadowOptions options,
+);
 
 @ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
+external TVsmShadowOptions View_getVsmShadowOptions(
+  ffi.Pointer<TView> tView,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(isLeaf: true)
-external void View_setBloom(ffi.Pointer<TView> tView, bool enabled, double strength);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(
+    isLeaf: true)
+external void View_setBloom(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  double strength,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
-external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
-external void View_setAntiAliasing(ffi.Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(isLeaf: true)
-external void View_setLayerEnabled(ffi.Pointer<TView> tView, int layer, bool visible);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(isLeaf: true)
-external void View_setCamera(ffi.Pointer<TView> tView, ffi.Pointer<TCamera> tCamera);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setStencilBufferEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void View_setScene(ffi.Pointer<TView> tView, ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrontFaceWindingInverted(ffi.Pointer<TView> tView, bool inverted);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(isLeaf: true)
-external void View_setAmbientOcclusionOptions(ffi.Pointer<TView> tView, TAmbientOcclusionOptions options);
-
-@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
-external void View_setFogOptions(ffi.Pointer<TView> tView, TFogOptions tFogOptions);
-
-@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setTransparentPickingEnabled(ffi.Pointer<TView> tView, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
-external void View_pick(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external void View_setName(ffi.Pointer<TView> tView, ffi.Pointer<ffi.Char> name);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void View_setRenderQuality(
+  ffi.Pointer<TView> tView,
+  int qualityLevel,
+);
 
 @ffi.Native<
-  ffi.Pointer<TMaterialInstance> Function(
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void View_setAntiAliasing(
+  ffi.Pointer<TView> tView,
+  bool msaa,
+  bool fxaa,
+  bool taa,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(
+    isLeaf: true)
+external void View_setLayerEnabled(
+  ffi.Pointer<TView> tView,
+  int layer,
+  bool visible,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(
+    isLeaf: true)
+external void View_setCamera(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TCamera> tCamera,
+);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TScene> View_getScene(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TCamera> View_getCamera(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setStencilBufferEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isStencilBufferEnabled(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setDitheringEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isDitheringEnabled(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void View_setScene(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrontFaceWindingInverted(
+  ffi.Pointer<TView> tView,
+  bool inverted,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(
+    isLeaf: true)
+external void View_setAmbientOcclusionOptions(
+  ffi.Pointer<TView> tView,
+  TAmbientOcclusionOptions options,
+);
+
+@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
+external void View_setFogOptions(
+  ffi.Pointer<TView> tView,
+  TFogOptions tFogOptions,
+);
+
+@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TFogOptions View_getFogOptions(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setTransparentPickingEnabled(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isTransparentPickingEnabled(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
+        PickCallback)>(isLeaf: true)
+external void View_pick(
+  ffi.Pointer<TView> tView,
+  int requestId,
+  int x,
+  int y,
+  PickCallback callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(
+    isLeaf: true)
+external void View_setName(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<ffi.Char> name,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> View_getName(
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external void NameComponentManager_destroy(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
+
+@ffi.Native<
+    ffi.Pointer<ffi.Char> Function(
+        ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientationBuilder>
+    SurfaceOrientationBuilder_create();
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_vertexCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_normals(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> normals,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_tangents(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> tangents,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_uvs(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> uvs,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_positions(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> positions,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangleCount(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_uint(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint32> triangles,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>,
+        ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_triangles_ushort(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Uint16> triangles,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSurfaceOrientation> Function(
+        ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(
+    isLeaf: true)
+external void SurfaceOrientationBuilder_destroy(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external int SurfaceOrientation_getVertexCount(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_float4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Float> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_short4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Int16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>,
+        ffi.Size, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientation_getQuats_half4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Uint16> out,
+  int quatCount,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external void SurfaceOrientation_destroy(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void IndirectLight_setRotation(
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+  ffi.Pointer<ffi.Double> rotation,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint8,
+        ffi.Uint16,
+        ffi.IntPtr,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTexture> Texture_build(
+  ffi.Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import$,
+  int sampler,
+  int format,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
+        ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void Texture_setExternalImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<ffi.Void> externalImage,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
+external int Texture_getLevels(
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TLinearImage>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Int)>(isLeaf: true)
+external bool Texture_loadImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Uint32,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32)>(isLeaf: true)
+external bool Texture_setImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getWidth(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getHeight(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getDepth(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>)>(isLeaf: true)
+external int Texture_getFormat(
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(
+    isLeaf: true)
+external int Texture_getUsage(
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external void Texture_generateMipMaps(
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TKtx1Bundle> Function(
+        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(
+  ffi.Pointer<ffi.Uint8> ktxData,
+  int length,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void Ktx1Bundle_getSphericalHarmonics(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  ffi.Pointer<ffi.Float> harmonics,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external bool Ktx1Bundle_isCubemap(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external void Ktx1Bundle_destroy(
+  ffi.Pointer<TKtx1Bundle> tBundle,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  VoidCallback onTextureUploadComplete,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTexture> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+);
+
+@ffi.Native<
+    ffi.Pointer<TLinearImage> Function(
+        ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+external ffi.Pointer<TLinearImage> Image_createEmpty(
+  int width,
+  int height,
+  int channel,
+);
+
+@ffi.Native<
+    ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
+        ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TLinearImage> Image_decode(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> name,
+  bool alpha,
+);
+
+@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(
+    isLeaf: true)
+external ffi.Pointer<ffi.Float> Image_getBytes(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external void Image_destroy(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getWidth(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getHeight(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getChannels(
+  ffi.Pointer<TLinearImage> tLinearImage,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
+    isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getColorTexture(
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(
+    isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+);
+
+@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_create();
+
+@ffi.Native<
+    ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt,
+        ffi.UnsignedInt, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+);
+
+@ffi.Native<
+    ffi.Pointer<TTextureSampler> Function(
+        ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(
+  int compareMode,
+  int compareFunc,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setMinFilter(
+  ffi.Pointer<TTextureSampler> sampler,
+  int filter,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setMagFilter(
+  ffi.Pointer<TTextureSampler> sampler,
+  int filter,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeS(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeT(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void TextureSampler_setWrapModeR(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(
+    isLeaf: true)
+external void TextureSampler_setAnisotropy(
+  ffi.Pointer<TTextureSampler> sampler,
+  double anisotropy,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
+        ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setCompareMode(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+  int func,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
+external void TextureSampler_destroy(
+  ffi.Pointer<TTextureSampler> sampler,
+);
+
+@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithCallback(
+  FrameTickCallback tickCallback,
+  int targetFps,
+);
+
+@ffi.Native<ffi.Void Function()>()
+external void FrameScheduler_stop();
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(
+  ffi.Pointer<ffi.Void> data,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(
+  int port,
+  int targetFps,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_setTargetFps(
+  int fps,
+);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
+
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(
+  int t,
+);
+
+@ffi.Native<
+    ffi.Pointer<TGizmo> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<TView>,
+        ffi.Pointer<TMaterial>,
+        ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TGizmo> Gizmo_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> assetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32,
+        GizmoPickCallback)>(isLeaf: true)
+external void Gizmo_pick(
+  ffi.Pointer<TGizmo> tGizmo,
+  int x,
+  int y,
+  GizmoPickCallback callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(
+    isLeaf: true)
+external void Gizmo_highlight(
+  ffi.Pointer<TGizmo> tGizmo,
+  int axis,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
+external void Gizmo_unhighlight(
+  ffi.Pointer<TGizmo> tGizmo,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialInstance> Function(
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Int,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool)>(isLeaf: true)
 external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   ffi.Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -1092,31 +1849,93 @@ external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   bool hasVolume,
 );
 
+@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(
+    isLeaf: true)
+external void IndexBufferBuilder_indexCount(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void IndexBufferBuilder_bufferType(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  int indexType,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndexBuffer> Function(
+        ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
+external void IndexBufferBuilder_destroy(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external int IndexBuffer_getIndexCount(
+  ffi.Pointer<TIndexBuffer> buffer,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+external void IndexBuffer_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(
+    isLeaf: true)
+external void IndexBuffer_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+);
+
 @ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(isLeaf: true)
-external void VertexBufferBuilder_bufferCount(ffi.Pointer<TVertexBufferBuilder> builder, int count);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(
+    isLeaf: true)
+external void VertexBufferBuilder_bufferCount(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  int count,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(isLeaf: true)
-external void VertexBufferBuilder_vertexCount(ffi.Pointer<TVertexBufferBuilder> builder, int count);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(
+    isLeaf: true)
+external void VertexBufferBuilder_vertexCount(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  int count,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Bool)>(isLeaf: true)
-external void VertexBufferBuilder_enableBufferObjects(ffi.Pointer<TVertexBufferBuilder> builder, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void VertexBufferBuilder_enableBufferObjects(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  bool enabled,
+);
 
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
-external int VertexBufferBuilder_getStorageMode(ffi.Pointer<TVertexBufferBuilder> builder);
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TVertexBufferBuilder>)>(
+    isLeaf: true)
+external int VertexBufferBuilder_getStorageMode(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+);
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.UnsignedInt,
-    ffi.Uint8,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    ffi.Uint8,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt,
+        ffi.Uint8, ffi.UnsignedInt, ffi.Uint32, ffi.Uint8)>(isLeaf: true)
 external void VertexBufferBuilder_attribute(
   ffi.Pointer<TVertexBufferBuilder> builder,
   int attribute,
@@ -1126,31 +1945,36 @@ external void VertexBufferBuilder_attribute(
   int byteStride,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void VertexBufferBuilder_normalized(ffi.Pointer<TVertexBufferBuilder> builder, int attribute, bool normalize);
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt,
+        ffi.Bool)>(isLeaf: true)
+external void VertexBufferBuilder_normalized(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  bool normalize,
+);
 
-@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Pointer<TVertexBuffer> Function(
+        ffi.Pointer<TVertexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TVertexBuffer> VertexBufferBuilder_build(
   ffi.Pointer<TVertexBufferBuilder> builder,
   ffi.Pointer<TEngine> engine,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
-external void VertexBufferBuilder_destroy(ffi.Pointer<TVertexBufferBuilder> builder);
+external void VertexBufferBuilder_destroy(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+);
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external int VertexBuffer_getVertexCount(ffi.Pointer<TVertexBuffer> buffer);
+external int VertexBuffer_getVertexCount(
+  ffi.Pointer<TVertexBuffer> buffer,
+);
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
+        ffi.Uint8, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
 external void VertexBuffer_setBufferAt(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
@@ -1160,9 +1984,9 @@ external void VertexBuffer_setBufferAt(
   int byteOffset,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>, ffi.Uint8, ffi.Pointer<TBufferObject>)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
+        ffi.Uint8, ffi.Pointer<TBufferObject>)>(isLeaf: true)
 external void VertexBuffer_setBufferObjectAt(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TVertexBuffer> buffer,
@@ -1170,94 +1994,349 @@ external void VertexBuffer_setBufferObjectAt(
   ffi.Pointer<TBufferObject> bufferObject,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external void VertexBuffer_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TVertexBuffer> buffer);
-
-@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(isLeaf: true)
-external void IndexBufferBuilder_indexCount(ffi.Pointer<TIndexBufferBuilder> builder, int count);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void IndexBufferBuilder_bufferType(ffi.Pointer<TIndexBufferBuilder> builder, int indexType);
-
-@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  ffi.Pointer<TIndexBufferBuilder> builder,
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
+external void VertexBuffer_destroy(
   ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TVertexBuffer> buffer,
 );
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
-external void IndexBufferBuilder_destroy(ffi.Pointer<TIndexBufferBuilder> builder);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)
->(isLeaf: true)
-external void IndexBuffer_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
+    ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external ffi.Pointer<TRenderTarget> RenderTarget_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> color,
+  ffi.Pointer<TTexture> depth,
 );
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external void IndexBuffer_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TIndexBuffer> buffer);
-
-@ffi.Native<ffi.Pointer<TBufferObjectBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TBufferObjectBuilder> BufferObjectBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Uint32)>(isLeaf: true)
-external void BufferObjectBuilder_size(ffi.Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
-
-@ffi.Native<ffi.Pointer<TBufferObject> Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TBufferObject> BufferObjectBuilder_build(
-  ffi.Pointer<TBufferObjectBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>)>(isLeaf: true)
-external void BufferObjectBuilder_destroy(ffi.Pointer<TBufferObjectBuilder> builder);
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)
->(isLeaf: true)
-external void BufferObject_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TBufferObject> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void RenderTarget_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>)>(isLeaf: true)
-external void BufferObject_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TBufferObject> buffer);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
+);
 
-@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external double4x4 TransformManager_getLocalTransform(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
+);
 
-@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external double4x4 TransformManager_getWorldTransform(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(
+    isLeaf: true)
+external void Scene_setSkybox(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TSkybox> skybox,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4)>(isLeaf: true)
+@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TScene>)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Scene_getSkybox(
+  ffi.Pointer<TScene> tScene,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Scene_setIndirectLight(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external void Scene_addFilamentAsset(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TFilamentAsset> asset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TRenderManager> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(
+    isLeaf: true)
+external void RenderManager_render(
+  ffi.Pointer<TRenderManager> tRenderer,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
+        ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)>(isLeaf: true)
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void RenderManager_removeSwapChain(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(
+  ffi.Pointer<TRenderManager> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_detachFromRenderThread(
+  ffi.Pointer<TRenderManager> tRenderManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderManager_setPaused(
+  ffi.Pointer<TRenderManager> tRenderer,
+  bool paused,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void Camera_setExposure(
+  ffi.Pointer<TCamera> camera,
+  double aperture,
+  double shutterSpeed,
+  double sensitivity,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(
+    isLeaf: true)
+external void Camera_getFrustum(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> out,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double, ffi.Bool)>(isLeaf: true)
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(
+    isLeaf: true)
+external void Camera_lookAt(
+  ffi.Pointer<TCamera> camera,
+  double3 eye,
+  double3 focus,
+  double3 up,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(
+  ffi.Pointer<TCamera> camera,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(
+  ffi.Pointer<TCamera> camera,
+  double focusDistance,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4)>(isLeaf: true)
+external void Camera_setModelMatrix(
+  ffi.Pointer<TCamera> camera,
+  double4x4 tModelMatrix,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(
+  ffi.Pointer<TCamera> camera,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TCamera>,
+        ffi.UnsignedInt,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
+    isLeaf: true)
+external double4x4 TransformManager_getLocalTransform(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(
+    isLeaf: true)
+external double4x4 TransformManager_getWorldTransform(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TTransformManager>, EntityId, double4x4)>(isLeaf: true)
 external void TransformManager_setTransform(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
   double4x4 transform,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(
+    isLeaf: true)
 external bool TransformManager_transformToUnitCube(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
   Aabb3 boundingBox,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId, ffi.Bool)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId,
+        ffi.Bool)>(isLeaf: true)
 external void TransformManager_setParent(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
@@ -1265,31 +2344,61 @@ external void TransformManager_setParent(
   bool preserveScaling,
 );
 
-@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external int TransformManager_getParent(ffi.Pointer<TTransformManager> tTransformManager, int child);
+@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
+    isLeaf: true)
+external int TransformManager_getParent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int child,
+);
 
-@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external int TransformManager_getAncestor(ffi.Pointer<TTransformManager> tTransformManager, int childEntityId);
+@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(
+    isLeaf: true)
+external int TransformManager_getAncestor(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int childEntityId,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external void TransformManager_createComponent(ffi.Pointer<TTransformManager> tTransformManager, int entity);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
+    isLeaf: true)
+external void TransformManager_createComponent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entity,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external void TransformManager_removeComponent(ffi.Pointer<TTransformManager> tTransformManager, int entity);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(
+    isLeaf: true)
+external void TransformManager_removeComponent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entity,
+);
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external bool TransformManager_hasComponent(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(
+    isLeaf: true)
+external bool TransformManager_hasComponent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external bool TransformManager_empty(ffi.Pointer<TTransformManager> tTransformManager);
+external bool TransformManager_empty(
+  ffi.Pointer<TTransformManager> tTransformManager,
+);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external int TransformManager_getComponentCount(ffi.Pointer<TTransformManager> tTransformManager);
+external int TransformManager_getComponentCount(
+  ffi.Pointer<TTransformManager> tTransformManager,
+);
 
-@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external int TransformManager_getChildCount(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(
+    isLeaf: true)
+external int TransformManager_getChildCount(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Pointer<EntityId>, ffi.Int)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId,
+        ffi.Pointer<EntityId>, ffi.Int)>(isLeaf: true)
 external void TransformManager_getChildren(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -1298,204 +2407,510 @@ external void TransformManager_getChildren(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external void TransformManager_openLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
+external void TransformManager_openLocalTransformTransaction(
+  ffi.Pointer<TTransformManager> tTransformManager,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external void TransformManager_commitLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
+external void TransformManager_commitLocalTransformTransaction(
+  ffi.Pointer<TTransformManager> tTransformManager,
+);
 
-@ffi.Native<ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>, ffi.UnsignedInt)>(isLeaf: true)
-external int LightManager_createLight(
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Double, ffi.Double,
+        ffi.Double, ffi.Double, ffi.Uint8, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void Renderer_setClearOptions(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>,
+        ffi.Uint64)>(isLeaf: true)
+external bool Renderer_beginFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Renderer_endFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Renderer_render(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Renderer_renderStandaloneView(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Pointer<TRenderTarget>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size)>(isLeaf: true)
+external void Renderer_readPixels(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8,
+        ffi.Uint8)>(isLeaf: true)
+external void Renderer_setFrameInterval(
+  ffi.Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+);
+
+@ffi.Native<
+    ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>,
+        ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)>(isLeaf: true)
+external ffi.Pointer<TEngine> Engine_create(
+  int backend,
+  ffi.Pointer<ffi.Void> platform,
+  ffi.Pointer<ffi.Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getSupportedFeatureLevel(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external void LightManager_destroyLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_hasComponent(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external int LightManager_getType(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isDirectional(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isPointLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isSpotLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_destroy(
+  ffi.Pointer<TEngine> tEngine,
 );
 
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getPosition(ffi.Pointer<TLightManager> tLightManager, int light);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
+@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TRenderer> Engine_createRenderer(
+  ffi.Pointer<TEngine> tEngine,
 );
 
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getDirection(ffi.Pointer<TLightManager> tLightManager, int light);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setColor(ffi.Pointer<TLightManager> tLightManager, int entity, double r, double g, double b);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(
+    isLeaf: true)
+external void Engine_destroyRenderer(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
 );
 
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getColor(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensity(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityCandela(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
+@ffi.Native<
+    ffi.Pointer<TSwapChain> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Void> window,
+  int flags,
 );
 
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getIntensity(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double falloff);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
+@ffi.Native<
+    ffi.Pointer<TSwapChain> Function(
+        ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  int flags,
 );
 
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSpotLightOuterCone(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSpotLightInnerCone(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(
+    isLeaf: true)
+external void Engine_destroySwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSwapChain> tSwapChain,
 );
 
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunAngularRadius(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity, double haloSize);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double haloFalloff);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void LightManager_setShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(
+    isLeaf: true)
+external void Engine_destroyView(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TView> tView,
 );
 
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external TShadowOptions LightManager_getShadowOptions(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void Engine_destroyScene(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TScene> tScene,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
-external bool LightManager_getLightChannel(ffi.Pointer<TLightManager> tLightManager, int entity, int channel);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(ffi.Pointer<ffi.Float> splitPositions, int cascades);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void Engine_destroyColorGrading(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TColorGrading> tColorGrading,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
+    isLeaf: true)
+external ffi.Pointer<TCamera> Engine_createCamera(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
 );
 
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external double LightManager_rgbToColorTemperature(double r, double g, double b);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(
+    isLeaf: true)
+external void Engine_destroyCamera(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TCamera> tCamera,
+);
+
+@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TView> Engine_createView(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(
+    isLeaf: true)
+external ffi.Pointer<TCamera> Engine_getCameraComponent(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+);
+
+@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TTransformManager> Engine_getTransformManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TLightManager> Engine_getLightManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TEntityManager> Engine_getEntityManager(
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
+external void Engine_setAutomaticInstancingEnabled(
+  ffi.Pointer<TEngine> tEngine,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getMaxAutomaticInstances(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(
+    isLeaf: true)
+external void Engine_destroyTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+);
+
+@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TFence> Engine_createFence(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(
+    isLeaf: true)
+external void Engine_destroyFence(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TFence> tFence,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_flushAndWait(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_execute(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterial> Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Engine_buildMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> materialData,
+  int length,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(
+    isLeaf: true)
+external void Engine_destroyMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterial> tMaterial,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void Engine_destroyMaterialInstance(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TScene> Engine_createScene(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
+        ffi.Bool, ffi.Float, ffi.Uint8)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float,
+        ffi.Float, ffi.Float, ffi.Bool, ffi.Float, ffi.Uint8)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TIndirectLight>
+    Engine_buildIndirectLightFromIrradianceTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+);
+
+@ffi.Native<
+    ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)>(isLeaf: true)
+external ffi.Pointer<TIndirectLight>
+    Engine_buildIndirectLightFromIrradianceHarmonics(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<ffi.Float> irradianceHarmonics,
+  double intensity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(
+    isLeaf: true)
+external void Engine_destroySkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSkybox> tSkybox,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Engine_destroyIndirectLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
+external int EntityManager_createEntity(
+  ffi.Pointer<TEntityManager> tEntityManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(
+    isLeaf: true)
+external void EntityManager_destroyEntity(
+  ffi.Pointer<TEntityManager> tEntityManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
+external void Fence_waitAndDestroy(
+  ffi.Pointer<TFence> tFence,
+);
+
+@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(
+  ffi.Pointer<TEngine> tEngine,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external bool DebugRegistry_hasProperty(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Bool)>(isLeaf: true)
+external bool DebugRegistry_setProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  bool value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Int)>(isLeaf: true)
+external bool DebugRegistry_setProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  int value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Float)>(isLeaf: true)
+external bool DebugRegistry_setProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  double value,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Bool>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Bool> outValue,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Int>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Int> outValue,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Float> outValue,
+);
+
+@ffi.Native<ffi.Pointer<TBufferObjectBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TBufferObjectBuilder> BufferObjectBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Uint32)>(
+    isLeaf: true)
+external void BufferObjectBuilder_size(
+  ffi.Pointer<TBufferObjectBuilder> builder,
+  int sizeInBytes,
+);
+
+@ffi.Native<
+    ffi.Pointer<TBufferObject> Function(
+        ffi.Pointer<TBufferObjectBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TBufferObject> BufferObjectBuilder_build(
+  ffi.Pointer<TBufferObjectBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>)>(isLeaf: true)
+external void BufferObjectBuilder_destroy(
+  ffi.Pointer<TBufferObjectBuilder> builder,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>,
+        ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)>(isLeaf: true)
+external void BufferObject_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TBufferObject> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>)>(isLeaf: true)
+external void BufferObject_destroy(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TBufferObject> buffer,
+);
 
 @ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
 external ffi.Pointer<ffi.Void> RenderThread_create();
 
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(ffi.Pointer<ffi.Char> canvasSelector);
+external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(
+  ffi.Pointer<ffi.Char> canvasSelector,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void RenderThread_destroy(ffi.Pointer<ffi.Void> renderThread);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)>(isLeaf: true)
-external void RenderThread_addTask(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> task);
+external void RenderThread_destroy(
+  ffi.Pointer<ffi.Void> renderThread,
+);
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Pointer<ffi.Pointer<TView>>,
-    ffi.Uint8,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)>(isLeaf: true)
+external void RenderThread_addTask(
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> task,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TSwapChain>,
+        ffi.Pointer<ffi.Pointer<TView>>,
+        ffi.Uint8,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderManager_setRenderableRenderThread(
   ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -1505,7 +2920,9 @@ external void RenderManager_setRenderableRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderManager_renderRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   int frameTimeInNanos,
@@ -1513,9 +2930,9 @@ external void RenderManager_renderRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderManager_addAnimationManagerRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TAnimationManager> tAnimationManager,
@@ -1523,9 +2940,9 @@ external void RenderManager_addAnimationManagerRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>,
+        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderManager_removeAnimationManagerRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TAnimationManager> tAnimationManager,
@@ -1533,9 +2950,9 @@ external void RenderManager_removeAnimationManagerRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderManager_removeSwapChainRenderThread(
   ffi.Pointer<TRenderManager> tRenderManager,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -1544,17 +2961,22 @@ external void RenderManager_removeSwapChainRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TAnimationManager>)>>)>(isLeaf: true)
 external void AnimationManager_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>> onComplete,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void AnimationManager_destroyRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int requestId,
@@ -1562,33 +2984,41 @@ external void AnimationManager_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.UnsignedInt,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Uint8,
+            ffi.Bool,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>)>(
+    isLeaf: true)
 external void Engine_createRenderThread(
   int backend,
   ffi.Pointer<ffi.Void> platform,
   ffi.Pointer<ffi.Void> sharedContext,
   int stereoscopicEyeCount,
   bool disableHandleUseAfterFreeCheck,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>)>(
+    isLeaf: true)
 external void Engine_createRendererRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyRendererRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderer> tRenderer,
@@ -1597,51 +3027,58 @@ external void Engine_destroyRendererRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Uint64,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>)>(
+    isLeaf: true)
 external void Engine_createSwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Void> window,
   int flags,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint64,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>)>(
+    isLeaf: true)
 external void Engine_createHeadlessSwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int width,
   int height,
   int flags,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    EntityId,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            EntityId,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>)>(
+    isLeaf: true)
 external void Engine_createCameraRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int entityId,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyCameraRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TCamera> tCamera,
@@ -1650,32 +3087,45 @@ external void Engine_destroyCameraRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>)>(
+    isLeaf: true)
 external void Engine_createViewRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<ffi.Uint8>,
+            ffi.Size,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Engine_buildMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> materialData,
   int length,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
+    isLeaf: true)
+external void Engine_destroyRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroySwapChainRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -1683,7 +3133,9 @@ external void Engine_destroySwapChainRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyViewRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TView> tView,
@@ -1691,7 +3143,9 @@ external void Engine_destroyViewRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroySceneRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TScene> tScene,
@@ -1699,7 +3153,9 @@ external void Engine_destroySceneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyColorGradingRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TColorGrading> tColorGrading,
@@ -1707,7 +3163,9 @@ external void Engine_destroyColorGradingRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterial> tMaterial,
@@ -1715,9 +3173,9 @@ external void Engine_destroyMaterialRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyMaterialInstanceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
@@ -1725,7 +3183,9 @@ external void Engine_destroyMaterialInstanceRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroySkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TSkybox> tSkybox,
@@ -1733,9 +3193,9 @@ external void Engine_destroySkyboxRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Engine_destroyIndirectLightRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -1744,19 +3204,19 @@ external void Engine_destroyIndirectLightRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint8,
-    ffi.Uint16,
-    ffi.IntPtr,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint8,
+            ffi.Uint16,
+            ffi.IntPtr,
+            ffi.UnsignedInt,
+            ffi.UnsignedInt,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
+    isLeaf: true)
 external void Texture_buildRenderThread(
   ffi.Pointer<TEngine> engine,
   int width,
@@ -1767,12 +3227,13 @@ external void Texture_buildRenderThread(
   int import$,
   int sampler,
   int format,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Void>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>,
+        ffi.Pointer<ffi.Void>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Texture_setExternalImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -1781,7 +3242,9 @@ external void Texture_setExternalImageRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Texture_generateMipMapsRenderThread(
   ffi.Pointer<TTexture> tTexture,
   ffi.Pointer<TEngine> tEngine,
@@ -1790,38 +3253,42 @@ external void Texture_generateMipMapsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TKtx1Bundle>,
-    ffi.Uint32,
-    VoidCallback,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TKtx1Bundle>,
+            ffi.Uint32,
+            VoidCallback,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
+    isLeaf: true)
 external void Ktx1Reader_createTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TKtx1Bundle> tBundle,
   int requestId,
   VoidCallback onTextureUploadComplete,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<ffi.Uint8>,
+            ffi.Size,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
+    isLeaf: true)
 external void Ktx2Reader_createTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<ffi.Uint8> data,
   int size,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyTextureRenderThread(
   ffi.Pointer<TEngine> engine,
   ffi.Pointer<TTexture> tTexture,
@@ -1830,17 +3297,28 @@ external void Engine_destroyTextureRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>)>(
+    isLeaf: true)
 external void Engine_createFenceRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Fence_waitAndDestroyRenderThread(ffi.Pointer<TFence> tFence, int requestId, VoidCallback onComplete);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(
+    isLeaf: true)
+external void Fence_waitAndDestroyRenderThread(
+  ffi.Pointer<TFence> tFence,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Engine_destroyFenceRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TFence> tFence,
@@ -1848,44 +3326,55 @@ external void Engine_destroyFenceRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_flushAndWaitRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
+    isLeaf: true)
+external void Engine_flushAndWaitRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_executeRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(
+    isLeaf: true)
+external void Engine_executeRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  int requestId,
+  VoidCallback onComplete,
+);
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Uint8,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TTexture>,
+            ffi.Bool,
+            ffi.Float,
+            ffi.Uint8,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>)>(
+    isLeaf: true)
 external void Engine_buildSkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
   bool showSun,
   double intensity,
   int priority,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Uint8,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Float,
+            ffi.Float,
+            ffi.Float,
+            ffi.Float,
+            ffi.Bool,
+            ffi.Float,
+            ffi.Uint8,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>)>(
+    isLeaf: true)
 external void Engine_buildColoredSkyboxRenderThread(
   ffi.Pointer<TEngine> tEngine,
   double r,
@@ -1895,57 +3384,60 @@ external void Engine_buildColoredSkyboxRenderThread(
   bool showSun,
   double intensity,
   int priority,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-    ffi.Float,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TTexture>,
+        ffi.Float,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TIndirectLight>)>>)>(isLeaf: true)
 external void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<TTexture> tIrradianceTexture,
   double intensity,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Float,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<ffi.Float>,
+        ffi.Float,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TIndirectLight>)>>)>(isLeaf: true)
 external void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tReflectionsTexture,
   ffi.Pointer<ffi.Float> harmonics,
   double intensity,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Double,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Renderer_setClearOptionsRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   double clearR,
@@ -1960,13 +3452,12 @@ external void Renderer_setClearOptionsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TRenderer>,
+            ffi.Pointer<TSwapChain>,
+            ffi.Uint64,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void Renderer_beginFrameRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TSwapChain> tSwapChain,
@@ -1974,10 +3465,18 @@ external void Renderer_beginFrameRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Renderer_endFrameRenderThread(ffi.Pointer<TRenderer> tRenderer, int requestId, VoidCallback onComplete);
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Renderer_endFrameRenderThread(
+  ffi.Pointer<TRenderer> tRenderer,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Renderer_renderRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
@@ -1985,7 +3484,9 @@ external void Renderer_renderRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Renderer_renderStandaloneViewRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   ffi.Pointer<TView> tView,
@@ -1994,21 +3495,19 @@ external void Renderer_renderStandaloneViewRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<TRenderTarget>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderer>,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Pointer<TRenderTarget>,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Renderer_readPixelsRenderThread(
   ffi.Pointer<TRenderer> tRenderer,
   int width,
@@ -2025,26 +3524,27 @@ external void Renderer_readPixelsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterial>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TMaterial>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TMaterialInstance>)>>)>(isLeaf: true)
 external void Material_createInstanceRenderThread(
   ffi.Pointer<TMaterial> tMaterial,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>> onComplete,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTextureSampler>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TMaterialInstance>,
+        ffi.Pointer<ffi.Char>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TTextureSampler>,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void MaterialInstance_setParameterTextureRenderThread(
   ffi.Pointer<TMaterialInstance> tMaterialInstance,
   ffi.Pointer<ffi.Char> propertyName,
@@ -2055,82 +3555,126 @@ external void MaterialInstance_setParameterTextureRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createImageMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createGizmoMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createBoneOverlayMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createSilhouetteMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createEdgeOutlineMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createWireframeMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)>(
+    isLeaf: true)
 external void Material_createTranslationAxisMaterialRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_createRenderThread(
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TColorGradingBuilder>)>>)>(isLeaf: true)
+external void ColorGradingBuilder_createRenderThread(
+  ffi.Pointer<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>
+      onComplete,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TColorGradingBuilder>,
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TColorGrading>)>>)>(isLeaf: true)
 external void ColorGradingBuilder_buildRenderThread(
   ffi.Pointer<TColorGradingBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void ColorGradingBuilder_destroyRenderThread(
   ffi.Pointer<TColorGradingBuilder> tBuilder,
   int requestId,
@@ -2138,104 +3682,155 @@ external void ColorGradingBuilder_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createLinearRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createACESRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createACESLegacyRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createFilmicRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createPBRNeutralRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createAGXRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Int,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createAGXWithLookRenderThread(
   ffi.Pointer<TEngine> tEngine,
   int look,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Float,
+            ffi.Float,
+            ffi.Float,
+            ffi.Float,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createGenericRenderThread(
   ffi.Pointer<TEngine> tEngine,
   double contrast,
   double midGrayIn,
   double midGrayOut,
   double hdrMax,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)>(
+    isLeaf: true)
 external void ToneMapper_createDisplayRangeRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void ToneMapper_destroyRenderThread(
   ffi.Pointer<TToneMapper> tToneMapper,
   int requestId,
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
-external void View_pickRenderThread(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
+        PickCallback)>(isLeaf: true)
+external void View_pickRenderThread(
+  ffi.Pointer<TView> tView,
+  int requestId,
+  int x,
+  int y,
+  PickCallback callback,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setColorGradingRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TColorGrading> tColorGrading,
@@ -2243,7 +3838,9 @@ external void View_setColorGradingRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Double, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Double, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setBloomRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -2252,7 +3849,9 @@ external void View_setBloomRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setCameraRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TCamera> tCamera,
@@ -2261,14 +3860,20 @@ external void View_setCameraRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>)
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TView>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>)>(
+    isLeaf: true)
 external void View_getNameRenderThread(
   ffi.Pointer<TView> tView,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setNameRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<ffi.Char> name,
@@ -2276,7 +3881,9 @@ external void View_setNameRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setViewportRenderThread(
   ffi.Pointer<TView> tView,
   int width,
@@ -2285,7 +3892,9 @@ external void View_setViewportRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setRenderTargetRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TRenderTarget> tRenderTarget,
@@ -2293,7 +3902,9 @@ external void View_setRenderTargetRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setAntiAliasingRenderThread(
   ffi.Pointer<TView> tView,
   bool msaa,
@@ -2303,7 +3914,9 @@ external void View_setAntiAliasingRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setPostProcessingRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -2311,7 +3924,9 @@ external void View_setPostProcessingRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setFrustumCullingEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -2319,7 +3934,9 @@ external void View_setFrustumCullingEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setStencilBufferEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -2327,7 +3944,9 @@ external void View_setStencilBufferEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setDitheringEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -2335,7 +3954,9 @@ external void View_setDitheringEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setRenderQualityRenderThread(
   ffi.Pointer<TView> tView,
   int qualityLevel,
@@ -2343,7 +3964,9 @@ external void View_setRenderQualityRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setSceneRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TScene> tScene,
@@ -2351,7 +3974,9 @@ external void View_setSceneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setLayerEnabledRenderThread(
   ffi.Pointer<TView> tView,
   int layer,
@@ -2360,7 +3985,9 @@ external void View_setLayerEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setBlendModeRenderThread(
   ffi.Pointer<TView> tView,
   int blendMode,
@@ -2368,7 +3995,9 @@ external void View_setBlendModeRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setFogOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TFogOptions tFogOptions,
@@ -2376,7 +4005,9 @@ external void View_setFogOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setAmbientOcclusionOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TAmbientOcclusionOptions options,
@@ -2384,7 +4015,9 @@ external void View_setAmbientOcclusionOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setFrontFaceWindingInvertedRenderThread(
   ffi.Pointer<TView> tView,
   bool inverted,
@@ -2392,7 +4025,9 @@ external void View_setFrontFaceWindingInvertedRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setShadowsEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -2400,7 +4035,9 @@ external void View_setShadowsEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setShadowTypeRenderThread(
   ffi.Pointer<TView> tView,
   int shadowType,
@@ -2408,7 +4045,9 @@ external void View_setShadowTypeRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setSoftShadowOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TSoftShadowOptions options,
@@ -2416,7 +4055,9 @@ external void View_setSoftShadowOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void View_setVsmShadowOptionsRenderThread(
   ffi.Pointer<TView> tView,
   TVsmShadowOptions options,
@@ -2424,7 +4065,9 @@ external void View_setVsmShadowOptionsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void View_setTransparentPickingEnabledRenderThread(
   ffi.Pointer<TView> tView,
   bool enabled,
@@ -2432,7 +4075,9 @@ external void View_setTransparentPickingEnabledRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_destroyRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int requestId,
@@ -2440,37 +4085,40 @@ external void SceneAsset_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TGltfAssetLoader>,
+            ffi.Pointer<TNameComponentManager>,
+            ffi.Pointer<TFilamentAsset>,
+            ffi.Uint32,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
+    isLeaf: true)
 external void SceneAsset_createFromFilamentAssetRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
   int requiredGeometryCapabilities,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    Aabb3,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TVertexBuffer>,
+            ffi.Pointer<TIndexBuffer>,
+            ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+            ffi.Int,
+            ffi.UnsignedInt,
+            ffi.UnsignedInt,
+            Aabb3,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
+    isLeaf: true)
 external void SceneAsset_createFromBuffersRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tVertexBuffer,
@@ -2480,32 +4128,39 @@ external void SceneAsset_createFromBuffersRenderThread(
   int tPrimitiveType,
   int vertexBufferStorageMode,
   Aabb3 boundingBox,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TSceneAsset>,
+            ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+            ffi.Int,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>)>(
+    isLeaf: true)
 external void SceneAsset_createInstanceRenderThread(
   ffi.Pointer<TSceneAsset> asset,
   ffi.Pointer<ffi.Pointer<TMaterialInstance>> tMaterialInstances,
   int materialInstanceCount,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>
+      callback,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void SceneAsset_releaseSourceDataRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int requestId,
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void SceneAsset_setFlatShadingRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   bool flatShading,
@@ -2514,49 +4169,50 @@ external void SceneAsset_setFlatShadingRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Int,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Uint8,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TMaterialInstance>)>>)>(isLeaf: true)
 external void MaterialProvider_createMaterialInstanceRenderThread(
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
   bool doubleSided,
@@ -2597,10 +4253,14 @@ external void MaterialProvider_createMaterialInstanceRenderThread(
   bool hasSheen,
   bool hasIOR,
   bool hasVolume,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>> callback,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>
+      callback,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void AnimationManager_updateRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int frameTimeInNanos,
@@ -2609,15 +4269,8 @@ external void AnimationManager_updateRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Float,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int, ffi.Float, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void AnimationManager_setGltfAnimationTimeRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -2628,12 +4281,11 @@ external void AnimationManager_setGltfAnimationTimeRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TAnimationManager>,
+            ffi.Pointer<TSceneAsset>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void AnimationManager_updateBoneMatricesRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -2641,14 +4293,13 @@ external void AnimationManager_updateBoneMatricesRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TAnimationManager>,
+            EntityId,
+            ffi.Pointer<ffi.Float>,
+            ffi.Int,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void AnimationManager_setMorphTargetWeightsRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -2658,86 +4309,98 @@ external void AnimationManager_setMorphTargetWeightsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Uint32,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TLinearImage>)>>)>(isLeaf: true)
 external void Image_createEmptyRenderThread(
   int width,
   int height,
   int channel,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.Char>,
-    ffi.Bool,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Pointer<ffi.Char>,
+        ffi.Bool,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TLinearImage>)>>)>(isLeaf: true)
 external void Image_decodeRenderThread(
   ffi.Pointer<ffi.Uint8> data,
   int length,
   ffi.Pointer<ffi.Char> name,
   bool alpha,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLinearImage>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TLinearImage>,
+            ffi.Pointer<
+                ffi
+                .NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>)>(
+    isLeaf: true)
 external void Image_getBytesRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Image_destroyRenderThread(ffi.Pointer<TLinearImage> tLinearImage, int requestId, VoidCallback onComplete);
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Image_destroyRenderThread(
+  ffi.Pointer<TLinearImage> tLinearImage,
+  int requestId,
+  VoidCallback onComplete,
+);
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TLinearImage>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
+    isLeaf: true)
 external void Image_getWidthRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TLinearImage>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
+    isLeaf: true)
 external void Image_getHeightRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TLinearImage>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)>(
+    isLeaf: true)
 external void Image_getChannelsRenderThread(
   ffi.Pointer<TLinearImage> tLinearImage,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TLinearImage>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TTexture>,
+            ffi.Pointer<TLinearImage>,
+            ffi.UnsignedInt,
+            ffi.UnsignedInt,
+            ffi.Int,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void Texture_loadImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -2749,23 +4412,22 @@ external void Texture_loadImageRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Uint32,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TTexture>,
+            ffi.Uint32,
+            ffi.Pointer<ffi.Uint8>,
+            ffi.Size,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Uint32,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void Texture_setImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> tTexture,
@@ -2784,32 +4446,36 @@ external void Texture_setImageRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderTarget>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TRenderTarget>,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>)>(
+    isLeaf: true)
 external void RenderTarget_getColorTextureRenderThread(
   ffi.Pointer<TRenderTarget> tRenderTarget,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<TTexture>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TRenderTarget>)>>)>(isLeaf: true)
 external void RenderTarget_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TTexture> color,
   ffi.Pointer<TTexture> depth,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderTarget_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TRenderTarget> tRenderTarget,
@@ -2817,46 +4483,59 @@ external void RenderTarget_destroyRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
 external void TextureSampler_createRenderThread(
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
 external void TextureSampler_createWithFilteringRenderThread(
   int minFilter,
   int magFilter,
   int wrapS,
   int wrapT,
   int wrapR,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TTextureSampler>)>>)>(isLeaf: true)
 external void TextureSampler_createWithComparisonRenderThread(
   int compareMode,
   int compareFunc,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setMinFilterRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
@@ -2864,7 +4543,9 @@ external void TextureSampler_setMinFilterRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setMagFilterRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int filter,
@@ -2872,7 +4553,9 @@ external void TextureSampler_setMagFilterRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeSRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -2880,7 +4563,9 @@ external void TextureSampler_setWrapModeSRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeTRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -2888,7 +4573,9 @@ external void TextureSampler_setWrapModeTRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setWrapModeRRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -2896,7 +4583,9 @@ external void TextureSampler_setWrapModeRRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TextureSampler_setAnisotropyRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   double anisotropy,
@@ -2905,8 +4594,8 @@ external void TextureSampler_setAnisotropyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.UnsignedInt, ffi.Uint32, VoidCallback)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt,
+        ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_setCompareModeRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int mode,
@@ -2915,16 +4604,18 @@ external void TextureSampler_setCompareModeRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TextureSampler_destroyRenderThread(
   ffi.Pointer<TTextureSampler> sampler,
   int requestId,
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void AnimationManager_resetToRestPoseRenderThread(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -2933,21 +4624,26 @@ external void AnimationManager_resetToRestPoseRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TMaterialProvider>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TGltfAssetLoader>)>>)>(isLeaf: true)
 external void GltfAssetLoader_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TMaterialProvider> tMaterialProvider,
   ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>> callback,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>>
+      callback,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void GltfAssetLoader_destroyRenderThread(
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   int requestId,
@@ -2955,19 +4651,23 @@ external void GltfAssetLoader_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(
+                    ffi.Pointer<TGltfResourceLoader>)>>)>(isLeaf: true)
 external void GltfResourceLoader_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>> callback,
+  ffi.Pointer<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>>
+      callback,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void GltfResourceLoader_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfResourceLoader> tResourceLoader,
@@ -2976,12 +4676,11 @@ external void GltfResourceLoader_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TGltfResourceLoader>,
+            ffi.Pointer<TFilamentAsset>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void GltfResourceLoader_loadResourcesRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -2989,15 +4688,13 @@ external void GltfResourceLoader_loadResourcesRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void GltfResourceLoader_addResourceDataRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.Char> uri,
@@ -3008,12 +4705,11 @@ external void GltfResourceLoader_addResourceDataRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TGltfResourceLoader>,
+            ffi.Pointer<TFilamentAsset>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void GltfResourceLoader_asyncBeginLoadRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
@@ -3021,36 +4717,43 @@ external void GltfResourceLoader_asyncBeginLoadRenderThread(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoadRenderThread(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
+external void GltfResourceLoader_asyncUpdateLoadRenderThread(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>)
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TGltfResourceLoader>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>)>(
+    isLeaf: true)
 external void GltfResourceLoader_asyncGetLoadProgressRenderThread(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>> callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<ffi.Uint8>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>)>(isLeaf: true)
 external void GltfAssetLoader_loadRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
   ffi.Pointer<ffi.Uint8> data,
   int length,
   int numInstances,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>> callback,
+  ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>
+      callback,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_addFilamentAssetRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TFilamentAsset> tAsset,
@@ -3059,14 +4762,17 @@ external void Scene_addFilamentAssetRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TFilamentAsset>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)>(
+    isLeaf: true)
 external void FilamentAsset_getWireframeRenderThread(
   ffi.Pointer<TFilamentAsset> tFilamentAsset,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_addEntityRenderThread(
   ffi.Pointer<TScene> tScene,
   int entityId,
@@ -3074,7 +4780,9 @@ external void Scene_addEntityRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_removeEntityRenderThread(
   ffi.Pointer<TScene> tScene,
   int entityId,
@@ -3082,7 +4790,9 @@ external void Scene_removeEntityRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void SceneAsset_addToSceneRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
@@ -3090,7 +4800,9 @@ external void SceneAsset_addToSceneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void SceneAsset_removeFromSceneRenderThread(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   ffi.Pointer<TScene> tScene,
@@ -3098,7 +4810,9 @@ external void SceneAsset_removeFromSceneRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void Scene_setSkyboxRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TSkybox> tSkybox,
@@ -3106,7 +4820,9 @@ external void Scene_setSkyboxRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void Scene_setIndirectLightRenderThread(
   ffi.Pointer<TScene> tScene,
   ffi.Pointer<TIndirectLight> tIndirectLight,
@@ -3115,17 +4831,17 @@ external void Scene_setIndirectLightRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TView>,
-    ffi.Pointer<TMaterial>,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TEngine>,
+            ffi.Pointer<TGltfAssetLoader>,
+            ffi.Pointer<TGltfResourceLoader>,
+            ffi.Pointer<TNameComponentManager>,
+            ffi.Pointer<TView>,
+            ffi.Pointer<TMaterial>,
+            ffi.UnsignedInt,
+            ffi.Pointer<
+                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>)>(
+    isLeaf: true)
 external void Gizmo_createRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -3134,23 +4850,27 @@ external void Gizmo_createRenderThread(
   ffi.Pointer<TView> tView,
   ffi.Pointer<TMaterial> tMaterial,
   int tGizmoType,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>> callback,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>
+      callback,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TVertexBufferBuilder>,
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>)>(isLeaf: true)
 external void VertexBufferBuilder_buildRenderThread(
   ffi.Pointer<TVertexBufferBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void VertexBuffer_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -3159,17 +4879,15 @@ external void VertexBuffer_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Uint8,
+        ffi.Pointer<ffi.Void>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void VertexBuffer_setBufferAtRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -3182,15 +4900,13 @@ external void VertexBuffer_setBufferAtRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<TBufferObject>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Uint8,
+        ffi.Pointer<TBufferObject>,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void VertexBuffer_setBufferObjectAtRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tBuffer,
@@ -3201,29 +4917,28 @@ external void VertexBuffer_setBufferObjectAtRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TBufferObjectBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TBufferObjectBuilder>,
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TBufferObject>)>>)>(isLeaf: true)
 external void BufferObjectBuilder_buildRenderThread(
   ffi.Pointer<TBufferObjectBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>>
+      onComplete,
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TBufferObject>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TBufferObject>,
+        ffi.Pointer<ffi.Void>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void BufferObject_setBufferRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TBufferObject> tBuffer,
@@ -3234,7 +4949,9 @@ external void BufferObject_setBufferRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void BufferObject_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TBufferObject> tBuffer,
@@ -3243,19 +4960,22 @@ external void BufferObject_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TIndexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TIndexBufferBuilder>,
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<
+            ffi.NativeFunction<
+                ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>)>(isLeaf: true)
 external void IndexBufferBuilder_buildRenderThread(
   ffi.Pointer<TIndexBufferBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>> onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>
+      onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void IndexBuffer_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndexBuffer> tBuffer,
@@ -3264,16 +4984,14 @@ external void IndexBuffer_destroyRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Void>,
+        ffi.Size,
+        ffi.Uint32,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void IndexBuffer_setBufferRenderThread(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TIndexBuffer> tBuffer,
@@ -3285,13 +5003,12 @@ external void IndexBuffer_setBufferRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Pointer<TEngine>,
-    EntityId,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TRenderableBuilder>,
+            ffi.Pointer<TEngine>,
+            EntityId,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>)>(
+    isLeaf: true)
 external void RenderableBuilder_buildRenderThread(
   ffi.Pointer<TRenderableBuilder> tBuilder,
   ffi.Pointer<TEngine> tEngine,
@@ -3300,14 +5017,17 @@ external void RenderableBuilder_buildRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEntityManager>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)
->(isLeaf: true)
+        ffi.Void Function(ffi.Pointer<TEntityManager>,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)>(
+    isLeaf: true)
 external void EntityManager_createEntityRenderThread(
   ffi.Pointer<TEntityManager> tEntityManager,
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void EntityManager_destroyEntityRenderThread(
   ffi.Pointer<TEntityManager> tEntityManager,
   int entityId,
@@ -3315,9 +5035,9 @@ external void EntityManager_destroyEntityRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TransformManager_setTransformRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -3326,9 +5046,9 @@ external void TransformManager_setTransformRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId,
+        ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void TransformManager_setParentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int child,
@@ -3338,7 +5058,9 @@ external void TransformManager_setParentRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TransformManager_createComponentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -3346,7 +5068,9 @@ external void TransformManager_createComponentRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void TransformManager_removeComponentRenderThread(
   ffi.Pointer<TTransformManager> tTransformManager,
   int entityId,
@@ -3354,7 +5078,9 @@ external void TransformManager_removeComponentRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderableManager_destroyEntityRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -3363,16 +5089,14 @@ external void RenderableManager_destroyEntityRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>,
+        EntityId,
+        ffi.Pointer<ffi.Float>,
+        ffi.Size,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderableManager_setMorphWeightsRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -3384,16 +5108,14 @@ external void RenderableManager_setMorphWeightsRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>,
+        EntityId,
+        ffi.Pointer<ffi.Float>,
+        ffi.Size,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderableManager_setBonesFromMat4RenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -3405,16 +5127,14 @@ external void RenderableManager_setBonesFromMat4RenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>,
+        EntityId,
+        ffi.Pointer<ffi.Float>,
+        ffi.Size,
+        ffi.Size,
+        ffi.Uint32,
+        VoidCallback)>(isLeaf: true)
 external void RenderableManager_setBonesFromBoneRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -3426,17 +5146,16 @@ external void RenderableManager_setBonesFromBoneRenderThread(
 );
 
 @ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Int,
-    ffi.Uint8,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
+        ffi.Void Function(
+            ffi.Pointer<TRenderableManager>,
+            EntityId,
+            ffi.Int,
+            ffi.Uint8,
+            ffi.Pointer<TVertexBuffer>,
+            ffi.Size,
+            ffi.Size,
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>)>(
+    isLeaf: true)
 external void RenderableManager_setGeometryAtNonIndexedRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -3448,9 +5167,9 @@ external void RenderableManager_setGeometryAtNonIndexedRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderableManager_setCastShadowsRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -3459,9 +5178,9 @@ external void RenderableManager_setCastShadowsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderableManager_setReceiveShadowsRenderThread(
   ffi.Pointer<TRenderableManager> tRenderableManager,
   int entityId,
@@ -3470,7 +5189,9 @@ external void RenderableManager_setReceiveShadowsRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void LightManager_setShadowCasterRenderThread(
   ffi.Pointer<TLightManager> tLightManager,
   int entityId,
@@ -3479,9 +5200,9 @@ external void LightManager_setShadowCasterRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions,
+        ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void LightManager_setShadowOptionsRenderThread(
   ffi.Pointer<TLightManager> tLightManager,
   int entityId,
@@ -3490,18 +5211,631 @@ external void LightManager_setShadowOptionsRenderThread(
   VoidCallback onComplete,
 );
 
+@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+);
+
 @ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    Aabb3,
-  )
->(isLeaf: true)
+    ffi.Void Function(
+        ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_asyncBeginLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_asyncUpdateLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external double GltfResourceLoader_asyncGetLoadProgress(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external void GltfResourceLoader_addResourceData(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.Char> uri,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>,
+        ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_loadResources(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double)>(isLeaf: true)
+external void Skybox_setColor(
+  ffi.Pointer<TSkybox> tSkybox,
+  double r,
+  double g,
+  double b,
+  double a,
+);
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Uint8, ffi.Uint8)>(
+    isLeaf: true)
+external void Skybox_setLayerMask(
+  ffi.Pointer<TSkybox> tSkybox,
+  int select,
+  int values,
+);
+
+/// Returns the visibility mask bits.
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external int Skybox_getLayerMask(
+  ffi.Pointer<TSkybox> tSkybox,
+);
+
+/// Returns the skybox intensity in lux.
+@ffi.Native<ffi.Float Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external double Skybox_getIntensity(
+  ffi.Pointer<TSkybox> tSkybox,
+);
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external ffi.Pointer<TTexture> Skybox_getTexture(
+  ffi.Pointer<TSkybox> tSkybox,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMeshData>)>(isLeaf: true)
+external void MeshData_dispose(
+  ffi.Pointer<TMeshData> meshData,
+);
+
+@ffi.Native<
+    ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>,
+        ffi.Pointer<TMeshData>)>(isLeaf: true)
+external int GltfParser_parseBuffer(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> meshName,
+  ffi.Pointer<TMeshData> outMeshData,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external void RenderableManager_destroyEntity(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external bool RenderableManager_hasComponent(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
+external bool RenderableManager_empty(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external bool RenderableManager_isRenderable(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
+external int RenderableManager_getComponentCount(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int,
+        ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external bool RenderableManager_setMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<
+    ffi.Pointer<TMaterialInstance> Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
+external void RenderableManager_clearMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+);
+
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TRenderableManager>,
+        EntityId,
+        ffi.Int,
+        ffi.Uint8,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Size,
+        ffi.Size)>(isLeaf: true)
+external bool RenderableManager_setGeometryAtNonIndexed(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  int type,
+  ffi.Pointer<TVertexBuffer> vertices,
+  int offset,
+  int count,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external int RenderableManager_getPrimitiveCount(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external Aabb3 RenderableManager_getAxisAlignedBoundingBox(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, Aabb3)>(isLeaf: true)
+external void RenderableManager_setAxisAlignedBoundingBox(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  Aabb3 aabb,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external Aabb3 RenderableManager_getAabb(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external Aabb3 RenderableManager_getBoundingBox(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8,
+        ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setLayerMask(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int select,
+  int values,
+);
+
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external int RenderableManager_getLayerMask(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setVisibilityLayer(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int layer,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setPriority(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int priority,
+);
+
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external int RenderableManager_getPriority(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setCulling(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external bool RenderableManager_getCulling(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setFogEnabled(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external bool RenderableManager_getFogEnabled(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setLightChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.UnsignedInt)>(isLeaf: true)
+external bool RenderableManager_getLightChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setCastShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool castShadows,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external bool RenderableManager_isShadowCaster(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setReceiveShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool receiveShadows,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external bool RenderableManager_isShadowReceiver(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setScreenSpaceContactShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size,
+        ffi.Uint16)>(isLeaf: true)
+external void RenderableManager_setBlendOrderAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  int order,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size,
+        ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setGlobalBlendOrderEnabledAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  bool enabled,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
+external void RenderableManager_setMorphWeights(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> weights,
+  int count,
+  int offset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(
+    isLeaf: true)
+external int RenderableManager_getMorphTargetCount(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
+external void RenderableManager_setBonesFromMat4(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> transforms,
+  int boneCount,
+  int offset,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId,
+        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
+external void RenderableManager_setBonesFromBone(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> bones,
+  int boneCount,
+  int offset,
+);
+
+@ffi.Native<ffi.Pointer<TRenderableBuilder> Function(ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TRenderableBuilder> RenderableBuilder_create(
+  int primitiveCount,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>)>(isLeaf: true)
+external void RenderableBuilder_destroy(
+  ffi.Pointer<TRenderableBuilder> builder,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, Aabb3)>(
+    isLeaf: true)
+external void RenderableBuilder_boundingBox(
+  ffi.Pointer<TRenderableBuilder> builder,
+  Aabb3 aabb,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
+        ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void RenderableBuilder_material(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  ffi.Pointer<TMaterialInstance> materialInstance,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableBuilder>,
+        ffi.Size,
+        ffi.Uint8,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Pointer<TIndexBuffer>,
+        ffi.Size,
+        ffi.Size)>(isLeaf: true)
+external void RenderableBuilder_geometry(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  int type,
+  ffi.Pointer<TVertexBuffer> vertices,
+  ffi.Pointer<TIndexBuffer> indices,
+  int offset,
+  int count,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint8,
+        ffi.Pointer<TVertexBuffer>, ffi.Size, ffi.Size)>(isLeaf: true)
+external void RenderableBuilder_geometryNonIndexed(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  int type,
+  ffi.Pointer<TVertexBuffer> vertices,
+  int offset,
+  int count,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(
+    isLeaf: true)
+external void RenderableBuilder_priority(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int priority,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(
+    isLeaf: true)
+external void RenderableBuilder_channel(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderableBuilder_culling(
+  ffi.Pointer<TRenderableBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderableBuilder_castShadows(
+  ffi.Pointer<TRenderableBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderableBuilder_receiveShadows(
+  ffi.Pointer<TRenderableBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderableBuilder_fog(
+  ffi.Pointer<TRenderableBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt,
+        ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_lightChannel(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int channel,
+  bool enabled,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void RenderableBuilder_layerMask(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int select,
+  int values,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderableBuilder_screenSpaceContactShadows(
+  ffi.Pointer<TRenderableBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
+external void RenderableBuilder_blendOrder(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  int order,
+);
+
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_globalBlendOrderEnabled(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size)>(
+    isLeaf: true)
+external void RenderableBuilder_instances(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int instanceCount,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
+        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void RenderableBuilder_skinningFromMat4(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int boneCount,
+  ffi.Pointer<ffi.Float> transforms,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
+        ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void RenderableBuilder_skinningFromBone(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int boneCount,
+  ffi.Pointer<ffi.Float> bones,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(
+    isLeaf: true)
+external void RenderableBuilder_enableSkinningBuffers(
+  ffi.Pointer<TRenderableBuilder> builder,
+  bool enabled,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size,
+        ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(isLeaf: true)
+external void RenderableBuilder_boneIndicesAndWeights(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  ffi.Pointer<ffi.Float> indicesAndWeights,
+  int count,
+  int bonesPerVertex,
+);
+
+@ffi.Native<
+    ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>,
+        EntityId)>(isLeaf: true)
+external int RenderableBuilder_build(
+  ffi.Pointer<TRenderableBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+  int entity,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TVertexBuffer>,
+        ffi.Pointer<TIndexBuffer>,
+        ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+        ffi.Int,
+        ffi.UnsignedInt,
+        ffi.UnsignedInt,
+        Aabb3)>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TVertexBuffer> tVertexBuffer,
@@ -3514,14 +5848,12 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
 );
 
 @ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Uint32,
-  )
->(isLeaf: true)
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TEngine>,
+        ffi.Pointer<TGltfAssetLoader>,
+        ffi.Pointer<TNameComponentManager>,
+        ffi.Pointer<TFilamentAsset>,
+        ffi.Uint32)>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
   ffi.Pointer<TEngine> tEngine,
   ffi.Pointer<TGltfAssetLoader> tAssetLoader,
@@ -3530,51 +5862,91 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
   int requiredGeometryCapabilities,
 );
 
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(ffi.Pointer<TSceneAsset> tSceneAsset);
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
+external int SceneAsset_getType(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
+external void SceneAsset_destroy(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void SceneAsset_addToScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void SceneAsset_addToScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void SceneAsset_removeFromScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(
+    isLeaf: true)
+external void SceneAsset_removeFromScene(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+);
 
 @ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
+external int SceneAsset_getEntity(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+external int SceneAsset_getChildEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getChildEntities(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<EntityId> out);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(
+    isLeaf: true)
+external void SceneAsset_getChildEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<EntityId> out,
+);
 
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(ffi.Pointer<TSceneAsset> tSceneAsset, int index);
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+external int SceneAsset_getCameraEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(
+    isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getLightEntityCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
 @ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)
->(isLeaf: true)
+    ffi.Pointer<TSceneAsset> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int index,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<
+    ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>,
+        ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)>(isLeaf: true)
 external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
   ffi.Pointer<TSceneAsset> asset,
   ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
@@ -3582,242 +5954,157 @@ external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
 );
 
 @ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
+external Aabb3 SceneAsset_getBoundingBox(
+  ffi.Pointer<TSceneAsset> asset,
+);
 
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getGeometryCapabilities(ffi.Pointer<TSceneAsset> asset);
+external int SceneAsset_getGeometryCapabilities(
+  ffi.Pointer<TSceneAsset> asset,
+);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool SceneAsset_supportsFlatShading(ffi.Pointer<TSceneAsset> asset);
+external bool SceneAsset_supportsFlatShading(
+  ffi.Pointer<TSceneAsset> asset,
+);
 
-@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+@ffi.Native<
+    ffi.Pointer<TVertexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
 external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int primitiveIndex,
 );
 
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external int SceneAsset_getVertexBufferStorageMode(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(
+    isLeaf: true)
+external int SceneAsset_getVertexBufferStorageMode(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
 
-@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+@ffi.Native<
+    ffi.Pointer<TIndexBuffer> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int SceneAsset_getPrimitiveOffsetForEntity(ffi.Pointer<TSceneAsset> tSceneAsset, int entity);
+external int SceneAsset_getPrimitiveOffsetForEntity(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int entity,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(ffi.Pointer<TSceneAsset> tSceneAsset);
+external void SceneAsset_releaseSourceData(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(ffi.Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+external void SceneAsset_setFlatShading(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getBones(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex, ffi.Pointer<EntityId> out);
+@ffi.Native<
+    ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size,
+        ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getBones(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  ffi.Pointer<EntityId> out,
+);
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex);
+external int SceneAsset_getBoneCount(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+);
 
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
+@ffi.Native<
+    ffi.Pointer<ffi.Char> Function(
+        ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
 external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
   ffi.Pointer<TSceneAsset> tSceneAsset,
   int skinIndex,
   int boneIndex,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMeshData>)>(isLeaf: true)
-external void MeshData_dispose(ffi.Pointer<TMeshData> meshData);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Pointer<TMeshData>)>(
-  isLeaf: true,
-)
-external int GltfParser_parseBuffer(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> meshName,
-  ffi.Pointer<TMeshData> outMeshData,
-);
-
-@ffi.Native<
-  ffi.Pointer<TGltfAssetLoader> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Pointer<TNameComponentManager>,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+@ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(
+    isLeaf: true)
+external ffi.Pointer<TAnimationManager> AnimationManager_create(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
 );
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external void GltfAssetLoader_destroy(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
-
-@ffi.Native<
-  ffi.Pointer<TFilamentAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int numInstances,
-);
-
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, ffi.Pointer<TFilamentAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  ffi.Pointer<TFilamentAsset> tAsset,
-);
-
-@ffi.Native<ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getResourceUriCount(ffi.Pointer<TFilamentAsset> tFilamentAsset);
-
-@ffi.Native<ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(ffi.Pointer<TFilamentAsset> tFilamentAsset);
-
-@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-
-@ffi.Native<ffi.Void Function()>()
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(int port, int targetFps);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_setTargetFps(int fps);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
-
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(int t);
-
-@ffi.Native<
-  ffi.Pointer<TGizmo> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TView>,
-    ffi.Pointer<TMaterial>,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TGizmo> Gizmo_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> assetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32, GizmoPickCallback)>(isLeaf: true)
-external void Gizmo_pick(ffi.Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
-external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
-
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external void NameComponentManager_destroy(ffi.Pointer<TNameComponentManager> tNameComponentManager);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TRenderTarget> RenderTarget_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> color,
-  ffi.Pointer<TTexture> depth,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external void RenderTarget_destroy(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderTarget> tRenderTarget);
-
-@ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TAnimationManager> AnimationManager_create(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void AnimationManager_destroy(ffi.Pointer<TAnimationManager> tAnimationManager);
+external void AnimationManager_destroy(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(isLeaf: true)
-external void AnimationManager_update(ffi.Pointer<TAnimationManager> tAnimationManager, int frameTimeInNanos);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(
+    isLeaf: true)
+external void AnimationManager_update(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int frameTimeInNanos,
+);
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_addGltfAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_removeGltfAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(
+    isLeaf: true)
 external void AnimationManager_addMorphAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(
+    isLeaf: true)
 external void AnimationManager_removeMorphAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_addBoneAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_removeBoneAnimationComponent(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Pointer<ffi.Uint32>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>,
+        EntityId,
+        ffi.Pointer<ffi.Float>,
+        ffi.Pointer<ffi.Uint32>,
+        ffi.Int,
+        ffi.Int,
+        ffi.Float)>(isLeaf: true)
 external bool AnimationManager_setMorphAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -3828,30 +6115,34 @@ external bool AnimationManager_setMorphAnimation(
   double frameLengthInMs,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
-external bool AnimationManager_clearMorphAnimation(ffi.Pointer<TAnimationManager> tAnimationManager, int entityId);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(
+    isLeaf: true)
+external bool AnimationManager_clearMorphAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external void AnimationManager_resetToRestPose(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Bool,
-  )
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>,
+        ffi.Pointer<TSceneAsset>,
+        ffi.Int,
+        ffi.Int,
+        ffi.Pointer<ffi.Float>,
+        ffi.Int,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float,
+        ffi.Bool)>(isLeaf: true)
 external bool AnimationManager_addBoneAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -3867,8 +6158,8 @@ external bool AnimationManager_addBoneAnimation(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
 external void AnimationManager_getRestLocalTransforms(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -3878,8 +6169,8 @@ external void AnimationManager_getRestLocalTransforms(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)>(isLeaf: true)
 external void AnimationManager_getInverseBindMatrix(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -3889,18 +6180,16 @@ external void AnimationManager_getInverseBindMatrix(
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>,
+        ffi.Pointer<TSceneAsset>,
+        ffi.Int,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Bool,
+        ffi.Float,
+        ffi.Float,
+        ffi.Float)>(isLeaf: true)
 external bool AnimationManager_playGltfAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -3913,29 +6202,35 @@ external bool AnimationManager_playGltfAnimation(
   double speed,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int)>(isLeaf: true)
 external bool AnimationManager_stopGltfAnimation(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
   int index,
 );
 
-@ffi.Native<ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+@ffi.Native<
+    ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int)>(isLeaf: true)
 external double AnimationManager_getGltfAnimationDuration(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
   int animationIndex,
 );
 
-@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Int Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external int AnimationManager_getGltfAnimationCount(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Char>, ffi.Int)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
 external void AnimationManager_getGltfAnimationName(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -3943,7 +6238,9 @@ external void AnimationManager_getGltfAnimationName(
   int index,
 );
 
-@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
+@ffi.Native<
+    ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        EntityId)>(isLeaf: true)
 external int AnimationManager_getMorphTargetNameCount(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -3951,8 +6248,8 @@ external int AnimationManager_getMorphTargetNameCount(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId, ffi.Pointer<ffi.Char>, ffi.Int)
->(isLeaf: true)
+    ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        EntityId, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
 external void AnimationManager_getMorphTargetName(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
@@ -3961,13 +6258,17 @@ external void AnimationManager_getMorphTargetName(
   int index,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+@ffi.Native<
+    ffi.Bool Function(
+        ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
 external bool AnimationManager_updateBoneMatrices(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> sceneAsset,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId,
+        ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
 external bool AnimationManager_setMorphTargetWeights(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   int entityId,
@@ -3975,9 +6276,9 @@ external bool AnimationManager_setMorphTargetWeights(
   int numWeights,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Float)>(
-  isLeaf: true,
-)
+@ffi.Native<
+    ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>,
+        ffi.Int, ffi.Float)>(isLeaf: true)
 external bool AnimationManager_setGltfAnimationTime(
   ffi.Pointer<TAnimationManager> tAnimationManager,
   ffi.Pointer<TSceneAsset> tSceneAsset,
@@ -3985,803 +6286,35 @@ external bool AnimationManager_setGltfAnimationTime(
   double timeInSeconds,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external void RenderableManager_destroyEntity(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_hasComponent(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
-external bool RenderableManager_empty(ffi.Pointer<TRenderableManager> tRenderableManager);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_isRenderable(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
-external int RenderableManager_getComponentCount(ffi.Pointer<TRenderableManager> tRenderableManager);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int, ffi.Pointer<TMaterialInstance>)>(
-  isLeaf: true,
-)
-external bool RenderableManager_setMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-);
-
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
-external void RenderableManager_clearMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
+    isLeaf: true)
+external void MovementIntentExecutor_destroy(
+  ffi.Pointer<TMovementIntentExecutor> executor,
 );
 
 @ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Int,
-    ffi.Uint8,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external bool RenderableManager_setGeometryAtNonIndexed(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  int type,
-  ffi.Pointer<TVertexBuffer> vertices,
-  int offset,
-  int count,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external int RenderableManager_getPrimitiveCount(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external Aabb3 RenderableManager_getAxisAlignedBoundingBox(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, Aabb3)>(isLeaf: true)
-external void RenderableManager_setAxisAlignedBoundingBox(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  Aabb3 aabb,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external Aabb3 RenderableManager_getAabb(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external Aabb3 RenderableManager_getBoundingBox(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setLayerMask(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int select,
-  int values,
-);
-
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external int RenderableManager_getLayerMask(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setVisibilityLayer(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int layer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setPriority(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int priority,
-);
-
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external int RenderableManager_getPriority(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setCulling(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_getCulling(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setFogEnabled(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_getFogEnabled(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setLightChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
-external bool RenderableManager_getLightChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setCastShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool castShadows,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_isShadowCaster(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setReceiveShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool receiveShadows,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_isShadowReceiver(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setScreenSpaceContactShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size, ffi.Uint16)>(isLeaf: true)
-external void RenderableManager_setBlendOrderAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  int order,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setGlobalBlendOrderEnabledAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void RenderableManager_setMorphWeights(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> weights,
-  int count,
-  int offset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external int RenderableManager_getMorphTargetCount(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void RenderableManager_setBonesFromMat4(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> transforms,
-  int boneCount,
-  int offset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void RenderableManager_setBonesFromBone(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> bones,
-  int boneCount,
-  int offset,
-);
-
-@ffi.Native<ffi.Pointer<TRenderableBuilder> Function(ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TRenderableBuilder> RenderableBuilder_create(int primitiveCount);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>)>(isLeaf: true)
-external void RenderableBuilder_destroy(ffi.Pointer<TRenderableBuilder> builder);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, Aabb3)>(isLeaf: true)
-external void RenderableBuilder_boundingBox(ffi.Pointer<TRenderableBuilder> builder, Aabb3 aabb);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external void RenderableBuilder_material(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  ffi.Pointer<TMaterialInstance> materialInstance,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Size,
-    ffi.Uint8,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void RenderableBuilder_geometry(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  int type,
-  ffi.Pointer<TVertexBuffer> vertices,
-  ffi.Pointer<TIndexBuffer> indices,
-  int offset,
-  int count,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableBuilder>,
-    ffi.Size,
-    ffi.Uint8,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void RenderableBuilder_geometryNonIndexed(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  int type,
-  ffi.Pointer<TVertexBuffer> vertices,
-  int offset,
-  int count,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(isLeaf: true)
-external void RenderableBuilder_priority(ffi.Pointer<TRenderableBuilder> builder, int priority);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(isLeaf: true)
-external void RenderableBuilder_channel(ffi.Pointer<TRenderableBuilder> builder, int channel);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_culling(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_castShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_receiveShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_fog(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_lightChannel(ffi.Pointer<TRenderableBuilder> builder, int channel, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void RenderableBuilder_layerMask(ffi.Pointer<TRenderableBuilder> builder, int select, int values);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_screenSpaceContactShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
-external void RenderableBuilder_blendOrder(ffi.Pointer<TRenderableBuilder> builder, int primitiveIndex, int order);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_globalBlendOrderEnabled(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size)>(isLeaf: true)
-external void RenderableBuilder_instances(ffi.Pointer<TRenderableBuilder> builder, int instanceCount);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void RenderableBuilder_skinningFromMat4(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int boneCount,
-  ffi.Pointer<ffi.Float> transforms,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void RenderableBuilder_skinningFromBone(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int boneCount,
-  ffi.Pointer<ffi.Float> bones,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_enableSkinningBuffers(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void RenderableBuilder_boneIndicesAndWeights(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  ffi.Pointer<ffi.Float> indicesAndWeights,
-  int count,
-  int bonesPerVertex,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
-external int RenderableBuilder_build(ffi.Pointer<TRenderableBuilder> builder, ffi.Pointer<TEngine> engine, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void Camera_setExposure(ffi.Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void Camera_getFrustum(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> out);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double, ffi.Bool)>(
-  isLeaf: true,
-)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(isLeaf: true)
-external void Camera_lookAt(ffi.Pointer<TCamera> camera, double3 eye, double3 focus, double3 up);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(ffi.Pointer<TCamera> camera, double focusDistance);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void Camera_setModelMatrix(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> tModelMatrix);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.UnsignedInt,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(isLeaf: true)
-external void Scene_setSkybox(ffi.Pointer<TScene> tScene, ffi.Pointer<TSkybox> skybox);
-
-@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TScene>)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Scene_getSkybox(ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Scene_setIndirectLight(ffi.Pointer<TScene> tScene, ffi.Pointer<TIndirectLight> tIndirectLight);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external void Scene_addFilamentAsset(ffi.Pointer<TScene> tScene, ffi.Pointer<TFilamentAsset> asset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Skybox_setColor(ffi.Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
-
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void Skybox_setLayerMask(ffi.Pointer<TSkybox> tSkybox, int select, int values);
-
-/// Returns the visibility mask bits.
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external int Skybox_getLayerMask(ffi.Pointer<TSkybox> tSkybox);
-
-/// Returns the skybox intensity in lux.
-@ffi.Native<ffi.Float Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external double Skybox_getIntensity(ffi.Pointer<TSkybox> tSkybox);
-
-/// Returns the environment texture, or nullptr for a color-only skybox.
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external ffi.Pointer<TTexture> Skybox_getTexture(ffi.Pointer<TSkybox> tSkybox);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void Renderer_setClearOptions(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)>(isLeaf: true)
-external bool Renderer_beginFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
-external void Renderer_render(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
-external void Renderer_renderStandaloneView(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<TRenderTarget>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void Renderer_readPixels(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void Renderer_setFrameInterval(
-  ffi.Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void IndirectLight_setRotation(ffi.Pointer<TIndirectLight> tIndirectLight, ffi.Pointer<ffi.Double> rotation);
-
-@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external bool GltfResourceLoader_asyncBeginLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoad(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external double GltfResourceLoader_asyncGetLoadProgress(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Uint8>, ffi.Size)
->(isLeaf: true)
-external void GltfResourceLoader_addResourceData(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.Char> uri,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external bool GltfResourceLoader_loadResources(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(ffi.Pointer<TFilamentAsset> filamentAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void FilamentAsset_getEntities(ffi.Pointer<TFilamentAsset> filamentAsset, ffi.Pointer<EntityId> out);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(ffi.Pointer<TFilamentAsset> filamentAsset);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(ffi.Pointer<TFilamentAsset> filamentAsset);
-
-@ffi.Native<ffi.Pointer<TRenderManager> Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(isLeaf: true)
-external void RenderManager_render(ffi.Pointer<TRenderManager> tRenderer, int frameTimeInNanos);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)
->(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
-external void RenderManager_removeSwapChain(ffi.Pointer<TRenderManager> tRenderer, ffi.Pointer<TSwapChain> swapChain);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(ffi.Pointer<TRenderManager> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_detachFromRenderThread(ffi.Pointer<TRenderManager> tRenderManager);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(isLeaf: true)
-external void RenderManager_setPaused(ffi.Pointer<TRenderManager> tRenderer, bool paused);
-
-@ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_vertexCount(ffi.Pointer<TSurfaceOrientationBuilder> builder, int count);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_normals(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> normals,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_tangents(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> tangents,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_uvs(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> uvs,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_positions(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> positions,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangleCount(ffi.Pointer<TSurfaceOrientationBuilder> builder, int count);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Uint32>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_uint(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint32> triangles,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Uint16>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_triangles_ushort(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Uint16> triangles,
-);
-
-@ffi.Native<ffi.Pointer<TSurfaceOrientation> Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_destroy(ffi.Pointer<TSurfaceOrientationBuilder> builder);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external int SurfaceOrientation_getVertexCount(ffi.Pointer<TSurfaceOrientation> orientation);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void SurfaceOrientation_getQuats_float4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Float> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void SurfaceOrientation_getQuats_short4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Int16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Uint16>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void SurfaceOrientation_getQuats_half4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Uint16> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external void SurfaceOrientation_destroy(ffi.Pointer<TSurfaceOrientation> orientation);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
-external void MovementIntentExecutor_destroy(ffi.Pointer<TMovementIntentExecutor> executor);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>, ffi.Pointer<TMovementIntent>, ffi.Uint64)>(
-  isLeaf: true,
-)
+    ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>,
+        ffi.Pointer<TMovementIntent>, ffi.Uint64)>(isLeaf: true)
 external void MovementIntentExecutor_process(
   ffi.Pointer<TMovementIntentExecutor> executor,
   ffi.Pointer<TMovementIntent> intent,
   int deltaTimeInNanos,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
-external void Pipeline_registerMovementIntentExecutor(ffi.Pointer<TMovementIntentExecutor> executor);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(
+    isLeaf: true)
+external void Pipeline_registerMovementIntentExecutor(
+  ffi.Pointer<TMovementIntentExecutor> executor,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void TransformPipeline_setEngine(ffi.Pointer<ffi.Void> enginePtr);
+external void TransformPipeline_setEngine(
+  ffi.Pointer<ffi.Void> enginePtr,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+@ffi.Native<
+    ffi.Void Function(ffi.Int, ffi.Int, ffi.Double, ffi.Double, ffi.Double,
+        ffi.Double)>(isLeaf: true)
 external void TransformPipeline_onMouseEvent(
   int eventType,
   int button,
@@ -4792,49 +6325,81 @@ external void TransformPipeline_onMouseEvent(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Int, ffi.Int)>(isLeaf: true)
-external void TransformPipeline_onKeyEvent(int eventType, int logicalKey, int physicalKey, int synthesized);
+external void TransformPipeline_onKeyEvent(
+  int eventType,
+  int logicalKey,
+  int physicalKey,
+  int synthesized,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void TransformPipeline_onScrollEvent(double localX, double localY, double delta);
+external void TransformPipeline_onScrollEvent(
+  double localX,
+  double localY,
+  double delta,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_update(double deltaTime);
+external void TransformPipeline_update(
+  double deltaTime,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>(
+    isLeaf: true)
 external void TransformPipeline_registerPipelineStage(
   ffi.Pointer<ffi.Void> pipelineStageHandle,
   ffi.Pointer<ffi.Char> name,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void TransformPipeline_unregisterPipelineStage(ffi.Pointer<ffi.Void> pipelineStageHandle);
+external void TransformPipeline_unregisterPipelineStage(
+  ffi.Pointer<ffi.Void> pipelineStageHandle,
+);
 
 @ffi.Native<ffi.Void Function()>(isLeaf: true)
 external void TransformPipeline_cleanup();
 
 @ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Float)>(isLeaf: true)
-external void TransformPipeline_addKeyBinding(int logicalKey, int intentAction, double value);
+external void TransformPipeline_addKeyBinding(
+  int logicalKey,
+  int intentAction,
+  double value,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForKey(int logicalKey);
+external void TransformPipeline_removeKeyBindingsForKey(
+  int logicalKey,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForAction(int intentAction);
+external void TransformPipeline_removeKeyBindingsForAction(
+  int intentAction,
+);
 
 @ffi.Native<ffi.Void Function()>(isLeaf: true)
 external void TransformPipeline_clearKeyBindings();
 
 @ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Float)>(isLeaf: true)
-external void TransformPipeline_addMouseButtonBinding(int mouseButton, int intentAction, double value);
+external void TransformPipeline_addMouseButtonBinding(
+  int mouseButton,
+  int intentAction,
+  double value,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeMouseButtonBindings(int mouseButton);
+external void TransformPipeline_removeMouseButtonBindings(
+  int mouseButton,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_setMouseSensitivity(double sensitivity);
+external void TransformPipeline_setMouseSensitivity(
+  double sensitivity,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_setInvertMouseY(int invert);
+external void TransformPipeline_setInvertMouseY(
+  int invert,
+);
 
 typedef VoidCallbackFunction = ffi.Void Function(ffi.Int32 requestId);
 typedef DartVoidCallbackFunction = void Function(int requestId);
@@ -5190,277 +6755,92 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
 }
 
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
+final class TShadowOptions extends ffi.Struct {
+  @ffi.Uint32()
+  external int mapSize;
 
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
+  @ffi.Uint8()
+  external int shadowCascades;
 
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.Float> cascadeSplitPositions;
 
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
+  @ffi.Float()
+  external double constantBias;
 
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+  @ffi.Float()
+  external double normalBias;
 
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
+  @ffi.Float()
+  external double shadowFar;
 
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+  @ffi.Float()
+  external double shadowNearHint;
 
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
+  @ffi.Float()
+  external double shadowFarHint;
 
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
+  @ffi.Bool()
+  external bool stable;
 
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+  @ffi.Bool()
+  external bool lispsm;
 
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
+  @ffi.Float()
+  external double polygonOffsetConstant;
 
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
+  @ffi.Float()
+  external double polygonOffsetSlope;
 
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
+  @ffi.Bool()
+  external bool screenSpaceContactShadows;
 
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
+  @ffi.Uint8()
+  external int stepCount;
 
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
+  @ffi.Float()
+  external double maxShadowDistance;
 
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
+  @ffi.Bool()
+  external bool vsmElvsm;
 
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
+  @ffi.Float()
+  external double vsmBlurWidth;
 
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
+  @ffi.Float()
+  external double shadowBulbRadius;
 
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
+  @ffi.Float()
+  external double penumbraScale;
 
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
+  @ffi.Float()
+  external double penumbraRatioScale;
 
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+  @ffi.Float()
+  external double maxPenumbraRatio;
 
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
+  @ffi.Float()
+  external double maxSearchRadius;
 
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
+  @ffi.Float()
+  external double transformX;
 
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
+  @ffi.Float()
+  external double transformY;
 
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+  @ffi.Float()
+  external double transformZ;
 
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
+  @ffi.Float()
+  external double transformW;
 }
 
 final class TViewport extends ffi.Struct {
@@ -5721,110 +7101,333 @@ final class TAmbientOcclusionOptions extends ffi.Struct {
   external int aoType;
 }
 
-typedef PickCallbackFunction =
-    ffi.Void Function(
-      ffi.Uint32 requestId,
-      EntityId entityId,
-      ffi.Float depth,
-      ffi.Float fragX,
-      ffi.Float fragY,
-      ffi.Float fragZ,
-    );
-typedef DartPickCallbackFunction =
-    void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
+typedef PickCallbackFunction = ffi.Void Function(
+    ffi.Uint32 requestId,
+    EntityId entityId,
+    ffi.Float depth,
+    ffi.Float fragX,
+    ffi.Float fragY,
+    ffi.Float fragZ);
+typedef DartPickCallbackFunction = void Function(
+    int requestId,
+    DartEntityId entityId,
+    double depth,
+    double fragX,
+    double fragY,
+    double fragZ);
 typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
 }
 
-final class TShadowOptions extends ffi.Struct {
-  @ffi.Uint32()
-  external int mapSize;
-
-  @ffi.Uint8()
-  external int shadowCascades;
-
-  @ffi.Array.multi([3])
-  external ffi.Array<ffi.Float> cascadeSplitPositions;
-
-  @ffi.Float()
-  external double constantBias;
-
-  @ffi.Float()
-  external double normalBias;
-
-  @ffi.Float()
-  external double shadowFar;
-
-  @ffi.Float()
-  external double shadowNearHint;
-
-  @ffi.Float()
-  external double shadowFarHint;
-
-  @ffi.Bool()
-  external bool stable;
-
-  @ffi.Bool()
-  external bool lispsm;
-
-  @ffi.Float()
-  external double polygonOffsetConstant;
-
-  @ffi.Float()
-  external double polygonOffsetSlope;
-
-  @ffi.Bool()
-  external bool screenSpaceContactShadows;
-
-  @ffi.Uint8()
-  external int stepCount;
-
-  @ffi.Float()
-  external double maxShadowDistance;
-
-  @ffi.Bool()
-  external bool vsmElvsm;
-
-  @ffi.Float()
-  external double vsmBlurWidth;
-
-  @ffi.Float()
-  external double shadowBulbRadius;
-
-  @ffi.Float()
-  external double penumbraScale;
-
-  @ffi.Float()
-  external double penumbraRatioScale;
-
-  @ffi.Float()
-  external double maxPenumbraRatio;
-
-  @ffi.Float()
-  external double maxSearchRadius;
-
-  @ffi.Float()
-  external double transformX;
-
-  @ffi.Float()
-  external double transformY;
-
-  @ffi.Float()
-  external double transformZ;
-
-  @ffi.Float()
-  external double transformW;
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
 }
 
-typedef FilamentRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> owner);
-typedef DartFilamentRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> owner);
-typedef FilamentRenderCallback = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+typedef FrameTickCallbackFunction = ffi.Void Function(
+    ffi.Uint64 frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(int frameTimeNanos);
+typedef FrameTickCallback
+    = ffi.Pointer<ffi.NativeFunction<FrameTickCallbackFunction>>;
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+typedef GizmoPickCallbackFunction = ffi.Void Function(
+    ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
+typedef DartGizmoPickCallbackFunction = void Function(
+    int resultType, double x, double y, double z);
+typedef GizmoPickCallback
+    = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+typedef FilamentRenderCallbackFunction = ffi.Void Function(
+    ffi.Pointer<ffi.Void> owner);
+typedef DartFilamentRenderCallbackFunction = void Function(
+    ffi.Pointer<ffi.Void> owner);
+typedef FilamentRenderCallback
+    = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
 
 final class TMeshData extends ffi.Struct {
   external ffi.Pointer<ffi.Char> name;
@@ -5853,34 +7456,6 @@ final class TMeshData extends ffi.Struct {
 
   @ffi.UnsignedInt()
   external int primitiveType;
-}
-
-typedef FrameTickCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameTickCallback = ffi.Pointer<ffi.NativeFunction<FrameTickCallbackFunction>>;
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-typedef GizmoPickCallbackFunction =
-    ffi.Void Function(ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef GizmoPickCallback = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
 }
 
 final class TMovementIntentCalculator extends ffi.Opaque {}

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -27,155 +27,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
   external Pointer<Int32> _TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
-  external void _View_getViewport(Pointer<TViewport> TViewport_out, Pointer<TView> view);
-  external Pointer<TToneMapper> _ToneMapper_createLinear(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createACES(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createACESLegacy(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createFilmic(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createAGX(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createAGXWithLook(Pointer<TEngine> tEngine, int look);
-  external Pointer<TToneMapper> _ToneMapper_createGeneric(
-    Pointer<TEngine> tEngine,
-    double contrast,
-    double midGrayIn,
-    double midGrayOut,
-    double hdrMax,
-  );
-  external Pointer<TToneMapper> _ToneMapper_createDisplayRange(Pointer<TEngine> tEngine);
-  external void _ToneMapper_destroy(Pointer<TToneMapper> toneMapper);
-  external Pointer<TColorGradingBuilder> _ColorGradingBuilder_create();
-  external Pointer<TColorGrading> _ColorGradingBuilder_build(
-    Pointer<TColorGradingBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder);
-  external void _ColorGrading_destroy(Pointer<TEngine> engine, Pointer<TColorGrading> colorGrading);
-  external void _ColorGradingBuilder_quality(Pointer<TColorGradingBuilder> builder, int level);
-  external void _ColorGradingBuilder_format(Pointer<TColorGradingBuilder> builder, int format);
-  external void _ColorGradingBuilder_dimensions(Pointer<TColorGradingBuilder> builder, int dim);
-  external void _ColorGradingBuilder_toneMapper(Pointer<TColorGradingBuilder> builder, Pointer<TToneMapper> toneMapper);
-  external void _ColorGradingBuilder_exposure(Pointer<TColorGradingBuilder> builder, double exposure);
-  external void _ColorGradingBuilder_nightAdaptation(Pointer<TColorGradingBuilder> builder, double adaptation);
-  external void _ColorGradingBuilder_whiteBalance(
-    Pointer<TColorGradingBuilder> builder,
-    double temperature,
-    double tint,
-  );
-  external void _ColorGradingBuilder_contrast(Pointer<TColorGradingBuilder> builder, double contrast);
-  external void _ColorGradingBuilder_vibrance(Pointer<TColorGradingBuilder> builder, double vibrance);
-  external void _ColorGradingBuilder_saturation(Pointer<TColorGradingBuilder> builder, double saturation);
-  external void _ColorGradingBuilder_channelMixer(
-    Pointer<TColorGradingBuilder> builder,
-    double outRedR,
-    double outRedG,
-    double outRedB,
-    double outGreenR,
-    double outGreenG,
-    double outGreenB,
-    double outBlueR,
-    double outBlueG,
-    double outBlueB,
-  );
-  external void _ColorGradingBuilder_shadowsMidtonesHighlights(
-    Pointer<TColorGradingBuilder> builder,
-    double shadowsR,
-    double shadowsG,
-    double shadowsB,
-    double shadowsW,
-    double midtonesR,
-    double midtonesG,
-    double midtonesB,
-    double midtonesW,
-    double highlightsR,
-    double highlightsG,
-    double highlightsB,
-    double highlightsW,
-    double rangesX,
-    double rangesY,
-    double rangesZ,
-    double rangesW,
-  );
-  external void _ColorGradingBuilder_slopeOffsetPower(
-    Pointer<TColorGradingBuilder> builder,
-    double slopeR,
-    double slopeG,
-    double slopeB,
-    double offsetR,
-    double offsetG,
-    double offsetB,
-    double powerR,
-    double powerG,
-    double powerB,
-  );
-  external void _ColorGradingBuilder_curves(
-    Pointer<TColorGradingBuilder> builder,
-    double shadowGammaR,
-    double shadowGammaG,
-    double shadowGammaB,
-    double midPointR,
-    double midPointG,
-    double midPointB,
-    double highlightScaleR,
-    double highlightScaleG,
-    double highlightScaleB,
-  );
-  external void _ColorGradingBuilder_luminanceScaling(Pointer<TColorGradingBuilder> builder, bool enabled);
-  external void _ColorGradingBuilder_gamutMapping(Pointer<TColorGradingBuilder> builder, bool enabled);
-  external void _View_setColorGrading(Pointer<TView> tView, Pointer<TColorGrading> tColorGrading);
-  external Pointer<TColorGrading> _View_getColorGrading(Pointer<TView> tView);
-  external void _View_setBlendMode(Pointer<TView> view, int blendMode);
-  external void _View_setViewport(Pointer<TView> view, int width, int height);
-  external void _View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget);
-  external void _View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled);
-  external int _View_getVisibleRenderableCount(Pointer<TView> view);
-  external Pointer<TRenderTarget> _View_getRenderTarget(Pointer<TView> tView);
-  external void _View_setPostProcessing(Pointer<TView> tView, bool enabled);
-  external void _View_setShadowsEnabled(Pointer<TView> tView, bool enabled);
-  external void _View_setShadowType(Pointer<TView> tView, int shadowType);
-  external int _View_getShadowType(Pointer<TView> tView);
-  external void _View_setSoftShadowOptions(Pointer<TView> tView, Pointer<TSoftShadowOptions> optionsPtr);
-  external void _View_getSoftShadowOptions(Pointer<TSoftShadowOptions> TSoftShadowOptions_out, Pointer<TView> tView);
-  external void _View_setVsmShadowOptions(Pointer<TView> tView, Pointer<TVsmShadowOptions> optionsPtr);
-  external void _View_getVsmShadowOptions(Pointer<TVsmShadowOptions> TVsmShadowOptions_out, Pointer<TView> tView);
-  external void _View_setBloom(Pointer<TView> tView, bool enabled, double strength);
-  external void _View_setRenderQuality(Pointer<TView> tView, int qualityLevel);
-  external void _View_setAntiAliasing(Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
-  external void _View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible);
-  external void _View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera);
-  external Pointer<TScene> _View_getScene(Pointer<TView> tView);
-  external Pointer<TCamera> _View_getCamera(Pointer<TView> tView);
-  external void _View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled);
-  external int _View_isStencilBufferEnabled(Pointer<TView> tView);
-  external void _View_setDitheringEnabled(Pointer<TView> tView, bool enabled);
-  external int _View_isDitheringEnabled(Pointer<TView> tView);
-  external void _View_setScene(Pointer<TView> tView, Pointer<TScene> tScene);
-  external void _View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted);
-  external void _View_setAmbientOcclusionOptions(Pointer<TView> tView, Pointer<TAmbientOcclusionOptions> optionsPtr);
-  external void _View_getAmbientOcclusionOptions(
-    Pointer<TAmbientOcclusionOptions> TAmbientOcclusionOptions_out,
-    Pointer<TView> tView,
-  );
-  external void _View_setFogOptions(Pointer<TView> tView, Pointer<TFogOptions> tFogOptionsPtr);
-  external void _View_getFogOptions(Pointer<TFogOptions> TFogOptions_out, Pointer<TView> tView);
-  external void _View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled);
-  external int _View_isTransparentPickingEnabled(Pointer<TView> tView);
-  external void _View_pick(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
-  external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
-  external Pointer<Char> _View_getName(Pointer<TView> tView);
-  external void _Gizmo_dummy(int t);
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
-  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
-  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
   external Pointer<TMaterialInstance> _Material_createInstance(Pointer<TMaterial> tMaterial);
   external int _Material_getFeatureLevel(Pointer<TMaterial> tMaterial);
   external Pointer<TMaterial> _Material_createImageMaterial(Pointer<TEngine> tEngine);
@@ -281,122 +132,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external int _MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance);
   external int _Material_getBlendingMode(Pointer<TMaterial> material);
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    int vertexBufferStorageMode,
-    Pointer<Aabb3> boundingBoxPtr,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TFilamentAsset> tFilamentAsset,
-    int requiredGeometryCapabilities,
-  );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
-  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
-  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-  );
-  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
-  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
-  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
-  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
-  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
-  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
-  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
-  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
-  );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix);
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
-  external void _MeshData_dispose(Pointer<TMeshData> meshData);
-  external int _GltfParser_parseBuffer(
-    Pointer<Uint8> data,
-    size_t length,
-    Pointer<Char> meshName,
-    Pointer<TMeshData> outMeshData,
-  );
   external Pointer<TTexture> _Texture_build(
     Pointer<TEngine> engine,
     int width,
@@ -583,6 +318,142 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<Char> name,
     Pointer<Float32> outValue,
   );
+  external void _View_getViewport(Pointer<TViewport> TViewport_out, Pointer<TView> view);
+  external Pointer<TToneMapper> _ToneMapper_createLinear(Pointer<TEngine> tEngine);
+  external Pointer<TToneMapper> _ToneMapper_createACES(Pointer<TEngine> tEngine);
+  external Pointer<TToneMapper> _ToneMapper_createACESLegacy(Pointer<TEngine> tEngine);
+  external Pointer<TToneMapper> _ToneMapper_createFilmic(Pointer<TEngine> tEngine);
+  external Pointer<TToneMapper> _ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine);
+  external Pointer<TToneMapper> _ToneMapper_createAGX(Pointer<TEngine> tEngine);
+  external Pointer<TToneMapper> _ToneMapper_createAGXWithLook(Pointer<TEngine> tEngine, int look);
+  external Pointer<TToneMapper> _ToneMapper_createGeneric(
+    Pointer<TEngine> tEngine,
+    double contrast,
+    double midGrayIn,
+    double midGrayOut,
+    double hdrMax,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createDisplayRange(Pointer<TEngine> tEngine);
+  external void _ToneMapper_destroy(Pointer<TToneMapper> toneMapper);
+  external Pointer<TColorGradingBuilder> _ColorGradingBuilder_create();
+  external Pointer<TColorGrading> _ColorGradingBuilder_build(
+    Pointer<TColorGradingBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder);
+  external void _ColorGrading_destroy(Pointer<TEngine> engine, Pointer<TColorGrading> colorGrading);
+  external void _ColorGradingBuilder_quality(Pointer<TColorGradingBuilder> builder, int level);
+  external void _ColorGradingBuilder_format(Pointer<TColorGradingBuilder> builder, int format);
+  external void _ColorGradingBuilder_dimensions(Pointer<TColorGradingBuilder> builder, int dim);
+  external void _ColorGradingBuilder_toneMapper(Pointer<TColorGradingBuilder> builder, Pointer<TToneMapper> toneMapper);
+  external void _ColorGradingBuilder_exposure(Pointer<TColorGradingBuilder> builder, double exposure);
+  external void _ColorGradingBuilder_nightAdaptation(Pointer<TColorGradingBuilder> builder, double adaptation);
+  external void _ColorGradingBuilder_whiteBalance(
+    Pointer<TColorGradingBuilder> builder,
+    double temperature,
+    double tint,
+  );
+  external void _ColorGradingBuilder_contrast(Pointer<TColorGradingBuilder> builder, double contrast);
+  external void _ColorGradingBuilder_vibrance(Pointer<TColorGradingBuilder> builder, double vibrance);
+  external void _ColorGradingBuilder_saturation(Pointer<TColorGradingBuilder> builder, double saturation);
+  external void _ColorGradingBuilder_channelMixer(
+    Pointer<TColorGradingBuilder> builder,
+    double outRedR,
+    double outRedG,
+    double outRedB,
+    double outGreenR,
+    double outGreenG,
+    double outGreenB,
+    double outBlueR,
+    double outBlueG,
+    double outBlueB,
+  );
+  external void _ColorGradingBuilder_shadowsMidtonesHighlights(
+    Pointer<TColorGradingBuilder> builder,
+    double shadowsR,
+    double shadowsG,
+    double shadowsB,
+    double shadowsW,
+    double midtonesR,
+    double midtonesG,
+    double midtonesB,
+    double midtonesW,
+    double highlightsR,
+    double highlightsG,
+    double highlightsB,
+    double highlightsW,
+    double rangesX,
+    double rangesY,
+    double rangesZ,
+    double rangesW,
+  );
+  external void _ColorGradingBuilder_slopeOffsetPower(
+    Pointer<TColorGradingBuilder> builder,
+    double slopeR,
+    double slopeG,
+    double slopeB,
+    double offsetR,
+    double offsetG,
+    double offsetB,
+    double powerR,
+    double powerG,
+    double powerB,
+  );
+  external void _ColorGradingBuilder_curves(
+    Pointer<TColorGradingBuilder> builder,
+    double shadowGammaR,
+    double shadowGammaG,
+    double shadowGammaB,
+    double midPointR,
+    double midPointG,
+    double midPointB,
+    double highlightScaleR,
+    double highlightScaleG,
+    double highlightScaleB,
+  );
+  external void _ColorGradingBuilder_luminanceScaling(Pointer<TColorGradingBuilder> builder, bool enabled);
+  external void _ColorGradingBuilder_gamutMapping(Pointer<TColorGradingBuilder> builder, bool enabled);
+  external void _View_setColorGrading(Pointer<TView> tView, Pointer<TColorGrading> tColorGrading);
+  external Pointer<TColorGrading> _View_getColorGrading(Pointer<TView> tView);
+  external void _View_setBlendMode(Pointer<TView> view, int blendMode);
+  external void _View_setViewport(Pointer<TView> view, int width, int height);
+  external void _View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget);
+  external void _View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled);
+  external int _View_getVisibleRenderableCount(Pointer<TView> view);
+  external Pointer<TRenderTarget> _View_getRenderTarget(Pointer<TView> tView);
+  external void _View_setPostProcessing(Pointer<TView> tView, bool enabled);
+  external void _View_setShadowsEnabled(Pointer<TView> tView, bool enabled);
+  external void _View_setShadowType(Pointer<TView> tView, int shadowType);
+  external int _View_getShadowType(Pointer<TView> tView);
+  external void _View_setSoftShadowOptions(Pointer<TView> tView, Pointer<TSoftShadowOptions> optionsPtr);
+  external void _View_getSoftShadowOptions(Pointer<TSoftShadowOptions> TSoftShadowOptions_out, Pointer<TView> tView);
+  external void _View_setVsmShadowOptions(Pointer<TView> tView, Pointer<TVsmShadowOptions> optionsPtr);
+  external void _View_getVsmShadowOptions(Pointer<TVsmShadowOptions> TVsmShadowOptions_out, Pointer<TView> tView);
+  external void _View_setBloom(Pointer<TView> tView, bool enabled, double strength);
+  external void _View_setRenderQuality(Pointer<TView> tView, int qualityLevel);
+  external void _View_setAntiAliasing(Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
+  external void _View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible);
+  external void _View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera);
+  external Pointer<TScene> _View_getScene(Pointer<TView> tView);
+  external Pointer<TCamera> _View_getCamera(Pointer<TView> tView);
+  external void _View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled);
+  external int _View_isStencilBufferEnabled(Pointer<TView> tView);
+  external void _View_setDitheringEnabled(Pointer<TView> tView, bool enabled);
+  external int _View_isDitheringEnabled(Pointer<TView> tView);
+  external void _View_setScene(Pointer<TView> tView, Pointer<TScene> tScene);
+  external void _View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted);
+  external void _View_setAmbientOcclusionOptions(Pointer<TView> tView, Pointer<TAmbientOcclusionOptions> optionsPtr);
+  external void _View_getAmbientOcclusionOptions(
+    Pointer<TAmbientOcclusionOptions> TAmbientOcclusionOptions_out,
+    Pointer<TView> tView,
+  );
+  external void _View_setFogOptions(Pointer<TView> tView, Pointer<TFogOptions> tFogOptionsPtr);
+  external void _View_getFogOptions(Pointer<TFogOptions> TFogOptions_out, Pointer<TView> tView);
+  external void _View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled);
+  external int _View_isTransparentPickingEnabled(Pointer<TView> tView);
+  external void _View_pick(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
+  external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
+  external Pointer<Char> _View_getName(Pointer<TView> tView);
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
     bool doubleSided,
@@ -1920,42 +1791,105 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    int vertexBufferStorageMode,
+    Pointer<Aabb3> boundingBoxPtr,
   );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    int requiredGeometryCapabilities,
   );
-  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
-  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
+  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
+  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
   );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
+  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
+  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
+  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
+  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
+  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
+  external void _MeshData_dispose(Pointer<TMeshData> meshData);
+  external int _GltfParser_parseBuffer(
+    Pointer<Uint8> data,
+    size_t length,
+    Pointer<Char> meshName,
+    Pointer<TMeshData> outMeshData,
+  );
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
+  );
+  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
+  );
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
+  );
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
+  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
+  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+  external void _FrameScheduler_stop();
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Gizmo_dummy(int t);
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+  );
+  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
   );
   external Pointer<TRenderTarget> _RenderTarget_create(
     Pointer<TEngine> tEngine,
@@ -1963,19 +1897,133 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TTexture> depth,
   );
   external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
-  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
-
-  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
-
-  /// Returns the visibility mask bits.
-  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
-
-  /// Returns the skybox intensity in lux.
-  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
-
-  /// Returns the environment texture, or nullptr for a color-only skybox.
-  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
+  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
+  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
+  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
+  external int _AnimationManager_addGltfAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_removeGltfAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _AnimationManager_addMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+  );
+  external void _AnimationManager_removeMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+  );
+  external int _AnimationManager_addBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_removeBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_setMorphAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    Pointer<Uint32> morphIndices,
+    int numMorphTargets,
+    int numFrames,
+    double frameLengthInMs,
+  );
+  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
+  external void _AnimationManager_resetToRestPose(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external int _AnimationManager_addBoneAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> frameData,
+    int numFrames,
+    double frameLengthInMs,
+    double fadeOutInSecs,
+    double fadeInInSecs,
+    double maxDelta,
+    bool loop,
+  );
+  external void _AnimationManager_getRestLocalTransforms(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    Pointer<Float32> out,
+    int numBones,
+  );
+  external void _AnimationManager_getInverseBindMatrix(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> out,
+  );
+  external int _AnimationManager_playGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+    bool loop,
+    bool reverse,
+    bool replaceActive,
+    double crossfade,
+    double startOffset,
+    double speed,
+  );
+  external int _AnimationManager_stopGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int index,
+  );
+  external double _AnimationManager_getGltfAnimationDuration(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int animationIndex,
+  );
+  external int _AnimationManager_getGltfAnimationCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external void _AnimationManager_getGltfAnimationName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_getMorphTargetNameCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+  );
+  external void _AnimationManager_getMorphTargetName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_updateBoneMatrices(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external int _AnimationManager_setMorphTargetWeights(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    int numWeights,
+  );
+  external int _AnimationManager_setGltfAnimationTime(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int animationIndex,
+    double timeInSeconds,
+  );
   external void _RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
   external int _RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
   external int _RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager);
@@ -2190,7 +2238,162 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t bonesPerVertex,
   );
   external int _RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, EntityId entity);
+  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
+  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
+  );
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix);
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
+  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
+  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
+  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
+  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
+
+  /// Returns the visibility mask bits.
+  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
+
+  /// Returns the skybox intensity in lux.
+  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
+
+  /// Returns the environment texture, or nullptr for a color-only skybox.
+  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
+  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
   external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
+  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
+  );
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
+  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
+  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
+  );
+  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
+  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
   external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
   external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
   external void _SurfaceOrientationBuilder_normals(
@@ -2244,209 +2447,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t stride,
   );
   external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
-  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
-  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
-  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
-  external int _AnimationManager_addGltfAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_removeGltfAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _AnimationManager_addMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-  );
-  external void _AnimationManager_removeMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-  );
-  external int _AnimationManager_addBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_removeBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_setMorphAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    Pointer<Uint32> morphIndices,
-    int numMorphTargets,
-    int numFrames,
-    double frameLengthInMs,
-  );
-  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
-  external void _AnimationManager_resetToRestPose(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_addBoneAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> frameData,
-    int numFrames,
-    double frameLengthInMs,
-    double fadeOutInSecs,
-    double fadeInInSecs,
-    double maxDelta,
-    bool loop,
-  );
-  external void _AnimationManager_getRestLocalTransforms(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    Pointer<Float32> out,
-    int numBones,
-  );
-  external void _AnimationManager_getInverseBindMatrix(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> out,
-  );
-  external int _AnimationManager_playGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-    bool loop,
-    bool reverse,
-    bool replaceActive,
-    double crossfade,
-    double startOffset,
-    double speed,
-  );
-  external int _AnimationManager_stopGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int index,
-  );
-  external double _AnimationManager_getGltfAnimationDuration(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int animationIndex,
-  );
-  external int _AnimationManager_getGltfAnimationCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external void _AnimationManager_getGltfAnimationName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_getMorphTargetNameCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-  );
-  external void _AnimationManager_getMorphTargetName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_updateBoneMatrices(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_setMorphTargetWeights(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    int numWeights,
-  );
-  external int _AnimationManager_setGltfAnimationTime(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int animationIndex,
-    double timeInSeconds,
-  );
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
-  );
-  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
-  );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
-  );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
-  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
-  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
-  );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
-  );
-  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
-  );
-  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
-  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
-  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
-  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
-  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
-  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
-  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
-  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
-  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-  external void _FrameScheduler_stop();
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
   external void _MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor);
   external void _MovementIntentExecutor_process(
     Pointer<TMovementIntentExecutor> executor,
@@ -2526,529 +2526,6 @@ BigInt get TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER {
     "i64",
   );
   return bigIntasUintN(64, value).toDart;
-}
-
-TViewport View_getViewport(Pointer<TView> view) {
-  final TViewport_out = TViewport.stackAlloc();
-  final result = GeneratedBindings.instance._View_getViewport(TViewport_out.cast(), view.cast());
-  return TViewport_out.toDart();
-}
-
-Pointer<TToneMapper> ToneMapper_createLinear(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createLinear(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createACES(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createACES(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createACESLegacy(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createACESLegacy(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createFilmic(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createFilmic(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createPBRNeutral(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createAGX(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createAGX(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createAGXWithLook(Pointer<TEngine> tEngine, int look) {
-  final result = GeneratedBindings.instance._ToneMapper_createAGXWithLook(tEngine.cast(), look);
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createGeneric(
-  Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createGeneric(
-    tEngine.cast(),
-    contrast,
-    midGrayIn,
-    midGrayOut,
-    hdrMax,
-  );
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createDisplayRange(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createDisplayRange(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-void ToneMapper_destroy(Pointer<TToneMapper> toneMapper) {
-  final result = GeneratedBindings.instance._ToneMapper_destroy(toneMapper.cast());
-  return result;
-}
-
-Pointer<TColorGradingBuilder> ColorGradingBuilder_create() {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_create();
-  return Pointer<TColorGradingBuilder>(result);
-}
-
-Pointer<TColorGrading> ColorGradingBuilder_build(Pointer<TColorGradingBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TColorGrading>(result);
-}
-
-void ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_destroy(builder.cast());
-  return result;
-}
-
-void ColorGrading_destroy(Pointer<TEngine> engine, Pointer<TColorGrading> colorGrading) {
-  final result = GeneratedBindings.instance._ColorGrading_destroy(engine.cast(), colorGrading.cast());
-  return result;
-}
-
-void ColorGradingBuilder_quality(Pointer<TColorGradingBuilder> builder, int level) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_quality(builder.cast(), level);
-  return result;
-}
-
-void ColorGradingBuilder_format(Pointer<TColorGradingBuilder> builder, int format) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_format(builder.cast(), format);
-  return result;
-}
-
-void ColorGradingBuilder_dimensions(Pointer<TColorGradingBuilder> builder, int dim) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_dimensions(builder.cast(), dim);
-  return result;
-}
-
-void ColorGradingBuilder_toneMapper(Pointer<TColorGradingBuilder> builder, Pointer<TToneMapper> toneMapper) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_toneMapper(builder.cast(), toneMapper.cast());
-  return result;
-}
-
-void ColorGradingBuilder_exposure(Pointer<TColorGradingBuilder> builder, double exposure) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_exposure(builder.cast(), exposure);
-  return result;
-}
-
-void ColorGradingBuilder_nightAdaptation(Pointer<TColorGradingBuilder> builder, double adaptation) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_nightAdaptation(builder.cast(), adaptation);
-  return result;
-}
-
-void ColorGradingBuilder_whiteBalance(Pointer<TColorGradingBuilder> builder, double temperature, double tint) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_whiteBalance(builder.cast(), temperature, tint);
-  return result;
-}
-
-void ColorGradingBuilder_contrast(Pointer<TColorGradingBuilder> builder, double contrast) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_contrast(builder.cast(), contrast);
-  return result;
-}
-
-void ColorGradingBuilder_vibrance(Pointer<TColorGradingBuilder> builder, double vibrance) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_vibrance(builder.cast(), vibrance);
-  return result;
-}
-
-void ColorGradingBuilder_saturation(Pointer<TColorGradingBuilder> builder, double saturation) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_saturation(builder.cast(), saturation);
-  return result;
-}
-
-void ColorGradingBuilder_channelMixer(
-  Pointer<TColorGradingBuilder> builder,
-  double outRedR,
-  double outRedG,
-  double outRedB,
-  double outGreenR,
-  double outGreenG,
-  double outGreenB,
-  double outBlueR,
-  double outBlueG,
-  double outBlueB,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_channelMixer(
-    builder.cast(),
-    outRedR,
-    outRedG,
-    outRedB,
-    outGreenR,
-    outGreenG,
-    outGreenB,
-    outBlueR,
-    outBlueG,
-    outBlueB,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_shadowsMidtonesHighlights(
-  Pointer<TColorGradingBuilder> builder,
-  double shadowsR,
-  double shadowsG,
-  double shadowsB,
-  double shadowsW,
-  double midtonesR,
-  double midtonesG,
-  double midtonesB,
-  double midtonesW,
-  double highlightsR,
-  double highlightsG,
-  double highlightsB,
-  double highlightsW,
-  double rangesX,
-  double rangesY,
-  double rangesZ,
-  double rangesW,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_shadowsMidtonesHighlights(
-    builder.cast(),
-    shadowsR,
-    shadowsG,
-    shadowsB,
-    shadowsW,
-    midtonesR,
-    midtonesG,
-    midtonesB,
-    midtonesW,
-    highlightsR,
-    highlightsG,
-    highlightsB,
-    highlightsW,
-    rangesX,
-    rangesY,
-    rangesZ,
-    rangesW,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_slopeOffsetPower(
-  Pointer<TColorGradingBuilder> builder,
-  double slopeR,
-  double slopeG,
-  double slopeB,
-  double offsetR,
-  double offsetG,
-  double offsetB,
-  double powerR,
-  double powerG,
-  double powerB,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_slopeOffsetPower(
-    builder.cast(),
-    slopeR,
-    slopeG,
-    slopeB,
-    offsetR,
-    offsetG,
-    offsetB,
-    powerR,
-    powerG,
-    powerB,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_curves(
-  Pointer<TColorGradingBuilder> builder,
-  double shadowGammaR,
-  double shadowGammaG,
-  double shadowGammaB,
-  double midPointR,
-  double midPointG,
-  double midPointB,
-  double highlightScaleR,
-  double highlightScaleG,
-  double highlightScaleB,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_curves(
-    builder.cast(),
-    shadowGammaR,
-    shadowGammaG,
-    shadowGammaB,
-    midPointR,
-    midPointG,
-    midPointB,
-    highlightScaleR,
-    highlightScaleG,
-    highlightScaleB,
-  );
-  return result;
-}
-
-void ColorGradingBuilder_luminanceScaling(Pointer<TColorGradingBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_luminanceScaling(builder.cast(), enabled);
-  return result;
-}
-
-void ColorGradingBuilder_gamutMapping(Pointer<TColorGradingBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_gamutMapping(builder.cast(), enabled);
-  return result;
-}
-
-void View_setColorGrading(Pointer<TView> tView, Pointer<TColorGrading> tColorGrading) {
-  final result = GeneratedBindings.instance._View_setColorGrading(tView.cast(), tColorGrading.cast());
-  return result;
-}
-
-Pointer<TColorGrading> View_getColorGrading(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getColorGrading(tView.cast());
-  return Pointer<TColorGrading>(result);
-}
-
-void View_setBlendMode(Pointer<TView> view, int blendMode) {
-  final result = GeneratedBindings.instance._View_setBlendMode(view.cast(), blendMode);
-  return result;
-}
-
-void View_setViewport(Pointer<TView> view, int width, int height) {
-  final result = GeneratedBindings.instance._View_setViewport(view.cast(), width, height);
-  return result;
-}
-
-void View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget) {
-  final result = GeneratedBindings.instance._View_setRenderTarget(view.cast(), renderTarget.cast());
-  return result;
-}
-
-void View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled) {
-  final result = GeneratedBindings.instance._View_setFrustumCullingEnabled(view.cast(), enabled);
-  return result;
-}
-
-int View_getVisibleRenderableCount(Pointer<TView> view) {
-  final result = GeneratedBindings.instance._View_getVisibleRenderableCount(view.cast());
-  return result;
-}
-
-Pointer<TRenderTarget> View_getRenderTarget(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getRenderTarget(tView.cast());
-  return Pointer<TRenderTarget>(result);
-}
-
-void View_setPostProcessing(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setPostProcessing(tView.cast(), enabled);
-  return result;
-}
-
-void View_setShadowsEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setShadowsEnabled(tView.cast(), enabled);
-  return result;
-}
-
-void View_setShadowType(Pointer<TView> tView, int shadowType) {
-  final result = GeneratedBindings.instance._View_setShadowType(tView.cast(), shadowType);
-  return result;
-}
-
-int View_getShadowType(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getShadowType(tView.cast());
-  return result;
-}
-
-void View_setSoftShadowOptions(Pointer<TView> tView, TSoftShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setSoftShadowOptions(tView.cast(), optionsPtr.cast());
-  return result;
-}
-
-TSoftShadowOptions View_getSoftShadowOptions(Pointer<TView> tView) {
-  final TSoftShadowOptions_out = TSoftShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getSoftShadowOptions(TSoftShadowOptions_out.cast(), tView.cast());
-  return TSoftShadowOptions_out.toDart();
-}
-
-void View_setVsmShadowOptions(Pointer<TView> tView, TVsmShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setVsmShadowOptions(tView.cast(), optionsPtr.cast());
-  return result;
-}
-
-TVsmShadowOptions View_getVsmShadowOptions(Pointer<TView> tView) {
-  final TVsmShadowOptions_out = TVsmShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getVsmShadowOptions(TVsmShadowOptions_out.cast(), tView.cast());
-  return TVsmShadowOptions_out.toDart();
-}
-
-void View_setBloom(Pointer<TView> tView, bool enabled, double strength) {
-  final result = GeneratedBindings.instance._View_setBloom(tView.cast(), enabled, strength);
-  return result;
-}
-
-void View_setRenderQuality(Pointer<TView> tView, int qualityLevel) {
-  final result = GeneratedBindings.instance._View_setRenderQuality(tView.cast(), qualityLevel);
-  return result;
-}
-
-void View_setAntiAliasing(Pointer<TView> tView, bool msaa, bool fxaa, bool taa) {
-  final result = GeneratedBindings.instance._View_setAntiAliasing(tView.cast(), msaa, fxaa, taa);
-  return result;
-}
-
-void View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible) {
-  final result = GeneratedBindings.instance._View_setLayerEnabled(tView.cast(), layer, visible);
-  return result;
-}
-
-void View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera) {
-  final result = GeneratedBindings.instance._View_setCamera(tView.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TScene> View_getScene(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getScene(tView.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TCamera> View_getCamera(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getCamera(tView.cast());
-  return Pointer<TCamera>(result);
-}
-
-void View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setStencilBufferEnabled(tView.cast(), enabled);
-  return result;
-}
-
-bool View_isStencilBufferEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isStencilBufferEnabled(tView.cast());
-  return result == 1;
-}
-
-void View_setDitheringEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setDitheringEnabled(tView.cast(), enabled);
-  return result;
-}
-
-bool View_isDitheringEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isDitheringEnabled(tView.cast());
-  return result == 1;
-}
-
-void View_setScene(Pointer<TView> tView, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._View_setScene(tView.cast(), tScene.cast());
-  return result;
-}
-
-void View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted) {
-  final result = GeneratedBindings.instance._View_setFrontFaceWindingInverted(tView.cast(), inverted);
-  return result;
-}
-
-void View_setAmbientOcclusionOptions(Pointer<TView> tView, TAmbientOcclusionOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setAmbientOcclusionOptions(tView.cast(), optionsPtr.cast());
-  return result;
-}
-
-TAmbientOcclusionOptions View_getAmbientOcclusionOptions(Pointer<TView> tView) {
-  final TAmbientOcclusionOptions_out = TAmbientOcclusionOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getAmbientOcclusionOptions(
-    TAmbientOcclusionOptions_out.cast(),
-    tView.cast(),
-  );
-  return TAmbientOcclusionOptions_out.toDart();
-}
-
-void View_setFogOptions(Pointer<TView> tView, TFogOptions tFogOptions) {
-  final tFogOptionsPtr = tFogOptions.address;
-  final result = GeneratedBindings.instance._View_setFogOptions(tView.cast(), tFogOptionsPtr.cast());
-  return result;
-}
-
-TFogOptions View_getFogOptions(Pointer<TView> tView) {
-  final TFogOptions_out = TFogOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getFogOptions(TFogOptions_out.cast(), tView.cast());
-  return TFogOptions_out.toDart();
-}
-
-void View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setTransparentPickingEnabled(tView.cast(), enabled);
-  return result;
-}
-
-bool View_isTransparentPickingEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isTransparentPickingEnabled(tView.cast());
-  return result == 1;
-}
-
-void View_pick(Pointer<TView> tView, int requestId, int x, int y, DartPickCallback callback) {
-  final result = GeneratedBindings.instance._View_pick(
-    tView.cast(),
-    requestId,
-    x,
-    y,
-    callback as Pointer<NativeFunction<PickCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setName(Pointer<TView> tView, Pointer<Char> name) {
-  final result = GeneratedBindings.instance._View_setName(tView.cast(), name);
-  return result;
-}
-
-Pointer<Char> View_getName(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getName(tView.cast());
-  return Pointer<Char>(result);
-}
-
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-    tEngine.cast(),
-    assetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
-  );
-  return Pointer<TGizmo>(result);
-}
-
-void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
-  final result = GeneratedBindings.instance._Gizmo_pick(
-    tGizmo.cast(),
-    x,
-    y,
-    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
-  );
-  return result;
-}
-
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
-  return result;
-}
-
-void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
 }
 
 Pointer<TMaterialInstance> Material_createInstance(Pointer<TMaterial> tMaterial) {
@@ -3353,386 +2830,6 @@ int MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInst
 
 int Material_getBlendingMode(Pointer<TMaterial> material) {
   final result = GeneratedBindings.instance._Material_getBlendingMode(material.cast());
-  return result;
-}
-
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
-  return result;
-}
-
-Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
-  return Pointer<Char>(result);
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tVertexBuffer,
-  Pointer<TIndexBuffer> tIndexBuffer,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  int vertexBufferStorageMode,
-  Aabb3 boundingBox,
-) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
-    tEngine.cast(),
-    tVertexBuffer.cast(),
-    tIndexBuffer.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-    tPrimitiveType,
-    vertexBufferStorageMode,
-    boundingBoxPtr.cast(),
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  int requiredGeometryCapabilities,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    tNameComponentManager.cast(),
-    tFilamentAsset.cast(),
-    requiredGeometryCapabilities,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(tSceneAsset.cast());
-  return Pointer<TFilamentAsset>(result);
-}
-
-int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getType(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_destroy(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._SceneAsset_addToScene(tSceneAsset.cast(), tScene.cast());
-  return result;
-}
-
-void SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(tSceneAsset.cast(), tScene.cast());
-  return result;
-}
-
-DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getEntity(tSceneAsset.cast());
-  return result;
-}
-
-int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(tSceneAsset.cast(), out);
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(tSceneAsset.cast());
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(tSceneAsset.cast());
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstance(tSceneAsset.cast(), index);
-  return Pointer<TSceneAsset>(result);
-}
-
-Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_createInstance(
-  Pointer<TSceneAsset> asset,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createInstance(
-    asset.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(Aabb3_out.cast(), asset.cast());
-  return Aabb3_out.toDart();
-}
-
-int SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset) {
-  final result = GeneratedBindings.instance._SceneAsset_getGeometryCapabilities(asset.cast());
-  return result;
-}
-
-bool SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset) {
-  final result = GeneratedBindings.instance._SceneAsset_supportsFlatShading(asset.cast());
-  return result == 1;
-}
-
-Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(tSceneAsset.cast(), primitiveIndex);
-  return Pointer<TVertexBuffer>(result);
-}
-
-int SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getVertexBufferStorageMode(tSceneAsset.cast(), primitiveIndex);
-  return result;
-}
-
-Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(tSceneAsset.cast(), primitiveIndex);
-  return Pointer<TIndexBuffer>(result);
-}
-
-int SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, DartEntityId entity) {
-  final result = GeneratedBindings.instance._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
-  return result;
-}
-
-void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading) {
-  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(tSceneAsset.cast(), flatShading);
-  return result;
-}
-
-void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
-  return result;
-}
-
-Dartsize_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
-  return result;
-}
-
-Pointer<Char> SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Dartsize_t boneIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
-  return Pointer<Char>(result);
-}
-
-void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
-  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
-  return result;
-}
-
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
-  return result;
-}
-
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
-  return result;
-}
-
-void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
-  return result;
-}
-
-void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
-    camera.cast(),
-    projectionMatrixPtr.cast(),
-    near,
-    far,
-  );
-  return result;
-}
-
-void Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix) {
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrix);
-  return result;
-}
-
-void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
-  return result;
-}
-
-void MeshData_dispose(Pointer<TMeshData> meshData) {
-  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  Pointer<Char> meshName,
-  Pointer<TMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
   return result;
 }
 
@@ -4317,6 +3414,483 @@ bool DebugRegistry_getProperty_float(
 ) {
   final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
   return result == 1;
+}
+
+TViewport View_getViewport(Pointer<TView> view) {
+  final TViewport_out = TViewport.stackAlloc();
+  final result = GeneratedBindings.instance._View_getViewport(TViewport_out.cast(), view.cast());
+  return TViewport_out.toDart();
+}
+
+Pointer<TToneMapper> ToneMapper_createLinear(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createLinear(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createACES(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createACES(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createACESLegacy(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createACESLegacy(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createFilmic(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createFilmic(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createPBRNeutral(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createAGX(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createAGX(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createAGXWithLook(Pointer<TEngine> tEngine, int look) {
+  final result = GeneratedBindings.instance._ToneMapper_createAGXWithLook(tEngine.cast(), look);
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createGeneric(
+  Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createGeneric(
+    tEngine.cast(),
+    contrast,
+    midGrayIn,
+    midGrayOut,
+    hdrMax,
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createDisplayRange(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createDisplayRange(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_destroy(Pointer<TToneMapper> toneMapper) {
+  final result = GeneratedBindings.instance._ToneMapper_destroy(toneMapper.cast());
+  return result;
+}
+
+Pointer<TColorGradingBuilder> ColorGradingBuilder_create() {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_create();
+  return Pointer<TColorGradingBuilder>(result);
+}
+
+Pointer<TColorGrading> ColorGradingBuilder_build(Pointer<TColorGradingBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TColorGrading>(result);
+}
+
+void ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_destroy(builder.cast());
+  return result;
+}
+
+void ColorGrading_destroy(Pointer<TEngine> engine, Pointer<TColorGrading> colorGrading) {
+  final result = GeneratedBindings.instance._ColorGrading_destroy(engine.cast(), colorGrading.cast());
+  return result;
+}
+
+void ColorGradingBuilder_quality(Pointer<TColorGradingBuilder> builder, int level) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_quality(builder.cast(), level);
+  return result;
+}
+
+void ColorGradingBuilder_format(Pointer<TColorGradingBuilder> builder, int format) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_format(builder.cast(), format);
+  return result;
+}
+
+void ColorGradingBuilder_dimensions(Pointer<TColorGradingBuilder> builder, int dim) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_dimensions(builder.cast(), dim);
+  return result;
+}
+
+void ColorGradingBuilder_toneMapper(Pointer<TColorGradingBuilder> builder, Pointer<TToneMapper> toneMapper) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_toneMapper(builder.cast(), toneMapper.cast());
+  return result;
+}
+
+void ColorGradingBuilder_exposure(Pointer<TColorGradingBuilder> builder, double exposure) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_exposure(builder.cast(), exposure);
+  return result;
+}
+
+void ColorGradingBuilder_nightAdaptation(Pointer<TColorGradingBuilder> builder, double adaptation) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_nightAdaptation(builder.cast(), adaptation);
+  return result;
+}
+
+void ColorGradingBuilder_whiteBalance(Pointer<TColorGradingBuilder> builder, double temperature, double tint) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_whiteBalance(builder.cast(), temperature, tint);
+  return result;
+}
+
+void ColorGradingBuilder_contrast(Pointer<TColorGradingBuilder> builder, double contrast) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_contrast(builder.cast(), contrast);
+  return result;
+}
+
+void ColorGradingBuilder_vibrance(Pointer<TColorGradingBuilder> builder, double vibrance) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_vibrance(builder.cast(), vibrance);
+  return result;
+}
+
+void ColorGradingBuilder_saturation(Pointer<TColorGradingBuilder> builder, double saturation) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_saturation(builder.cast(), saturation);
+  return result;
+}
+
+void ColorGradingBuilder_channelMixer(
+  Pointer<TColorGradingBuilder> builder,
+  double outRedR,
+  double outRedG,
+  double outRedB,
+  double outGreenR,
+  double outGreenG,
+  double outGreenB,
+  double outBlueR,
+  double outBlueG,
+  double outBlueB,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_channelMixer(
+    builder.cast(),
+    outRedR,
+    outRedG,
+    outRedB,
+    outGreenR,
+    outGreenG,
+    outGreenB,
+    outBlueR,
+    outBlueG,
+    outBlueB,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_shadowsMidtonesHighlights(
+  Pointer<TColorGradingBuilder> builder,
+  double shadowsR,
+  double shadowsG,
+  double shadowsB,
+  double shadowsW,
+  double midtonesR,
+  double midtonesG,
+  double midtonesB,
+  double midtonesW,
+  double highlightsR,
+  double highlightsG,
+  double highlightsB,
+  double highlightsW,
+  double rangesX,
+  double rangesY,
+  double rangesZ,
+  double rangesW,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_shadowsMidtonesHighlights(
+    builder.cast(),
+    shadowsR,
+    shadowsG,
+    shadowsB,
+    shadowsW,
+    midtonesR,
+    midtonesG,
+    midtonesB,
+    midtonesW,
+    highlightsR,
+    highlightsG,
+    highlightsB,
+    highlightsW,
+    rangesX,
+    rangesY,
+    rangesZ,
+    rangesW,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_slopeOffsetPower(
+  Pointer<TColorGradingBuilder> builder,
+  double slopeR,
+  double slopeG,
+  double slopeB,
+  double offsetR,
+  double offsetG,
+  double offsetB,
+  double powerR,
+  double powerG,
+  double powerB,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_slopeOffsetPower(
+    builder.cast(),
+    slopeR,
+    slopeG,
+    slopeB,
+    offsetR,
+    offsetG,
+    offsetB,
+    powerR,
+    powerG,
+    powerB,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_curves(
+  Pointer<TColorGradingBuilder> builder,
+  double shadowGammaR,
+  double shadowGammaG,
+  double shadowGammaB,
+  double midPointR,
+  double midPointG,
+  double midPointB,
+  double highlightScaleR,
+  double highlightScaleG,
+  double highlightScaleB,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_curves(
+    builder.cast(),
+    shadowGammaR,
+    shadowGammaG,
+    shadowGammaB,
+    midPointR,
+    midPointG,
+    midPointB,
+    highlightScaleR,
+    highlightScaleG,
+    highlightScaleB,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_luminanceScaling(Pointer<TColorGradingBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_luminanceScaling(builder.cast(), enabled);
+  return result;
+}
+
+void ColorGradingBuilder_gamutMapping(Pointer<TColorGradingBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_gamutMapping(builder.cast(), enabled);
+  return result;
+}
+
+void View_setColorGrading(Pointer<TView> tView, Pointer<TColorGrading> tColorGrading) {
+  final result = GeneratedBindings.instance._View_setColorGrading(tView.cast(), tColorGrading.cast());
+  return result;
+}
+
+Pointer<TColorGrading> View_getColorGrading(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getColorGrading(tView.cast());
+  return Pointer<TColorGrading>(result);
+}
+
+void View_setBlendMode(Pointer<TView> view, int blendMode) {
+  final result = GeneratedBindings.instance._View_setBlendMode(view.cast(), blendMode);
+  return result;
+}
+
+void View_setViewport(Pointer<TView> view, int width, int height) {
+  final result = GeneratedBindings.instance._View_setViewport(view.cast(), width, height);
+  return result;
+}
+
+void View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget) {
+  final result = GeneratedBindings.instance._View_setRenderTarget(view.cast(), renderTarget.cast());
+  return result;
+}
+
+void View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled) {
+  final result = GeneratedBindings.instance._View_setFrustumCullingEnabled(view.cast(), enabled);
+  return result;
+}
+
+int View_getVisibleRenderableCount(Pointer<TView> view) {
+  final result = GeneratedBindings.instance._View_getVisibleRenderableCount(view.cast());
+  return result;
+}
+
+Pointer<TRenderTarget> View_getRenderTarget(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getRenderTarget(tView.cast());
+  return Pointer<TRenderTarget>(result);
+}
+
+void View_setPostProcessing(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setPostProcessing(tView.cast(), enabled);
+  return result;
+}
+
+void View_setShadowsEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setShadowsEnabled(tView.cast(), enabled);
+  return result;
+}
+
+void View_setShadowType(Pointer<TView> tView, int shadowType) {
+  final result = GeneratedBindings.instance._View_setShadowType(tView.cast(), shadowType);
+  return result;
+}
+
+int View_getShadowType(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getShadowType(tView.cast());
+  return result;
+}
+
+void View_setSoftShadowOptions(Pointer<TView> tView, TSoftShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setSoftShadowOptions(tView.cast(), optionsPtr.cast());
+  return result;
+}
+
+TSoftShadowOptions View_getSoftShadowOptions(Pointer<TView> tView) {
+  final TSoftShadowOptions_out = TSoftShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getSoftShadowOptions(TSoftShadowOptions_out.cast(), tView.cast());
+  return TSoftShadowOptions_out.toDart();
+}
+
+void View_setVsmShadowOptions(Pointer<TView> tView, TVsmShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setVsmShadowOptions(tView.cast(), optionsPtr.cast());
+  return result;
+}
+
+TVsmShadowOptions View_getVsmShadowOptions(Pointer<TView> tView) {
+  final TVsmShadowOptions_out = TVsmShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getVsmShadowOptions(TVsmShadowOptions_out.cast(), tView.cast());
+  return TVsmShadowOptions_out.toDart();
+}
+
+void View_setBloom(Pointer<TView> tView, bool enabled, double strength) {
+  final result = GeneratedBindings.instance._View_setBloom(tView.cast(), enabled, strength);
+  return result;
+}
+
+void View_setRenderQuality(Pointer<TView> tView, int qualityLevel) {
+  final result = GeneratedBindings.instance._View_setRenderQuality(tView.cast(), qualityLevel);
+  return result;
+}
+
+void View_setAntiAliasing(Pointer<TView> tView, bool msaa, bool fxaa, bool taa) {
+  final result = GeneratedBindings.instance._View_setAntiAliasing(tView.cast(), msaa, fxaa, taa);
+  return result;
+}
+
+void View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible) {
+  final result = GeneratedBindings.instance._View_setLayerEnabled(tView.cast(), layer, visible);
+  return result;
+}
+
+void View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera) {
+  final result = GeneratedBindings.instance._View_setCamera(tView.cast(), tCamera.cast());
+  return result;
+}
+
+Pointer<TScene> View_getScene(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getScene(tView.cast());
+  return Pointer<TScene>(result);
+}
+
+Pointer<TCamera> View_getCamera(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getCamera(tView.cast());
+  return Pointer<TCamera>(result);
+}
+
+void View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setStencilBufferEnabled(tView.cast(), enabled);
+  return result;
+}
+
+bool View_isStencilBufferEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isStencilBufferEnabled(tView.cast());
+  return result == 1;
+}
+
+void View_setDitheringEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setDitheringEnabled(tView.cast(), enabled);
+  return result;
+}
+
+bool View_isDitheringEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isDitheringEnabled(tView.cast());
+  return result == 1;
+}
+
+void View_setScene(Pointer<TView> tView, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._View_setScene(tView.cast(), tScene.cast());
+  return result;
+}
+
+void View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted) {
+  final result = GeneratedBindings.instance._View_setFrontFaceWindingInverted(tView.cast(), inverted);
+  return result;
+}
+
+void View_setAmbientOcclusionOptions(Pointer<TView> tView, TAmbientOcclusionOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setAmbientOcclusionOptions(tView.cast(), optionsPtr.cast());
+  return result;
+}
+
+TAmbientOcclusionOptions View_getAmbientOcclusionOptions(Pointer<TView> tView) {
+  final TAmbientOcclusionOptions_out = TAmbientOcclusionOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getAmbientOcclusionOptions(
+    TAmbientOcclusionOptions_out.cast(),
+    tView.cast(),
+  );
+  return TAmbientOcclusionOptions_out.toDart();
+}
+
+void View_setFogOptions(Pointer<TView> tView, TFogOptions tFogOptions) {
+  final tFogOptionsPtr = tFogOptions.address;
+  final result = GeneratedBindings.instance._View_setFogOptions(tView.cast(), tFogOptionsPtr.cast());
+  return result;
+}
+
+TFogOptions View_getFogOptions(Pointer<TView> tView) {
+  final TFogOptions_out = TFogOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getFogOptions(TFogOptions_out.cast(), tView.cast());
+  return TFogOptions_out.toDart();
+}
+
+void View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setTransparentPickingEnabled(tView.cast(), enabled);
+  return result;
+}
+
+bool View_isTransparentPickingEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isTransparentPickingEnabled(tView.cast());
+  return result == 1;
+}
+
+void View_pick(Pointer<TView> tView, int requestId, int x, int y, DartPickCallback callback) {
+  final result = GeneratedBindings.instance._View_pick(
+    tView.cast(),
+    requestId,
+    x,
+    y,
+    callback as Pointer<NativeFunction<PickCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setName(Pointer<TView> tView, Pointer<Char> name) {
+  final result = GeneratedBindings.instance._View_setName(tView.cast(), name);
+  return result;
+}
+
+Pointer<Char> View_getName(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getName(tView.cast());
+  return Pointer<Char>(result);
 }
 
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
@@ -7593,95 +7167,359 @@ void LightManager_setShadowOptionsRenderThread(
   return result;
 }
 
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
+Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tVertexBuffer,
+  Pointer<TIndexBuffer> tIndexBuffer,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  int vertexBufferStorageMode,
+  Aabb3 boundingBox,
 ) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
+    tEngine.cast(),
+    tVertexBuffer.cast(),
+    tIndexBuffer.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+    tPrimitiveType,
+    vertexBufferStorageMode,
+    boundingBoxPtr.cast(),
   );
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  int requiredGeometryCapabilities,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    tNameComponentManager.cast(),
+    tFilamentAsset.cast(),
+    requiredGeometryCapabilities,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(tSceneAsset.cast());
+  return Pointer<TFilamentAsset>(result);
+}
+
+int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getType(tSceneAsset.cast());
   return result;
 }
 
-bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
+void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_destroy(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._SceneAsset_addToScene(tSceneAsset.cast(), tScene.cast());
+  return result;
+}
+
+void SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(tSceneAsset.cast(), tScene.cast());
+  return result;
+}
+
+DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getEntity(tSceneAsset.cast());
+  return result;
+}
+
+int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(tSceneAsset.cast(), out);
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(tSceneAsset.cast());
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(tSceneAsset.cast());
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstance(tSceneAsset.cast(), index);
+  return Pointer<TSceneAsset>(result);
+}
+
+Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createInstance(
+  Pointer<TSceneAsset> asset,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createInstance(
+    asset.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
   );
+  return Pointer<TSceneAsset>(result);
+}
+
+Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(Aabb3_out.cast(), asset.cast());
+  return Aabb3_out.toDart();
+}
+
+int SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset) {
+  final result = GeneratedBindings.instance._SceneAsset_getGeometryCapabilities(asset.cast());
+  return result;
+}
+
+bool SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset) {
+  final result = GeneratedBindings.instance._SceneAsset_supportsFlatShading(asset.cast());
   return result == 1;
 }
 
-void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(tSceneAsset.cast(), primitiveIndex);
+  return Pointer<TVertexBuffer>(result);
+}
+
+int SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getVertexBufferStorageMode(tSceneAsset.cast(), primitiveIndex);
   return result;
 }
 
-void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
+Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(tSceneAsset.cast(), primitiveIndex);
+  return Pointer<TIndexBuffer>(result);
+}
+
+int SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, DartEntityId entity) {
+  final result = GeneratedBindings.instance._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
   return result;
 }
 
-void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(tSceneAsset.cast());
   return result;
 }
 
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dartsize_t outLength,
+void SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading) {
+  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(tSceneAsset.cast(), flatShading);
+  return result;
+}
+
+void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
+  return result;
+}
+
+Dartsize_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
+  return result;
+}
+
+Pointer<Char> SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Dartsize_t boneIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
+  return Pointer<Char>(result);
+}
+
+void MeshData_dispose(Pointer<TMeshData> meshData) {
+  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
+  return result;
+}
+
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  Pointer<Char> meshName,
+  Pointer<TMeshData> outMeshData,
 ) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
+  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
+  return result;
+}
+
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+    tEngine.cast(),
+    tMaterialProvider.cast(),
+    tNameComponentManager.cast(),
+  );
+  return Pointer<TGltfAssetLoader>(result);
+}
+
+void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
+  return result;
+}
+
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  int numInstances,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    data,
+    length,
+    numInstances,
+  );
+  return Pointer<TFilamentAsset>(result);
+}
+
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
+    tRenderableManager.cast(),
+    tAsset.cast(),
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
+}
+
+int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
+  return result;
+}
+
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
+  return Pointer<PointerClass<Char>>(result);
+}
+
+void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
+    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
+    targetFps,
   );
   return result;
 }
 
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
 ) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-    tRenderer.cast(),
-    headRoomRatio,
-    scaleRate,
-    history,
-    interval,
+  final result = GeneratedBindings.instance._Gizmo_create(
+    tEngine.cast(),
+    assetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+  );
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
+  final result = GeneratedBindings.instance._Gizmo_pick(
+    tGizmo.cast(),
+    x,
+    y,
+    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
   );
   return result;
+}
+
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
+  return result;
+}
+
+void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
+}
+
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
+  return result;
+}
+
+Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
+  return Pointer<Char>(result);
 }
 
 Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
@@ -7694,33 +7532,330 @@ void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRend
   return result;
 }
 
-void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
-  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
+Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._AnimationManager_create(tEngine.cast());
+  return Pointer<TAnimationManager>(result);
+}
+
+void AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager) {
+  final result = GeneratedBindings.instance._AnimationManager_destroy(tAnimationManager.cast());
   return result;
 }
 
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
-  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
+void AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._AnimationManager_update(
+    tAnimationManager.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
   return result;
 }
 
-/// Returns the visibility mask bits.
-int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
+bool AnimationManager_addGltfAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_addGltfAnimationComponent(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+bool AnimationManager_removeGltfAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_removeGltfAnimationComponent(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+void AnimationManager_addMorphAnimationComponent(Pointer<TAnimationManager> tAnimationManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._AnimationManager_addMorphAnimationComponent(
+    tAnimationManager.cast(),
+    entityId,
+  );
   return result;
 }
 
-/// Returns the skybox intensity in lux.
-double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
+void AnimationManager_removeMorphAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_removeMorphAnimationComponent(
+    tAnimationManager.cast(),
+    entityId,
+  );
   return result;
 }
 
-/// Returns the environment texture, or nullptr for a color-only skybox.
-Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
-  return Pointer<TTexture>(result);
+bool AnimationManager_addBoneAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_addBoneAnimationComponent(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+bool AnimationManager_removeBoneAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_removeBoneAnimationComponent(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+bool AnimationManager_setMorphAnimation(
+  Pointer<TAnimationManager> tAnimationManager,
+  DartEntityId entityId,
+  Pointer<Float32> morphData,
+  Pointer<Uint32> morphIndices,
+  int numMorphTargets,
+  int numFrames,
+  double frameLengthInMs,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_setMorphAnimation(
+    tAnimationManager.cast(),
+    entityId,
+    morphData,
+    morphIndices,
+    numMorphTargets,
+    numFrames,
+    frameLengthInMs,
+  );
+  return result == 1;
+}
+
+bool AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._AnimationManager_clearMorphAnimation(tAnimationManager.cast(), entityId);
+  return result == 1;
+}
+
+void AnimationManager_resetToRestPose(Pointer<TAnimationManager> tAnimationManager, Pointer<TSceneAsset> sceneAsset) {
+  final result = GeneratedBindings.instance._AnimationManager_resetToRestPose(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+  );
+  return result;
+}
+
+bool AnimationManager_addBoneAnimation(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+  Pointer<Float32> frameData,
+  int numFrames,
+  double frameLengthInMs,
+  double fadeOutInSecs,
+  double fadeInInSecs,
+  double maxDelta,
+  bool loop,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_addBoneAnimation(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+    skinIndex,
+    boneIndex,
+    frameData,
+    numFrames,
+    frameLengthInMs,
+    fadeOutInSecs,
+    fadeInInSecs,
+    maxDelta,
+    loop,
+  );
+  return result == 1;
+}
+
+void AnimationManager_getRestLocalTransforms(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  int skinIndex,
+  Pointer<Float32> out,
+  int numBones,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getRestLocalTransforms(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    skinIndex,
+    out,
+    numBones,
+  );
+  return result;
+}
+
+void AnimationManager_getInverseBindMatrix(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  int skinIndex,
+  int boneIndex,
+  Pointer<Float32> out,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getInverseBindMatrix(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    skinIndex,
+    boneIndex,
+    out,
+  );
+  return result;
+}
+
+bool AnimationManager_playGltfAnimation(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+  int index,
+  bool loop,
+  bool reverse,
+  bool replaceActive,
+  double crossfade,
+  double startOffset,
+  double speed,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_playGltfAnimation(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+    index,
+    loop,
+    reverse,
+    replaceActive,
+    crossfade,
+    startOffset,
+    speed,
+  );
+  return result == 1;
+}
+
+bool AnimationManager_stopGltfAnimation(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  int index,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_stopGltfAnimation(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    index,
+  );
+  return result == 1;
+}
+
+double AnimationManager_getGltfAnimationDuration(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  int animationIndex,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationDuration(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    animationIndex,
+  );
+  return result;
+}
+
+int AnimationManager_getGltfAnimationCount(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationCount(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+  );
+  return result;
+}
+
+void AnimationManager_getGltfAnimationName(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  Pointer<Char> outPtr,
+  int index,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationName(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    outPtr,
+    index,
+  );
+  return result;
+}
+
+int AnimationManager_getMorphTargetNameCount(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  DartEntityId childEntity,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getMorphTargetNameCount(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    childEntity,
+  );
+  return result;
+}
+
+void AnimationManager_getMorphTargetName(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  DartEntityId childEntity,
+  Pointer<Char> outPtr,
+  int index,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getMorphTargetName(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    childEntity,
+    outPtr,
+    index,
+  );
+  return result;
+}
+
+bool AnimationManager_updateBoneMatrices(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_updateBoneMatrices(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+bool AnimationManager_setMorphTargetWeights(
+  Pointer<TAnimationManager> tAnimationManager,
+  DartEntityId entityId,
+  Pointer<Float32> morphData,
+  int numWeights,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_setMorphTargetWeights(
+    tAnimationManager.cast(),
+    entityId,
+    morphData,
+    numWeights,
+  );
+  return result == 1;
+}
+
+bool AnimationManager_setGltfAnimationTime(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+  int animationIndex,
+  double timeInSeconds,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_setGltfAnimationTime(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+    animationIndex,
+    timeInSeconds,
+  );
+  return result == 1;
 }
 
 void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
@@ -8294,8 +8429,477 @@ int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine
   return result;
 }
 
+void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
+  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
+  return result;
+}
+
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
+  return result;
+}
+
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
+  return result;
+}
+
+void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
+  return result;
+}
+
+void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
+  return result;
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
+    camera.cast(),
+    projectionMatrixPtr.cast(),
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix) {
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrix);
+  return result;
+}
+
+void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
+  return result;
+}
+
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
+  return result;
+}
+
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
+  return result;
+}
+
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
+  return result;
+}
+
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
+  return result;
+}
+
+Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
+  return Pointer<TSkybox>(result);
+}
+
+void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
+  return result;
+}
+
+void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
+  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
+  return result;
+}
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
+  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
+  return result;
+}
+
+/// Returns the visibility mask bits.
+int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
+  return result;
+}
+
+/// Returns the skybox intensity in lux.
+double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
+  return result;
+}
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
+  return Pointer<TTexture>(result);
+}
+
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+  );
+  return result;
+}
+
+bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+  return result;
+}
+
+void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dartsize_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+  );
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+    tRenderer.cast(),
+    headRoomRatio,
+    scaleRate,
+    history,
+    interval,
+  );
+  return result;
+}
+
 void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
   final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+  return result;
+}
+
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
+  return Pointer<TGltfResourceLoader>(result);
+}
+
+void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
+  return result;
+}
+
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
+  return result;
+}
+
+double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
+  return result;
+}
+
+void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
+  return Pointer<Void>(result);
+}
+
+Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
+  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
   return result;
 }
 
@@ -8428,610 +9032,6 @@ void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
   return result;
 }
 
-Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._AnimationManager_create(tEngine.cast());
-  return Pointer<TAnimationManager>(result);
-}
-
-void AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager) {
-  final result = GeneratedBindings.instance._AnimationManager_destroy(tAnimationManager.cast());
-  return result;
-}
-
-void AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._AnimationManager_update(
-    tAnimationManager.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result;
-}
-
-bool AnimationManager_addGltfAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_addGltfAnimationComponent(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-bool AnimationManager_removeGltfAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_removeGltfAnimationComponent(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-void AnimationManager_addMorphAnimationComponent(Pointer<TAnimationManager> tAnimationManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._AnimationManager_addMorphAnimationComponent(
-    tAnimationManager.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void AnimationManager_removeMorphAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_removeMorphAnimationComponent(
-    tAnimationManager.cast(),
-    entityId,
-  );
-  return result;
-}
-
-bool AnimationManager_addBoneAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_addBoneAnimationComponent(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-bool AnimationManager_removeBoneAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_removeBoneAnimationComponent(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-bool AnimationManager_setMorphAnimation(
-  Pointer<TAnimationManager> tAnimationManager,
-  DartEntityId entityId,
-  Pointer<Float32> morphData,
-  Pointer<Uint32> morphIndices,
-  int numMorphTargets,
-  int numFrames,
-  double frameLengthInMs,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_setMorphAnimation(
-    tAnimationManager.cast(),
-    entityId,
-    morphData,
-    morphIndices,
-    numMorphTargets,
-    numFrames,
-    frameLengthInMs,
-  );
-  return result == 1;
-}
-
-bool AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._AnimationManager_clearMorphAnimation(tAnimationManager.cast(), entityId);
-  return result == 1;
-}
-
-void AnimationManager_resetToRestPose(Pointer<TAnimationManager> tAnimationManager, Pointer<TSceneAsset> sceneAsset) {
-  final result = GeneratedBindings.instance._AnimationManager_resetToRestPose(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-  );
-  return result;
-}
-
-bool AnimationManager_addBoneAnimation(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-  Pointer<Float32> frameData,
-  int numFrames,
-  double frameLengthInMs,
-  double fadeOutInSecs,
-  double fadeInInSecs,
-  double maxDelta,
-  bool loop,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_addBoneAnimation(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-    skinIndex,
-    boneIndex,
-    frameData,
-    numFrames,
-    frameLengthInMs,
-    fadeOutInSecs,
-    fadeInInSecs,
-    maxDelta,
-    loop,
-  );
-  return result == 1;
-}
-
-void AnimationManager_getRestLocalTransforms(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  int skinIndex,
-  Pointer<Float32> out,
-  int numBones,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_getRestLocalTransforms(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    skinIndex,
-    out,
-    numBones,
-  );
-  return result;
-}
-
-void AnimationManager_getInverseBindMatrix(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  int skinIndex,
-  int boneIndex,
-  Pointer<Float32> out,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_getInverseBindMatrix(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    skinIndex,
-    boneIndex,
-    out,
-  );
-  return result;
-}
-
-bool AnimationManager_playGltfAnimation(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-  int index,
-  bool loop,
-  bool reverse,
-  bool replaceActive,
-  double crossfade,
-  double startOffset,
-  double speed,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_playGltfAnimation(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-    index,
-    loop,
-    reverse,
-    replaceActive,
-    crossfade,
-    startOffset,
-    speed,
-  );
-  return result == 1;
-}
-
-bool AnimationManager_stopGltfAnimation(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  int index,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_stopGltfAnimation(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    index,
-  );
-  return result == 1;
-}
-
-double AnimationManager_getGltfAnimationDuration(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  int animationIndex,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationDuration(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    animationIndex,
-  );
-  return result;
-}
-
-int AnimationManager_getGltfAnimationCount(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationCount(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-  );
-  return result;
-}
-
-void AnimationManager_getGltfAnimationName(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  Pointer<Char> outPtr,
-  int index,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationName(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    outPtr,
-    index,
-  );
-  return result;
-}
-
-int AnimationManager_getMorphTargetNameCount(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  DartEntityId childEntity,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_getMorphTargetNameCount(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    childEntity,
-  );
-  return result;
-}
-
-void AnimationManager_getMorphTargetName(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  DartEntityId childEntity,
-  Pointer<Char> outPtr,
-  int index,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_getMorphTargetName(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    childEntity,
-    outPtr,
-    index,
-  );
-  return result;
-}
-
-bool AnimationManager_updateBoneMatrices(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_updateBoneMatrices(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-bool AnimationManager_setMorphTargetWeights(
-  Pointer<TAnimationManager> tAnimationManager,
-  DartEntityId entityId,
-  Pointer<Float32> morphData,
-  int numWeights,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_setMorphTargetWeights(
-    tAnimationManager.cast(),
-    entityId,
-    morphData,
-    numWeights,
-  );
-  return result == 1;
-}
-
-bool AnimationManager_setGltfAnimationTime(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-  int animationIndex,
-  double timeInSeconds,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_setGltfAnimationTime(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-    animationIndex,
-    timeInSeconds,
-  );
-  return result == 1;
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
-    tEngine.cast(),
-    tMaterialProvider.cast(),
-    tNameComponentManager.cast(),
-  );
-  return Pointer<TGltfAssetLoader>(result);
-}
-
-void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
-  return result;
-}
-
-Pointer<TFilamentAsset> GltfAssetLoader_load(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  int numInstances,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    data,
-    length,
-    numInstances,
-  );
-  return Pointer<TFilamentAsset>(result);
-}
-
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
-    tRenderableManager.cast(),
-    tAsset.cast(),
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
-}
-
-int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
-  return result;
-}
-
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
-  return Pointer<PointerClass<Char>>(result);
-}
-
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
-  return Pointer<TGltfResourceLoader>(result);
-}
-
-void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
-  return result;
-}
-
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
-  return result;
-}
-
-double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
-  return result;
-}
-
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
-  );
-  return result;
-}
-
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
-  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
-  return result;
-}
-
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
-  return result;
-}
-
-void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
-  return Pointer<Void>(result);
-}
-
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
-  return result;
-}
-
-Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
-  return Pointer<TSkybox>(result);
-}
-
-void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
-  return result;
-}
-
-void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
-  return result;
-}
-
-void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
-    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
-  return result;
-}
-
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
 void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
   final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(executor.cast());
   return result;
@@ -9154,6 +9154,702 @@ void TransformPipeline_setInvertMouseY(int invert) {
   return result;
 }
 
+extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
+  TMaterialInstance toDart() {
+    return TMaterialInstance(this);
+  }
+}
+
+final class TMaterialInstance extends Struct {
+  Pointer<TMaterialInstance> get address => super.address.cast();
+  TMaterialInstance(super.address);
+
+  static Pointer<TMaterialInstance> stackAlloc() {
+    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
+  }
+}
+
+extension TMaterialExt on Pointer<TMaterial> {
+  TMaterial toDart() {
+    return TMaterial(this);
+  }
+}
+
+final class TMaterial extends Struct {
+  Pointer<TMaterial> get address => super.address.cast();
+  TMaterial(super.address);
+
+  static Pointer<TMaterial> stackAlloc() {
+    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  }
+}
+
+sealed class TFeatureLevel {
+  static const FEATURE_LEVEL_0 = 0;
+  static const FEATURE_LEVEL_1 = 1;
+  static const FEATURE_LEVEL_2 = 2;
+  static const FEATURE_LEVEL_3 = 3;
+}
+
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
+  }
+}
+
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
+
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  }
+}
+
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
+extension TTextureExt on Pointer<TTexture> {
+  TTexture toDart() {
+    return TTexture(this);
+  }
+}
+
+final class TTexture extends Struct {
+  Pointer<TTexture> get address => super.address.cast();
+  TTexture(super.address);
+
+  static Pointer<TTexture> stackAlloc() {
+    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
+  }
+}
+
+extension TTextureSamplerExt on Pointer<TTextureSampler> {
+  TTextureSampler toDart() {
+    return TTextureSampler(this);
+  }
+}
+
+final class TTextureSampler extends Struct {
+  Pointer<TTextureSampler> get address => super.address.cast();
+  TTextureSampler(super.address);
+
+  static Pointer<TTextureSampler> stackAlloc() {
+    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
+  }
+}
+
+sealed class TSamplerCompareFunc {
+  /// !< Less or equal
+  static const LE = 0;
+
+  /// !< Greater or equal
+  static const GE = 1;
+
+  /// !< Strictly less than
+  static const L = 2;
+
+  /// !< Strictly greater than
+  static const G = 3;
+
+  /// !< Equal
+  static const E = 4;
+
+  /// !< Not equal
+  static const NE = 5;
+
+  /// !< Always. Depth / stencil testing is deactivated.
+  static const A = 6;
+
+  /// !< Never. The depth / stencil test always fails.
+  static const N = 7;
+}
+
+sealed class TStencilOperation {
+  static const KEEP = 0;
+  static const ZERO = 1;
+  static const REPLACE = 2;
+  static const INCR = 3;
+  static const INCR_WRAP = 4;
+  static const DECR = 5;
+  static const DECR_WRAP = 6;
+  static const INVERT = 7;
+}
+
+sealed class TStencilFace {
+  static const STENCIL_FACE_FRONT = 1;
+  static const STENCIL_FACE_BACK = 2;
+  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+}
+
+sealed class TTransparencyMode {
+  /// ! the transparent object is drawn honoring the raster state
+  static const DEFAULT = 0;
+
+  /// the transparent object is first drawn in the depth buffer,
+  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
+  static const TWO_PASSES_ONE_SIDE = 1;
+
+  /// the transparent object is drawn twice in the color buffer,
+  /// first with back faces only, then with front faces; the culling
+  /// mode is ignored. Can be combined with two-sided lighting
+  static const TWO_PASSES_TWO_SIDES = 2;
+}
+
+sealed class TBlendingMode {
+  static const BLENDING_MODE_OPAQUE = 0;
+  static const BLENDING_MODE_TRANSPARENT = 1;
+  static const BLENDING_MODE_ADD = 2;
+  static const BLENDING_MODE_MASKED = 3;
+  static const BLENDING_MODE_FADE = 4;
+  static const BLENDING_MODE_MULTIPLY = 5;
+  static const BLENDING_MODE_SCREEN = 6;
+  static const BLENDING_MODE_CUSTOM = 7;
+}
+
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+typedef size_t = int;
+typedef Dartsize_t = int;
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  }
+}
+
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
+  }
+}
+
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
+
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
+  }
+}
+
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
+
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
+  }
+}
+
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
+
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
+  }
+}
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
+  }
+}
+
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
+
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  }
+}
+
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
+  }
+}
+
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
+
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
+  }
+}
+
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
+  }
+}
+
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
+  }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+typedef EntityId = int;
+typedef DartEntityId = int;
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
+  }
+}
+
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
+
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
+  }
+}
+
+extension TRenderableManagerExt on Pointer<TRenderableManager> {
+  TRenderableManager toDart() {
+    return TRenderableManager(this);
+  }
+}
+
+final class TRenderableManager extends Struct {
+  Pointer<TRenderableManager> get address => super.address.cast();
+  TRenderableManager(super.address);
+
+  static Pointer<TRenderableManager> stackAlloc() {
+    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
+  }
+}
+
+extension TLightManagerExt on Pointer<TLightManager> {
+  TLightManager toDart() {
+    return TLightManager(this);
+  }
+}
+
+final class TLightManager extends Struct {
+  Pointer<TLightManager> get address => super.address.cast();
+  TLightManager(super.address);
+
+  static Pointer<TLightManager> stackAlloc() {
+    return Pointer<TLightManager>(NativeLibrary.instance.stackAlloc<TLightManager>(0));
+  }
+}
+
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
+  }
+}
+
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
+
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  }
+}
+
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
+  }
+}
+
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
+
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  }
+}
+
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
+  }
+}
+
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
+
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  }
+}
+
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
+  }
+}
+
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
+
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
+  }
+}
+
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
+  }
+}
+
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
+
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
+  }
+}
+
 extension TViewportExt on Pointer<TViewport> {
   TViewport toDart() {
     return TViewport(this);
@@ -9209,21 +9905,6 @@ final class TViewport extends Struct {
   }
 }
 
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
-}
-
 extension TToneMapperExt on Pointer<TToneMapper> {
   TToneMapper toDart() {
     return TToneMapper(this);
@@ -9236,21 +9917,6 @@ final class TToneMapper extends Struct {
 
   static Pointer<TToneMapper> stackAlloc() {
     return Pointer<TToneMapper>(NativeLibrary.instance.stackAlloc<TToneMapper>(0));
-  }
-}
-
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
-  }
-}
-
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
-
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
   }
 }
 
@@ -9269,21 +9935,6 @@ final class TColorGradingBuilder extends Struct {
   }
 }
 
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
-}
-
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
-  }
-}
-
 sealed class TQualityLevel {
   static const LOW = 0;
   static const MEDIUM = 1;
@@ -9299,21 +9950,6 @@ sealed class TLutFormat {
 sealed class TBlendMode {
   static const OPAQUE = 0;
   static const TRANSLUCENT = 1;
-}
-
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
-  }
-}
-
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
-
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
-  }
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -9447,36 +10083,6 @@ final class TVsmShadowOptions extends Struct {
 
   static Pointer<TVsmShadowOptions> stackAlloc() {
     return Pointer<TVsmShadowOptions>(NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
-
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
-
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
   }
 }
 
@@ -10066,254 +10672,94 @@ final class TFogOptions extends Struct {
   }
 }
 
-extension TTextureExt on Pointer<TTexture> {
-  TTexture toDart() {
-    return TTexture(this);
-  }
-}
-
-final class TTexture extends Struct {
-  Pointer<TTexture> get address => super.address.cast();
-  TTexture(super.address);
-
-  static Pointer<TTexture> stackAlloc() {
-    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
-  }
-}
-
 typedef PickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
 typedef DartPickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
 typedef PickCallbackFunction =
     void Function(int requestId, EntityId entityId, double depth, double fragX, double fragY, double fragZ);
 typedef DartPickCallbackFunction =
     void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
-typedef EntityId = int;
-typedef DartEntityId = int;
 
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
   }
 }
 
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
 
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
   }
 }
 
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
+extension TVertexBufferBuilderExt on Pointer<TVertexBufferBuilder> {
+  TVertexBufferBuilder toDart() {
+    return TVertexBufferBuilder(this);
   }
 }
 
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
+final class TVertexBufferBuilder extends Struct {
+  Pointer<TVertexBufferBuilder> get address => super.address.cast();
+  TVertexBufferBuilder(super.address);
 
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
+  static Pointer<TVertexBufferBuilder> stackAlloc() {
+    return Pointer<TVertexBufferBuilder>(NativeLibrary.instance.stackAlloc<TVertexBufferBuilder>(0));
   }
 }
 
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
-  }
+sealed class TVertexBufferStorageMode {
+  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
+  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
+  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
 }
 
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
-
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
-  }
+sealed class TVertexAttribute {
+  static const TVERTEX_ATTRIBUTE_POSITION = 0;
+  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
+  static const TVERTEX_ATTRIBUTE_COLOR = 2;
+  static const TVERTEX_ATTRIBUTE_UV0 = 3;
+  static const TVERTEX_ATTRIBUTE_UV1 = 4;
+  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
+  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
+  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
+  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
+  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
+  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
+  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
+  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
+  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
+  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
 }
 
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
-  }
-}
-
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
-
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
-  }
-}
-
-extension TMaterialExt on Pointer<TMaterial> {
-  TMaterial toDart() {
-    return TMaterial(this);
-  }
-}
-
-final class TMaterial extends Struct {
-  Pointer<TMaterial> get address => super.address.cast();
-  TMaterial(super.address);
-
-  static Pointer<TMaterial> stackAlloc() {
-    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
-  }
-}
-
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
-  TMaterialInstance toDart() {
-    return TMaterialInstance(this);
-  }
-}
-
-final class TMaterialInstance extends Struct {
-  Pointer<TMaterialInstance> get address => super.address.cast();
-  TMaterialInstance(super.address);
-
-  static Pointer<TMaterialInstance> stackAlloc() {
-    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
-  }
-}
-
-sealed class TFeatureLevel {
-  static const FEATURE_LEVEL_0 = 0;
-  static const FEATURE_LEVEL_1 = 1;
-  static const FEATURE_LEVEL_2 = 2;
-  static const FEATURE_LEVEL_3 = 3;
-}
-
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
-}
-
-extension TTextureSamplerExt on Pointer<TTextureSampler> {
-  TTextureSampler toDart() {
-    return TTextureSampler(this);
-  }
-}
-
-final class TTextureSampler extends Struct {
-  Pointer<TTextureSampler> get address => super.address.cast();
-  TTextureSampler(super.address);
-
-  static Pointer<TTextureSampler> stackAlloc() {
-    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
-  }
-}
-
-sealed class TSamplerCompareFunc {
-  /// !< Less or equal
-  static const LE = 0;
-
-  /// !< Greater or equal
-  static const GE = 1;
-
-  /// !< Strictly less than
-  static const L = 2;
-
-  /// !< Strictly greater than
-  static const G = 3;
-
-  /// !< Equal
-  static const E = 4;
-
-  /// !< Not equal
-  static const NE = 5;
-
-  /// !< Always. Depth / stencil testing is deactivated.
-  static const A = 6;
-
-  /// !< Never. The depth / stencil test always fails.
-  static const N = 7;
-}
-
-sealed class TStencilOperation {
-  static const KEEP = 0;
-  static const ZERO = 1;
-  static const REPLACE = 2;
-  static const INCR = 3;
-  static const INCR_WRAP = 4;
-  static const DECR = 5;
-  static const DECR_WRAP = 6;
-  static const INVERT = 7;
-}
-
-sealed class TStencilFace {
-  static const STENCIL_FACE_FRONT = 1;
-  static const STENCIL_FACE_BACK = 2;
-  static const STENCIL_FACE_FRONT_AND_BACK = 3;
-}
-
-sealed class TTransparencyMode {
-  /// ! the transparent object is drawn honoring the raster state
-  static const DEFAULT = 0;
-
-  /// the transparent object is first drawn in the depth buffer,
-  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
-  static const TWO_PASSES_ONE_SIDE = 1;
-
-  /// the transparent object is drawn twice in the color buffer,
-  /// first with back faces only, then with front faces; the culling
-  /// mode is ignored. Can be combined with two-sided lighting
-  static const TWO_PASSES_TWO_SIDES = 2;
-}
-
-sealed class TBlendingMode {
-  static const BLENDING_MODE_OPAQUE = 0;
-  static const BLENDING_MODE_TRANSPARENT = 1;
-  static const BLENDING_MODE_ADD = 2;
-  static const BLENDING_MODE_MASKED = 3;
-  static const BLENDING_MODE_FADE = 4;
-  static const BLENDING_MODE_MULTIPLY = 5;
-  static const BLENDING_MODE_SCREEN = 6;
-  static const BLENDING_MODE_CUSTOM = 7;
-}
-
-extension TSceneAssetExt on Pointer<TSceneAsset> {
-  TSceneAsset toDart() {
-    return TSceneAsset(this);
-  }
-}
-
-final class TSceneAsset extends Struct {
-  Pointer<TSceneAsset> get address => super.address.cast();
-  TSceneAsset(super.address);
-
-  static Pointer<TSceneAsset> stackAlloc() {
-    return Pointer<TSceneAsset>(NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
-  }
+sealed class TVertexAttributeType {
+  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
+  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
+  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
+  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
+  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
+  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
+  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
 extension TVertexBufferExt on Pointer<TVertexBuffer> {
@@ -10331,6 +10777,41 @@ final class TVertexBuffer extends Struct {
   }
 }
 
+extension TBufferObjectExt on Pointer<TBufferObject> {
+  TBufferObject toDart() {
+    return TBufferObject(this);
+  }
+}
+
+final class TBufferObject extends Struct {
+  Pointer<TBufferObject> get address => super.address.cast();
+  TBufferObject(super.address);
+
+  static Pointer<TBufferObject> stackAlloc() {
+    return Pointer<TBufferObject>(NativeLibrary.instance.stackAlloc<TBufferObject>(0));
+  }
+}
+
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
+  }
+}
+
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
+
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
+  }
+}
+
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
 extension TIndexBufferExt on Pointer<TIndexBuffer> {
   TIndexBuffer toDart() {
     return TIndexBuffer(this);
@@ -10346,27 +10827,74 @@ final class TIndexBuffer extends Struct {
   }
 }
 
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
+extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
+  TBufferObjectBuilder toDart() {
+    return TBufferObjectBuilder(this);
+  }
 }
 
-sealed class TVertexBufferStorageMode {
-  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
-  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
-  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
+final class TBufferObjectBuilder extends Struct {
+  Pointer<TBufferObjectBuilder> get address => super.address.cast();
+  TBufferObjectBuilder(super.address);
+
+  static Pointer<TBufferObjectBuilder> stackAlloc() {
+    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
+  }
+}
+
+extension double4x4Ext on Pointer<double4x4> {
+  double4x4 toDart() {
+    return double4x4(this);
+  }
+}
+
+final class double4x4 extends Struct {
+  Pointer<double4x4> get address => super.address.cast();
+  Array<Float64> get col1 {
+    final addr = Pointer<double4x4>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 0)));
+  }
+
+  set col1(Array<Float64> val) {
+    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 0), val.internal.addr.addr.toJS, '*');
+  }
+
+  Array<Float64> get col2 {
+    final addr = Pointer<double4x4>(this.address.addr + 32);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 32)));
+  }
+
+  set col2(Array<Float64> val) {
+    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 32), val.internal.addr.addr.toJS, '*');
+  }
+
+  Array<Float64> get col3 {
+    final addr = Pointer<double4x4>(this.address.addr + 64);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 64)));
+  }
+
+  set col3(Array<Float64> val) {
+    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 64), val.internal.addr.addr.toJS, '*');
+  }
+
+  Array<Float64> get col4 {
+    final addr = Pointer<double4x4>(this.address.addr + 96);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 96)));
+  }
+
+  set col4(Array<Float64> val) {
+    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 96), val.internal.addr.addr.toJS, '*');
+  }
+
+  double4x4(super.address);
+
+  static Pointer<double4x4> stackAlloc() {
+    return Pointer<double4x4>(NativeLibrary.instance.stackAlloc<double4x4>(128));
+  }
 }
 
 extension Aabb3Ext on Pointer<Aabb3> {
@@ -10444,87 +10972,12 @@ final class Aabb3 extends Struct {
   }
 }
 
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
-  }
-}
-
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
-
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
-  }
-}
-
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
-}
-
-typedef size_t = int;
-typedef Dartsize_t = int;
-
-extension double4x4Ext on Pointer<double4x4> {
-  double4x4 toDart() {
-    return double4x4(this);
-  }
-}
-
-final class double4x4 extends Struct {
-  Pointer<double4x4> get address => super.address.cast();
-  Array<Float64> get col1 {
-    final addr = Pointer<double4x4>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 0)));
-  }
-
-  set col1(Array<Float64> val) {
-    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 0), val.internal.addr.addr.toJS, '*');
-  }
-
-  Array<Float64> get col2 {
-    final addr = Pointer<double4x4>(this.address.addr + 32);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 32)));
-  }
-
-  set col2(Array<Float64> val) {
-    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 32), val.internal.addr.addr.toJS, '*');
-  }
-
-  Array<Float64> get col3 {
-    final addr = Pointer<double4x4>(this.address.addr + 64);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 64)));
-  }
-
-  set col3(Array<Float64> val) {
-    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 64), val.internal.addr.addr.toJS, '*');
-  }
-
-  Array<Float64> get col4 {
-    final addr = Pointer<double4x4>(this.address.addr + 96);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 96)));
-  }
-
-  set col4(Array<Float64> val) {
-    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 96), val.internal.addr.addr.toJS, '*');
-  }
-
-  double4x4(super.address);
-
-  static Pointer<double4x4> stackAlloc() {
-    return Pointer<double4x4>(NativeLibrary.instance.stackAlloc<double4x4>(128));
-  }
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
 }
 
 extension double3Ext on Pointer<double3> {
@@ -10570,619 +11023,6 @@ final class double3 extends Struct {
   static Pointer<double3> stackAlloc() {
     return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
   }
-}
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-extension TMeshDataExt on Pointer<TMeshData> {
-  TMeshData toDart() {
-    return TMeshData(this);
-  }
-}
-
-final class TMeshData extends Struct {
-  Pointer<TMeshData> get address => super.address.cast();
-  TMeshData(super.address);
-
-  static Pointer<TMeshData> stackAlloc() {
-    return Pointer<TMeshData>(NativeLibrary.instance.stackAlloc<TMeshData>(0));
-  }
-}
-
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
-  }
-}
-
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
-
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
-  }
-}
-
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
-  }
-}
-
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
-
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
-  }
-}
-
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
-  }
-}
-
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
-
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
-  }
-}
-
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
-  }
-}
-
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
-
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
-  }
-}
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
-  }
-}
-
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
-
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
-  }
-}
-
-extension TRenderableManagerExt on Pointer<TRenderableManager> {
-  TRenderableManager toDart() {
-    return TRenderableManager(this);
-  }
-}
-
-final class TRenderableManager extends Struct {
-  Pointer<TRenderableManager> get address => super.address.cast();
-  TRenderableManager(super.address);
-
-  static Pointer<TRenderableManager> stackAlloc() {
-    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
-  }
-}
-
-extension TLightManagerExt on Pointer<TLightManager> {
-  TLightManager toDart() {
-    return TLightManager(this);
-  }
-}
-
-final class TLightManager extends Struct {
-  Pointer<TLightManager> get address => super.address.cast();
-  TLightManager(super.address);
-
-  static Pointer<TLightManager> stackAlloc() {
-    return Pointer<TLightManager>(NativeLibrary.instance.stackAlloc<TLightManager>(0));
-  }
-}
-
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
-  }
-}
-
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
-
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
-  }
-}
-
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
-  }
-}
-
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
-
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
-  }
-}
-
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
-  }
-}
-
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
-
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
-  }
-}
-
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
-  }
-}
-
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
-
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
-  }
-}
-
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
-  }
-}
-
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
-
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
-  }
-}
-
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
-  }
-}
-
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
-
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
-  }
-}
-
-extension TVertexBufferBuilderExt on Pointer<TVertexBufferBuilder> {
-  TVertexBufferBuilder toDart() {
-    return TVertexBufferBuilder(this);
-  }
-}
-
-final class TVertexBufferBuilder extends Struct {
-  Pointer<TVertexBufferBuilder> get address => super.address.cast();
-  TVertexBufferBuilder(super.address);
-
-  static Pointer<TVertexBufferBuilder> stackAlloc() {
-    return Pointer<TVertexBufferBuilder>(NativeLibrary.instance.stackAlloc<TVertexBufferBuilder>(0));
-  }
-}
-
-sealed class TVertexAttribute {
-  static const TVERTEX_ATTRIBUTE_POSITION = 0;
-  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
-  static const TVERTEX_ATTRIBUTE_COLOR = 2;
-  static const TVERTEX_ATTRIBUTE_UV0 = 3;
-  static const TVERTEX_ATTRIBUTE_UV1 = 4;
-  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
-  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
-  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
-  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
-  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
-  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
-  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
-  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
-  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
-  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
-}
-
-sealed class TVertexAttributeType {
-  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
-  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
-  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
-  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
-  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
-  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
-  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
-}
-
-extension TBufferObjectExt on Pointer<TBufferObject> {
-  TBufferObject toDart() {
-    return TBufferObject(this);
-  }
-}
-
-final class TBufferObject extends Struct {
-  Pointer<TBufferObject> get address => super.address.cast();
-  TBufferObject(super.address);
-
-  static Pointer<TBufferObject> stackAlloc() {
-    return Pointer<TBufferObject>(NativeLibrary.instance.stackAlloc<TBufferObject>(0));
-  }
-}
-
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
-  }
-}
-
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
-
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
-  }
-}
-
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
-  TBufferObjectBuilder toDart() {
-    return TBufferObjectBuilder(this);
-  }
-}
-
-final class TBufferObjectBuilder extends Struct {
-  Pointer<TBufferObjectBuilder> get address => super.address.cast();
-  TBufferObjectBuilder(super.address);
-
-  static Pointer<TBufferObjectBuilder> stackAlloc() {
-    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
-  }
-}
-
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
 }
 
 extension TShadowOptionsExt on Pointer<TShadowOptions> {
@@ -11490,6 +11330,118 @@ final class TAnimationManager extends Struct {
   }
 }
 
+extension TSceneAssetExt on Pointer<TSceneAsset> {
+  TSceneAsset toDart() {
+    return TSceneAsset(this);
+  }
+}
+
+final class TSceneAsset extends Struct {
+  Pointer<TSceneAsset> get address => super.address.cast();
+  TSceneAsset(super.address);
+
+  static Pointer<TSceneAsset> stackAlloc() {
+    return Pointer<TSceneAsset>(NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
+  }
+}
+
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
+  }
+}
+
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
+
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
+  }
+}
+
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
+  }
+}
+
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
+  }
+}
+
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
+
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
+  }
+}
+
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
+}
+
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
+  }
+}
+
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
+
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
+  }
+}
+
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
+  }
+}
+
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
+
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  }
+}
+
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
   TRenderableBuilder toDart() {
     return TRenderableBuilder(this);
@@ -11503,6 +11455,60 @@ final class TRenderableBuilder extends Struct {
   static Pointer<TRenderableBuilder> stackAlloc() {
     return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
   }
+}
+
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
+}
+
+extension TMeshDataExt on Pointer<TMeshData> {
+  TMeshData toDart() {
+    return TMeshData(this);
+  }
+}
+
+final class TMeshData extends Struct {
+  Pointer<TMeshData> get address => super.address.cast();
+  TMeshData(super.address);
+
+  static Pointer<TMeshData> stackAlloc() {
+    return Pointer<TMeshData>(NativeLibrary.instance.stackAlloc<TMeshData>(0));
+  }
+}
+
+typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
 }
 
 extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
@@ -11534,11 +11540,6 @@ final class TSurfaceOrientation extends Struct {
     return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
   }
 }
-
-typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
   TMovementIntentExecutor toDart() {
@@ -11585,98 +11586,20 @@ const int SPRINT_INTENT_MASK = 8;
 extension StructAllocator on Struct {
   static T create<T>() {
     switch (T) {
-      case TViewport:
-        final ptr = TViewport.stackAlloc();
-        return ptr.toDart() as T;
-      case TView:
-        final ptr = TView.stackAlloc();
-        return ptr.toDart() as T;
-      case TToneMapper:
-        final ptr = TToneMapper.stackAlloc();
-        return ptr.toDart() as T;
-      case TEngine:
-        final ptr = TEngine.stackAlloc();
-        return ptr.toDart() as T;
-      case TColorGradingBuilder:
-        final ptr = TColorGradingBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
-        return ptr.toDart() as T;
-      case TSoftShadowOptions:
-        final ptr = TSoftShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TVsmShadowOptions:
-        final ptr = TVsmShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
-        return ptr.toDart() as T;
-      case TAmbientOcclusionOptions:
-        final ptr = TAmbientOcclusionOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TSsct:
-        final ptr = TSsct.stackAlloc();
-        return ptr.toDart() as T;
-      case TGtao:
-        final ptr = TGtao.stackAlloc();
-        return ptr.toDart() as T;
-      case TFogOptions:
-        final ptr = TFogOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TTexture:
-        final ptr = TTexture.stackAlloc();
-        return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
+      case TMaterialInstance:
+        final ptr = TMaterialInstance.stackAlloc();
         return ptr.toDart() as T;
       case TMaterial:
         final ptr = TMaterial.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialInstance:
-        final ptr = TMaterialInstance.stackAlloc();
+      case TEngine:
+        final ptr = TEngine.stackAlloc();
+        return ptr.toDart() as T;
+      case TTexture:
+        final ptr = TTexture.stackAlloc();
         return ptr.toDart() as T;
       case TTextureSampler:
         final ptr = TTextureSampler.stackAlloc();
-        return ptr.toDart() as T;
-      case TSceneAsset:
-        final ptr = TSceneAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBuffer:
-        final ptr = TVertexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
-        return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
-        return ptr.toDart() as T;
-      case TMeshData:
-        final ptr = TMeshData.stackAlloc();
         return ptr.toDart() as T;
       case TLinearImage:
         final ptr = TLinearImage.stackAlloc();
@@ -11684,11 +11607,26 @@ extension StructAllocator on Struct {
       case TKtx1Bundle:
         final ptr = TKtx1Bundle.stackAlloc();
         return ptr.toDart() as T;
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
+        return ptr.toDart() as T;
       case TRenderer:
         final ptr = TRenderer.stackAlloc();
         return ptr.toDart() as T;
       case TSwapChain:
         final ptr = TSwapChain.stackAlloc();
+        return ptr.toDart() as T;
+      case TView:
+        final ptr = TView.stackAlloc();
+        return ptr.toDart() as T;
+      case TScene:
+        final ptr = TScene.stackAlloc();
+        return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
+        return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
         return ptr.toDart() as T;
       case TTransformManager:
         final ptr = TTransformManager.stackAlloc();
@@ -11714,11 +11652,41 @@ extension StructAllocator on Struct {
       case TDebugRegistry:
         final ptr = TDebugRegistry.stackAlloc();
         return ptr.toDart() as T;
+      case TViewport:
+        final ptr = TViewport.stackAlloc();
+        return ptr.toDart() as T;
+      case TToneMapper:
+        final ptr = TToneMapper.stackAlloc();
+        return ptr.toDart() as T;
+      case TColorGradingBuilder:
+        final ptr = TColorGradingBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TSoftShadowOptions:
+        final ptr = TSoftShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TVsmShadowOptions:
+        final ptr = TVsmShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TAmbientOcclusionOptions:
+        final ptr = TAmbientOcclusionOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TSsct:
+        final ptr = TSsct.stackAlloc();
+        return ptr.toDart() as T;
+      case TGtao:
+        final ptr = TGtao.stackAlloc();
+        return ptr.toDart() as T;
+      case TFogOptions:
+        final ptr = TFogOptions.stackAlloc();
+        return ptr.toDart() as T;
       case TMaterialProvider:
         final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
       case TVertexBufferBuilder:
         final ptr = TVertexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBuffer:
+        final ptr = TVertexBuffer.stackAlloc();
         return ptr.toDart() as T;
       case TBufferObject:
         final ptr = TBufferObject.stackAlloc();
@@ -11726,8 +11694,20 @@ extension StructAllocator on Struct {
       case TIndexBufferBuilder:
         final ptr = TIndexBufferBuilder.stackAlloc();
         return ptr.toDart() as T;
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
+        return ptr.toDart() as T;
       case TBufferObjectBuilder:
         final ptr = TBufferObjectBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
+        return ptr.toDart() as T;
+      case double3:
+        final ptr = double3.stackAlloc();
         return ptr.toDart() as T;
       case TShadowOptions:
         final ptr = TShadowOptions.stackAlloc();
@@ -11738,8 +11718,29 @@ extension StructAllocator on Struct {
       case TAnimationManager:
         final ptr = TAnimationManager.stackAlloc();
         return ptr.toDart() as T;
+      case TSceneAsset:
+        final ptr = TSceneAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
+        return ptr.toDart() as T;
       case TRenderableBuilder:
         final ptr = TRenderableBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TMeshData:
+        final ptr = TMeshData.stackAlloc();
         return ptr.toDart() as T;
       case TSurfaceOrientationBuilder:
         final ptr = TSurfaceOrientationBuilder.stackAlloc();

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -132,148 +132,192 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external int _MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance);
   external int _Material_getBlendingMode(Pointer<TMaterial> material);
-  external int _LightManager_createLight(
+  external Pointer<TTexture> _Texture_build(
+    Pointer<TEngine> engine,
+    int width,
+    int height,
+    int depth,
+    int levels,
+    int tUsage,
+    int import1,
+    int sampler,
+    int format,
+  );
+  external void _Texture_setExternalImage(
     Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
+    Pointer<TTexture> tTexture,
+    Pointer<Void> externalImage,
   );
-  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
+  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
+  external int _Texture_loadImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<TLinearImage> tImage,
+    int bufferFormat,
+    int pixelDataType,
+    int level,
   );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
+  external int _Texture_setImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    int level,
+    Pointer<Uint8> data,
+    size_t size,
+    int x_offset,
+    int y_offset,
+    int z_offset,
+    int width,
+    int height,
+    int depth,
+    int bufferFormat,
+    int pixelDataType,
   );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
+  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getFormat(Pointer<TTexture> tTexture);
+  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
+  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
+  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
+  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
+  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
+  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
+  external Pointer<TTexture> _Ktx1Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TKtx1Bundle> tBundle,
+    int requestId,
+    VoidCallback onTextureUploadComplete,
   );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
+  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
+  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
+  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
+  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
+  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
+  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TTextureSampler> _TextureSampler_create();
+  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
+    int minFilter,
+    int magFilter,
+    int wrapS,
+    int wrapT,
+    int wrapR,
   );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
+  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
+  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
+  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
+  external Pointer<TEngine> _Engine_create(
+    int backend,
+    Pointer<Void> platform,
+    Pointer<Void> sharedContext,
+    int stereoscopicEyeCount,
+    bool disableHandleUseAfterFreeCheck,
+  );
+  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
+  external void _Engine_destroy(Pointer<TEngine> tEngine);
+  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
+  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
+  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
+    Pointer<TEngine> tEngine,
+    int width,
+    int height,
+    JSBigInt flags,
+  );
+  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
+  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
+  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
+  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
+  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
+  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
+  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
+  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
+  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
+  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
+  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
+  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
+  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
+  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
+  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
+  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
+  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
+  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
+  external void _Engine_execute(Pointer<TEngine> tEngine);
+  external Pointer<TMaterial> _Engine_buildMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> materialData,
+    size_t length,
+  );
+  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
+  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
+  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
+  external Pointer<TSkybox> _Engine_buildSkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    bool showSun,
+    double intensity,
+    int priority,
+  );
+  external Pointer<TSkybox> _Engine_buildColoredSkybox(
+    Pointer<TEngine> tEngine,
     double r,
     double g,
     double b,
+    double a,
+    bool showSun,
+    double intensity,
+    int priority,
   );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<TTexture> tIrradianceTexture,
     double intensity,
   );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
-  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
-  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
-  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
-  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
-  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
-  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
-  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
-  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
     Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<Float32> irradianceHarmonics,
+    double intensity,
   );
-  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
+  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
+  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
+  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
+  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
+  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
+  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
+  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
+  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
+  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
+  external int _DebugRegistry_setProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    double value,
   );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
+  external int _DebugRegistry_getProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Bool> outValue,
   );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
-  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
+  external int _DebugRegistry_getProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Int32> outValue,
+  );
+  external int _DebugRegistry_getProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Float32> outValue,
+  );
   external void _View_getViewport(Pointer<TViewport> TViewport_out, Pointer<TView> view);
   external Pointer<TToneMapper> _ToneMapper_createLinear(Pointer<TEngine> tEngine);
   external Pointer<TToneMapper> _ToneMapper_createACES(Pointer<TEngine> tEngine);
@@ -410,168 +454,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _View_pick(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
   external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
   external Pointer<Char> _View_getName(Pointer<TView> tView);
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
-  );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
-  );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
-  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
-  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
-  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
-  external Pointer<TTexture> _Texture_build(
-    Pointer<TEngine> engine,
-    int width,
-    int height,
-    int depth,
-    int levels,
-    int tUsage,
-    int import1,
-    int sampler,
-    int format,
-  );
-  external void _Texture_setExternalImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<Void> externalImage,
-  );
-  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
-  external int _Texture_loadImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<TLinearImage> tImage,
-    int bufferFormat,
-    int pixelDataType,
-    int level,
-  );
-  external int _Texture_setImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    int level,
-    Pointer<Uint8> data,
-    size_t size,
-    int x_offset,
-    int y_offset,
-    int z_offset,
-    int width,
-    int height,
-    int depth,
-    int bufferFormat,
-    int pixelDataType,
-  );
-  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getFormat(Pointer<TTexture> tTexture);
-  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
-  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
-  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
-  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
-  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
-  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
-  external Pointer<TTexture> _Ktx1Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TKtx1Bundle> tBundle,
-    int requestId,
-    VoidCallback onTextureUploadComplete,
-  );
-  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
-  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
-  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
-  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
-  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
-  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTextureSampler> _TextureSampler_create();
-  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
-    int minFilter,
-    int magFilter,
-    int wrapS,
-    int wrapT,
-    int wrapR,
-  );
-  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
-  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
-  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
-  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
-  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-  external void _FrameScheduler_stop();
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external void _Gizmo_dummy(int t);
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
-  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
-  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
     bool doubleSided,
@@ -613,23 +495,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     bool hasIOR,
     bool hasVolume,
   );
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
-  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
-  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
   external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
   external void _VertexBufferBuilder_bufferCount(Pointer<TVertexBufferBuilder> builder, int count);
   external void _VertexBufferBuilder_vertexCount(Pointer<TVertexBufferBuilder> builder, int count);
@@ -665,95 +530,38 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TBufferObject> bufferObject,
   );
   external void _VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer);
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
+  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
-  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
-  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
-  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
-  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
+  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
+  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
   );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
+  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
+  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
+  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
+  external Pointer<TBufferObject> _BufferObjectBuilder_build(
+    Pointer<TBufferObjectBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
+  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
+  external void _BufferObject_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TBufferObject> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
   );
-  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
-  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
-  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
-  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
-  );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<double4x4> tModelMatrixPtr);
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
+  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
   external void _TransformManager_getLocalTransform(
     Pointer<double4x4> double4x4_out,
     Pointer<TTransformManager> tTransformManager,
@@ -796,161 +604,124 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
   external void _TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
-  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
-  external Pointer<TEngine> _Engine_create(
-    int backend,
-    Pointer<Void> platform,
-    Pointer<Void> sharedContext,
-    int stereoscopicEyeCount,
-    bool disableHandleUseAfterFreeCheck,
-  );
-  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
-  external void _Engine_destroy(Pointer<TEngine> tEngine);
-  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
-  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
-  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
+  external int _LightManager_createLight(
     Pointer<TEngine> tEngine,
-    int width,
-    int height,
-    JSBigInt flags,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
   );
-  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
-  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
-  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
-  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
-  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
-  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
-  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
-  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
-  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
-  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
-  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
-  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
-  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
-  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
-  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
-  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
-  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
-  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
-  external void _Engine_execute(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Engine_buildMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> materialData,
-    size_t length,
+  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
   );
-  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
-  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
-  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
-  external Pointer<TSkybox> _Engine_buildSkybox(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    bool showSun,
-    double intensity,
-    int priority,
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
   );
-  external Pointer<TSkybox> _Engine_buildColoredSkybox(
-    Pointer<TEngine> tEngine,
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double r,
     double g,
     double b,
-    double a,
-    bool showSun,
+  );
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double intensity,
-    int priority,
   );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<TTexture> tIrradianceTexture,
-    double intensity,
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
   );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<Float32> irradianceHarmonics,
-    double intensity,
+  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
+  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
   );
-  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
-  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
-  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
-  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
-  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
-  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
-  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
-  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
-  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
-  external int _DebugRegistry_setProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    double value,
+  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
   );
-  external int _DebugRegistry_getProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Bool> outValue,
+  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
+  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
   );
-  external int _DebugRegistry_getProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Int32> outValue,
+  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
+  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
   );
-  external int _DebugRegistry_getProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Float32> outValue,
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
   );
-  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
-  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
-  external Pointer<TBufferObject> _BufferObjectBuilder_build(
-    Pointer<TBufferObjectBuilder> builder,
-    Pointer<TEngine> engine,
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
   );
-  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
-  external void _BufferObject_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TBufferObject> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
+  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
+  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
+  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
   );
-  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
+  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
   external Pointer<Void> _RenderThread_create();
   external Pointer<Void> _RenderThread_createForCanvas(Pointer<Char> canvasSelector);
   external void _RenderThread_destroy(Pointer<Void> renderThread);
@@ -2020,43 +1791,238 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
-  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    int vertexBufferStorageMode,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
     Pointer<TFilamentAsset> tFilamentAsset,
+    int requiredGeometryCapabilities,
   );
-  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
+  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
+  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
   );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
-
-  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
-
-  /// Returns the visibility mask bits.
-  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
-
-  /// Returns the skybox intensity in lux.
-  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
-
-  /// Returns the environment texture, or nullptr for a color-only skybox.
-  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
+  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
+  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
+  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
+  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
+  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
   external void _MeshData_dispose(Pointer<TMeshData> meshData);
   external int _GltfParser_parseBuffer(
     Pointer<Uint8> data,
     size_t length,
     Pointer<Char> meshName,
     Pointer<TMeshData> outMeshData,
+  );
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
+  );
+  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
+  );
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
+  );
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
+  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
+  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+  external void _FrameScheduler_stop();
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Gizmo_dummy(int t);
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+  );
+  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
+  );
+  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
+  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
+  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
+  external int _AnimationManager_addGltfAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_removeGltfAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _AnimationManager_addMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+  );
+  external void _AnimationManager_removeMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+  );
+  external int _AnimationManager_addBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_removeBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_setMorphAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    Pointer<Uint32> morphIndices,
+    int numMorphTargets,
+    int numFrames,
+    double frameLengthInMs,
+  );
+  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
+  external void _AnimationManager_resetToRestPose(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external int _AnimationManager_addBoneAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> frameData,
+    int numFrames,
+    double frameLengthInMs,
+    double fadeOutInSecs,
+    double fadeInInSecs,
+    double maxDelta,
+    bool loop,
+  );
+  external void _AnimationManager_getRestLocalTransforms(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    Pointer<Float32> out,
+    int numBones,
+  );
+  external void _AnimationManager_getInverseBindMatrix(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> out,
+  );
+  external int _AnimationManager_playGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+    bool loop,
+    bool reverse,
+    bool replaceActive,
+    double crossfade,
+    double startOffset,
+    double speed,
+  );
+  external int _AnimationManager_stopGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int index,
+  );
+  external double _AnimationManager_getGltfAnimationDuration(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int animationIndex,
+  );
+  external int _AnimationManager_getGltfAnimationCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external void _AnimationManager_getGltfAnimationName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_getMorphTargetNameCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+  );
+  external void _AnimationManager_getMorphTargetName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_updateBoneMatrices(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external int _AnimationManager_setMorphTargetWeights(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    int numWeights,
+  );
+  external int _AnimationManager_setGltfAnimationTime(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int animationIndex,
+    double timeInSeconds,
   );
   external void _RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
   external int _RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
@@ -2272,181 +2238,215 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t bonesPerVertex,
   );
   external int _RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, EntityId entity);
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    int vertexBufferStorageMode,
-    Pointer<Aabb3> boundingBoxPtr,
+  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
+  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<double4x4> tModelMatrixPtr);
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
+  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
+  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
+  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
+  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
+
+  /// Returns the visibility mask bits.
+  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
+
+  /// Returns the skybox intensity in lux.
+  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
+
+  /// Returns the environment texture, or nullptr for a color-only skybox.
+  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
+  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
+  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
+  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
     Pointer<TFilamentAsset> tFilamentAsset,
-    int requiredGeometryCapabilities,
   );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
-  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
-  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
+  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
   );
-  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
-  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
-  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
-  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
-  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
-  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
-  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
-  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
-  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
-  external int _AnimationManager_addGltfAnimationComponent(
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
+  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
+  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
     Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
   );
-  external int _AnimationManager_removeGltfAnimationComponent(
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
     Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _AnimationManager_addMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
+  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
   );
-  external void _AnimationManager_removeMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
+  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
+  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
+  external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
   );
-  external int _AnimationManager_addBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
   );
-  external int _AnimationManager_removeBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
   );
-  external int _AnimationManager_setMorphAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    Pointer<Uint32> morphIndices,
-    int numMorphTargets,
-    int numFrames,
-    double frameLengthInMs,
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
   );
-  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
-  external void _AnimationManager_resetToRestPose(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
+  external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
   );
-  external int _AnimationManager_addBoneAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> frameData,
-    int numFrames,
-    double frameLengthInMs,
-    double fadeOutInSecs,
-    double fadeInInSecs,
-    double maxDelta,
-    bool loop,
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
   );
-  external void _AnimationManager_getRestLocalTransforms(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
+  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
+  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
     Pointer<Float32> out,
-    int numBones,
+    size_t quatCount,
+    size_t stride,
   );
-  external void _AnimationManager_getInverseBindMatrix(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> out,
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
   );
-  external int _AnimationManager_playGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-    bool loop,
-    bool reverse,
-    bool replaceActive,
-    double crossfade,
-    double startOffset,
-    double speed,
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
   );
-  external int _AnimationManager_stopGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int index,
-  );
-  external double _AnimationManager_getGltfAnimationDuration(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int animationIndex,
-  );
-  external int _AnimationManager_getGltfAnimationCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external void _AnimationManager_getGltfAnimationName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_getMorphTargetNameCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-  );
-  external void _AnimationManager_getMorphTargetName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_updateBoneMatrices(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_setMorphTargetWeights(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    int numWeights,
-  );
-  external int _AnimationManager_setGltfAnimationTime(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int animationIndex,
-    double timeInSeconds,
-  );
+  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
   external void _MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor);
   external void _MovementIntentExecutor_process(
     Pointer<TMovementIntentExecutor> executor,
@@ -2833,341 +2833,587 @@ int Material_getBlendingMode(Pointer<TMaterial> material) {
   return result;
 }
 
-int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-    tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
-  );
-  return result;
-}
-
-void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
+Pointer<TTexture> Texture_build(
+  Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import1,
+  int sampler,
+  int format,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
+  final result = GeneratedBindings.instance._Texture_build(
+    engine.cast(),
+    width,
+    height,
+    depth,
+    levels,
+    tUsage,
+    import1,
+    sampler,
+    format,
   );
+  return Pointer<TTexture>(result);
+}
+
+void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
+  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
   return result;
 }
 
-double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+Dartsize_t Texture_getLevels(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
   return result;
 }
 
-void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
-  );
-  return result;
-}
-
-double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
-  return result;
-}
-
-double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
-  );
-  return result;
-}
-
-double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
-  return result;
-}
-
-double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
-  return result;
-}
-
-double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
-  return result;
-}
-
-bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
-  return result;
-}
-
-void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
-  return result;
-}
-
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-) {
-  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
-    splitPositions,
-    cascades,
-    near,
-    far,
-    lambda,
-  );
-  return result;
-}
-
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
-  return result;
-}
-
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
-  return result;
-}
-
-void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
-  return Pointer<Void>(result);
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+bool Texture_loadImage(
   Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TTexture> tTexture,
+  Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
 ) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+  final result = GeneratedBindings.instance._Texture_loadImage(
     tEngine.cast(),
-    tMaterialProvider.cast(),
-    tNameComponentManager.cast(),
+    tTexture.cast(),
+    tImage.cast(),
+    bufferFormat,
+    pixelDataType,
+    level,
   );
-  return Pointer<TGltfAssetLoader>(result);
+  return result == 1;
 }
 
-void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
-  return result;
-}
-
-Pointer<TFilamentAsset> GltfAssetLoader_load(
+bool Texture_setImage(
   Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TTexture> tTexture,
+  int level,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-  int numInstances,
+  Dartsize_t size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
 ) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+  final result = GeneratedBindings.instance._Texture_setImage(
     tEngine.cast(),
-    tAssetLoader.cast(),
+    tTexture.cast(),
+    level,
     data,
-    length,
-    numInstances,
+    size,
+    x_offset,
+    y_offset,
+    z_offset,
+    width,
+    height,
+    depth,
+    bufferFormat,
+    pixelDataType,
   );
-  return Pointer<TFilamentAsset>(result);
+  return result == 1;
 }
 
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
-    tRenderableManager.cast(),
-    tAsset.cast(),
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
-}
-
-int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
+int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
   return result;
 }
 
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
-  return Pointer<PointerClass<Char>>(result);
+int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getFormat(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
+  return result;
+}
+
+int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
+  return result;
+}
+
+void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
+  return result;
+}
+
+Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dartsize_t length) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
+  return Pointer<TKtx1Bundle>(result);
+}
+
+void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
+  return result;
+}
+
+bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
+  return result == 1;
+}
+
+void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
+  return result;
+}
+
+Pointer<TTexture> Ktx1Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  DartVoidCallback onTextureUploadComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
+    tEngine.cast(),
+    tBundle.cast(),
+    requestId,
+    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dartsize_t size) {
+  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
+  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dartsize_t length, Pointer<Char> name, bool alpha) {
+  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
+  return Pointer<Float32>(result);
+}
+
+void Image_destroy(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+  return result;
+}
+
+int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
+  return result;
+}
+
+int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
+  return result;
+}
+
+int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
+  return result;
+}
+
+Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_create() {
+  final result = GeneratedBindings.instance._TextureSampler_create();
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
+    minFilter,
+    magFilter,
+    wrapS,
+    wrapT,
+    wrapR,
+  );
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
+  return Pointer<TTextureSampler>(result);
+}
+
+void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
+  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
+  return result;
+}
+
+void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
+  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
+  return result;
+}
+
+void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
+  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
+  return result;
+}
+
+Pointer<TEngine> Engine_create(
+  int backend,
+  Pointer<Void> platform,
+  Pointer<Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+) {
+  final result = GeneratedBindings.instance._Engine_create(
+    backend,
+    platform,
+    sharedContext,
+    stereoscopicEyeCount,
+    disableHandleUseAfterFreeCheck,
+  );
+  return Pointer<TEngine>(result);
+}
+
+int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
+  return result;
+}
+
+void Engine_destroy(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
+  return result;
+}
+
+Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
+  return Pointer<TRenderer>(result);
+}
+
+void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
+  return result;
+}
+
+Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
+    tEngine.cast(),
+    width,
+    height,
+    flags.toJSBigInt,
+  );
+  return Pointer<TSwapChain>(result);
+}
+
+void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
+  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
+  return result;
+}
+
+void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
+  return result;
+}
+
+void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
+  return result;
+}
+
+void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
+  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
+  return result;
+}
+
+Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
+  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
+  return result;
+}
+
+Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
+  return Pointer<TView>(result);
+}
+
+Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
+  return Pointer<TTransformManager>(result);
+}
+
+Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
+  return Pointer<TRenderableManager>(result);
+}
+
+Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
+  return Pointer<TLightManager>(result);
+}
+
+Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
+  return Pointer<TEntityManager>(result);
+}
+
+void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
+  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
+  return result;
+}
+
+Dartsize_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
+  return result;
+}
+
+void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
+  return result;
+}
+
+Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
+  return Pointer<TFence>(result);
+}
+
+void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
+  return result;
+}
+
+void Engine_flushAndWait(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
+  return result;
+}
+
+void Engine_execute(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
+  return result;
+}
+
+Pointer<TMaterial> Engine_buildMaterial(Pointer<TEngine> tEngine, Pointer<Uint8> materialData, Dartsize_t length) {
+  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
+  return Pointer<TMaterial>(result);
+}
+
+void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
+  return result;
+}
+
+void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
+  return result;
+}
+
+Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
+  return Pointer<TScene>(result);
+}
+
+Pointer<TSkybox> Engine_buildSkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._Engine_buildSkybox(
+    tEngine.cast(),
+    tTexture.cast(),
+    showSun,
+    intensity,
+    priority,
+  );
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TSkybox> Engine_buildColoredSkybox(
+  Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
+    tEngine.cast(),
+    r,
+    g,
+    b,
+    a,
+    showSun,
+    intensity,
+    priority,
+  );
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    tIrradianceTexture.cast(),
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<Float32> irradianceHarmonics,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    irradianceHarmonics,
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
+  return result;
+}
+
+void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
+  return result;
+}
+
+DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
+  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
+  return result;
+}
+
+void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
+  return result;
+}
+
+void Fence_waitAndDestroy(Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
+  return result;
+}
+
+Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
+  return Pointer<TDebugRegistry>(result);
+}
+
+bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
+  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Bool> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Int32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Float32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
 }
 
 TViewport View_getViewport(Pointer<TView> view) {
@@ -3647,503 +3893,6 @@ Pointer<Char> View_getName(Pointer<TView> tView) {
   return Pointer<Char>(result);
 }
 
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
-  return result;
-}
-
-Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
-  return Pointer<Char>(result);
-}
-
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dart__darwin_size_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, Dart__darwin_size_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(Pointer<TSurfaceOrientationBuilder> builder, Pointer<Uint32> triangles) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dart__darwin_size_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
-  return result;
-}
-
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
-  return result;
-}
-
-void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
-  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
-  return result;
-}
-
-Pointer<TTexture> Texture_build(
-  Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import1,
-  int sampler,
-  int format,
-) {
-  final result = GeneratedBindings.instance._Texture_build(
-    engine.cast(),
-    width,
-    height,
-    depth,
-    levels,
-    tUsage,
-    import1,
-    sampler,
-    format,
-  );
-  return Pointer<TTexture>(result);
-}
-
-void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
-  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
-  return result;
-}
-
-Dart__darwin_size_t Texture_getLevels(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
-  return result;
-}
-
-bool Texture_loadImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-) {
-  final result = GeneratedBindings.instance._Texture_loadImage(
-    tEngine.cast(),
-    tTexture.cast(),
-    tImage.cast(),
-    bufferFormat,
-    pixelDataType,
-    level,
-  );
-  return result == 1;
-}
-
-bool Texture_setImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  int level,
-  Pointer<Uint8> data,
-  Dart__darwin_size_t size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-) {
-  final result = GeneratedBindings.instance._Texture_setImage(
-    tEngine.cast(),
-    tTexture.cast(),
-    level,
-    data,
-    size,
-    x_offset,
-    y_offset,
-    z_offset,
-    width,
-    height,
-    depth,
-    bufferFormat,
-    pixelDataType,
-  );
-  return result == 1;
-}
-
-int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getFormat(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
-  return result;
-}
-
-int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
-  return result;
-}
-
-void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
-  return result;
-}
-
-Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dart__darwin_size_t length) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
-  return Pointer<TKtx1Bundle>(result);
-}
-
-void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
-  return result;
-}
-
-bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
-  return result == 1;
-}
-
-void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
-  return result;
-}
-
-Pointer<TTexture> Ktx1Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  DartVoidCallback onTextureUploadComplete,
-) {
-  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
-    tEngine.cast(),
-    tBundle.cast(),
-    requestId,
-    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dart__darwin_size_t size) {
-  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
-  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dart__darwin_size_t length, Pointer<Char> name, bool alpha) {
-  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
-  return Pointer<Float32>(result);
-}
-
-void Image_destroy(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
-  return result;
-}
-
-int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
-  return result;
-}
-
-int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
-  return result;
-}
-
-int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
-  return result;
-}
-
-Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_create() {
-  final result = GeneratedBindings.instance._TextureSampler_create();
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
-    minFilter,
-    magFilter,
-    wrapS,
-    wrapT,
-    wrapR,
-  );
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
-  return Pointer<TTextureSampler>(result);
-}
-
-void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
-  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
-  return result;
-}
-
-void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
-  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
-  return result;
-}
-
-void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
-  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
-  return result;
-}
-
-void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
-    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
-  return result;
-}
-
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-    tEngine.cast(),
-    assetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
-  );
-  return Pointer<TGizmo>(result);
-}
-
-void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
-  final result = GeneratedBindings.instance._Gizmo_pick(
-    tGizmo.cast(),
-    x,
-    y,
-    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
-  );
-  return result;
-}
-
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
-  return result;
-}
-
-void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
-}
-
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -4229,58 +3978,6 @@ Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   return Pointer<TMaterialInstance>(result);
 }
 
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
-}
-
-void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
-  return result;
-}
-
-void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
-  return result;
-}
-
-Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dart__darwin_size_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
-  return result;
-}
-
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
-  return result;
-}
-
 Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
   final result = GeneratedBindings.instance._VertexBufferBuilder_create();
   return Pointer<TVertexBufferBuilder>(result);
@@ -4340,7 +4037,7 @@ void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
   return result;
 }
 
-Dart__darwin_size_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
+Dartsize_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
   final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(buffer.cast());
   return result;
 }
@@ -4350,7 +4047,7 @@ void VertexBuffer_setBufferAt(
   Pointer<TVertexBuffer> buffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
 ) {
   final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
@@ -4384,286 +4081,97 @@ void VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer
   return result;
 }
 
-Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
-  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
-  return Pointer<TRenderTarget>(result);
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
 }
 
-void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
+void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
   return result;
 }
 
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
+void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
   return result;
 }
 
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
+Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
   return result;
 }
 
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
+Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
   return result;
 }
 
-Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
-  return Pointer<TSkybox>(result);
-}
-
-void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
-  return result;
-}
-
-void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
-  return result;
-}
-
-Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
 ) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
   );
   return result;
 }
 
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
+void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
+  return result;
+}
+
+Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
+  return Pointer<TBufferObjectBuilder>(result);
+}
+
+void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
+  return result;
+}
+
+Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TBufferObject>(result);
+}
+
+void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
+  return result;
+}
+
+void BufferObject_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TBufferObject> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
 ) {
-  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
+  final result = GeneratedBindings.instance._BufferObject_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
   );
   return result;
 }
 
-void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
-  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
-  return result;
-}
-
-void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
-  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
-  return result;
-}
-
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
-  return result;
-}
-
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
-  return result;
-}
-
-void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
-  return result;
-}
-
-void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
-    camera.cast(),
-    projectionMatrixPtr.cast(),
-    near,
-    far,
-  );
-  return result;
-}
-
-void Camera_setModelMatrix(Pointer<TCamera> camera, double4x4 tModelMatrix) {
-  final tModelMatrixPtr = tModelMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrixPtr.cast());
-  return result;
-}
-
-void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
+void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
+  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
   return result;
 }
 
@@ -4795,454 +4303,259 @@ void TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager>
   return result;
 }
 
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
-  );
-  return result;
-}
-
-bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
-  return result;
-}
-
-void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dart__darwin_size_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
-  );
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-    tRenderer.cast(),
-    headRoomRatio,
-    scaleRate,
-    history,
-    interval,
-  );
-  return result;
-}
-
-Pointer<TEngine> Engine_create(
-  int backend,
-  Pointer<Void> platform,
-  Pointer<Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-) {
-  final result = GeneratedBindings.instance._Engine_create(
-    backend,
-    platform,
-    sharedContext,
-    stereoscopicEyeCount,
-    disableHandleUseAfterFreeCheck,
-  );
-  return Pointer<TEngine>(result);
-}
-
-int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
-  return result;
-}
-
-void Engine_destroy(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
-  return result;
-}
-
-Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
-  return Pointer<TRenderer>(result);
-}
-
-void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
-  return result;
-}
-
-Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
+int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
     tEngine.cast(),
-    width,
-    height,
-    flags.toJSBigInt,
-  );
-  return Pointer<TSwapChain>(result);
-}
-
-void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
-  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
-  return result;
-}
-
-void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
-  return result;
-}
-
-void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
-  return result;
-}
-
-void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
-  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
-  return result;
-}
-
-Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
-  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
-  return Pointer<TView>(result);
-}
-
-Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
-  return Pointer<TTransformManager>(result);
-}
-
-Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
-  return Pointer<TRenderableManager>(result);
-}
-
-Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
-  return Pointer<TLightManager>(result);
-}
-
-Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
-  return Pointer<TEntityManager>(result);
-}
-
-void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
-  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
-  return result;
-}
-
-Dart__darwin_size_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
-  return result;
-}
-
-void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
-  return result;
-}
-
-Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
-  return Pointer<TFence>(result);
-}
-
-void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
-  return result;
-}
-
-void Engine_flushAndWait(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
-  return result;
-}
-
-void Engine_execute(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
-  return result;
-}
-
-Pointer<TMaterial> Engine_buildMaterial(
-  Pointer<TEngine> tEngine,
-  Pointer<Uint8> materialData,
-  Dart__darwin_size_t length,
-) {
-  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
-  return Pointer<TMaterial>(result);
-}
-
-void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
-  return result;
-}
-
-void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
-  return result;
-}
-
-Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TSkybox> Engine_buildSkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildSkybox(
-    tEngine.cast(),
-    tTexture.cast(),
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TSkybox> Engine_buildColoredSkybox(
-  Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
-    tEngine.cast(),
-    r,
-    g,
-    b,
-    a,
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    tIrradianceTexture.cast(),
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<Float32> irradianceHarmonics,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    irradianceHarmonics,
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
-  return result;
-}
-
-void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
-  return result;
-}
-
-DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
-  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
-  return result;
-}
-
-void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
-  return result;
-}
-
-void Fence_waitAndDestroy(Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
-  return result;
-}
-
-Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
-  return Pointer<TDebugRegistry>(result);
-}
-
-bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
-  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Bool> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Int32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Float32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
-  return Pointer<TBufferObjectBuilder>(result);
-}
-
-void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
-  return result;
-}
-
-Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TBufferObject>(result);
-}
-
-void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
-  return result;
-}
-
-void BufferObject_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TBufferObject> buffer,
-  Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._BufferObject_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
+    tLightManager.cast(),
+    tLightTtype,
   );
   return result;
 }
 
-void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
-  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
+void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
+  return result;
+}
+
+double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+  return result;
+}
+
+double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+  return result;
+}
+
+bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
+  return result;
+}
+
+void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+    lambda,
+  );
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
   return result;
 }
 
@@ -5479,7 +4792,7 @@ void Engine_createViewRenderThread(
 void Engine_buildMaterialRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
@@ -5699,7 +5012,7 @@ void Ktx1Reader_createTextureRenderThread(
 void Ktx2Reader_createTextureRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
   Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Ktx2Reader_createTextureRenderThread(
@@ -5945,7 +5258,7 @@ void Renderer_readPixelsRenderThread(
   int tPixelBufferFormat,
   int tPixelDataType,
   Pointer<Uint8> out,
-  Dart__darwin_size_t outLength,
+  Dartsize_t outLength,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -6823,7 +6136,7 @@ void Image_createEmptyRenderThread(
 
 void Image_decodeRenderThread(
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<Char> name,
   bool alpha,
   Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
@@ -6899,7 +6212,7 @@ void Texture_setImageRenderThread(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -7206,7 +6519,7 @@ void GltfResourceLoader_addResourceDataRenderThread(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7254,7 +6567,7 @@ void GltfAssetLoader_loadRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int numInstances,
   Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
 ) {
@@ -7441,7 +6754,7 @@ void VertexBuffer_setBufferAtRenderThread(
   Pointer<TVertexBuffer> tBuffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7495,7 +6808,7 @@ void BufferObject_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TBufferObject> tBuffer,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7559,7 +6872,7 @@ void IndexBuffer_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TIndexBuffer> tBuffer,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7703,8 +7016,8 @@ void RenderableManager_setMorphWeightsRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> weights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t offset,
+  Dartsize_t count,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7724,8 +7037,8 @@ void RenderableManager_setBonesFromMat4RenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7745,8 +7058,8 @@ void RenderableManager_setBonesFromBoneRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7768,8 +7081,8 @@ void RenderableManager_setGeometryAtNonIndexedRenderThread(
   int primitiveIndex,
   int type,
   Pointer<TVertexBuffer> tVertices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
+  Dartsize_t offset,
+  Dartsize_t count,
   Pointer<NativeFunction<void Function(bool)>> callback,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexedRenderThread(
@@ -7851,681 +7164,6 @@ void LightManager_setShadowOptionsRenderThread(
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
-  return result;
-}
-
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
-  return Pointer<TGltfResourceLoader>(result);
-}
-
-void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
-  return result;
-}
-
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
-  return result;
-}
-
-double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
-  return result;
-}
-
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
-  );
-  return result;
-}
-
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
-  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
-  return result;
-}
-
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
-  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
-  return result;
-}
-
-/// Returns the visibility mask bits.
-int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
-  return result;
-}
-
-/// Returns the skybox intensity in lux.
-double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
-  return result;
-}
-
-/// Returns the environment texture, or nullptr for a color-only skybox.
-Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
-  return Pointer<TTexture>(result);
-}
-
-void MeshData_dispose(Pointer<TMeshData> meshData) {
-  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-  Pointer<Char> meshName,
-  Pointer<TMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
-  return result;
-}
-
-void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
-  return result == 1;
-}
-
-bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-Dart__darwin_size_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
-  return result;
-}
-
-bool RenderableManager_setMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  Pointer<TMaterialInstance> tMaterialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    tMaterialInstance.cast(),
-  );
-  return result == 1;
-}
-
-Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-void RenderableManager_clearMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return result;
-}
-
-bool RenderableManager_setGeometryAtNonIndexed(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result == 1;
-}
-
-Dart__darwin_size_t RenderableManager_getPrimitiveCount(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-Aabb3 RenderableManager_getAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Aabb3 aabb,
-) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
-    tRenderableManager.cast(),
-    entityId,
-    aabbPtr.cast(),
-  );
-  return result;
-}
-
-Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAabb(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setLayerMask(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int select,
-  int values,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
-    tRenderableManager.cast(),
-    entityId,
-    select,
-    values,
-  );
-  return result;
-}
-
-int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setVisibilityLayer(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int layer,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
-    tRenderableManager.cast(),
-    entityId,
-    layer,
-  );
-  return result;
-}
-
-void RenderableManager_setPriority(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setPriority(
-    tRenderableManager.cast(),
-    entityId,
-    priority,
-  );
-  return result;
-}
-
-int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
-  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
-  return result;
-}
-
-void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
-  return result;
-}
-
-bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setFogEnabled(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool RenderableManager_getLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-  );
-  return result == 1;
-}
-
-void RenderableManager_setCastShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool castShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
-    tRenderableManager.cast(),
-    entityId,
-    castShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setReceiveShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool receiveShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
-    tRenderableManager.cast(),
-    entityId,
-    receiveShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setScreenSpaceContactShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setBlendOrderAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dart__darwin_size_t primitiveIndex,
-  int order,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    order,
-  );
-  return result;
-}
-
-void RenderableManager_setGlobalBlendOrderEnabledAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dart__darwin_size_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setMorphWeights(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> weights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
-    tRenderableManager.cast(),
-    entityId,
-    weights,
-    count,
-    offset,
-  );
-  return result;
-}
-
-Dart__darwin_size_t RenderableManager_getMorphTargetCount(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setBonesFromMat4(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> transforms,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
-    tRenderableManager.cast(),
-    entityId,
-    transforms,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-void RenderableManager_setBonesFromBone(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> bones,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
-    tRenderableManager.cast(),
-    entityId,
-    bones,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-Pointer<TRenderableBuilder> RenderableBuilder_create(Dart__darwin_size_t primitiveCount) {
-  final result = GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
-  return Pointer<TRenderableBuilder>(result);
-}
-
-void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
-  final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
-  return result;
-}
-
-void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
-  return result;
-}
-
-void RenderableBuilder_material(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_material(
-    builder.cast(),
-    primitiveIndex,
-    materialInstance.cast(),
-  );
-  return result;
-}
-
-void RenderableBuilder_geometry(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Pointer<TIndexBuffer> indices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_geometry(
-    builder.cast(),
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    indices.cast(),
-    offset,
-    count,
-  );
-  return result;
-}
-
-void RenderableBuilder_geometryNonIndexed(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_geometryNonIndexed(
-    builder.cast(),
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result;
-}
-
-void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
-  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
-  return result;
-}
-
-void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
-  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
-  return result;
-}
-
-void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
-  return result;
-}
-
-void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
-  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
-  return result;
-}
-
-void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dart__darwin_size_t primitiveIndex, int order) {
-  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
-  return result;
-}
-
-void RenderableBuilder_globalBlendOrderEnabled(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_globalBlendOrderEnabled(
-    builder.cast(),
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dart__darwin_size_t instanceCount) {
-  final result = GeneratedBindings.instance._RenderableBuilder_instances(builder.cast(), instanceCount);
-  return result;
-}
-
-void RenderableBuilder_skinningFromMat4(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t boneCount,
-  Pointer<Float32> transforms,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
-  return result;
-}
-
-void RenderableBuilder_skinningFromBone(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t boneCount,
-  Pointer<Float32> bones,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(builder.cast(), boneCount, bones);
-  return result;
-}
-
-void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_boneIndicesAndWeights(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  Pointer<Float32> indicesAndWeights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t bonesPerVertex,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
-    builder.cast(),
-    primitiveIndex,
-    indicesAndWeights,
-    count,
-    bonesPerVertex,
-  );
-  return result;
-}
-
-int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
-  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
   return result;
 }
 
@@ -8615,7 +7253,7 @@ Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
   return Pointer<Int32>(result);
 }
 
-Dart__darwin_size_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
   return result;
 }
@@ -8625,7 +7263,7 @@ Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
   return Pointer<Int32>(result);
 }
 
-Dart__darwin_size_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(tSceneAsset.cast());
   return result;
 }
@@ -8635,7 +7273,7 @@ Pointer<TSceneAsset> SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, in
   return Pointer<TSceneAsset>(result);
 }
 
-Dart__darwin_size_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
+Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(tSceneAsset.cast());
   return result;
 }
@@ -8699,23 +7337,199 @@ void SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShadin
   return result;
 }
 
-void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dart__darwin_size_t skinIndex, Pointer<Int32> out) {
+void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Pointer<Int32> out) {
   final result = GeneratedBindings.instance._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
   return result;
 }
 
-Dart__darwin_size_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dart__darwin_size_t skinIndex) {
+Dartsize_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex) {
   final result = GeneratedBindings.instance._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
   return result;
 }
 
-Pointer<Char> SceneAsset_getBoneName(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dart__darwin_size_t skinIndex,
-  Dart__darwin_size_t boneIndex,
-) {
+Pointer<Char> SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Dartsize_t boneIndex) {
   final result = GeneratedBindings.instance._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
   return Pointer<Char>(result);
+}
+
+void MeshData_dispose(Pointer<TMeshData> meshData) {
+  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
+  return result;
+}
+
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  Pointer<Char> meshName,
+  Pointer<TMeshData> outMeshData,
+) {
+  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
+  return result;
+}
+
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+    tEngine.cast(),
+    tMaterialProvider.cast(),
+    tNameComponentManager.cast(),
+  );
+  return Pointer<TGltfAssetLoader>(result);
+}
+
+void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
+  return result;
+}
+
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  int numInstances,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    data,
+    length,
+    numInstances,
+  );
+  return Pointer<TFilamentAsset>(result);
+}
+
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
+    tRenderableManager.cast(),
+    tAsset.cast(),
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
+}
+
+int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
+  return result;
+}
+
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
+  return Pointer<PointerClass<Char>>(result);
+}
+
+void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
+    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+    tEngine.cast(),
+    assetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+  );
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
+  final result = GeneratedBindings.instance._Gizmo_pick(
+    tGizmo.cast(),
+    x,
+    y,
+    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
+  );
+  return result;
+}
+
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
+  return result;
+}
+
+void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
+}
+
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
+  return result;
+}
+
+Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
+  return Pointer<Char>(result);
+}
+
+Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
+  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
+  return Pointer<TRenderTarget>(result);
+}
+
+void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
+  return result;
 }
 
 Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
@@ -9044,6 +7858,1181 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
+void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
+  return result == 1;
+}
+
+bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+Dartsize_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
+  return result;
+}
+
+bool RenderableManager_setMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  Pointer<TMaterialInstance> tMaterialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    tMaterialInstance.cast(),
+  );
+  return result == 1;
+}
+
+Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+void RenderableManager_clearMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return result;
+}
+
+bool RenderableManager_setGeometryAtNonIndexed(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dartsize_t offset,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result == 1;
+}
+
+Dartsize_t RenderableManager_getPrimitiveCount(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+Aabb3 RenderableManager_getAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+void RenderableManager_setAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Aabb3 aabb,
+) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
+    tRenderableManager.cast(),
+    entityId,
+    aabbPtr.cast(),
+  );
+  return result;
+}
+
+Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAabb(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+void RenderableManager_setLayerMask(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int select,
+  int values,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
+    tRenderableManager.cast(),
+    entityId,
+    select,
+    values,
+  );
+  return result;
+}
+
+int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setVisibilityLayer(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int layer,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
+    tRenderableManager.cast(),
+    entityId,
+    layer,
+  );
+  return result;
+}
+
+void RenderableManager_setPriority(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setPriority(
+    tRenderableManager.cast(),
+    entityId,
+    priority,
+  );
+  return result;
+}
+
+int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
+  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
+  return result;
+}
+
+void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
+  return result;
+}
+
+bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setFogEnabled(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool RenderableManager_getLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+  );
+  return result == 1;
+}
+
+void RenderableManager_setCastShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool castShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
+    tRenderableManager.cast(),
+    entityId,
+    castShadows,
+  );
+  return result;
+}
+
+bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setReceiveShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool receiveShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
+    tRenderableManager.cast(),
+    entityId,
+    receiveShadows,
+  );
+  return result;
+}
+
+bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setScreenSpaceContactShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setBlendOrderAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dartsize_t primitiveIndex,
+  int order,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    order,
+  );
+  return result;
+}
+
+void RenderableManager_setGlobalBlendOrderEnabledAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dartsize_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setMorphWeights(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> weights,
+  Dartsize_t count,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
+    tRenderableManager.cast(),
+    entityId,
+    weights,
+    count,
+    offset,
+  );
+  return result;
+}
+
+Dartsize_t RenderableManager_getMorphTargetCount(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setBonesFromMat4(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> transforms,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
+    tRenderableManager.cast(),
+    entityId,
+    transforms,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+void RenderableManager_setBonesFromBone(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> bones,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
+    tRenderableManager.cast(),
+    entityId,
+    bones,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+Pointer<TRenderableBuilder> RenderableBuilder_create(Dartsize_t primitiveCount) {
+  final result = GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
+  return Pointer<TRenderableBuilder>(result);
+}
+
+void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
+  final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
+  return result;
+}
+
+void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
+  return result;
+}
+
+void RenderableBuilder_material(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  Pointer<TMaterialInstance> materialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_material(
+    builder.cast(),
+    primitiveIndex,
+    materialInstance.cast(),
+  );
+  return result;
+}
+
+void RenderableBuilder_geometry(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Pointer<TIndexBuffer> indices,
+  Dartsize_t offset,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_geometry(
+    builder.cast(),
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    indices.cast(),
+    offset,
+    count,
+  );
+  return result;
+}
+
+void RenderableBuilder_geometryNonIndexed(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dartsize_t offset,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_geometryNonIndexed(
+    builder.cast(),
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result;
+}
+
+void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
+  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
+  return result;
+}
+
+void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
+  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
+  return result;
+}
+
+void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
+  return result;
+}
+
+void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
+  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
+  return result;
+}
+
+void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dartsize_t primitiveIndex, int order) {
+  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
+  return result;
+}
+
+void RenderableBuilder_globalBlendOrderEnabled(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_globalBlendOrderEnabled(
+    builder.cast(),
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dartsize_t instanceCount) {
+  final result = GeneratedBindings.instance._RenderableBuilder_instances(builder.cast(), instanceCount);
+  return result;
+}
+
+void RenderableBuilder_skinningFromMat4(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t boneCount,
+  Pointer<Float32> transforms,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
+  return result;
+}
+
+void RenderableBuilder_skinningFromBone(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t boneCount,
+  Pointer<Float32> bones,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(builder.cast(), boneCount, bones);
+  return result;
+}
+
+void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_boneIndicesAndWeights(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  Pointer<Float32> indicesAndWeights,
+  Dartsize_t count,
+  Dartsize_t bonesPerVertex,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
+    builder.cast(),
+    primitiveIndex,
+    indicesAndWeights,
+    count,
+    bonesPerVertex,
+  );
+  return result;
+}
+
+int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
+  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
+  return result;
+}
+
+void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
+  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
+  return result;
+}
+
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
+  return result;
+}
+
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
+  return result;
+}
+
+void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
+  return result;
+}
+
+void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
+  return result;
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
+    camera.cast(),
+    projectionMatrixPtr.cast(),
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setModelMatrix(Pointer<TCamera> camera, double4x4 tModelMatrix) {
+  final tModelMatrixPtr = tModelMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrixPtr.cast());
+  return result;
+}
+
+void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
+  return result;
+}
+
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
+  return result;
+}
+
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
+  return result;
+}
+
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
+  return result;
+}
+
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
+  return result;
+}
+
+Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
+  return Pointer<TSkybox>(result);
+}
+
+void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
+  return result;
+}
+
+void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
+  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
+  return result;
+}
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
+  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
+  return result;
+}
+
+/// Returns the visibility mask bits.
+int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
+  return result;
+}
+
+/// Returns the skybox intensity in lux.
+double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
+  return result;
+}
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
+  return Pointer<TTexture>(result);
+}
+
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+  );
+  return result;
+}
+
+bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+  return result;
+}
+
+void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dartsize_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+  );
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+    tRenderer.cast(),
+    headRoomRatio,
+    scaleRate,
+    history,
+    interval,
+  );
+  return result;
+}
+
+void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
+  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+  return result;
+}
+
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
+  return Pointer<TGltfResourceLoader>(result);
+}
+
+void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
+  return result;
+}
+
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
+  return result;
+}
+
+double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
+  return result;
+}
+
+void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
+  return Pointer<Void>(result);
+}
+
+Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
+  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
+  return result;
+}
+
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(Pointer<TSurfaceOrientationBuilder> builder, Pointer<Uint32> triangles) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dartsize_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
+  return result;
+}
+
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
+  return result;
+}
+
 void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
   final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(executor.cast());
   return result;
@@ -9323,6 +9312,455 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+typedef size_t = int;
+typedef Dartsize_t = int;
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  }
+}
+
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
+  }
+}
+
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
+
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
+  }
+}
+
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
+
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
+  }
+}
+
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
+
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
+  }
+}
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
+  }
+}
+
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
+
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  }
+}
+
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
+  }
+}
+
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
+
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
+  }
+}
+
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
+  }
+}
+
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
+  }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+typedef EntityId = int;
+typedef DartEntityId = int;
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
+  }
+}
+
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
+
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
+  }
+}
+
+extension TRenderableManagerExt on Pointer<TRenderableManager> {
+  TRenderableManager toDart() {
+    return TRenderableManager(this);
+  }
+}
+
+final class TRenderableManager extends Struct {
+  Pointer<TRenderableManager> get address => super.address.cast();
+  TRenderableManager(super.address);
+
+  static Pointer<TRenderableManager> stackAlloc() {
+    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
+  }
+}
+
 extension TLightManagerExt on Pointer<TLightManager> {
   TLightManager toDart() {
     return TLightManager(this);
@@ -9338,413 +9776,78 @@ final class TLightManager extends Struct {
   }
 }
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-typedef EntityId = int;
-typedef DartEntityId = int;
-
-extension double3Ext on Pointer<double3> {
-  double3 toDart() {
-    return double3(this);
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
   }
 }
 
-final class double3 extends Struct {
-  Pointer<double3> get address => super.address.cast();
-  double get x {
-    final addr = Pointer<double3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
 
-  set x(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
-  }
-
-  double get y {
-    final addr = Pointer<double3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set y(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
-  }
-
-  double get z {
-    final addr = Pointer<double3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set z(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
-  }
-
-  double3(super.address);
-
-  static Pointer<double3> stackAlloc() {
-    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
   }
 }
 
-extension TShadowOptionsExt on Pointer<TShadowOptions> {
-  TShadowOptions toDart() {
-    return TShadowOptions(this);
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
   }
 }
 
-final class TShadowOptions extends Struct {
-  Pointer<TShadowOptions> get address => super.address.cast();
-  int get mapSize {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
 
-  set mapSize(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
-  }
-
-  int get shadowCascades {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set shadowCascades(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
-  }
-
-  Array<Float32> get cascadeSplitPositions {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float32>((numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
-  }
-
-  set cascadeSplitPositions(Array<Float32> val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 5), val.internal.addr.addr.toJS, '*');
-  }
-
-  double get constantBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constantBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
-  }
-
-  double get normalBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set normalBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
-  }
-
-  double get shadowFar {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFar(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
-  }
-
-  double get shadowNearHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowNearHint(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
-  }
-
-  double get shadowFarHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFarHint(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
-  }
-
-  bool get stable {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set stable(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 37), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  bool get lispsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set lispsm(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get polygonOffsetConstant {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetConstant(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
-  }
-
-  double get polygonOffsetSlope {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetSlope(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
-  }
-
-  bool get screenSpaceContactShadows {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set screenSpaceContactShadows(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 47), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  int get stepCount {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set stepCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
-  }
-
-  double get maxShadowDistance {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxShadowDistance(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
-  }
-
-  bool get vsmElvsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set vsmElvsm(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 53), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get vsmBlurWidth {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set vsmBlurWidth(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
-  }
-
-  double get shadowBulbRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowBulbRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
-  }
-
-  double get penumbraScale {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set penumbraScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
-  }
-
-  double get penumbraRatioScale {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set penumbraRatioScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
-  }
-
-  double get maxPenumbraRatio {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxPenumbraRatio(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
-  }
-
-  double get maxSearchRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxSearchRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
-  }
-
-  double get transformX {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformX(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
-  }
-
-  double get transformY {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformY(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
-  }
-
-  double get transformZ {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformZ(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
-  }
-
-  double get transformW {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformW(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
-  }
-
-  TShadowOptions(super.address);
-
-  static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
   }
 }
 
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
   }
 }
 
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
   }
 }
 
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
 
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
   }
 }
 
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
   }
 }
 
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
 
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
-  }
-}
-
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
-  }
-}
-
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
-
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
-  }
-}
-
-typedef size_t = __darwin_size_t;
-typedef __darwin_size_t = int;
-typedef Dart__darwin_size_t = int;
-
-extension TRenderableManagerExt on Pointer<TRenderableManager> {
-  TRenderableManager toDart() {
-    return TRenderableManager(this);
-  }
-}
-
-final class TRenderableManager extends Struct {
-  Pointer<TRenderableManager> get address => super.address.cast();
-  TRenderableManager(super.address);
-
-  static Pointer<TRenderableManager> stackAlloc() {
-    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
   }
 }
 
@@ -9803,21 +9906,6 @@ final class TViewport extends Struct {
   }
 }
 
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
-}
-
 extension TToneMapperExt on Pointer<TToneMapper> {
   TToneMapper toDart() {
     return TToneMapper(this);
@@ -9848,21 +9936,6 @@ final class TColorGradingBuilder extends Struct {
   }
 }
 
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
-}
-
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
-  }
-}
-
 sealed class TQualityLevel {
   static const LOW = 0;
   static const MEDIUM = 1;
@@ -9878,21 +9951,6 @@ sealed class TLutFormat {
 sealed class TBlendMode {
   static const OPAQUE = 0;
   static const TRANSLUCENT = 1;
-}
-
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
-  }
-}
-
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
-
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
-  }
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -10026,36 +10084,6 @@ final class TVsmShadowOptions extends Struct {
 
   static Pointer<TVsmShadowOptions> stackAlloc() {
     return Pointer<TVsmShadowOptions>(NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
-
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
-
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
   }
 }
 
@@ -10652,433 +10680,18 @@ typedef PickCallbackFunction =
 typedef DartPickCallbackFunction =
     void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
 
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
   }
 }
 
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
-
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
-  }
-}
-
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
-  }
-}
-
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
-
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
-  }
-}
-
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
-  }
-}
-
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
-
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
-  }
-}
-
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
-  }
-}
-
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
-
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
-  }
-}
-
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
-  }
-}
-
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
-
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
-  }
-}
-
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
-  }
-}
-
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
-
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
-  }
-}
-
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
-  }
-}
-
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
-
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
-  }
-}
-
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
-  }
-}
-
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
-
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
-  }
-}
-
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
-  }
-}
-
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
-
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
+
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
   }
 }
 
@@ -11180,78 +10793,53 @@ final class TBufferObject extends Struct {
   }
 }
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
   }
 }
 
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
 
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
   }
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
   }
 }
 
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
 
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
   }
 }
 
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
+extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
+  TBufferObjectBuilder toDart() {
+    return TBufferObjectBuilder(this);
   }
 }
 
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
+final class TBufferObjectBuilder extends Struct {
+  Pointer<TBufferObjectBuilder> get address => super.address.cast();
+  TBufferObjectBuilder(super.address);
 
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
-  }
-}
-
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
-  }
-}
-
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
-
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
-  }
-}
-
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
-  }
-}
-
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
-
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
+  static Pointer<TBufferObjectBuilder> stackAlloc() {
+    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
   }
 }
 
@@ -11307,26 +10895,6 @@ final class double4x4 extends Struct {
 
   static Pointer<double4x4> stackAlloc() {
     return Pointer<double4x4>(NativeLibrary.instance.stackAlloc<double4x4>(128));
-  }
-}
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
-  }
-}
-
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
-
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
   }
 }
 
@@ -11405,80 +10973,361 @@ final class Aabb3 extends Struct {
   }
 }
 
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
 }
 
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+extension double3Ext on Pointer<double3> {
+  double3 toDart() {
+    return double3(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class double3 extends Struct {
+  Pointer<double3> get address => super.address.cast();
+  double get x {
+    final addr = Pointer<double3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  set x(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
+  }
+
+  double get y {
+    final addr = Pointer<double3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set y(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
+  }
+
+  double get z {
+    final addr = Pointer<double3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set z(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
+  }
+
+  double3(super.address);
+
+  static Pointer<double3> stackAlloc() {
+    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
   }
 }
 
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
+extension TShadowOptionsExt on Pointer<TShadowOptions> {
+  TShadowOptions toDart() {
+    return TShadowOptions(this);
   }
 }
 
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
+final class TShadowOptions extends Struct {
+  Pointer<TShadowOptions> get address => super.address.cast();
+  int get mapSize {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
 
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  set mapSize(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
+  }
+
+  int get shadowCascades {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set shadowCascades(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
+  }
+
+  Array<Float32> get cascadeSplitPositions {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float32>((numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
+  }
+
+  set cascadeSplitPositions(Array<Float32> val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 5), val.internal.addr.addr.toJS, '*');
+  }
+
+  double get constantBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set constantBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
+  }
+
+  double get normalBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set normalBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
+  }
+
+  double get shadowFar {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFar(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
+  }
+
+  double get shadowNearHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowNearHint(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
+  }
+
+  double get shadowFarHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFarHint(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
+  }
+
+  bool get stable {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set stable(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 37), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  bool get lispsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set lispsm(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get polygonOffsetConstant {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetConstant(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
+  }
+
+  double get polygonOffsetSlope {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetSlope(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
+  }
+
+  bool get screenSpaceContactShadows {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set screenSpaceContactShadows(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 47), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  int get stepCount {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set stepCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
+  }
+
+  double get maxShadowDistance {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxShadowDistance(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
+  }
+
+  bool get vsmElvsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set vsmElvsm(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 53), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get vsmBlurWidth {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set vsmBlurWidth(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
+  }
+
+  double get shadowBulbRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowBulbRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
+  }
+
+  double get penumbraScale {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
+  }
+
+  double get penumbraRatioScale {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraRatioScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
+  }
+
+  double get maxPenumbraRatio {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxPenumbraRatio(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
+  }
+
+  double get maxSearchRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxSearchRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
+  }
+
+  TShadowOptions(super.address);
+
+  static Pointer<TShadowOptions> stackAlloc() {
+    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
   }
 }
 
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
   }
 }
 
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
 
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
   }
 }
 
-extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
-  TBufferObjectBuilder toDart() {
-    return TBufferObjectBuilder(this);
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
   }
 }
 
-final class TBufferObjectBuilder extends Struct {
-  Pointer<TBufferObjectBuilder> get address => super.address.cast();
-  TBufferObjectBuilder(super.address);
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
 
-  static Pointer<TBufferObjectBuilder> stackAlloc() {
-    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
   }
 }
 
@@ -11494,6 +11343,51 @@ final class TSceneAsset extends Struct {
 
   static Pointer<TSceneAsset> stackAlloc() {
     return Pointer<TSceneAsset>(NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
+  }
+}
+
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
+  }
+}
+
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
+
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
+  }
+}
+
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
+  }
+}
+
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
+  }
+}
+
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
+
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
   }
 }
 
@@ -11514,6 +11408,41 @@ sealed class TPrimitiveType {
   static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
+  }
+}
+
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
+
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
+  }
+}
+
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
+  }
+}
+
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
+
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  }
+}
+
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
   TRenderableBuilder toDart() {
     return TRenderableBuilder(this);
@@ -11527,6 +11456,16 @@ final class TRenderableBuilder extends Struct {
   static Pointer<TRenderableBuilder> stackAlloc() {
     return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
   }
+}
+
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
 extension TMeshDataExt on Pointer<TMeshData> {
@@ -11544,14 +11483,63 @@ final class TMeshData extends Struct {
   }
 }
 
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
+typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
+  }
+}
+
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
+
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
+  }
+}
+
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
+  }
+}
+
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
+
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
+  }
 }
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
@@ -11614,35 +11602,59 @@ extension StructAllocator on Struct {
       case TTextureSampler:
         final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
+      case TLinearImage:
+        final ptr = TLinearImage.stackAlloc();
         return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
+      case TKtx1Bundle:
+        final ptr = TKtx1Bundle.stackAlloc();
         return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
         return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
+      case TRenderer:
+        final ptr = TRenderer.stackAlloc();
         return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
+      case TSwapChain:
+        final ptr = TSwapChain.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
+      case TView:
+        final ptr = TView.stackAlloc();
         return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
+      case TScene:
+        final ptr = TScene.stackAlloc();
+        return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
+        return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
+        return ptr.toDart() as T;
+      case TTransformManager:
+        final ptr = TTransformManager.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableManager:
         final ptr = TRenderableManager.stackAlloc();
         return ptr.toDart() as T;
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TEntityManager:
+        final ptr = TEntityManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFence:
+        final ptr = TFence.stackAlloc();
+        return ptr.toDart() as T;
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
+      case TDebugRegistry:
+        final ptr = TDebugRegistry.stackAlloc();
+        return ptr.toDart() as T;
       case TViewport:
         final ptr = TViewport.stackAlloc();
-        return ptr.toDart() as T;
-      case TView:
-        final ptr = TView.stackAlloc();
         return ptr.toDart() as T;
       case TToneMapper:
         final ptr = TToneMapper.stackAlloc();
@@ -11650,23 +11662,11 @@ extension StructAllocator on Struct {
       case TColorGradingBuilder:
         final ptr = TColorGradingBuilder.stackAlloc();
         return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
-        return ptr.toDart() as T;
       case TSoftShadowOptions:
         final ptr = TSoftShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TVsmShadowOptions:
         final ptr = TVsmShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
         return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
@@ -11680,32 +11680,8 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TSurfaceOrientationBuilder:
-        final ptr = TSurfaceOrientationBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientation:
-        final ptr = TSurfaceOrientation.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
-      case TLinearImage:
-        final ptr = TLinearImage.stackAlloc();
-        return ptr.toDart() as T;
-      case TKtx1Bundle:
-        final ptr = TKtx1Bundle.stackAlloc();
-        return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
       case TVertexBufferBuilder:
         final ptr = TVertexBufferBuilder.stackAlloc();
@@ -11716,50 +11692,62 @@ extension StructAllocator on Struct {
       case TBufferObject:
         final ptr = TBufferObject.stackAlloc();
         return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderManager:
-        final ptr = TRenderManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderer:
-        final ptr = TRenderer.stackAlloc();
-        return ptr.toDart() as T;
-      case TAnimationManager:
-        final ptr = TAnimationManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TSwapChain:
-        final ptr = TSwapChain.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case TTransformManager:
-        final ptr = TTransformManager.stackAlloc();
-        return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
-        return ptr.toDart() as T;
-      case TEntityManager:
-        final ptr = TEntityManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFence:
-        final ptr = TFence.stackAlloc();
-        return ptr.toDart() as T;
-      case TDebugRegistry:
-        final ptr = TDebugRegistry.stackAlloc();
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
         return ptr.toDart() as T;
       case TBufferObjectBuilder:
         final ptr = TBufferObjectBuilder.stackAlloc();
         return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
+        return ptr.toDart() as T;
+      case double3:
+        final ptr = double3.stackAlloc();
+        return ptr.toDart() as T;
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderManager:
+        final ptr = TRenderManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TAnimationManager:
+        final ptr = TAnimationManager.stackAlloc();
+        return ptr.toDart() as T;
       case TSceneAsset:
         final ptr = TSceneAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableBuilder:
         final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TMeshData:
         final ptr = TMeshData.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientationBuilder:
+        final ptr = TSurfaceOrientationBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientation:
+        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -9155,34 +9155,34 @@ void TransformPipeline_setInvertMouseY(int invert) {
   return result;
 }
 
-extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
-  TMaterialInstance toDart() {
-    return TMaterialInstance(this);
-  }
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
 }
 
-final class TMaterialInstance extends Struct {
-  Pointer<TMaterialInstance> get address => super.address.cast();
-  TMaterialInstance(super.address);
-
-  static Pointer<TMaterialInstance> stackAlloc() {
-    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
-  }
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
-extension TMaterialExt on Pointer<TMaterial> {
-  TMaterial toDart() {
-    return TMaterial(this);
-  }
+sealed class TVertexBufferStorageMode {
+  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
+  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
+  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
 }
 
-final class TMaterial extends Struct {
-  Pointer<TMaterial> get address => super.address.cast();
-  TMaterial(super.address);
-
-  static Pointer<TMaterial> stackAlloc() {
-    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
-  }
+sealed class TSceneAssetGeometryCapability {
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_NONE = 0;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_BARYCENTRICS = 1;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_WRITABLE_VERTICES = 2;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_ACCESSIBLE_GEOMETRY_BUFFERS = 4;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_PRESERVED_TOPOLOGY = 8;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_UNIQUE_TRIANGLE_CORNERS = 16;
 }
 
 sealed class TFeatureLevel {
@@ -9192,56 +9192,73 @@ sealed class TFeatureLevel {
   static const FEATURE_LEVEL_3 = 3;
 }
 
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
-  }
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
-
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
-  }
+sealed class TVertexAttribute {
+  static const TVERTEX_ATTRIBUTE_POSITION = 0;
+  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
+  static const TVERTEX_ATTRIBUTE_COLOR = 2;
+  static const TVERTEX_ATTRIBUTE_UV0 = 3;
+  static const TVERTEX_ATTRIBUTE_UV1 = 4;
+  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
+  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
+  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
+  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
+  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
+  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
+  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
+  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
+  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
+  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
 }
 
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
+sealed class TVertexAttributeType {
+  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
+  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
+  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
+  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
+  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
+  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
+  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-extension TTextureExt on Pointer<TTexture> {
-  TTexture toDart() {
-    return TTexture(this);
-  }
-}
-
-final class TTexture extends Struct {
-  Pointer<TTexture> get address => super.address.cast();
-  TTexture(super.address);
-
-  static Pointer<TTexture> stackAlloc() {
-    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
-  }
-}
-
-extension TTextureSamplerExt on Pointer<TTextureSampler> {
-  TTextureSampler toDart() {
-    return TTextureSampler(this);
-  }
-}
-
-final class TTextureSampler extends Struct {
-  Pointer<TTextureSampler> get address => super.address.cast();
-  TTextureSampler(super.address);
-
-  static Pointer<TTextureSampler> stackAlloc() {
-    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
-  }
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
 }
 
 sealed class TSamplerCompareFunc {
@@ -9287,6 +9304,13 @@ sealed class TStencilFace {
   static const STENCIL_FACE_FRONT_AND_BACK = 3;
 }
 
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
 sealed class TTransparencyMode {
   /// ! the transparent object is drawn honoring the raster state
   static const DEFAULT = 0;
@@ -9310,6 +9334,81 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_MULTIPLY = 5;
   static const BLENDING_MODE_SCREEN = 6;
   static const BLENDING_MODE_CUSTOM = 7;
+}
+
+extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
+  TMaterialInstance toDart() {
+    return TMaterialInstance(this);
+  }
+}
+
+final class TMaterialInstance extends Struct {
+  Pointer<TMaterialInstance> get address => super.address.cast();
+  TMaterialInstance(super.address);
+
+  static Pointer<TMaterialInstance> stackAlloc() {
+    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
+  }
+}
+
+extension TMaterialExt on Pointer<TMaterial> {
+  TMaterial toDart() {
+    return TMaterial(this);
+  }
+}
+
+final class TMaterial extends Struct {
+  Pointer<TMaterial> get address => super.address.cast();
+  TMaterial(super.address);
+
+  static Pointer<TMaterial> stackAlloc() {
+    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  }
+}
+
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
+  }
+}
+
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
+
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  }
+}
+
+extension TTextureExt on Pointer<TTexture> {
+  TTexture toDart() {
+    return TTexture(this);
+  }
+}
+
+final class TTexture extends Struct {
+  Pointer<TTexture> get address => super.address.cast();
+  TTexture(super.address);
+
+  static Pointer<TTexture> stackAlloc() {
+    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
+  }
+}
+
+extension TTextureSamplerExt on Pointer<TTextureSampler> {
+  TTextureSampler toDart() {
+    return TTextureSampler(this);
+  }
+}
+
+final class TTextureSampler extends Struct {
+  Pointer<TTextureSampler> get address => super.address.cast();
+  TTextureSampler(super.address);
+
+  static Pointer<TTextureSampler> stackAlloc() {
+    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
+  }
 }
 
 sealed class TTextureSamplerType {
@@ -9433,24 +9532,6 @@ sealed class TTextureFormat {
   static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
 }
 
-typedef size_t = int;
-typedef Dartsize_t = int;
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
-  }
-}
-
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
-
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
-  }
-}
-
 /// ! Pixel Data Format
 sealed class TPixelDataFormat {
   /// !< One Red channel, float
@@ -9561,6 +9642,24 @@ sealed class TTextureUsage {
   static const TEXTURE_USAGE_DEFAULT = 24;
 }
 
+typedef size_t = int;
+typedef Dartsize_t = int;
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  }
+}
+
 extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
   TKtx1Bundle toDart() {
     return TKtx1Bundle(this);
@@ -9596,6 +9695,12 @@ final class TRenderTarget extends Struct {
   }
 }
 
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
 sealed class TSamplerMinFilter {
   static const FILTER_NEAREST = 0;
   static const FILTER_LINEAR = 1;
@@ -9608,12 +9713,6 @@ sealed class TSamplerMinFilter {
 sealed class TSamplerMagFilter {
   static const MAG_FILTER_NEAREST = 0;
   static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
 }
 
 sealed class TSamplerCompareMode {
@@ -9851,6 +9950,23 @@ final class TDebugRegistry extends Struct {
   }
 }
 
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
+}
+
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
+}
+
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
+}
+
 extension TViewportExt on Pointer<TViewport> {
   TViewport toDart() {
     return TViewport(this);
@@ -9934,23 +10050,6 @@ final class TColorGradingBuilder extends Struct {
   static Pointer<TColorGradingBuilder> stackAlloc() {
     return Pointer<TColorGradingBuilder>(NativeLibrary.instance.stackAlloc<TColorGradingBuilder>(0));
   }
-}
-
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
-}
-
-sealed class TLutFormat {
-  static const INTEGER = 0;
-  static const FLOAT = 1;
-}
-
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -10085,6 +10184,11 @@ final class TVsmShadowOptions extends Struct {
   static Pointer<TVsmShadowOptions> stackAlloc() {
     return Pointer<TVsmShadowOptions>(NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
   }
+}
+
+sealed class TAmbientOcclusionType {
+  static const SAO = 0;
+  static const GTAO = 1;
 }
 
 /// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
@@ -10511,11 +10615,6 @@ final class TGtao extends Struct {
   }
 }
 
-sealed class TAmbientOcclusionType {
-  static const SAO = 0;
-  static const GTAO = 1;
-}
-
 /// Copied from FogOptions in View.h
 
 extension TFogOptionsExt on Pointer<TFogOptions> {
@@ -10710,59 +10809,6 @@ final class TVertexBufferBuilder extends Struct {
   }
 }
 
-sealed class TVertexBufferStorageMode {
-  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
-  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
-  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
-}
-
-sealed class TVertexAttribute {
-  static const TVERTEX_ATTRIBUTE_POSITION = 0;
-  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
-  static const TVERTEX_ATTRIBUTE_COLOR = 2;
-  static const TVERTEX_ATTRIBUTE_UV0 = 3;
-  static const TVERTEX_ATTRIBUTE_UV1 = 4;
-  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
-  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
-  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
-  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
-  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
-  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
-  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
-  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
-  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
-  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
-}
-
-sealed class TVertexAttributeType {
-  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
-  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
-  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
-  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
-  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
-  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
-  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
-}
-
 extension TVertexBufferExt on Pointer<TVertexBuffer> {
   TVertexBuffer toDart() {
     return TVertexBuffer(this);
@@ -10806,11 +10852,6 @@ final class TIndexBufferBuilder extends Struct {
   static Pointer<TIndexBufferBuilder> stackAlloc() {
     return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
   }
-}
-
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
 }
 
 extension TIndexBufferExt on Pointer<TIndexBuffer> {
@@ -11391,23 +11432,6 @@ final class TFilamentAsset extends Struct {
   }
 }
 
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
-}
-
 extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
   TGltfResourceLoader toDart() {
     return TGltfResourceLoader(this);
@@ -11421,11 +11445,6 @@ final class TGltfResourceLoader extends Struct {
   static Pointer<TGltfResourceLoader> stackAlloc() {
     return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
   }
-}
-
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
 }
 
 extension TGizmoExt on Pointer<TGizmo> {
@@ -11458,16 +11477,6 @@ final class TRenderableBuilder extends Struct {
   }
 }
 
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
-}
-
 extension TMeshDataExt on Pointer<TMeshData> {
   TMeshData toDart() {
     return TMeshData(this);
@@ -11488,6 +11497,12 @@ typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction
 typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
 typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
 
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
 sealed class TGizmoPickResultType {
   static const AxisX = 0;
   static const AxisY = 1;
@@ -11500,12 +11515,6 @@ typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
 typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
 typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
 typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
 
 sealed class TProjection {
   static const Perspective = 0;
@@ -11540,6 +11549,35 @@ final class TSurfaceOrientation extends Struct {
   static Pointer<TSurfaceOrientation> stackAlloc() {
     return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
   }
+}
+
+sealed class TIntentAction {
+  static const INTENT_ACTION_MOVE_FORWARD = 0;
+  static const INTENT_ACTION_MOVE_BACKWARD = 1;
+  static const INTENT_ACTION_MOVE_LEFT = 2;
+  static const INTENT_ACTION_MOVE_RIGHT = 3;
+  static const INTENT_ACTION_JUMP = 4;
+  static const INTENT_ACTION_SPRINT = 5;
+  static const INTENT_ACTION_CUSTOM1 = 6;
+  static const INTENT_ACTION_CUSTOM2 = 7;
+  static const INTENT_ACTION_CUSTOM3 = 8;
+  static const INTENT_ACTION_CUSTOM4 = 9;
+  static const INTENT_ACTION_CUSTOM5 = 10;
+  static const INTENT_ACTION_CUSTOM6 = 11;
+  static const INTENT_ACTION_CUSTOM7 = 12;
+  static const INTENT_ACTION_CUSTOM8 = 13;
+  static const INTENT_ACTION_CUSTOM9 = 14;
+  static const INTENT_ACTION_CUSTOM10 = 15;
+  static const INTENT_ACTION_CROUCH = 16;
+  static const INTENT_ACTION_INTERACT = 17;
+  static const INTENT_ACTION_USE_ITEM = 18;
+  static const INTENT_ACTION_RELOAD = 19;
+  static const INTENT_ACTION_ALT_FIRE = 20;
+}
+
+sealed class TMovementSpace {
+  static const MOVEMENT_SPACE_WORLD = 0;
+  static const MOVEMENT_SPACE_OBJECT = 1;
 }
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -132,148 +132,192 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external int _MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance);
   external int _Material_getBlendingMode(Pointer<TMaterial> material);
-  external int _LightManager_createLight(
+  external Pointer<TTexture> _Texture_build(
+    Pointer<TEngine> engine,
+    int width,
+    int height,
+    int depth,
+    int levels,
+    int tUsage,
+    int import1,
+    int sampler,
+    int format,
+  );
+  external void _Texture_setExternalImage(
     Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
+    Pointer<TTexture> tTexture,
+    Pointer<Void> externalImage,
   );
-  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
+  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
+  external int _Texture_loadImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<TLinearImage> tImage,
+    int bufferFormat,
+    int pixelDataType,
+    int level,
   );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
+  external int _Texture_setImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    int level,
+    Pointer<Uint8> data,
+    size_t size,
+    int x_offset,
+    int y_offset,
+    int z_offset,
+    int width,
+    int height,
+    int depth,
+    int bufferFormat,
+    int pixelDataType,
   );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
+  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getFormat(Pointer<TTexture> tTexture);
+  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
+  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
+  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
+  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
+  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
+  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
+  external Pointer<TTexture> _Ktx1Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TKtx1Bundle> tBundle,
+    int requestId,
+    VoidCallback onTextureUploadComplete,
   );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
+  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
+  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
+  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
+  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
+  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
+  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TTextureSampler> _TextureSampler_create();
+  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
+    int minFilter,
+    int magFilter,
+    int wrapS,
+    int wrapT,
+    int wrapR,
   );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
+  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
+  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
+  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
+  external Pointer<TEngine> _Engine_create(
+    int backend,
+    Pointer<Void> platform,
+    Pointer<Void> sharedContext,
+    int stereoscopicEyeCount,
+    bool disableHandleUseAfterFreeCheck,
+  );
+  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
+  external void _Engine_destroy(Pointer<TEngine> tEngine);
+  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
+  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
+  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
+    Pointer<TEngine> tEngine,
+    int width,
+    int height,
+    JSBigInt flags,
+  );
+  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
+  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
+  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
+  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
+  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
+  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
+  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
+  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
+  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
+  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
+  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
+  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
+  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
+  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
+  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
+  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
+  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
+  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
+  external void _Engine_execute(Pointer<TEngine> tEngine);
+  external Pointer<TMaterial> _Engine_buildMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> materialData,
+    size_t length,
+  );
+  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
+  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
+  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
+  external Pointer<TSkybox> _Engine_buildSkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    bool showSun,
+    double intensity,
+    int priority,
+  );
+  external Pointer<TSkybox> _Engine_buildColoredSkybox(
+    Pointer<TEngine> tEngine,
     double r,
     double g,
     double b,
+    double a,
+    bool showSun,
+    double intensity,
+    int priority,
   );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<TTexture> tIrradianceTexture,
     double intensity,
   );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
-  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
-  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
-  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
-  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
-  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
-  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
-  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
-  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
     Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<Float32> irradianceHarmonics,
+    double intensity,
   );
-  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
+  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
+  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
+  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
+  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
+  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
+  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
+  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
+  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
+  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
+  external int _DebugRegistry_setProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    double value,
   );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
+  external int _DebugRegistry_getProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Bool> outValue,
   );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
-  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
+  external int _DebugRegistry_getProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Int32> outValue,
+  );
+  external int _DebugRegistry_getProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Float32> outValue,
+  );
   external void _View_getViewport(Pointer<TViewport> TViewport_out, Pointer<TView> view);
   external Pointer<TToneMapper> _ToneMapper_createLinear(Pointer<TEngine> tEngine);
   external Pointer<TToneMapper> _ToneMapper_createACES(Pointer<TEngine> tEngine);
@@ -410,168 +454,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _View_pick(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
   external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
   external Pointer<Char> _View_getName(Pointer<TView> tView);
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
-  );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
-  );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
-  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
-  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
-  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
-  external Pointer<TTexture> _Texture_build(
-    Pointer<TEngine> engine,
-    int width,
-    int height,
-    int depth,
-    int levels,
-    int tUsage,
-    int import1,
-    int sampler,
-    int format,
-  );
-  external void _Texture_setExternalImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<Void> externalImage,
-  );
-  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
-  external int _Texture_loadImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<TLinearImage> tImage,
-    int bufferFormat,
-    int pixelDataType,
-    int level,
-  );
-  external int _Texture_setImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    int level,
-    Pointer<Uint8> data,
-    size_t size,
-    int x_offset,
-    int y_offset,
-    int z_offset,
-    int width,
-    int height,
-    int depth,
-    int bufferFormat,
-    int pixelDataType,
-  );
-  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getFormat(Pointer<TTexture> tTexture);
-  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
-  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
-  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
-  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
-  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
-  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
-  external Pointer<TTexture> _Ktx1Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TKtx1Bundle> tBundle,
-    int requestId,
-    VoidCallback onTextureUploadComplete,
-  );
-  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
-  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
-  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
-  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
-  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
-  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTextureSampler> _TextureSampler_create();
-  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
-    int minFilter,
-    int magFilter,
-    int wrapS,
-    int wrapT,
-    int wrapR,
-  );
-  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
-  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
-  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
-  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
-  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-  external void _FrameScheduler_stop();
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external void _Gizmo_dummy(int t);
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
-  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
-  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
     bool doubleSided,
@@ -613,23 +495,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     bool hasIOR,
     bool hasVolume,
   );
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
-  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
-  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
   external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
   external void _VertexBufferBuilder_bufferCount(Pointer<TVertexBufferBuilder> builder, int count);
   external void _VertexBufferBuilder_vertexCount(Pointer<TVertexBufferBuilder> builder, int count);
@@ -665,95 +530,38 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TBufferObject> bufferObject,
   );
   external void _VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer);
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
+  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
-  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
-  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
-  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
-  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
+  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
+  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
   );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
+  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
+  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
+  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
+  external Pointer<TBufferObject> _BufferObjectBuilder_build(
+    Pointer<TBufferObjectBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
+  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
+  external void _BufferObject_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TBufferObject> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
   );
-  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
-  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
-  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
-  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
-  );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<double4x4> tModelMatrixPtr);
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
+  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
   external void _TransformManager_getLocalTransform(
     Pointer<double4x4> double4x4_out,
     Pointer<TTransformManager> tTransformManager,
@@ -796,161 +604,124 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
   external void _TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
-  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
-  external Pointer<TEngine> _Engine_create(
-    int backend,
-    Pointer<Void> platform,
-    Pointer<Void> sharedContext,
-    int stereoscopicEyeCount,
-    bool disableHandleUseAfterFreeCheck,
-  );
-  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
-  external void _Engine_destroy(Pointer<TEngine> tEngine);
-  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
-  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
-  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
+  external int _LightManager_createLight(
     Pointer<TEngine> tEngine,
-    int width,
-    int height,
-    JSBigInt flags,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
   );
-  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
-  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
-  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
-  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
-  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
-  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
-  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
-  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
-  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
-  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
-  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
-  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
-  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
-  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
-  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
-  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
-  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
-  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
-  external void _Engine_execute(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Engine_buildMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> materialData,
-    size_t length,
+  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
   );
-  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
-  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
-  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
-  external Pointer<TSkybox> _Engine_buildSkybox(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    bool showSun,
-    double intensity,
-    int priority,
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
   );
-  external Pointer<TSkybox> _Engine_buildColoredSkybox(
-    Pointer<TEngine> tEngine,
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double r,
     double g,
     double b,
-    double a,
-    bool showSun,
+  );
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double intensity,
-    int priority,
   );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<TTexture> tIrradianceTexture,
-    double intensity,
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
   );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<Float32> irradianceHarmonics,
-    double intensity,
+  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
+  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
   );
-  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
-  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
-  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
-  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
-  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
-  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
-  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
-  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
-  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
-  external int _DebugRegistry_setProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    double value,
+  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
   );
-  external int _DebugRegistry_getProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Bool> outValue,
+  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
+  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
   );
-  external int _DebugRegistry_getProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Int32> outValue,
+  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
+  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
   );
-  external int _DebugRegistry_getProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Float32> outValue,
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
   );
-  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
-  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
-  external Pointer<TBufferObject> _BufferObjectBuilder_build(
-    Pointer<TBufferObjectBuilder> builder,
-    Pointer<TEngine> engine,
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
   );
-  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
-  external void _BufferObject_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TBufferObject> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
+  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
+  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
+  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
   );
-  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
+  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
   external Pointer<Void> _RenderThread_create();
   external Pointer<Void> _RenderThread_createForCanvas(Pointer<Char> canvasSelector);
   external void _RenderThread_destroy(Pointer<Void> renderThread);
@@ -2020,43 +1791,238 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
-  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    int vertexBufferStorageMode,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
     Pointer<TFilamentAsset> tFilamentAsset,
+    int requiredGeometryCapabilities,
   );
-  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
+  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
+  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
   );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
-
-  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
-
-  /// Returns the visibility mask bits.
-  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
-
-  /// Returns the skybox intensity in lux.
-  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
-
-  /// Returns the environment texture, or nullptr for a color-only skybox.
-  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
+  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
+  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
+  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
+  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
+  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
   external void _MeshData_dispose(Pointer<TMeshData> meshData);
   external int _GltfParser_parseBuffer(
     Pointer<Uint8> data,
     size_t length,
     Pointer<Char> meshName,
     Pointer<TMeshData> outMeshData,
+  );
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
+  );
+  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
+  );
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
+  );
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
+  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
+  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+  external void _FrameScheduler_stop();
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Gizmo_dummy(int t);
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+  );
+  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
+  );
+  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
+  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
+  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
+  external int _AnimationManager_addGltfAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_removeGltfAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _AnimationManager_addMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+  );
+  external void _AnimationManager_removeMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+  );
+  external int _AnimationManager_addBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_removeBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_setMorphAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    Pointer<Uint32> morphIndices,
+    int numMorphTargets,
+    int numFrames,
+    double frameLengthInMs,
+  );
+  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
+  external void _AnimationManager_resetToRestPose(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external int _AnimationManager_addBoneAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> frameData,
+    int numFrames,
+    double frameLengthInMs,
+    double fadeOutInSecs,
+    double fadeInInSecs,
+    double maxDelta,
+    bool loop,
+  );
+  external void _AnimationManager_getRestLocalTransforms(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    Pointer<Float32> out,
+    int numBones,
+  );
+  external void _AnimationManager_getInverseBindMatrix(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> out,
+  );
+  external int _AnimationManager_playGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+    bool loop,
+    bool reverse,
+    bool replaceActive,
+    double crossfade,
+    double startOffset,
+    double speed,
+  );
+  external int _AnimationManager_stopGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int index,
+  );
+  external double _AnimationManager_getGltfAnimationDuration(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int animationIndex,
+  );
+  external int _AnimationManager_getGltfAnimationCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external void _AnimationManager_getGltfAnimationName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_getMorphTargetNameCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+  );
+  external void _AnimationManager_getMorphTargetName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_updateBoneMatrices(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external int _AnimationManager_setMorphTargetWeights(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    int numWeights,
+  );
+  external int _AnimationManager_setGltfAnimationTime(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int animationIndex,
+    double timeInSeconds,
   );
   external void _RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
   external int _RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
@@ -2272,181 +2238,215 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t bonesPerVertex,
   );
   external int _RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, EntityId entity);
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    int vertexBufferStorageMode,
-    Pointer<Aabb3> boundingBoxPtr,
+  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
+  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<double4x4> tModelMatrixPtr);
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
+  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
+  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
+  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
+  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
+
+  /// Returns the visibility mask bits.
+  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
+
+  /// Returns the skybox intensity in lux.
+  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
+
+  /// Returns the environment texture, or nullptr for a color-only skybox.
+  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
+  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
+  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
+  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
     Pointer<TFilamentAsset> tFilamentAsset,
-    int requiredGeometryCapabilities,
   );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
-  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
-  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
+  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
   );
-  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
-  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
-  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
-  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
-  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
-  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
-  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
-  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
-  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
-  external int _AnimationManager_addGltfAnimationComponent(
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
+  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
+  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
     Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
   );
-  external int _AnimationManager_removeGltfAnimationComponent(
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
     Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _AnimationManager_addMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
+  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
   );
-  external void _AnimationManager_removeMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
+  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
+  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
+  external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
   );
-  external int _AnimationManager_addBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
   );
-  external int _AnimationManager_removeBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
   );
-  external int _AnimationManager_setMorphAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    Pointer<Uint32> morphIndices,
-    int numMorphTargets,
-    int numFrames,
-    double frameLengthInMs,
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
   );
-  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
-  external void _AnimationManager_resetToRestPose(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
+  external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
   );
-  external int _AnimationManager_addBoneAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> frameData,
-    int numFrames,
-    double frameLengthInMs,
-    double fadeOutInSecs,
-    double fadeInInSecs,
-    double maxDelta,
-    bool loop,
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
   );
-  external void _AnimationManager_getRestLocalTransforms(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
+  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
+  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
     Pointer<Float32> out,
-    int numBones,
+    size_t quatCount,
+    size_t stride,
   );
-  external void _AnimationManager_getInverseBindMatrix(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> out,
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
   );
-  external int _AnimationManager_playGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-    bool loop,
-    bool reverse,
-    bool replaceActive,
-    double crossfade,
-    double startOffset,
-    double speed,
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
   );
-  external int _AnimationManager_stopGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int index,
-  );
-  external double _AnimationManager_getGltfAnimationDuration(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int animationIndex,
-  );
-  external int _AnimationManager_getGltfAnimationCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external void _AnimationManager_getGltfAnimationName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_getMorphTargetNameCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-  );
-  external void _AnimationManager_getMorphTargetName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_updateBoneMatrices(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_setMorphTargetWeights(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    int numWeights,
-  );
-  external int _AnimationManager_setGltfAnimationTime(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int animationIndex,
-    double timeInSeconds,
-  );
+  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
   external void _MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor);
   external void _MovementIntentExecutor_process(
     Pointer<TMovementIntentExecutor> executor,
@@ -2833,341 +2833,587 @@ int Material_getBlendingMode(Pointer<TMaterial> material) {
   return result;
 }
 
-int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-    tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
-  );
-  return result;
-}
-
-void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
+Pointer<TTexture> Texture_build(
+  Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import1,
+  int sampler,
+  int format,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
+  final result = GeneratedBindings.instance._Texture_build(
+    engine.cast(),
+    width,
+    height,
+    depth,
+    levels,
+    tUsage,
+    import1,
+    sampler,
+    format,
   );
+  return Pointer<TTexture>(result);
+}
+
+void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
+  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
   return result;
 }
 
-double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+Dartsize_t Texture_getLevels(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
   return result;
 }
 
-void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
-  );
-  return result;
-}
-
-double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
-  return result;
-}
-
-double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
-  );
-  return result;
-}
-
-double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
-  return result;
-}
-
-double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
-  return result;
-}
-
-double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
-  return result;
-}
-
-bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
-  return result;
-}
-
-void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
-  return result;
-}
-
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-) {
-  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
-    splitPositions,
-    cascades,
-    near,
-    far,
-    lambda,
-  );
-  return result;
-}
-
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
-  return result;
-}
-
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
-  return result;
-}
-
-void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
-  return Pointer<Void>(result);
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+bool Texture_loadImage(
   Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TTexture> tTexture,
+  Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
 ) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+  final result = GeneratedBindings.instance._Texture_loadImage(
     tEngine.cast(),
-    tMaterialProvider.cast(),
-    tNameComponentManager.cast(),
+    tTexture.cast(),
+    tImage.cast(),
+    bufferFormat,
+    pixelDataType,
+    level,
   );
-  return Pointer<TGltfAssetLoader>(result);
+  return result == 1;
 }
 
-void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
-  return result;
-}
-
-Pointer<TFilamentAsset> GltfAssetLoader_load(
+bool Texture_setImage(
   Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TTexture> tTexture,
+  int level,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-  int numInstances,
+  Dartsize_t size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
 ) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+  final result = GeneratedBindings.instance._Texture_setImage(
     tEngine.cast(),
-    tAssetLoader.cast(),
+    tTexture.cast(),
+    level,
     data,
-    length,
-    numInstances,
+    size,
+    x_offset,
+    y_offset,
+    z_offset,
+    width,
+    height,
+    depth,
+    bufferFormat,
+    pixelDataType,
   );
-  return Pointer<TFilamentAsset>(result);
+  return result == 1;
 }
 
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
-    tRenderableManager.cast(),
-    tAsset.cast(),
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
-}
-
-int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
+int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
   return result;
 }
 
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
-  return Pointer<PointerClass<Char>>(result);
+int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getFormat(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
+  return result;
+}
+
+int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
+  return result;
+}
+
+void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
+  return result;
+}
+
+Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dartsize_t length) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
+  return Pointer<TKtx1Bundle>(result);
+}
+
+void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
+  return result;
+}
+
+bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
+  return result == 1;
+}
+
+void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
+  return result;
+}
+
+Pointer<TTexture> Ktx1Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  DartVoidCallback onTextureUploadComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
+    tEngine.cast(),
+    tBundle.cast(),
+    requestId,
+    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dartsize_t size) {
+  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
+  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dartsize_t length, Pointer<Char> name, bool alpha) {
+  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
+  return Pointer<Float32>(result);
+}
+
+void Image_destroy(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+  return result;
+}
+
+int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
+  return result;
+}
+
+int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
+  return result;
+}
+
+int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
+  return result;
+}
+
+Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_create() {
+  final result = GeneratedBindings.instance._TextureSampler_create();
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
+    minFilter,
+    magFilter,
+    wrapS,
+    wrapT,
+    wrapR,
+  );
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
+  return Pointer<TTextureSampler>(result);
+}
+
+void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
+  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
+  return result;
+}
+
+void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
+  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
+  return result;
+}
+
+void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
+  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
+  return result;
+}
+
+Pointer<TEngine> Engine_create(
+  int backend,
+  Pointer<Void> platform,
+  Pointer<Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+) {
+  final result = GeneratedBindings.instance._Engine_create(
+    backend,
+    platform,
+    sharedContext,
+    stereoscopicEyeCount,
+    disableHandleUseAfterFreeCheck,
+  );
+  return Pointer<TEngine>(result);
+}
+
+int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
+  return result;
+}
+
+void Engine_destroy(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
+  return result;
+}
+
+Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
+  return Pointer<TRenderer>(result);
+}
+
+void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
+  return result;
+}
+
+Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
+    tEngine.cast(),
+    width,
+    height,
+    flags.toJSBigInt,
+  );
+  return Pointer<TSwapChain>(result);
+}
+
+void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
+  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
+  return result;
+}
+
+void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
+  return result;
+}
+
+void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
+  return result;
+}
+
+void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
+  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
+  return result;
+}
+
+Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
+  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
+  return result;
+}
+
+Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
+  return Pointer<TView>(result);
+}
+
+Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
+  return Pointer<TTransformManager>(result);
+}
+
+Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
+  return Pointer<TRenderableManager>(result);
+}
+
+Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
+  return Pointer<TLightManager>(result);
+}
+
+Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
+  return Pointer<TEntityManager>(result);
+}
+
+void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
+  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
+  return result;
+}
+
+Dartsize_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
+  return result;
+}
+
+void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
+  return result;
+}
+
+Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
+  return Pointer<TFence>(result);
+}
+
+void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
+  return result;
+}
+
+void Engine_flushAndWait(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
+  return result;
+}
+
+void Engine_execute(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
+  return result;
+}
+
+Pointer<TMaterial> Engine_buildMaterial(Pointer<TEngine> tEngine, Pointer<Uint8> materialData, Dartsize_t length) {
+  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
+  return Pointer<TMaterial>(result);
+}
+
+void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
+  return result;
+}
+
+void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
+  return result;
+}
+
+Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
+  return Pointer<TScene>(result);
+}
+
+Pointer<TSkybox> Engine_buildSkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._Engine_buildSkybox(
+    tEngine.cast(),
+    tTexture.cast(),
+    showSun,
+    intensity,
+    priority,
+  );
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TSkybox> Engine_buildColoredSkybox(
+  Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
+    tEngine.cast(),
+    r,
+    g,
+    b,
+    a,
+    showSun,
+    intensity,
+    priority,
+  );
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    tIrradianceTexture.cast(),
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<Float32> irradianceHarmonics,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    irradianceHarmonics,
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
+  return result;
+}
+
+void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
+  return result;
+}
+
+DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
+  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
+  return result;
+}
+
+void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
+  return result;
+}
+
+void Fence_waitAndDestroy(Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
+  return result;
+}
+
+Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
+  return Pointer<TDebugRegistry>(result);
+}
+
+bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
+  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Bool> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Int32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Float32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
 }
 
 TViewport View_getViewport(Pointer<TView> view) {
@@ -3647,503 +3893,6 @@ Pointer<Char> View_getName(Pointer<TView> tView) {
   return Pointer<Char>(result);
 }
 
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
-  return result;
-}
-
-Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
-  return Pointer<Char>(result);
-}
-
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dart__darwin_size_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, Dart__darwin_size_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(Pointer<TSurfaceOrientationBuilder> builder, Pointer<Uint32> triangles) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dart__darwin_size_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
-  return result;
-}
-
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dart__darwin_size_t quatCount,
-  Dart__darwin_size_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
-  return result;
-}
-
-void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
-  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
-  return result;
-}
-
-Pointer<TTexture> Texture_build(
-  Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import1,
-  int sampler,
-  int format,
-) {
-  final result = GeneratedBindings.instance._Texture_build(
-    engine.cast(),
-    width,
-    height,
-    depth,
-    levels,
-    tUsage,
-    import1,
-    sampler,
-    format,
-  );
-  return Pointer<TTexture>(result);
-}
-
-void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
-  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
-  return result;
-}
-
-Dart__darwin_size_t Texture_getLevels(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
-  return result;
-}
-
-bool Texture_loadImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-) {
-  final result = GeneratedBindings.instance._Texture_loadImage(
-    tEngine.cast(),
-    tTexture.cast(),
-    tImage.cast(),
-    bufferFormat,
-    pixelDataType,
-    level,
-  );
-  return result == 1;
-}
-
-bool Texture_setImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  int level,
-  Pointer<Uint8> data,
-  Dart__darwin_size_t size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-) {
-  final result = GeneratedBindings.instance._Texture_setImage(
-    tEngine.cast(),
-    tTexture.cast(),
-    level,
-    data,
-    size,
-    x_offset,
-    y_offset,
-    z_offset,
-    width,
-    height,
-    depth,
-    bufferFormat,
-    pixelDataType,
-  );
-  return result == 1;
-}
-
-int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getFormat(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
-  return result;
-}
-
-int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
-  return result;
-}
-
-void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
-  return result;
-}
-
-Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dart__darwin_size_t length) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
-  return Pointer<TKtx1Bundle>(result);
-}
-
-void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
-  return result;
-}
-
-bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
-  return result == 1;
-}
-
-void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
-  return result;
-}
-
-Pointer<TTexture> Ktx1Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  DartVoidCallback onTextureUploadComplete,
-) {
-  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
-    tEngine.cast(),
-    tBundle.cast(),
-    requestId,
-    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dart__darwin_size_t size) {
-  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
-  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dart__darwin_size_t length, Pointer<Char> name, bool alpha) {
-  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
-  return Pointer<Float32>(result);
-}
-
-void Image_destroy(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
-  return result;
-}
-
-int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
-  return result;
-}
-
-int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
-  return result;
-}
-
-int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
-  return result;
-}
-
-Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_create() {
-  final result = GeneratedBindings.instance._TextureSampler_create();
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
-    minFilter,
-    magFilter,
-    wrapS,
-    wrapT,
-    wrapR,
-  );
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
-  return Pointer<TTextureSampler>(result);
-}
-
-void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
-  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
-  return result;
-}
-
-void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
-  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
-  return result;
-}
-
-void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
-  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
-  return result;
-}
-
-void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
-    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
-  return result;
-}
-
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-    tEngine.cast(),
-    assetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
-  );
-  return Pointer<TGizmo>(result);
-}
-
-void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
-  final result = GeneratedBindings.instance._Gizmo_pick(
-    tGizmo.cast(),
-    x,
-    y,
-    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
-  );
-  return result;
-}
-
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
-  return result;
-}
-
-void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
-}
-
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -4229,58 +3978,6 @@ Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   return Pointer<TMaterialInstance>(result);
 }
 
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
-}
-
-void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
-  return result;
-}
-
-void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
-  return result;
-}
-
-Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dart__darwin_size_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
-  return result;
-}
-
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
-  return result;
-}
-
 Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
   final result = GeneratedBindings.instance._VertexBufferBuilder_create();
   return Pointer<TVertexBufferBuilder>(result);
@@ -4340,7 +4037,7 @@ void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
   return result;
 }
 
-Dart__darwin_size_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
+Dartsize_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
   final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(buffer.cast());
   return result;
 }
@@ -4350,7 +4047,7 @@ void VertexBuffer_setBufferAt(
   Pointer<TVertexBuffer> buffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
 ) {
   final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
@@ -4384,286 +4081,97 @@ void VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer
   return result;
 }
 
-Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
-  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
-  return Pointer<TRenderTarget>(result);
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
 }
 
-void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
+void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
   return result;
 }
 
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
+void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
   return result;
 }
 
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
+Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
   return result;
 }
 
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
+Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
   return result;
 }
 
-Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
-  return Pointer<TSkybox>(result);
-}
-
-void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
-  return result;
-}
-
-void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
-  return result;
-}
-
-Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
 ) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
   );
   return result;
 }
 
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
+void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
+  return result;
+}
+
+Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
+  return Pointer<TBufferObjectBuilder>(result);
+}
+
+void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
+  return result;
+}
+
+Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TBufferObject>(result);
+}
+
+void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
+  return result;
+}
+
+void BufferObject_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TBufferObject> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
 ) {
-  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
+  final result = GeneratedBindings.instance._BufferObject_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
   );
   return result;
 }
 
-void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
-  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
-  return result;
-}
-
-void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
-  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
-  return result;
-}
-
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
-  return result;
-}
-
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
-  return result;
-}
-
-void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
-  return result;
-}
-
-void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
-    camera.cast(),
-    projectionMatrixPtr.cast(),
-    near,
-    far,
-  );
-  return result;
-}
-
-void Camera_setModelMatrix(Pointer<TCamera> camera, double4x4 tModelMatrix) {
-  final tModelMatrixPtr = tModelMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrixPtr.cast());
-  return result;
-}
-
-void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
+void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
+  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
   return result;
 }
 
@@ -4795,454 +4303,259 @@ void TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager>
   return result;
 }
 
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
-  );
-  return result;
-}
-
-bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
-  return result;
-}
-
-void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dart__darwin_size_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
-  );
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-    tRenderer.cast(),
-    headRoomRatio,
-    scaleRate,
-    history,
-    interval,
-  );
-  return result;
-}
-
-Pointer<TEngine> Engine_create(
-  int backend,
-  Pointer<Void> platform,
-  Pointer<Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-) {
-  final result = GeneratedBindings.instance._Engine_create(
-    backend,
-    platform,
-    sharedContext,
-    stereoscopicEyeCount,
-    disableHandleUseAfterFreeCheck,
-  );
-  return Pointer<TEngine>(result);
-}
-
-int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
-  return result;
-}
-
-void Engine_destroy(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
-  return result;
-}
-
-Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
-  return Pointer<TRenderer>(result);
-}
-
-void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
-  return result;
-}
-
-Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
+int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
     tEngine.cast(),
-    width,
-    height,
-    flags.toJSBigInt,
-  );
-  return Pointer<TSwapChain>(result);
-}
-
-void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
-  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
-  return result;
-}
-
-void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
-  return result;
-}
-
-void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
-  return result;
-}
-
-void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
-  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
-  return result;
-}
-
-Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
-  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
-  return Pointer<TView>(result);
-}
-
-Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
-  return Pointer<TTransformManager>(result);
-}
-
-Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
-  return Pointer<TRenderableManager>(result);
-}
-
-Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
-  return Pointer<TLightManager>(result);
-}
-
-Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
-  return Pointer<TEntityManager>(result);
-}
-
-void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
-  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
-  return result;
-}
-
-Dart__darwin_size_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
-  return result;
-}
-
-void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
-  return result;
-}
-
-Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
-  return Pointer<TFence>(result);
-}
-
-void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
-  return result;
-}
-
-void Engine_flushAndWait(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
-  return result;
-}
-
-void Engine_execute(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
-  return result;
-}
-
-Pointer<TMaterial> Engine_buildMaterial(
-  Pointer<TEngine> tEngine,
-  Pointer<Uint8> materialData,
-  Dart__darwin_size_t length,
-) {
-  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
-  return Pointer<TMaterial>(result);
-}
-
-void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
-  return result;
-}
-
-void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
-  return result;
-}
-
-Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TSkybox> Engine_buildSkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildSkybox(
-    tEngine.cast(),
-    tTexture.cast(),
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TSkybox> Engine_buildColoredSkybox(
-  Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
-    tEngine.cast(),
-    r,
-    g,
-    b,
-    a,
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    tIrradianceTexture.cast(),
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<Float32> irradianceHarmonics,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    irradianceHarmonics,
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
-  return result;
-}
-
-void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
-  return result;
-}
-
-DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
-  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
-  return result;
-}
-
-void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
-  return result;
-}
-
-void Fence_waitAndDestroy(Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
-  return result;
-}
-
-Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
-  return Pointer<TDebugRegistry>(result);
-}
-
-bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
-  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Bool> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Int32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Float32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
-  return Pointer<TBufferObjectBuilder>(result);
-}
-
-void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
-  return result;
-}
-
-Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TBufferObject>(result);
-}
-
-void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
-  return result;
-}
-
-void BufferObject_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TBufferObject> buffer,
-  Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._BufferObject_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
+    tLightManager.cast(),
+    tLightTtype,
   );
   return result;
 }
 
-void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
-  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
+void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
+  return result;
+}
+
+double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+  return result;
+}
+
+double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+  return result;
+}
+
+bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
+  return result;
+}
+
+void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+    lambda,
+  );
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
   return result;
 }
 
@@ -5479,7 +4792,7 @@ void Engine_createViewRenderThread(
 void Engine_buildMaterialRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
@@ -5699,7 +5012,7 @@ void Ktx1Reader_createTextureRenderThread(
 void Ktx2Reader_createTextureRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
   Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Ktx2Reader_createTextureRenderThread(
@@ -5945,7 +5258,7 @@ void Renderer_readPixelsRenderThread(
   int tPixelBufferFormat,
   int tPixelDataType,
   Pointer<Uint8> out,
-  Dart__darwin_size_t outLength,
+  Dartsize_t outLength,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -6823,7 +6136,7 @@ void Image_createEmptyRenderThread(
 
 void Image_decodeRenderThread(
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   Pointer<Char> name,
   bool alpha,
   Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
@@ -6899,7 +6212,7 @@ void Texture_setImageRenderThread(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dart__darwin_size_t size,
+  Dartsize_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -7206,7 +6519,7 @@ void GltfResourceLoader_addResourceDataRenderThread(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7254,7 +6567,7 @@ void GltfAssetLoader_loadRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dart__darwin_size_t length,
+  Dartsize_t length,
   int numInstances,
   Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
 ) {
@@ -7441,7 +6754,7 @@ void VertexBuffer_setBufferAtRenderThread(
   Pointer<TVertexBuffer> tBuffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7495,7 +6808,7 @@ void BufferObject_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TBufferObject> tBuffer,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7559,7 +6872,7 @@ void IndexBuffer_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TIndexBuffer> tBuffer,
   Pointer<Void> data,
-  Dart__darwin_size_t sizeInBytes,
+  Dartsize_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7703,8 +7016,8 @@ void RenderableManager_setMorphWeightsRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> weights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t offset,
+  Dartsize_t count,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7724,8 +7037,8 @@ void RenderableManager_setBonesFromMat4RenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7745,8 +7058,8 @@ void RenderableManager_setBonesFromBoneRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7768,8 +7081,8 @@ void RenderableManager_setGeometryAtNonIndexedRenderThread(
   int primitiveIndex,
   int type,
   Pointer<TVertexBuffer> tVertices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
+  Dartsize_t offset,
+  Dartsize_t count,
   Pointer<NativeFunction<void Function(bool)>> callback,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexedRenderThread(
@@ -7851,681 +7164,6 @@ void LightManager_setShadowOptionsRenderThread(
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
-  return result;
-}
-
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
-  return Pointer<TGltfResourceLoader>(result);
-}
-
-void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
-  return result;
-}
-
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
-  return result;
-}
-
-double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
-  return result;
-}
-
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
-  );
-  return result;
-}
-
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
-  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
-  return result;
-}
-
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
-  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
-  return result;
-}
-
-/// Returns the visibility mask bits.
-int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
-  return result;
-}
-
-/// Returns the skybox intensity in lux.
-double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
-  return result;
-}
-
-/// Returns the environment texture, or nullptr for a color-only skybox.
-Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
-  return Pointer<TTexture>(result);
-}
-
-void MeshData_dispose(Pointer<TMeshData> meshData) {
-  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dart__darwin_size_t length,
-  Pointer<Char> meshName,
-  Pointer<TMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
-  return result;
-}
-
-void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
-  return result == 1;
-}
-
-bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-Dart__darwin_size_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
-  return result;
-}
-
-bool RenderableManager_setMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  Pointer<TMaterialInstance> tMaterialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    tMaterialInstance.cast(),
-  );
-  return result == 1;
-}
-
-Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-void RenderableManager_clearMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return result;
-}
-
-bool RenderableManager_setGeometryAtNonIndexed(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result == 1;
-}
-
-Dart__darwin_size_t RenderableManager_getPrimitiveCount(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-Aabb3 RenderableManager_getAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Aabb3 aabb,
-) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
-    tRenderableManager.cast(),
-    entityId,
-    aabbPtr.cast(),
-  );
-  return result;
-}
-
-Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAabb(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setLayerMask(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int select,
-  int values,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
-    tRenderableManager.cast(),
-    entityId,
-    select,
-    values,
-  );
-  return result;
-}
-
-int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setVisibilityLayer(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int layer,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
-    tRenderableManager.cast(),
-    entityId,
-    layer,
-  );
-  return result;
-}
-
-void RenderableManager_setPriority(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setPriority(
-    tRenderableManager.cast(),
-    entityId,
-    priority,
-  );
-  return result;
-}
-
-int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
-  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
-  return result;
-}
-
-void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
-  return result;
-}
-
-bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setFogEnabled(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool RenderableManager_getLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-  );
-  return result == 1;
-}
-
-void RenderableManager_setCastShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool castShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
-    tRenderableManager.cast(),
-    entityId,
-    castShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setReceiveShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool receiveShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
-    tRenderableManager.cast(),
-    entityId,
-    receiveShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setScreenSpaceContactShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setBlendOrderAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dart__darwin_size_t primitiveIndex,
-  int order,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    order,
-  );
-  return result;
-}
-
-void RenderableManager_setGlobalBlendOrderEnabledAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dart__darwin_size_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setMorphWeights(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> weights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
-    tRenderableManager.cast(),
-    entityId,
-    weights,
-    count,
-    offset,
-  );
-  return result;
-}
-
-Dart__darwin_size_t RenderableManager_getMorphTargetCount(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setBonesFromMat4(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> transforms,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
-    tRenderableManager.cast(),
-    entityId,
-    transforms,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-void RenderableManager_setBonesFromBone(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> bones,
-  Dart__darwin_size_t boneCount,
-  Dart__darwin_size_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
-    tRenderableManager.cast(),
-    entityId,
-    bones,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-Pointer<TRenderableBuilder> RenderableBuilder_create(Dart__darwin_size_t primitiveCount) {
-  final result = GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
-  return Pointer<TRenderableBuilder>(result);
-}
-
-void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
-  final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
-  return result;
-}
-
-void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
-  return result;
-}
-
-void RenderableBuilder_material(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_material(
-    builder.cast(),
-    primitiveIndex,
-    materialInstance.cast(),
-  );
-  return result;
-}
-
-void RenderableBuilder_geometry(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Pointer<TIndexBuffer> indices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_geometry(
-    builder.cast(),
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    indices.cast(),
-    offset,
-    count,
-  );
-  return result;
-}
-
-void RenderableBuilder_geometryNonIndexed(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dart__darwin_size_t offset,
-  Dart__darwin_size_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_geometryNonIndexed(
-    builder.cast(),
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result;
-}
-
-void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
-  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
-  return result;
-}
-
-void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
-  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
-  return result;
-}
-
-void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
-  return result;
-}
-
-void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
-  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
-  return result;
-}
-
-void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dart__darwin_size_t primitiveIndex, int order) {
-  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
-  return result;
-}
-
-void RenderableBuilder_globalBlendOrderEnabled(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_globalBlendOrderEnabled(
-    builder.cast(),
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dart__darwin_size_t instanceCount) {
-  final result = GeneratedBindings.instance._RenderableBuilder_instances(builder.cast(), instanceCount);
-  return result;
-}
-
-void RenderableBuilder_skinningFromMat4(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t boneCount,
-  Pointer<Float32> transforms,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
-  return result;
-}
-
-void RenderableBuilder_skinningFromBone(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t boneCount,
-  Pointer<Float32> bones,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(builder.cast(), boneCount, bones);
-  return result;
-}
-
-void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_boneIndicesAndWeights(
-  Pointer<TRenderableBuilder> builder,
-  Dart__darwin_size_t primitiveIndex,
-  Pointer<Float32> indicesAndWeights,
-  Dart__darwin_size_t count,
-  Dart__darwin_size_t bonesPerVertex,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
-    builder.cast(),
-    primitiveIndex,
-    indicesAndWeights,
-    count,
-    bonesPerVertex,
-  );
-  return result;
-}
-
-int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
-  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
   return result;
 }
 
@@ -8615,7 +7253,7 @@ Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
   return Pointer<Int32>(result);
 }
 
-Dart__darwin_size_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
   return result;
 }
@@ -8625,7 +7263,7 @@ Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
   return Pointer<Int32>(result);
 }
 
-Dart__darwin_size_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(tSceneAsset.cast());
   return result;
 }
@@ -8635,7 +7273,7 @@ Pointer<TSceneAsset> SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, in
   return Pointer<TSceneAsset>(result);
 }
 
-Dart__darwin_size_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
+Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(tSceneAsset.cast());
   return result;
 }
@@ -8699,23 +7337,199 @@ void SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShadin
   return result;
 }
 
-void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dart__darwin_size_t skinIndex, Pointer<Int32> out) {
+void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Pointer<Int32> out) {
   final result = GeneratedBindings.instance._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
   return result;
 }
 
-Dart__darwin_size_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dart__darwin_size_t skinIndex) {
+Dartsize_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex) {
   final result = GeneratedBindings.instance._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
   return result;
 }
 
-Pointer<Char> SceneAsset_getBoneName(
-  Pointer<TSceneAsset> tSceneAsset,
-  Dart__darwin_size_t skinIndex,
-  Dart__darwin_size_t boneIndex,
-) {
+Pointer<Char> SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Dartsize_t boneIndex) {
   final result = GeneratedBindings.instance._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
   return Pointer<Char>(result);
+}
+
+void MeshData_dispose(Pointer<TMeshData> meshData) {
+  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
+  return result;
+}
+
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  Pointer<Char> meshName,
+  Pointer<TMeshData> outMeshData,
+) {
+  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
+  return result;
+}
+
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+    tEngine.cast(),
+    tMaterialProvider.cast(),
+    tNameComponentManager.cast(),
+  );
+  return Pointer<TGltfAssetLoader>(result);
+}
+
+void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
+  return result;
+}
+
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  int numInstances,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    data,
+    length,
+    numInstances,
+  );
+  return Pointer<TFilamentAsset>(result);
+}
+
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
+    tRenderableManager.cast(),
+    tAsset.cast(),
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
+}
+
+int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
+  return result;
+}
+
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
+  return Pointer<PointerClass<Char>>(result);
+}
+
+void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
+    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+    tEngine.cast(),
+    assetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+  );
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
+  final result = GeneratedBindings.instance._Gizmo_pick(
+    tGizmo.cast(),
+    x,
+    y,
+    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
+  );
+  return result;
+}
+
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
+  return result;
+}
+
+void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
+}
+
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
+  return result;
+}
+
+Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
+  return Pointer<Char>(result);
+}
+
+Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
+  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
+  return Pointer<TRenderTarget>(result);
+}
+
+void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
+  return result;
 }
 
 Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
@@ -9044,6 +7858,1181 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
+void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
+  return result == 1;
+}
+
+bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+Dartsize_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
+  return result;
+}
+
+bool RenderableManager_setMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  Pointer<TMaterialInstance> tMaterialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    tMaterialInstance.cast(),
+  );
+  return result == 1;
+}
+
+Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+void RenderableManager_clearMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return result;
+}
+
+bool RenderableManager_setGeometryAtNonIndexed(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dartsize_t offset,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result == 1;
+}
+
+Dartsize_t RenderableManager_getPrimitiveCount(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+Aabb3 RenderableManager_getAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+void RenderableManager_setAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Aabb3 aabb,
+) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
+    tRenderableManager.cast(),
+    entityId,
+    aabbPtr.cast(),
+  );
+  return result;
+}
+
+Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAabb(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+void RenderableManager_setLayerMask(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int select,
+  int values,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
+    tRenderableManager.cast(),
+    entityId,
+    select,
+    values,
+  );
+  return result;
+}
+
+int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setVisibilityLayer(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int layer,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
+    tRenderableManager.cast(),
+    entityId,
+    layer,
+  );
+  return result;
+}
+
+void RenderableManager_setPriority(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setPriority(
+    tRenderableManager.cast(),
+    entityId,
+    priority,
+  );
+  return result;
+}
+
+int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
+  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
+  return result;
+}
+
+void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
+  return result;
+}
+
+bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setFogEnabled(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool RenderableManager_getLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+  );
+  return result == 1;
+}
+
+void RenderableManager_setCastShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool castShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
+    tRenderableManager.cast(),
+    entityId,
+    castShadows,
+  );
+  return result;
+}
+
+bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setReceiveShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool receiveShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
+    tRenderableManager.cast(),
+    entityId,
+    receiveShadows,
+  );
+  return result;
+}
+
+bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setScreenSpaceContactShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setBlendOrderAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dartsize_t primitiveIndex,
+  int order,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    order,
+  );
+  return result;
+}
+
+void RenderableManager_setGlobalBlendOrderEnabledAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dartsize_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setMorphWeights(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> weights,
+  Dartsize_t count,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
+    tRenderableManager.cast(),
+    entityId,
+    weights,
+    count,
+    offset,
+  );
+  return result;
+}
+
+Dartsize_t RenderableManager_getMorphTargetCount(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setBonesFromMat4(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> transforms,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
+    tRenderableManager.cast(),
+    entityId,
+    transforms,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+void RenderableManager_setBonesFromBone(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> bones,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
+    tRenderableManager.cast(),
+    entityId,
+    bones,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+Pointer<TRenderableBuilder> RenderableBuilder_create(Dartsize_t primitiveCount) {
+  final result = GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
+  return Pointer<TRenderableBuilder>(result);
+}
+
+void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
+  final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
+  return result;
+}
+
+void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
+  return result;
+}
+
+void RenderableBuilder_material(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  Pointer<TMaterialInstance> materialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_material(
+    builder.cast(),
+    primitiveIndex,
+    materialInstance.cast(),
+  );
+  return result;
+}
+
+void RenderableBuilder_geometry(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Pointer<TIndexBuffer> indices,
+  Dartsize_t offset,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_geometry(
+    builder.cast(),
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    indices.cast(),
+    offset,
+    count,
+  );
+  return result;
+}
+
+void RenderableBuilder_geometryNonIndexed(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dartsize_t offset,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_geometryNonIndexed(
+    builder.cast(),
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result;
+}
+
+void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
+  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
+  return result;
+}
+
+void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
+  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
+  return result;
+}
+
+void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
+  return result;
+}
+
+void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
+  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
+  return result;
+}
+
+void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dartsize_t primitiveIndex, int order) {
+  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
+  return result;
+}
+
+void RenderableBuilder_globalBlendOrderEnabled(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_globalBlendOrderEnabled(
+    builder.cast(),
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dartsize_t instanceCount) {
+  final result = GeneratedBindings.instance._RenderableBuilder_instances(builder.cast(), instanceCount);
+  return result;
+}
+
+void RenderableBuilder_skinningFromMat4(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t boneCount,
+  Pointer<Float32> transforms,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
+  return result;
+}
+
+void RenderableBuilder_skinningFromBone(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t boneCount,
+  Pointer<Float32> bones,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(builder.cast(), boneCount, bones);
+  return result;
+}
+
+void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_boneIndicesAndWeights(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  Pointer<Float32> indicesAndWeights,
+  Dartsize_t count,
+  Dartsize_t bonesPerVertex,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
+    builder.cast(),
+    primitiveIndex,
+    indicesAndWeights,
+    count,
+    bonesPerVertex,
+  );
+  return result;
+}
+
+int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
+  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
+  return result;
+}
+
+void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
+  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
+  return result;
+}
+
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
+  return result;
+}
+
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
+  return result;
+}
+
+void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
+  return result;
+}
+
+void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
+  return result;
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
+    camera.cast(),
+    projectionMatrixPtr.cast(),
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setModelMatrix(Pointer<TCamera> camera, double4x4 tModelMatrix) {
+  final tModelMatrixPtr = tModelMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrixPtr.cast());
+  return result;
+}
+
+void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
+  return result;
+}
+
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
+  return result;
+}
+
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
+  return result;
+}
+
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
+  return result;
+}
+
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
+  return result;
+}
+
+Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
+  return Pointer<TSkybox>(result);
+}
+
+void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
+  return result;
+}
+
+void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
+  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
+  return result;
+}
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
+  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
+  return result;
+}
+
+/// Returns the visibility mask bits.
+int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
+  return result;
+}
+
+/// Returns the skybox intensity in lux.
+double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
+  return result;
+}
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
+  return Pointer<TTexture>(result);
+}
+
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+  );
+  return result;
+}
+
+bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+  return result;
+}
+
+void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dartsize_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+  );
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+    tRenderer.cast(),
+    headRoomRatio,
+    scaleRate,
+    history,
+    interval,
+  );
+  return result;
+}
+
+void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
+  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+  return result;
+}
+
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
+  return Pointer<TGltfResourceLoader>(result);
+}
+
+void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
+  return result;
+}
+
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
+  return result;
+}
+
+double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
+  return result;
+}
+
+void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
+  return Pointer<Void>(result);
+}
+
+Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
+  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
+  return result;
+}
+
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(Pointer<TSurfaceOrientationBuilder> builder, Pointer<Uint32> triangles) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dartsize_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
+  return result;
+}
+
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
+  return result;
+}
+
 void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
   final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(executor.cast());
   return result;
@@ -9166,34 +9155,34 @@ void TransformPipeline_setInvertMouseY(int invert) {
   return result;
 }
 
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
+extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
+  TMaterialInstance toDart() {
+    return TMaterialInstance(this);
+  }
 }
 
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
+final class TMaterialInstance extends Struct {
+  Pointer<TMaterialInstance> get address => super.address.cast();
+  TMaterialInstance(super.address);
+
+  static Pointer<TMaterialInstance> stackAlloc() {
+    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
+  }
 }
 
-sealed class TVertexBufferStorageMode {
-  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
-  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
-  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
+extension TMaterialExt on Pointer<TMaterial> {
+  TMaterial toDart() {
+    return TMaterial(this);
+  }
 }
 
-sealed class TSceneAssetGeometryCapability {
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_NONE = 0;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_BARYCENTRICS = 1;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_WRITABLE_VERTICES = 2;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_ACCESSIBLE_GEOMETRY_BUFFERS = 4;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_PRESERVED_TOPOLOGY = 8;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_UNIQUE_TRIANGLE_CORNERS = 16;
+final class TMaterial extends Struct {
+  Pointer<TMaterial> get address => super.address.cast();
+  TMaterial(super.address);
+
+  static Pointer<TMaterial> stackAlloc() {
+    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  }
 }
 
 sealed class TFeatureLevel {
@@ -9203,73 +9192,56 @@ sealed class TFeatureLevel {
   static const FEATURE_LEVEL_3 = 3;
 }
 
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
+  }
 }
 
-sealed class TVertexAttribute {
-  static const TVERTEX_ATTRIBUTE_POSITION = 0;
-  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
-  static const TVERTEX_ATTRIBUTE_COLOR = 2;
-  static const TVERTEX_ATTRIBUTE_UV0 = 3;
-  static const TVERTEX_ATTRIBUTE_UV1 = 4;
-  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
-  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
-  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
-  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
-  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
-  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
-  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
-  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
-  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
-  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
+
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  }
 }
 
-sealed class TVertexAttributeType {
-  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
-  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
-  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
-  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
-  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
-  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
-  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
 }
 
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
+extension TTextureExt on Pointer<TTexture> {
+  TTexture toDart() {
+    return TTexture(this);
+  }
+}
+
+final class TTexture extends Struct {
+  Pointer<TTexture> get address => super.address.cast();
+  TTexture(super.address);
+
+  static Pointer<TTexture> stackAlloc() {
+    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
+  }
+}
+
+extension TTextureSamplerExt on Pointer<TTextureSampler> {
+  TTextureSampler toDart() {
+    return TTextureSampler(this);
+  }
+}
+
+final class TTextureSampler extends Struct {
+  Pointer<TTextureSampler> get address => super.address.cast();
+  TTextureSampler(super.address);
+
+  static Pointer<TTextureSampler> stackAlloc() {
+    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
+  }
 }
 
 sealed class TSamplerCompareFunc {
@@ -9315,13 +9287,6 @@ sealed class TStencilFace {
   static const STENCIL_FACE_FRONT_AND_BACK = 3;
 }
 
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
-}
-
 sealed class TTransparencyMode {
   /// ! the transparent object is drawn honoring the raster state
   static const DEFAULT = 0;
@@ -9347,87 +9312,453 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
-extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
-  TMaterialInstance toDart() {
-    return TMaterialInstance(this);
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+typedef size_t = int;
+typedef Dartsize_t = int;
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
   }
 }
 
-final class TMaterialInstance extends Struct {
-  Pointer<TMaterialInstance> get address => super.address.cast();
-  TMaterialInstance(super.address);
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
 
-  static Pointer<TMaterialInstance> stackAlloc() {
-    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
   }
 }
 
-extension TMaterialExt on Pointer<TMaterial> {
-  TMaterial toDart() {
-    return TMaterial(this);
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
   }
 }
 
-final class TMaterial extends Struct {
-  Pointer<TMaterial> get address => super.address.cast();
-  TMaterial(super.address);
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
 
-  static Pointer<TMaterial> stackAlloc() {
-    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
   }
 }
 
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
+
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
   }
 }
 
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
 
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
   }
 }
 
-extension TTextureExt on Pointer<TTexture> {
-  TTexture toDart() {
-    return TTexture(this);
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
   }
 }
 
-final class TTexture extends Struct {
-  Pointer<TTexture> get address => super.address.cast();
-  TTexture(super.address);
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
 
-  static Pointer<TTexture> stackAlloc() {
-    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
   }
 }
 
-extension TTextureSamplerExt on Pointer<TTextureSampler> {
-  TTextureSampler toDart() {
-    return TTextureSampler(this);
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
   }
 }
 
-final class TTextureSampler extends Struct {
-  Pointer<TTextureSampler> get address => super.address.cast();
-  TTextureSampler(super.address);
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
 
-  static Pointer<TTextureSampler> stackAlloc() {
-    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
   }
 }
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
+  }
+}
+
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
+  }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+typedef EntityId = int;
+typedef DartEntityId = int;
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
+  }
+}
+
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
+
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
+  }
+}
+
+extension TRenderableManagerExt on Pointer<TRenderableManager> {
+  TRenderableManager toDart() {
+    return TRenderableManager(this);
+  }
+}
+
+final class TRenderableManager extends Struct {
+  Pointer<TRenderableManager> get address => super.address.cast();
+  TRenderableManager(super.address);
+
+  static Pointer<TRenderableManager> stackAlloc() {
+    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
+  }
 }
 
 extension TLightManagerExt on Pointer<TLightManager> {
@@ -9445,423 +9776,79 @@ final class TLightManager extends Struct {
   }
 }
 
-typedef EntityId = int;
-typedef DartEntityId = int;
-
-extension double3Ext on Pointer<double3> {
-  double3 toDart() {
-    return double3(this);
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
   }
 }
 
-final class double3 extends Struct {
-  Pointer<double3> get address => super.address.cast();
-  double get x {
-    final addr = Pointer<double3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
 
-  set x(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
-  }
-
-  double get y {
-    final addr = Pointer<double3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set y(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
-  }
-
-  double get z {
-    final addr = Pointer<double3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set z(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
-  }
-
-  double3(super.address);
-
-  static Pointer<double3> stackAlloc() {
-    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
   }
 }
 
-extension TShadowOptionsExt on Pointer<TShadowOptions> {
-  TShadowOptions toDart() {
-    return TShadowOptions(this);
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
   }
 }
 
-final class TShadowOptions extends Struct {
-  Pointer<TShadowOptions> get address => super.address.cast();
-  int get mapSize {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
 
-  set mapSize(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
-  }
-
-  int get shadowCascades {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set shadowCascades(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
-  }
-
-  Array<Float32> get cascadeSplitPositions {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float32>((numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
-  }
-
-  set cascadeSplitPositions(Array<Float32> val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 5), val.internal.addr.addr.toJS, '*');
-  }
-
-  double get constantBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constantBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
-  }
-
-  double get normalBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set normalBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
-  }
-
-  double get shadowFar {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFar(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
-  }
-
-  double get shadowNearHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowNearHint(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
-  }
-
-  double get shadowFarHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFarHint(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
-  }
-
-  bool get stable {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set stable(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 37), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  bool get lispsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set lispsm(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get polygonOffsetConstant {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetConstant(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
-  }
-
-  double get polygonOffsetSlope {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetSlope(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
-  }
-
-  bool get screenSpaceContactShadows {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set screenSpaceContactShadows(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 47), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  int get stepCount {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set stepCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
-  }
-
-  double get maxShadowDistance {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxShadowDistance(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
-  }
-
-  bool get vsmElvsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set vsmElvsm(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 53), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get vsmBlurWidth {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set vsmBlurWidth(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
-  }
-
-  double get shadowBulbRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowBulbRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
-  }
-
-  double get penumbraScale {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set penumbraScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
-  }
-
-  double get penumbraRatioScale {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set penumbraRatioScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
-  }
-
-  double get maxPenumbraRatio {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxPenumbraRatio(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
-  }
-
-  double get maxSearchRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxSearchRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
-  }
-
-  double get transformX {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformX(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
-  }
-
-  double get transformY {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformY(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
-  }
-
-  double get transformZ {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformZ(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
-  }
-
-  double get transformW {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformW(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
-  }
-
-  TShadowOptions(super.address);
-
-  static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
   }
 }
 
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
   }
 }
 
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
   }
 }
 
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
 
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
   }
 }
 
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
   }
 }
 
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
 
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
   }
-}
-
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
-  }
-}
-
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
-
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
-  }
-}
-
-typedef size_t = __darwin_size_t;
-typedef __darwin_size_t = int;
-typedef Dart__darwin_size_t = int;
-
-extension TRenderableManagerExt on Pointer<TRenderableManager> {
-  TRenderableManager toDart() {
-    return TRenderableManager(this);
-  }
-}
-
-final class TRenderableManager extends Struct {
-  Pointer<TRenderableManager> get address => super.address.cast();
-  TRenderableManager(super.address);
-
-  static Pointer<TRenderableManager> stackAlloc() {
-    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
-  }
-}
-
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
-}
-
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
-}
-
-sealed class TLutFormat {
-  static const INTEGER = 0;
-  static const FLOAT = 1;
 }
 
 extension TViewportExt on Pointer<TViewport> {
@@ -9919,21 +9906,6 @@ final class TViewport extends Struct {
   }
 }
 
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
-}
-
 extension TToneMapperExt on Pointer<TToneMapper> {
   TToneMapper toDart() {
     return TToneMapper(this);
@@ -9964,34 +9936,21 @@ final class TColorGradingBuilder extends Struct {
   }
 }
 
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
 }
 
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
-  }
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
 }
 
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
-  }
-}
-
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
-
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
-  }
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -10126,41 +10085,6 @@ final class TVsmShadowOptions extends Struct {
   static Pointer<TVsmShadowOptions> stackAlloc() {
     return Pointer<TVsmShadowOptions>(NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
   }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
-
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
-
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
-  }
-}
-
-sealed class TAmbientOcclusionType {
-  static const SAO = 0;
-  static const GTAO = 1;
 }
 
 /// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
@@ -10587,6 +10511,11 @@ final class TGtao extends Struct {
   }
 }
 
+sealed class TAmbientOcclusionType {
+  static const SAO = 0;
+  static const GTAO = 1;
+}
+
 /// Copied from FogOptions in View.h
 
 extension TFogOptionsExt on Pointer<TFogOptions> {
@@ -10751,423 +10680,18 @@ typedef PickCallbackFunction =
 typedef DartPickCallbackFunction =
     void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
 
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
   }
 }
 
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
-
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
-  }
-}
-
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
-  }
-}
-
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
-
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
-  }
-}
-
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
-  }
-}
-
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
-
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
-  }
-}
-
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
-  }
-}
-
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
-
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
-  }
-}
-
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
-  }
-}
-
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
-
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
-  }
-}
-
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
-  }
-}
-
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
-
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
-  }
-}
-
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
-  }
-}
-
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
-
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
-  }
-}
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
-  }
-}
-
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
-
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
-  }
-}
-
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
-  }
-}
-
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
-
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
+
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
   }
 }
 
@@ -11184,6 +10708,59 @@ final class TVertexBufferBuilder extends Struct {
   static Pointer<TVertexBufferBuilder> stackAlloc() {
     return Pointer<TVertexBufferBuilder>(NativeLibrary.instance.stackAlloc<TVertexBufferBuilder>(0));
   }
+}
+
+sealed class TVertexBufferStorageMode {
+  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
+  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
+  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
+}
+
+sealed class TVertexAttribute {
+  static const TVERTEX_ATTRIBUTE_POSITION = 0;
+  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
+  static const TVERTEX_ATTRIBUTE_COLOR = 2;
+  static const TVERTEX_ATTRIBUTE_UV0 = 3;
+  static const TVERTEX_ATTRIBUTE_UV1 = 4;
+  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
+  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
+  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
+  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
+  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
+  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
+  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
+  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
+  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
+  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
+}
+
+sealed class TVertexAttributeType {
+  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
+  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
+  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
+  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
+  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
+  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
+  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
 extension TVertexBufferExt on Pointer<TVertexBuffer> {
@@ -11216,84 +10793,54 @@ final class TBufferObject extends Struct {
   }
 }
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
   }
 }
 
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
 
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
   }
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
   }
 }
 
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
 
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
   }
 }
 
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
+extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
+  TBufferObjectBuilder toDart() {
+    return TBufferObjectBuilder(this);
   }
 }
 
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
+final class TBufferObjectBuilder extends Struct {
+  Pointer<TBufferObjectBuilder> get address => super.address.cast();
+  TBufferObjectBuilder(super.address);
 
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  static Pointer<TBufferObjectBuilder> stackAlloc() {
+    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
   }
-}
-
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
-  }
-}
-
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
-
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
-  }
-}
-
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
-  }
-}
-
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
-
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
-  }
-}
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
 }
 
 extension double4x4Ext on Pointer<double4x4> {
@@ -11348,21 +10895,6 @@ final class double4x4 extends Struct {
 
   static Pointer<double4x4> stackAlloc() {
     return Pointer<double4x4>(NativeLibrary.instance.stackAlloc<double4x4>(128));
-  }
-}
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
-  }
-}
-
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
-
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
   }
 }
 
@@ -11441,80 +10973,361 @@ final class Aabb3 extends Struct {
   }
 }
 
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
 }
 
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+extension double3Ext on Pointer<double3> {
+  double3 toDart() {
+    return double3(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class double3 extends Struct {
+  Pointer<double3> get address => super.address.cast();
+  double get x {
+    final addr = Pointer<double3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  set x(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
+  }
+
+  double get y {
+    final addr = Pointer<double3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set y(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
+  }
+
+  double get z {
+    final addr = Pointer<double3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set z(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
+  }
+
+  double3(super.address);
+
+  static Pointer<double3> stackAlloc() {
+    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
   }
 }
 
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
+extension TShadowOptionsExt on Pointer<TShadowOptions> {
+  TShadowOptions toDart() {
+    return TShadowOptions(this);
   }
 }
 
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
+final class TShadowOptions extends Struct {
+  Pointer<TShadowOptions> get address => super.address.cast();
+  int get mapSize {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
 
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  set mapSize(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
+  }
+
+  int get shadowCascades {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set shadowCascades(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
+  }
+
+  Array<Float32> get cascadeSplitPositions {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float32>((numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
+  }
+
+  set cascadeSplitPositions(Array<Float32> val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 5), val.internal.addr.addr.toJS, '*');
+  }
+
+  double get constantBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set constantBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
+  }
+
+  double get normalBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set normalBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
+  }
+
+  double get shadowFar {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFar(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
+  }
+
+  double get shadowNearHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowNearHint(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
+  }
+
+  double get shadowFarHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFarHint(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
+  }
+
+  bool get stable {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set stable(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 37), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  bool get lispsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set lispsm(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get polygonOffsetConstant {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetConstant(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
+  }
+
+  double get polygonOffsetSlope {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetSlope(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
+  }
+
+  bool get screenSpaceContactShadows {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set screenSpaceContactShadows(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 47), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  int get stepCount {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set stepCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
+  }
+
+  double get maxShadowDistance {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxShadowDistance(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
+  }
+
+  bool get vsmElvsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set vsmElvsm(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 53), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get vsmBlurWidth {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set vsmBlurWidth(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
+  }
+
+  double get shadowBulbRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowBulbRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
+  }
+
+  double get penumbraScale {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
+  }
+
+  double get penumbraRatioScale {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraRatioScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
+  }
+
+  double get maxPenumbraRatio {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxPenumbraRatio(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
+  }
+
+  double get maxSearchRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxSearchRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
+  }
+
+  TShadowOptions(super.address);
+
+  static Pointer<TShadowOptions> stackAlloc() {
+    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
   }
 }
 
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
   }
 }
 
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
 
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
   }
 }
 
-extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
-  TBufferObjectBuilder toDart() {
-    return TBufferObjectBuilder(this);
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
   }
 }
 
-final class TBufferObjectBuilder extends Struct {
-  Pointer<TBufferObjectBuilder> get address => super.address.cast();
-  TBufferObjectBuilder(super.address);
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
 
-  static Pointer<TBufferObjectBuilder> stackAlloc() {
-    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
   }
 }
 
@@ -11533,6 +11346,103 @@ final class TSceneAsset extends Struct {
   }
 }
 
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
+  }
+}
+
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
+
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
+  }
+}
+
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
+  }
+}
+
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
+  }
+}
+
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
+
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
+  }
+}
+
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
+}
+
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
+  }
+}
+
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
+
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
+  }
+}
+
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
+  }
+}
+
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
+
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  }
+}
+
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
   TRenderableBuilder toDart() {
     return TRenderableBuilder(this);
@@ -11546,6 +11456,16 @@ final class TRenderableBuilder extends Struct {
   static Pointer<TRenderableBuilder> stackAlloc() {
     return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
   }
+}
+
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
 extension TMeshDataExt on Pointer<TMeshData> {
@@ -11563,33 +11483,63 @@ final class TMeshData extends Struct {
   }
 }
 
-sealed class TIntentAction {
-  static const INTENT_ACTION_MOVE_FORWARD = 0;
-  static const INTENT_ACTION_MOVE_BACKWARD = 1;
-  static const INTENT_ACTION_MOVE_LEFT = 2;
-  static const INTENT_ACTION_MOVE_RIGHT = 3;
-  static const INTENT_ACTION_JUMP = 4;
-  static const INTENT_ACTION_SPRINT = 5;
-  static const INTENT_ACTION_CUSTOM1 = 6;
-  static const INTENT_ACTION_CUSTOM2 = 7;
-  static const INTENT_ACTION_CUSTOM3 = 8;
-  static const INTENT_ACTION_CUSTOM4 = 9;
-  static const INTENT_ACTION_CUSTOM5 = 10;
-  static const INTENT_ACTION_CUSTOM6 = 11;
-  static const INTENT_ACTION_CUSTOM7 = 12;
-  static const INTENT_ACTION_CUSTOM8 = 13;
-  static const INTENT_ACTION_CUSTOM9 = 14;
-  static const INTENT_ACTION_CUSTOM10 = 15;
-  static const INTENT_ACTION_CROUCH = 16;
-  static const INTENT_ACTION_INTERACT = 17;
-  static const INTENT_ACTION_USE_ITEM = 18;
-  static const INTENT_ACTION_RELOAD = 19;
-  static const INTENT_ACTION_ALT_FIRE = 20;
+typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
 }
 
-sealed class TMovementSpace {
-  static const MOVEMENT_SPACE_WORLD = 0;
-  static const MOVEMENT_SPACE_OBJECT = 1;
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
+  }
+}
+
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
+
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
+  }
+}
+
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
+  }
+}
+
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
+
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
+  }
 }
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
@@ -11652,35 +11602,59 @@ extension StructAllocator on Struct {
       case TTextureSampler:
         final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
+      case TLinearImage:
+        final ptr = TLinearImage.stackAlloc();
         return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
+      case TKtx1Bundle:
+        final ptr = TKtx1Bundle.stackAlloc();
         return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
         return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
+      case TRenderer:
+        final ptr = TRenderer.stackAlloc();
         return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
+      case TSwapChain:
+        final ptr = TSwapChain.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
+      case TView:
+        final ptr = TView.stackAlloc();
         return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
+      case TScene:
+        final ptr = TScene.stackAlloc();
+        return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
+        return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
+        return ptr.toDart() as T;
+      case TTransformManager:
+        final ptr = TTransformManager.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableManager:
         final ptr = TRenderableManager.stackAlloc();
         return ptr.toDart() as T;
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TEntityManager:
+        final ptr = TEntityManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFence:
+        final ptr = TFence.stackAlloc();
+        return ptr.toDart() as T;
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
+      case TDebugRegistry:
+        final ptr = TDebugRegistry.stackAlloc();
+        return ptr.toDart() as T;
       case TViewport:
         final ptr = TViewport.stackAlloc();
-        return ptr.toDart() as T;
-      case TView:
-        final ptr = TView.stackAlloc();
         return ptr.toDart() as T;
       case TToneMapper:
         final ptr = TToneMapper.stackAlloc();
@@ -11688,23 +11662,11 @@ extension StructAllocator on Struct {
       case TColorGradingBuilder:
         final ptr = TColorGradingBuilder.stackAlloc();
         return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
-        return ptr.toDart() as T;
       case TSoftShadowOptions:
         final ptr = TSoftShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TVsmShadowOptions:
         final ptr = TVsmShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
         return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
@@ -11718,32 +11680,8 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TSurfaceOrientationBuilder:
-        final ptr = TSurfaceOrientationBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientation:
-        final ptr = TSurfaceOrientation.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
-      case TLinearImage:
-        final ptr = TLinearImage.stackAlloc();
-        return ptr.toDart() as T;
-      case TKtx1Bundle:
-        final ptr = TKtx1Bundle.stackAlloc();
-        return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
       case TVertexBufferBuilder:
         final ptr = TVertexBufferBuilder.stackAlloc();
@@ -11754,50 +11692,62 @@ extension StructAllocator on Struct {
       case TBufferObject:
         final ptr = TBufferObject.stackAlloc();
         return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderManager:
-        final ptr = TRenderManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderer:
-        final ptr = TRenderer.stackAlloc();
-        return ptr.toDart() as T;
-      case TAnimationManager:
-        final ptr = TAnimationManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TSwapChain:
-        final ptr = TSwapChain.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case TTransformManager:
-        final ptr = TTransformManager.stackAlloc();
-        return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
-        return ptr.toDart() as T;
-      case TEntityManager:
-        final ptr = TEntityManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFence:
-        final ptr = TFence.stackAlloc();
-        return ptr.toDart() as T;
-      case TDebugRegistry:
-        final ptr = TDebugRegistry.stackAlloc();
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
         return ptr.toDart() as T;
       case TBufferObjectBuilder:
         final ptr = TBufferObjectBuilder.stackAlloc();
         return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
+        return ptr.toDart() as T;
+      case double3:
+        final ptr = double3.stackAlloc();
+        return ptr.toDart() as T;
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderManager:
+        final ptr = TRenderManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TAnimationManager:
+        final ptr = TAnimationManager.stackAlloc();
+        return ptr.toDart() as T;
       case TSceneAsset:
         final ptr = TSceneAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableBuilder:
         final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TMeshData:
         final ptr = TMeshData.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientationBuilder:
+        final ptr = TSurfaceOrientationBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientation:
+        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -132,192 +132,148 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external int _MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance);
   external int _Material_getBlendingMode(Pointer<TMaterial> material);
-  external Pointer<TTexture> _Texture_build(
-    Pointer<TEngine> engine,
-    int width,
-    int height,
-    int depth,
-    int levels,
-    int tUsage,
-    int import1,
-    int sampler,
-    int format,
-  );
-  external void _Texture_setExternalImage(
+  external int _LightManager_createLight(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<Void> externalImage,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
   );
-  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
-  external int _Texture_loadImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<TLinearImage> tImage,
-    int bufferFormat,
-    int pixelDataType,
-    int level,
+  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
   );
-  external int _Texture_setImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    int level,
-    Pointer<Uint8> data,
-    size_t size,
-    int x_offset,
-    int y_offset,
-    int z_offset,
-    int width,
-    int height,
-    int depth,
-    int bufferFormat,
-    int pixelDataType,
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
   );
-  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getFormat(Pointer<TTexture> tTexture);
-  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
-  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
-  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
-  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
-  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
-  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
-  external Pointer<TTexture> _Ktx1Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TKtx1Bundle> tBundle,
-    int requestId,
-    VoidCallback onTextureUploadComplete,
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
   );
-  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
-  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
-  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
-  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
-  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
-  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTextureSampler> _TextureSampler_create();
-  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
-    int minFilter,
-    int magFilter,
-    int wrapS,
-    int wrapT,
-    int wrapR,
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
   );
-  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
-  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
-  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
-  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
-  external Pointer<TEngine> _Engine_create(
-    int backend,
-    Pointer<Void> platform,
-    Pointer<Void> sharedContext,
-    int stereoscopicEyeCount,
-    bool disableHandleUseAfterFreeCheck,
-  );
-  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
-  external void _Engine_destroy(Pointer<TEngine> tEngine);
-  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
-  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
-  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
-    Pointer<TEngine> tEngine,
-    int width,
-    int height,
-    JSBigInt flags,
-  );
-  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
-  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
-  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
-  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
-  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
-  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
-  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
-  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
-  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
-  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
-  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
-  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
-  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
-  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
-  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
-  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
-  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
-  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
-  external void _Engine_execute(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Engine_buildMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> materialData,
-    size_t length,
-  );
-  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
-  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
-  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
-  external Pointer<TSkybox> _Engine_buildSkybox(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    bool showSun,
-    double intensity,
-    int priority,
-  );
-  external Pointer<TSkybox> _Engine_buildColoredSkybox(
-    Pointer<TEngine> tEngine,
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double r,
     double g,
     double b,
-    double a,
-    bool showSun,
-    double intensity,
-    int priority,
   );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
+  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
+  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
+  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
+  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
+  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
+  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
+  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
+  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<TTexture> tIrradianceTexture,
-    double intensity,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
   );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
+  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<Float32> irradianceHarmonics,
-    double intensity,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
   );
-  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
-  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
-  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
-  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
-  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
-  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
-  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
-  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
-  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
-  external int _DebugRegistry_setProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    double value,
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
   );
-  external int _DebugRegistry_getProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Bool> outValue,
-  );
-  external int _DebugRegistry_getProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Int32> outValue,
-  );
-  external int _DebugRegistry_getProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Float32> outValue,
-  );
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
+  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
   external void _View_getViewport(Pointer<TViewport> TViewport_out, Pointer<TView> view);
   external Pointer<TToneMapper> _ToneMapper_createLinear(Pointer<TEngine> tEngine);
   external Pointer<TToneMapper> _ToneMapper_createACES(Pointer<TEngine> tEngine);
@@ -454,6 +410,168 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _View_pick(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
   external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
   external Pointer<Char> _View_getName(Pointer<TView> tView);
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
+  );
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
+  );
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
+  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
+  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Float32> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
+  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
+  external Pointer<TTexture> _Texture_build(
+    Pointer<TEngine> engine,
+    int width,
+    int height,
+    int depth,
+    int levels,
+    int tUsage,
+    int import1,
+    int sampler,
+    int format,
+  );
+  external void _Texture_setExternalImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<Void> externalImage,
+  );
+  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
+  external int _Texture_loadImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<TLinearImage> tImage,
+    int bufferFormat,
+    int pixelDataType,
+    int level,
+  );
+  external int _Texture_setImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    int level,
+    Pointer<Uint8> data,
+    size_t size,
+    int x_offset,
+    int y_offset,
+    int z_offset,
+    int width,
+    int height,
+    int depth,
+    int bufferFormat,
+    int pixelDataType,
+  );
+  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getFormat(Pointer<TTexture> tTexture);
+  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
+  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
+  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
+  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
+  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
+  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
+  external Pointer<TTexture> _Ktx1Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TKtx1Bundle> tBundle,
+    int requestId,
+    VoidCallback onTextureUploadComplete,
+  );
+  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
+  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
+  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
+  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
+  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
+  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TTextureSampler> _TextureSampler_create();
+  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
+    int minFilter,
+    int magFilter,
+    int wrapS,
+    int wrapT,
+    int wrapR,
+  );
+  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
+  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
+  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
+  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
+  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+  external void _FrameScheduler_stop();
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Gizmo_dummy(int t);
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+  );
+  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
     bool doubleSided,
@@ -495,6 +613,23 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     bool hasIOR,
     bool hasVolume,
   );
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
+  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
+  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
   external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
   external void _VertexBufferBuilder_bufferCount(Pointer<TVertexBufferBuilder> builder, int count);
   external void _VertexBufferBuilder_vertexCount(Pointer<TVertexBufferBuilder> builder, int count);
@@ -530,38 +665,95 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TBufferObject> bufferObject,
   );
   external void _VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer);
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
-  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
   );
-  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
-  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
+  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
+  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
+  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
+  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
+  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
   );
-  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
-  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
-  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
-  external Pointer<TBufferObject> _BufferObjectBuilder_build(
-    Pointer<TBufferObjectBuilder> builder,
-    Pointer<TEngine> engine,
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
   );
-  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
-  external void _BufferObject_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TBufferObject> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
+  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
   );
-  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
+  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
+  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
+  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
+  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
+  );
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<double4x4> tModelMatrixPtr);
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
   external void _TransformManager_getLocalTransform(
     Pointer<double4x4> double4x4_out,
     Pointer<TTransformManager> tTransformManager,
@@ -604,124 +796,161 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
   external void _TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
-  external int _LightManager_createLight(
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
+  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
+  external Pointer<TEngine> _Engine_create(
+    int backend,
+    Pointer<Void> platform,
+    Pointer<Void> sharedContext,
+    int stereoscopicEyeCount,
+    bool disableHandleUseAfterFreeCheck,
+  );
+  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
+  external void _Engine_destroy(Pointer<TEngine> tEngine);
+  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
+  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
+  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
     Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
+    int width,
+    int height,
+    JSBigInt flags,
   );
-  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
+  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
+  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
+  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
+  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
+  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
+  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
+  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
+  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
+  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
+  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
+  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
+  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
+  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
+  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
+  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
+  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
+  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
+  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
+  external void _Engine_execute(Pointer<TEngine> tEngine);
+  external Pointer<TMaterial> _Engine_buildMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> materialData,
+    size_t length,
   );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
+  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
+  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
+  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
+  external Pointer<TSkybox> _Engine_buildSkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    bool showSun,
+    double intensity,
+    int priority,
   );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TSkybox> _Engine_buildColoredSkybox(
+    Pointer<TEngine> tEngine,
     double r,
     double g,
     double b,
+    double a,
+    bool showSun,
+    double intensity,
+    int priority,
   );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<TTexture> tIrradianceTexture,
     double intensity,
   );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<Float32> irradianceHarmonics,
+    double intensity,
   );
-  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
-  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
+  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
+  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
+  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
+  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
+  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
+  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
+  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
+  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
+  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
+  external int _DebugRegistry_setProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    double value,
   );
-  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
+  external int _DebugRegistry_getProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Bool> outValue,
   );
-  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
-  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
+  external int _DebugRegistry_getProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Int32> outValue,
   );
-  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
-  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
+  external int _DebugRegistry_getProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Float32> outValue,
   );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
+  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
+  external Pointer<TBufferObject> _BufferObjectBuilder_build(
+    Pointer<TBufferObjectBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
+  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
+  external void _BufferObject_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TBufferObject> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
   );
-  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
-  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
-  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
+  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
   external Pointer<Void> _RenderThread_create();
   external Pointer<Void> _RenderThread_createForCanvas(Pointer<Char> canvasSelector);
   external void _RenderThread_destroy(Pointer<Void> renderThread);
@@ -1791,238 +2020,43 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    int vertexBufferStorageMode,
-    Pointer<Aabb3> boundingBoxPtr,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
+  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
     Pointer<TFilamentAsset> tFilamentAsset,
-    int requiredGeometryCapabilities,
   );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
-  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
-  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
+  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
   );
-  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
-  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
-  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
-  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
-  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
-  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
+
+  /// Returns the visibility mask bits.
+  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
+
+  /// Returns the skybox intensity in lux.
+  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
+
+  /// Returns the environment texture, or nullptr for a color-only skybox.
+  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
   external void _MeshData_dispose(Pointer<TMeshData> meshData);
   external int _GltfParser_parseBuffer(
     Pointer<Uint8> data,
     size_t length,
     Pointer<Char> meshName,
     Pointer<TMeshData> outMeshData,
-  );
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
-  );
-  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
-  );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
-  );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
-  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
-  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-  external void _FrameScheduler_stop();
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external void _Gizmo_dummy(int t);
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
-  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
-  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
-  );
-  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
-  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
-  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
-  external int _AnimationManager_addGltfAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_removeGltfAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _AnimationManager_addMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-  );
-  external void _AnimationManager_removeMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-  );
-  external int _AnimationManager_addBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_removeBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_setMorphAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    Pointer<Uint32> morphIndices,
-    int numMorphTargets,
-    int numFrames,
-    double frameLengthInMs,
-  );
-  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
-  external void _AnimationManager_resetToRestPose(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_addBoneAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> frameData,
-    int numFrames,
-    double frameLengthInMs,
-    double fadeOutInSecs,
-    double fadeInInSecs,
-    double maxDelta,
-    bool loop,
-  );
-  external void _AnimationManager_getRestLocalTransforms(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    Pointer<Float32> out,
-    int numBones,
-  );
-  external void _AnimationManager_getInverseBindMatrix(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> out,
-  );
-  external int _AnimationManager_playGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-    bool loop,
-    bool reverse,
-    bool replaceActive,
-    double crossfade,
-    double startOffset,
-    double speed,
-  );
-  external int _AnimationManager_stopGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int index,
-  );
-  external double _AnimationManager_getGltfAnimationDuration(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int animationIndex,
-  );
-  external int _AnimationManager_getGltfAnimationCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external void _AnimationManager_getGltfAnimationName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_getMorphTargetNameCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-  );
-  external void _AnimationManager_getMorphTargetName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_updateBoneMatrices(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_setMorphTargetWeights(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    int numWeights,
-  );
-  external int _AnimationManager_setGltfAnimationTime(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int animationIndex,
-    double timeInSeconds,
   );
   external void _RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
   external int _RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
@@ -2238,215 +2272,181 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t bonesPerVertex,
   );
   external int _RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, EntityId entity);
-  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
-  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    int vertexBufferStorageMode,
+    Pointer<Aabb3> boundingBoxPtr,
   );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<double4x4> tModelMatrixPtr);
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
-  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
-  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
-  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
-  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
-
-  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
-
-  /// Returns the visibility mask bits.
-  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
-
-  /// Returns the skybox intensity in lux.
-  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
-
-  /// Returns the environment texture, or nullptr for a color-only skybox.
-  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
-  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
-  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
-  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
     Pointer<TFilamentAsset> tFilamentAsset,
+    int requiredGeometryCapabilities,
   );
-  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
+  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
+  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
   );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
-  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
-  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
+  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
+  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
+  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
+  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
+  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
+  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
+  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
+  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
+  external int _AnimationManager_addGltfAnimationComponent(
     Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
+  external int _AnimationManager_removeGltfAnimationComponent(
     Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
+  external void _AnimationManager_addMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
   );
-  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
-  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
-  external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
+  external void _AnimationManager_removeMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
   );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
+  external int _AnimationManager_addBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
+  external int _AnimationManager_removeBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
+  external int _AnimationManager_setMorphAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    Pointer<Uint32> morphIndices,
+    int numMorphTargets,
+    int numFrames,
+    double frameLengthInMs,
   );
-  external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
+  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
+  external void _AnimationManager_resetToRestPose(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
   );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
+  external int _AnimationManager_addBoneAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> frameData,
+    int numFrames,
+    double frameLengthInMs,
+    double fadeOutInSecs,
+    double fadeInInSecs,
+    double maxDelta,
+    bool loop,
   );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
-  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
-  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
+  external void _AnimationManager_getRestLocalTransforms(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
     Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
+    int numBones,
   );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
+  external void _AnimationManager_getInverseBindMatrix(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> out,
   );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
+  external int _AnimationManager_playGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+    bool loop,
+    bool reverse,
+    bool replaceActive,
+    double crossfade,
+    double startOffset,
+    double speed,
   );
-  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
+  external int _AnimationManager_stopGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int index,
+  );
+  external double _AnimationManager_getGltfAnimationDuration(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int animationIndex,
+  );
+  external int _AnimationManager_getGltfAnimationCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external void _AnimationManager_getGltfAnimationName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_getMorphTargetNameCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+  );
+  external void _AnimationManager_getMorphTargetName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_updateBoneMatrices(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external int _AnimationManager_setMorphTargetWeights(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    int numWeights,
+  );
+  external int _AnimationManager_setGltfAnimationTime(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int animationIndex,
+    double timeInSeconds,
+  );
   external void _MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor);
   external void _MovementIntentExecutor_process(
     Pointer<TMovementIntentExecutor> executor,
@@ -2833,587 +2833,341 @@ int Material_getBlendingMode(Pointer<TMaterial> material) {
   return result;
 }
 
-Pointer<TTexture> Texture_build(
-  Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import1,
-  int sampler,
-  int format,
-) {
-  final result = GeneratedBindings.instance._Texture_build(
-    engine.cast(),
-    width,
-    height,
-    depth,
-    levels,
-    tUsage,
-    import1,
-    sampler,
-    format,
-  );
-  return Pointer<TTexture>(result);
-}
-
-void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
-  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
-  return result;
-}
-
-Dartsize_t Texture_getLevels(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
-  return result;
-}
-
-bool Texture_loadImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-) {
-  final result = GeneratedBindings.instance._Texture_loadImage(
+int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
     tEngine.cast(),
-    tTexture.cast(),
-    tImage.cast(),
-    bufferFormat,
-    pixelDataType,
-    level,
+    tLightManager.cast(),
+    tLightTtype,
   );
+  return result;
+}
+
+void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
   return result == 1;
 }
 
-bool Texture_setImage(
+int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
+  return result;
+}
+
+double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+  return result;
+}
+
+double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+  return result;
+}
+
+bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
+  return result;
+}
+
+void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+    lambda,
+  );
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
+  return result;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
+  return result;
+}
+
+void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
+  return Pointer<Void>(result);
+}
+
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
   Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  int level,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+    tEngine.cast(),
+    tMaterialProvider.cast(),
+    tNameComponentManager.cast(),
+  );
+  return Pointer<TGltfAssetLoader>(result);
+}
+
+void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
+  return result;
+}
+
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dartsize_t size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
+  Dart__darwin_size_t length,
+  int numInstances,
 ) {
-  final result = GeneratedBindings.instance._Texture_setImage(
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
     tEngine.cast(),
-    tTexture.cast(),
-    level,
+    tAssetLoader.cast(),
     data,
-    size,
-    x_offset,
-    y_offset,
-    z_offset,
-    width,
-    height,
-    depth,
-    bufferFormat,
-    pixelDataType,
+    length,
+    numInstances,
   );
-  return result == 1;
+  return Pointer<TFilamentAsset>(result);
 }
 
-int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getFormat(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
-  return result;
-}
-
-int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
-  return result;
-}
-
-void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
-  return result;
-}
-
-Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dartsize_t length) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
-  return Pointer<TKtx1Bundle>(result);
-}
-
-void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
-  return result;
-}
-
-bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
-  return result == 1;
-}
-
-void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
-  return result;
-}
-
-Pointer<TTexture> Ktx1Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  DartVoidCallback onTextureUploadComplete,
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
 ) {
-  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
-    tEngine.cast(),
-    tBundle.cast(),
-    requestId,
-    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
+    tRenderableManager.cast(),
+    tAsset.cast(),
   );
-  return Pointer<TTexture>(result);
+  return Pointer<TMaterialInstance>(result);
 }
 
-Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dartsize_t size) {
-  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
-  return Pointer<TTexture>(result);
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
 }
 
-Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
-  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dartsize_t length, Pointer<Char> name, bool alpha) {
-  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
-  return Pointer<Float32>(result);
-}
-
-void Image_destroy(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
   return result;
 }
 
-int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
-  return result;
-}
-
-int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
-  return result;
-}
-
-int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
-  return result;
-}
-
-Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_create() {
-  final result = GeneratedBindings.instance._TextureSampler_create();
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
-    minFilter,
-    magFilter,
-    wrapS,
-    wrapT,
-    wrapR,
-  );
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
-  return Pointer<TTextureSampler>(result);
-}
-
-void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
-  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
-  return result;
-}
-
-void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
-  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
-  return result;
-}
-
-void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
-  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
-  return result;
-}
-
-Pointer<TEngine> Engine_create(
-  int backend,
-  Pointer<Void> platform,
-  Pointer<Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-) {
-  final result = GeneratedBindings.instance._Engine_create(
-    backend,
-    platform,
-    sharedContext,
-    stereoscopicEyeCount,
-    disableHandleUseAfterFreeCheck,
-  );
-  return Pointer<TEngine>(result);
-}
-
-int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
-  return result;
-}
-
-void Engine_destroy(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
-  return result;
-}
-
-Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
-  return Pointer<TRenderer>(result);
-}
-
-void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
-  return result;
-}
-
-Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
-    tEngine.cast(),
-    width,
-    height,
-    flags.toJSBigInt,
-  );
-  return Pointer<TSwapChain>(result);
-}
-
-void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
-  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
-  return result;
-}
-
-void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
-  return result;
-}
-
-void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
-  return result;
-}
-
-void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
-  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
-  return result;
-}
-
-Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
-  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
-  return Pointer<TView>(result);
-}
-
-Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
-  return Pointer<TTransformManager>(result);
-}
-
-Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
-  return Pointer<TRenderableManager>(result);
-}
-
-Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
-  return Pointer<TLightManager>(result);
-}
-
-Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
-  return Pointer<TEntityManager>(result);
-}
-
-void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
-  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
-  return result;
-}
-
-Dartsize_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
-  return result;
-}
-
-void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
-  return result;
-}
-
-Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
-  return Pointer<TFence>(result);
-}
-
-void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
-  return result;
-}
-
-void Engine_flushAndWait(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
-  return result;
-}
-
-void Engine_execute(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
-  return result;
-}
-
-Pointer<TMaterial> Engine_buildMaterial(Pointer<TEngine> tEngine, Pointer<Uint8> materialData, Dartsize_t length) {
-  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
-  return Pointer<TMaterial>(result);
-}
-
-void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
-  return result;
-}
-
-void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
-  return result;
-}
-
-Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TSkybox> Engine_buildSkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildSkybox(
-    tEngine.cast(),
-    tTexture.cast(),
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TSkybox> Engine_buildColoredSkybox(
-  Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
-    tEngine.cast(),
-    r,
-    g,
-    b,
-    a,
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    tIrradianceTexture.cast(),
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<Float32> irradianceHarmonics,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    irradianceHarmonics,
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
-  return result;
-}
-
-void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
-  return result;
-}
-
-DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
-  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
-  return result;
-}
-
-void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
-  return result;
-}
-
-void Fence_waitAndDestroy(Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
-  return result;
-}
-
-Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
-  return Pointer<TDebugRegistry>(result);
-}
-
-bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
-  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Bool> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Int32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Float32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
+  return Pointer<PointerClass<Char>>(result);
 }
 
 TViewport View_getViewport(Pointer<TView> view) {
@@ -3893,6 +3647,503 @@ Pointer<Char> View_getName(Pointer<TView> tView) {
   return Pointer<Char>(result);
 }
 
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
+  return result;
+}
+
+Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
+  return Pointer<Char>(result);
+}
+
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dart__darwin_size_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, Dart__darwin_size_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(Pointer<TSurfaceOrientationBuilder> builder, Pointer<Uint32> triangles) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dart__darwin_size_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
+  return result;
+}
+
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
+  return result;
+}
+
+void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
+  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+  return result;
+}
+
+Pointer<TTexture> Texture_build(
+  Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import1,
+  int sampler,
+  int format,
+) {
+  final result = GeneratedBindings.instance._Texture_build(
+    engine.cast(),
+    width,
+    height,
+    depth,
+    levels,
+    tUsage,
+    import1,
+    sampler,
+    format,
+  );
+  return Pointer<TTexture>(result);
+}
+
+void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
+  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
+  return result;
+}
+
+Dart__darwin_size_t Texture_getLevels(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
+  return result;
+}
+
+bool Texture_loadImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+) {
+  final result = GeneratedBindings.instance._Texture_loadImage(
+    tEngine.cast(),
+    tTexture.cast(),
+    tImage.cast(),
+    bufferFormat,
+    pixelDataType,
+    level,
+  );
+  return result == 1;
+}
+
+bool Texture_setImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  int level,
+  Pointer<Uint8> data,
+  Dart__darwin_size_t size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+) {
+  final result = GeneratedBindings.instance._Texture_setImage(
+    tEngine.cast(),
+    tTexture.cast(),
+    level,
+    data,
+    size,
+    x_offset,
+    y_offset,
+    z_offset,
+    width,
+    height,
+    depth,
+    bufferFormat,
+    pixelDataType,
+  );
+  return result == 1;
+}
+
+int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getFormat(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
+  return result;
+}
+
+int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
+  return result;
+}
+
+void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
+  return result;
+}
+
+Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dart__darwin_size_t length) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
+  return Pointer<TKtx1Bundle>(result);
+}
+
+void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
+  return result;
+}
+
+bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
+  return result == 1;
+}
+
+void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
+  return result;
+}
+
+Pointer<TTexture> Ktx1Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  DartVoidCallback onTextureUploadComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
+    tEngine.cast(),
+    tBundle.cast(),
+    requestId,
+    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dart__darwin_size_t size) {
+  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
+  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dart__darwin_size_t length, Pointer<Char> name, bool alpha) {
+  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
+  return Pointer<Float32>(result);
+}
+
+void Image_destroy(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+  return result;
+}
+
+int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
+  return result;
+}
+
+int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
+  return result;
+}
+
+int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
+  return result;
+}
+
+Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_create() {
+  final result = GeneratedBindings.instance._TextureSampler_create();
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
+    minFilter,
+    magFilter,
+    wrapS,
+    wrapT,
+    wrapR,
+  );
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
+  return Pointer<TTextureSampler>(result);
+}
+
+void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
+  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
+  return result;
+}
+
+void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
+  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
+  return result;
+}
+
+void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
+  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
+  return result;
+}
+
+void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
+    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+    tEngine.cast(),
+    assetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+  );
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
+  final result = GeneratedBindings.instance._Gizmo_pick(
+    tGizmo.cast(),
+    x,
+    y,
+    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
+  );
+  return result;
+}
+
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
+  return result;
+}
+
+void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
+}
+
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -3978,6 +4229,58 @@ Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   return Pointer<TMaterialInstance>(result);
 }
 
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
+}
+
+void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
+  return result;
+}
+
+void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
+  return result;
+}
+
+Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dart__darwin_size_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
+  return result;
+}
+
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dart__darwin_size_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
+  return result;
+}
+
 Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
   final result = GeneratedBindings.instance._VertexBufferBuilder_create();
   return Pointer<TVertexBufferBuilder>(result);
@@ -4037,7 +4340,7 @@ void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
   return result;
 }
 
-Dartsize_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
+Dart__darwin_size_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
   final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(buffer.cast());
   return result;
 }
@@ -4047,7 +4350,7 @@ void VertexBuffer_setBufferAt(
   Pointer<TVertexBuffer> buffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
 ) {
   final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
@@ -4081,97 +4384,286 @@ void VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer
   return result;
 }
 
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
+Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
+  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
+  return Pointer<TRenderTarget>(result);
 }
 
-void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
+void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
   return result;
 }
 
-void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
   return result;
 }
 
-Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
   return result;
 }
 
-Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
   return result;
 }
 
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
+Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
+  return Pointer<TSkybox>(result);
+}
+
+void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
+  return result;
+}
+
+Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
 ) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
   );
   return result;
 }
 
-void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
-  return result;
-}
-
-Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
-  return Pointer<TBufferObjectBuilder>(result);
-}
-
-void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
-  return result;
-}
-
-Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TBufferObject>(result);
-}
-
-void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
-  return result;
-}
-
-void BufferObject_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TBufferObject> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
 ) {
-  final result = GeneratedBindings.instance._BufferObject_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
+  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
   );
   return result;
 }
 
-void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
-  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
+void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
+  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
+  return result;
+}
+
+void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
+  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
+  return result;
+}
+
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
+  return result;
+}
+
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
+  return result;
+}
+
+void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
+  return result;
+}
+
+void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
+  return result;
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
+    camera.cast(),
+    projectionMatrixPtr.cast(),
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setModelMatrix(Pointer<TCamera> camera, double4x4 tModelMatrix) {
+  final tModelMatrixPtr = tModelMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrixPtr.cast());
+  return result;
+}
+
+void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
+  return result;
+}
+
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
   return result;
 }
 
@@ -4303,259 +4795,454 @@ void TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager>
   return result;
 }
 
-int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+  );
+  return result;
+}
+
+bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+  return result;
+}
+
+void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dart__darwin_size_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+  );
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+    tRenderer.cast(),
+    headRoomRatio,
+    scaleRate,
+    history,
+    interval,
+  );
+  return result;
+}
+
+Pointer<TEngine> Engine_create(
+  int backend,
+  Pointer<Void> platform,
+  Pointer<Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+) {
+  final result = GeneratedBindings.instance._Engine_create(
+    backend,
+    platform,
+    sharedContext,
+    stereoscopicEyeCount,
+    disableHandleUseAfterFreeCheck,
+  );
+  return Pointer<TEngine>(result);
+}
+
+int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
+  return result;
+}
+
+void Engine_destroy(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
+  return result;
+}
+
+Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
+  return Pointer<TRenderer>(result);
+}
+
+void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
+  return result;
+}
+
+Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
     tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
+    width,
+    height,
+    flags.toJSBigInt,
   );
+  return Pointer<TSwapChain>(result);
+}
+
+void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
+  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
   return result;
 }
 
-void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
+void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
   return result;
 }
 
-bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
+void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
   return result;
 }
 
-bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
+  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
   return result;
 }
 
-double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
+Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
 }
 
-void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
+  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
   return result;
 }
 
-double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
+Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
+  return Pointer<TView>(result);
 }
 
-void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
+  return Pointer<TTransformManager>(result);
+}
+
+Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
+  return Pointer<TRenderableManager>(result);
+}
+
+Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
+  return Pointer<TLightManager>(result);
+}
+
+Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
+  return Pointer<TEntityManager>(result);
+}
+
+void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
+  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
   return result;
 }
 
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
+Dart__darwin_size_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
+  return result;
+}
+
+void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
+  return result;
+}
+
+Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
+  return Pointer<TFence>(result);
+}
+
+void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
+  return result;
+}
+
+void Engine_flushAndWait(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
+  return result;
+}
+
+void Engine_execute(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
+  return result;
+}
+
+Pointer<TMaterial> Engine_buildMaterial(
+  Pointer<TEngine> tEngine,
+  Pointer<Uint8> materialData,
+  Dart__darwin_size_t length,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
-  );
+  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
+  return Pointer<TMaterial>(result);
+}
+
+void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
   return result;
 }
 
-double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
   return result;
 }
 
-void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
-  return result;
+Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
+  return Pointer<TScene>(result);
 }
 
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
+Pointer<TSkybox> Engine_buildSkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
+  final result = GeneratedBindings.instance._Engine_buildSkybox(
+    tEngine.cast(),
+    tTexture.cast(),
+    showSun,
+    intensity,
+    priority,
   );
-  return result;
+  return Pointer<TSkybox>(result);
 }
 
-double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
-  return result;
-}
-
-double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
+Pointer<TSkybox> Engine_buildColoredSkybox(
+  Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
+  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
+    tEngine.cast(),
+    r,
+    g,
+    b,
+    a,
+    showSun,
+    intensity,
+    priority,
   );
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    tIrradianceTexture.cast(),
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<Float32> irradianceHarmonics,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    irradianceHarmonics,
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
   return result;
 }
 
-double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
   return result;
 }
 
-void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
+  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
   return result;
 }
 
-double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
   return result;
 }
 
-void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
+void Fence_waitAndDestroy(Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
   return result;
 }
 
-double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
-  return result;
+Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
+  return Pointer<TDebugRegistry>(result);
 }
 
-void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
-  return result;
-}
-
-bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
+bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
+  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
   return result == 1;
 }
 
-void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
   return result == 1;
 }
 
-void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
-  return result;
+bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
+  return result == 1;
 }
 
-void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
-  return result;
+bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
+  return result == 1;
 }
 
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
+bool DebugRegistry_getProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Bool> outValue,
 ) {
-  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
-    splitPositions,
-    cascades,
-    near,
-    far,
-    lambda,
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Int32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Float32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
+  return Pointer<TBufferObjectBuilder>(result);
+}
+
+void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
+  return result;
+}
+
+Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TBufferObject>(result);
+}
+
+void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
+  return result;
+}
+
+void BufferObject_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TBufferObject> buffer,
+  Pointer<Void> data,
+  Dart__darwin_size_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._BufferObject_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
   );
   return result;
 }
 
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
+void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
+  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
   return result;
 }
 
@@ -4792,7 +5479,7 @@ void Engine_createViewRenderThread(
 void Engine_buildMaterialRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
@@ -5012,7 +5699,7 @@ void Ktx1Reader_createTextureRenderThread(
 void Ktx2Reader_createTextureRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
   Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Ktx2Reader_createTextureRenderThread(
@@ -5258,7 +5945,7 @@ void Renderer_readPixelsRenderThread(
   int tPixelBufferFormat,
   int tPixelDataType,
   Pointer<Uint8> out,
-  Dartsize_t outLength,
+  Dart__darwin_size_t outLength,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -6136,7 +6823,7 @@ void Image_createEmptyRenderThread(
 
 void Image_decodeRenderThread(
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<Char> name,
   bool alpha,
   Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
@@ -6212,7 +6899,7 @@ void Texture_setImageRenderThread(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -6519,7 +7206,7 @@ void GltfResourceLoader_addResourceDataRenderThread(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -6567,7 +7254,7 @@ void GltfAssetLoader_loadRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int numInstances,
   Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
 ) {
@@ -6754,7 +7441,7 @@ void VertexBuffer_setBufferAtRenderThread(
   Pointer<TVertexBuffer> tBuffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -6808,7 +7495,7 @@ void BufferObject_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TBufferObject> tBuffer,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -6872,7 +7559,7 @@ void IndexBuffer_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TIndexBuffer> tBuffer,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7016,8 +7703,8 @@ void RenderableManager_setMorphWeightsRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> weights,
-  Dartsize_t count,
-  Dartsize_t offset,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7037,8 +7724,8 @@ void RenderableManager_setBonesFromMat4RenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7058,8 +7745,8 @@ void RenderableManager_setBonesFromBoneRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7081,8 +7768,8 @@ void RenderableManager_setGeometryAtNonIndexedRenderThread(
   int primitiveIndex,
   int type,
   Pointer<TVertexBuffer> tVertices,
-  Dartsize_t offset,
-  Dartsize_t count,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
   Pointer<NativeFunction<void Function(bool)>> callback,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexedRenderThread(
@@ -7164,6 +7851,681 @@ void LightManager_setShadowOptionsRenderThread(
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
+  return result;
+}
+
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
+  return Pointer<TGltfResourceLoader>(result);
+}
+
+void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
+  return result;
+}
+
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
+  return result;
+}
+
+double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dart__darwin_size_t length,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
+  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
+  return result;
+}
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
+  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
+  return result;
+}
+
+/// Returns the visibility mask bits.
+int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
+  return result;
+}
+
+/// Returns the skybox intensity in lux.
+double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
+  return result;
+}
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
+  return Pointer<TTexture>(result);
+}
+
+void MeshData_dispose(Pointer<TMeshData> meshData) {
+  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
+  return result;
+}
+
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dart__darwin_size_t length,
+  Pointer<Char> meshName,
+  Pointer<TMeshData> outMeshData,
+) {
+  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
+  return result;
+}
+
+void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
+  return result == 1;
+}
+
+bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+Dart__darwin_size_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
+  return result;
+}
+
+bool RenderableManager_setMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  Pointer<TMaterialInstance> tMaterialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    tMaterialInstance.cast(),
+  );
+  return result == 1;
+}
+
+Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+void RenderableManager_clearMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return result;
+}
+
+bool RenderableManager_setGeometryAtNonIndexed(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result == 1;
+}
+
+Dart__darwin_size_t RenderableManager_getPrimitiveCount(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+Aabb3 RenderableManager_getAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+void RenderableManager_setAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Aabb3 aabb,
+) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
+    tRenderableManager.cast(),
+    entityId,
+    aabbPtr.cast(),
+  );
+  return result;
+}
+
+Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAabb(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+void RenderableManager_setLayerMask(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int select,
+  int values,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
+    tRenderableManager.cast(),
+    entityId,
+    select,
+    values,
+  );
+  return result;
+}
+
+int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setVisibilityLayer(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int layer,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
+    tRenderableManager.cast(),
+    entityId,
+    layer,
+  );
+  return result;
+}
+
+void RenderableManager_setPriority(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setPriority(
+    tRenderableManager.cast(),
+    entityId,
+    priority,
+  );
+  return result;
+}
+
+int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
+  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
+  return result;
+}
+
+void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
+  return result;
+}
+
+bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setFogEnabled(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool RenderableManager_getLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+  );
+  return result == 1;
+}
+
+void RenderableManager_setCastShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool castShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
+    tRenderableManager.cast(),
+    entityId,
+    castShadows,
+  );
+  return result;
+}
+
+bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setReceiveShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool receiveShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
+    tRenderableManager.cast(),
+    entityId,
+    receiveShadows,
+  );
+  return result;
+}
+
+bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setScreenSpaceContactShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setBlendOrderAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dart__darwin_size_t primitiveIndex,
+  int order,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    order,
+  );
+  return result;
+}
+
+void RenderableManager_setGlobalBlendOrderEnabledAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dart__darwin_size_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setMorphWeights(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> weights,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
+    tRenderableManager.cast(),
+    entityId,
+    weights,
+    count,
+    offset,
+  );
+  return result;
+}
+
+Dart__darwin_size_t RenderableManager_getMorphTargetCount(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setBonesFromMat4(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> transforms,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
+    tRenderableManager.cast(),
+    entityId,
+    transforms,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+void RenderableManager_setBonesFromBone(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> bones,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
+    tRenderableManager.cast(),
+    entityId,
+    bones,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+Pointer<TRenderableBuilder> RenderableBuilder_create(Dart__darwin_size_t primitiveCount) {
+  final result = GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
+  return Pointer<TRenderableBuilder>(result);
+}
+
+void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
+  final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
+  return result;
+}
+
+void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
+  return result;
+}
+
+void RenderableBuilder_material(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  Pointer<TMaterialInstance> materialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_material(
+    builder.cast(),
+    primitiveIndex,
+    materialInstance.cast(),
+  );
+  return result;
+}
+
+void RenderableBuilder_geometry(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Pointer<TIndexBuffer> indices,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_geometry(
+    builder.cast(),
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    indices.cast(),
+    offset,
+    count,
+  );
+  return result;
+}
+
+void RenderableBuilder_geometryNonIndexed(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_geometryNonIndexed(
+    builder.cast(),
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result;
+}
+
+void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
+  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
+  return result;
+}
+
+void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
+  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
+  return result;
+}
+
+void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
+  return result;
+}
+
+void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
+  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
+  return result;
+}
+
+void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dart__darwin_size_t primitiveIndex, int order) {
+  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
+  return result;
+}
+
+void RenderableBuilder_globalBlendOrderEnabled(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_globalBlendOrderEnabled(
+    builder.cast(),
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dart__darwin_size_t instanceCount) {
+  final result = GeneratedBindings.instance._RenderableBuilder_instances(builder.cast(), instanceCount);
+  return result;
+}
+
+void RenderableBuilder_skinningFromMat4(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t boneCount,
+  Pointer<Float32> transforms,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
+  return result;
+}
+
+void RenderableBuilder_skinningFromBone(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t boneCount,
+  Pointer<Float32> bones,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(builder.cast(), boneCount, bones);
+  return result;
+}
+
+void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_boneIndicesAndWeights(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  Pointer<Float32> indicesAndWeights,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t bonesPerVertex,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
+    builder.cast(),
+    primitiveIndex,
+    indicesAndWeights,
+    count,
+    bonesPerVertex,
+  );
+  return result;
+}
+
+int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
+  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
   return result;
 }
 
@@ -7253,7 +8615,7 @@ Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
   return Pointer<Int32>(result);
 }
 
-Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+Dart__darwin_size_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
   return result;
 }
@@ -7263,7 +8625,7 @@ Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
   return Pointer<Int32>(result);
 }
 
-Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+Dart__darwin_size_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(tSceneAsset.cast());
   return result;
 }
@@ -7273,7 +8635,7 @@ Pointer<TSceneAsset> SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, in
   return Pointer<TSceneAsset>(result);
 }
 
-Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
+Dart__darwin_size_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(tSceneAsset.cast());
   return result;
 }
@@ -7337,199 +8699,23 @@ void SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShadin
   return result;
 }
 
-void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Pointer<Int32> out) {
+void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dart__darwin_size_t skinIndex, Pointer<Int32> out) {
   final result = GeneratedBindings.instance._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
   return result;
 }
 
-Dartsize_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex) {
+Dart__darwin_size_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dart__darwin_size_t skinIndex) {
   final result = GeneratedBindings.instance._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
   return result;
 }
 
-Pointer<Char> SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Dartsize_t boneIndex) {
+Pointer<Char> SceneAsset_getBoneName(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dart__darwin_size_t skinIndex,
+  Dart__darwin_size_t boneIndex,
+) {
   final result = GeneratedBindings.instance._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
   return Pointer<Char>(result);
-}
-
-void MeshData_dispose(Pointer<TMeshData> meshData) {
-  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  Pointer<Char> meshName,
-  Pointer<TMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
-  return result;
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
-    tEngine.cast(),
-    tMaterialProvider.cast(),
-    tNameComponentManager.cast(),
-  );
-  return Pointer<TGltfAssetLoader>(result);
-}
-
-void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
-  return result;
-}
-
-Pointer<TFilamentAsset> GltfAssetLoader_load(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  int numInstances,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    data,
-    length,
-    numInstances,
-  );
-  return Pointer<TFilamentAsset>(result);
-}
-
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
-    tRenderableManager.cast(),
-    tAsset.cast(),
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
-}
-
-int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
-  return result;
-}
-
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
-  return Pointer<PointerClass<Char>>(result);
-}
-
-void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
-    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
-  return result;
-}
-
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-    tEngine.cast(),
-    assetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
-  );
-  return Pointer<TGizmo>(result);
-}
-
-void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
-  final result = GeneratedBindings.instance._Gizmo_pick(
-    tGizmo.cast(),
-    x,
-    y,
-    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
-  );
-  return result;
-}
-
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
-  return result;
-}
-
-void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
-}
-
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
-  return result;
-}
-
-Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
-  return Pointer<Char>(result);
-}
-
-Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
-  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
-  return Pointer<TRenderTarget>(result);
-}
-
-void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
-  return result;
 }
 
 Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
@@ -7858,1181 +9044,6 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
-void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
-  return result == 1;
-}
-
-bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-Dartsize_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
-  return result;
-}
-
-bool RenderableManager_setMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  Pointer<TMaterialInstance> tMaterialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    tMaterialInstance.cast(),
-  );
-  return result == 1;
-}
-
-Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-void RenderableManager_clearMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return result;
-}
-
-bool RenderableManager_setGeometryAtNonIndexed(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dartsize_t offset,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result == 1;
-}
-
-Dartsize_t RenderableManager_getPrimitiveCount(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-Aabb3 RenderableManager_getAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Aabb3 aabb,
-) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
-    tRenderableManager.cast(),
-    entityId,
-    aabbPtr.cast(),
-  );
-  return result;
-}
-
-Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAabb(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setLayerMask(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int select,
-  int values,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
-    tRenderableManager.cast(),
-    entityId,
-    select,
-    values,
-  );
-  return result;
-}
-
-int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setVisibilityLayer(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int layer,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
-    tRenderableManager.cast(),
-    entityId,
-    layer,
-  );
-  return result;
-}
-
-void RenderableManager_setPriority(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setPriority(
-    tRenderableManager.cast(),
-    entityId,
-    priority,
-  );
-  return result;
-}
-
-int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
-  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
-  return result;
-}
-
-void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
-  return result;
-}
-
-bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setFogEnabled(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool RenderableManager_getLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-  );
-  return result == 1;
-}
-
-void RenderableManager_setCastShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool castShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
-    tRenderableManager.cast(),
-    entityId,
-    castShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setReceiveShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool receiveShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
-    tRenderableManager.cast(),
-    entityId,
-    receiveShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setScreenSpaceContactShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setBlendOrderAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dartsize_t primitiveIndex,
-  int order,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    order,
-  );
-  return result;
-}
-
-void RenderableManager_setGlobalBlendOrderEnabledAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dartsize_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setMorphWeights(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> weights,
-  Dartsize_t count,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
-    tRenderableManager.cast(),
-    entityId,
-    weights,
-    count,
-    offset,
-  );
-  return result;
-}
-
-Dartsize_t RenderableManager_getMorphTargetCount(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setBonesFromMat4(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
-    tRenderableManager.cast(),
-    entityId,
-    transforms,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-void RenderableManager_setBonesFromBone(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
-    tRenderableManager.cast(),
-    entityId,
-    bones,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-Pointer<TRenderableBuilder> RenderableBuilder_create(Dartsize_t primitiveCount) {
-  final result = GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
-  return Pointer<TRenderableBuilder>(result);
-}
-
-void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
-  final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
-  return result;
-}
-
-void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
-  return result;
-}
-
-void RenderableBuilder_material(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_material(
-    builder.cast(),
-    primitiveIndex,
-    materialInstance.cast(),
-  );
-  return result;
-}
-
-void RenderableBuilder_geometry(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Pointer<TIndexBuffer> indices,
-  Dartsize_t offset,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_geometry(
-    builder.cast(),
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    indices.cast(),
-    offset,
-    count,
-  );
-  return result;
-}
-
-void RenderableBuilder_geometryNonIndexed(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dartsize_t offset,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_geometryNonIndexed(
-    builder.cast(),
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result;
-}
-
-void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
-  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
-  return result;
-}
-
-void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
-  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
-  return result;
-}
-
-void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
-  return result;
-}
-
-void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
-  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
-  return result;
-}
-
-void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dartsize_t primitiveIndex, int order) {
-  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
-  return result;
-}
-
-void RenderableBuilder_globalBlendOrderEnabled(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_globalBlendOrderEnabled(
-    builder.cast(),
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dartsize_t instanceCount) {
-  final result = GeneratedBindings.instance._RenderableBuilder_instances(builder.cast(), instanceCount);
-  return result;
-}
-
-void RenderableBuilder_skinningFromMat4(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
-  Pointer<Float32> transforms,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
-  return result;
-}
-
-void RenderableBuilder_skinningFromBone(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
-  Pointer<Float32> bones,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(builder.cast(), boneCount, bones);
-  return result;
-}
-
-void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_boneIndicesAndWeights(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  Pointer<Float32> indicesAndWeights,
-  Dartsize_t count,
-  Dartsize_t bonesPerVertex,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
-    builder.cast(),
-    primitiveIndex,
-    indicesAndWeights,
-    count,
-    bonesPerVertex,
-  );
-  return result;
-}
-
-int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
-  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
-  return result;
-}
-
-void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
-  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
-  return result;
-}
-
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
-  return result;
-}
-
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
-  return result;
-}
-
-void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
-  return result;
-}
-
-void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
-    camera.cast(),
-    projectionMatrixPtr.cast(),
-    near,
-    far,
-  );
-  return result;
-}
-
-void Camera_setModelMatrix(Pointer<TCamera> camera, double4x4 tModelMatrix) {
-  final tModelMatrixPtr = tModelMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrixPtr.cast());
-  return result;
-}
-
-void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
-  return result;
-}
-
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
-  return result;
-}
-
-Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
-  return Pointer<TSkybox>(result);
-}
-
-void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
-  return result;
-}
-
-void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
-  return result;
-}
-
-void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
-  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
-  return result;
-}
-
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
-  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
-  return result;
-}
-
-/// Returns the visibility mask bits.
-int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
-  return result;
-}
-
-/// Returns the skybox intensity in lux.
-double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
-  return result;
-}
-
-/// Returns the environment texture, or nullptr for a color-only skybox.
-Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
-  return Pointer<TTexture>(result);
-}
-
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
-  );
-  return result;
-}
-
-bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
-  return result;
-}
-
-void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dartsize_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
-  );
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-    tRenderer.cast(),
-    headRoomRatio,
-    scaleRate,
-    history,
-    interval,
-  );
-  return result;
-}
-
-void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
-  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
-  return result;
-}
-
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
-  return Pointer<TGltfResourceLoader>(result);
-}
-
-void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
-  return result;
-}
-
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
-  return result;
-}
-
-double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
-  return result;
-}
-
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
-  );
-  return result;
-}
-
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
-  return result;
-}
-
-void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
-  return Pointer<Void>(result);
-}
-
-Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
-  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
-  return result;
-}
-
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(Pointer<TSurfaceOrientationBuilder> builder, Pointer<Uint32> triangles) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dartsize_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
-  return result;
-}
-
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
-  return result;
-}
-
 void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
   final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(executor.cast());
   return result;
@@ -9155,34 +9166,34 @@ void TransformPipeline_setInvertMouseY(int invert) {
   return result;
 }
 
-extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
-  TMaterialInstance toDart() {
-    return TMaterialInstance(this);
-  }
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
 }
 
-final class TMaterialInstance extends Struct {
-  Pointer<TMaterialInstance> get address => super.address.cast();
-  TMaterialInstance(super.address);
-
-  static Pointer<TMaterialInstance> stackAlloc() {
-    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
-  }
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
-extension TMaterialExt on Pointer<TMaterial> {
-  TMaterial toDart() {
-    return TMaterial(this);
-  }
+sealed class TVertexBufferStorageMode {
+  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
+  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
+  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
 }
 
-final class TMaterial extends Struct {
-  Pointer<TMaterial> get address => super.address.cast();
-  TMaterial(super.address);
-
-  static Pointer<TMaterial> stackAlloc() {
-    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
-  }
+sealed class TSceneAssetGeometryCapability {
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_NONE = 0;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_BARYCENTRICS = 1;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_WRITABLE_VERTICES = 2;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_ACCESSIBLE_GEOMETRY_BUFFERS = 4;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_PRESERVED_TOPOLOGY = 8;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_UNIQUE_TRIANGLE_CORNERS = 16;
 }
 
 sealed class TFeatureLevel {
@@ -9192,56 +9203,73 @@ sealed class TFeatureLevel {
   static const FEATURE_LEVEL_3 = 3;
 }
 
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
-  }
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
-
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
-  }
+sealed class TVertexAttribute {
+  static const TVERTEX_ATTRIBUTE_POSITION = 0;
+  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
+  static const TVERTEX_ATTRIBUTE_COLOR = 2;
+  static const TVERTEX_ATTRIBUTE_UV0 = 3;
+  static const TVERTEX_ATTRIBUTE_UV1 = 4;
+  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
+  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
+  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
+  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
+  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
+  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
+  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
+  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
+  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
+  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
 }
 
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
+sealed class TVertexAttributeType {
+  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
+  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
+  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
+  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
+  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
+  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
+  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-extension TTextureExt on Pointer<TTexture> {
-  TTexture toDart() {
-    return TTexture(this);
-  }
-}
-
-final class TTexture extends Struct {
-  Pointer<TTexture> get address => super.address.cast();
-  TTexture(super.address);
-
-  static Pointer<TTexture> stackAlloc() {
-    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
-  }
-}
-
-extension TTextureSamplerExt on Pointer<TTextureSampler> {
-  TTextureSampler toDart() {
-    return TTextureSampler(this);
-  }
-}
-
-final class TTextureSampler extends Struct {
-  Pointer<TTextureSampler> get address => super.address.cast();
-  TTextureSampler(super.address);
-
-  static Pointer<TTextureSampler> stackAlloc() {
-    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
-  }
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
 }
 
 sealed class TSamplerCompareFunc {
@@ -9287,6 +9315,13 @@ sealed class TStencilFace {
   static const STENCIL_FACE_FRONT_AND_BACK = 3;
 }
 
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
 sealed class TTransparencyMode {
   /// ! the transparent object is drawn honoring the raster state
   static const DEFAULT = 0;
@@ -9312,453 +9347,87 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-typedef size_t = int;
-typedef Dartsize_t = int;
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
+extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
+  TMaterialInstance toDart() {
+    return TMaterialInstance(this);
   }
 }
 
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
+final class TMaterialInstance extends Struct {
+  Pointer<TMaterialInstance> get address => super.address.cast();
+  TMaterialInstance(super.address);
 
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  static Pointer<TMaterialInstance> stackAlloc() {
+    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
   }
 }
 
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
+extension TMaterialExt on Pointer<TMaterial> {
+  TMaterial toDart() {
+    return TMaterial(this);
   }
 }
 
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
+final class TMaterial extends Struct {
+  Pointer<TMaterial> get address => super.address.cast();
+  TMaterial(super.address);
 
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
+  static Pointer<TMaterial> stackAlloc() {
+    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
   }
 }
 
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
   }
 }
 
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
 
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
   }
 }
 
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
+extension TTextureExt on Pointer<TTexture> {
+  TTexture toDart() {
+    return TTexture(this);
   }
 }
 
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
+final class TTexture extends Struct {
+  Pointer<TTexture> get address => super.address.cast();
+  TTexture(super.address);
 
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  static Pointer<TTexture> stackAlloc() {
+    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
   }
 }
 
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
+extension TTextureSamplerExt on Pointer<TTextureSampler> {
+  TTextureSampler toDart() {
+    return TTextureSampler(this);
   }
 }
 
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
+final class TTextureSampler extends Struct {
+  Pointer<TTextureSampler> get address => super.address.cast();
+  TTextureSampler(super.address);
 
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
+  static Pointer<TTextureSampler> stackAlloc() {
+    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
   }
 }
 
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
-
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
-
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
-  }
-}
-
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
-}
-
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-typedef EntityId = int;
-typedef DartEntityId = int;
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
-  }
-}
-
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
-
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
-  }
-}
-
-extension TRenderableManagerExt on Pointer<TRenderableManager> {
-  TRenderableManager toDart() {
-    return TRenderableManager(this);
-  }
-}
-
-final class TRenderableManager extends Struct {
-  Pointer<TRenderableManager> get address => super.address.cast();
-  TRenderableManager(super.address);
-
-  static Pointer<TRenderableManager> stackAlloc() {
-    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
-  }
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
 }
 
 extension TLightManagerExt on Pointer<TLightManager> {
@@ -9776,79 +9445,423 @@ final class TLightManager extends Struct {
   }
 }
 
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+typedef EntityId = int;
+typedef DartEntityId = int;
+
+extension double3Ext on Pointer<double3> {
+  double3 toDart() {
+    return double3(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class double3 extends Struct {
+  Pointer<double3> get address => super.address.cast();
+  double get x {
+    final addr = Pointer<double3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  set x(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
+  }
+
+  double get y {
+    final addr = Pointer<double3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set y(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
+  }
+
+  double get z {
+    final addr = Pointer<double3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set z(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
+  }
+
+  double3(super.address);
+
+  static Pointer<double3> stackAlloc() {
+    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
   }
 }
 
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
+extension TShadowOptionsExt on Pointer<TShadowOptions> {
+  TShadowOptions toDart() {
+    return TShadowOptions(this);
   }
 }
 
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
+final class TShadowOptions extends Struct {
+  Pointer<TShadowOptions> get address => super.address.cast();
+  int get mapSize {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
 
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  set mapSize(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
+  }
+
+  int get shadowCascades {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set shadowCascades(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
+  }
+
+  Array<Float32> get cascadeSplitPositions {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float32>((numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
+  }
+
+  set cascadeSplitPositions(Array<Float32> val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 5), val.internal.addr.addr.toJS, '*');
+  }
+
+  double get constantBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set constantBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
+  }
+
+  double get normalBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set normalBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
+  }
+
+  double get shadowFar {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFar(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
+  }
+
+  double get shadowNearHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowNearHint(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
+  }
+
+  double get shadowFarHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFarHint(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
+  }
+
+  bool get stable {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set stable(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 37), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  bool get lispsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set lispsm(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get polygonOffsetConstant {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetConstant(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
+  }
+
+  double get polygonOffsetSlope {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetSlope(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
+  }
+
+  bool get screenSpaceContactShadows {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set screenSpaceContactShadows(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 47), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  int get stepCount {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set stepCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
+  }
+
+  double get maxShadowDistance {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxShadowDistance(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
+  }
+
+  bool get vsmElvsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set vsmElvsm(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 53), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get vsmBlurWidth {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set vsmBlurWidth(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
+  }
+
+  double get shadowBulbRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowBulbRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
+  }
+
+  double get penumbraScale {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
+  }
+
+  double get penumbraRatioScale {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraRatioScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
+  }
+
+  double get maxPenumbraRatio {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxPenumbraRatio(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
+  }
+
+  double get maxSearchRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxSearchRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
+  }
+
+  TShadowOptions(super.address);
+
+  static Pointer<TShadowOptions> stackAlloc() {
+    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
   }
 }
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
   }
 }
 
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
 
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
   }
 }
 
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
   }
 }
 
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
 
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
   }
 }
 
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
   }
 }
 
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
 
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
   }
+}
+
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
+  }
+}
+
+typedef size_t = __darwin_size_t;
+typedef __darwin_size_t = int;
+typedef Dart__darwin_size_t = int;
+
+extension TRenderableManagerExt on Pointer<TRenderableManager> {
+  TRenderableManager toDart() {
+    return TRenderableManager(this);
+  }
+}
+
+final class TRenderableManager extends Struct {
+  Pointer<TRenderableManager> get address => super.address.cast();
+  TRenderableManager(super.address);
+
+  static Pointer<TRenderableManager> stackAlloc() {
+    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
+  }
+}
+
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
+}
+
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
+}
+
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
 }
 
 extension TViewportExt on Pointer<TViewport> {
@@ -9906,6 +9919,21 @@ final class TViewport extends Struct {
   }
 }
 
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
 extension TToneMapperExt on Pointer<TToneMapper> {
   TToneMapper toDart() {
     return TToneMapper(this);
@@ -9936,21 +9964,34 @@ final class TColorGradingBuilder extends Struct {
   }
 }
 
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
 }
 
-sealed class TLutFormat {
-  static const INTEGER = 0;
-  static const FLOAT = 1;
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
+  }
 }
 
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
+  }
+}
+
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
+
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
+  }
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -10085,6 +10126,41 @@ final class TVsmShadowOptions extends Struct {
   static Pointer<TVsmShadowOptions> stackAlloc() {
     return Pointer<TVsmShadowOptions>(NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
   }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
+  }
+}
+
+sealed class TAmbientOcclusionType {
+  static const SAO = 0;
+  static const GTAO = 1;
 }
 
 /// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
@@ -10511,11 +10587,6 @@ final class TGtao extends Struct {
   }
 }
 
-sealed class TAmbientOcclusionType {
-  static const SAO = 0;
-  static const GTAO = 1;
-}
-
 /// Copied from FogOptions in View.h
 
 extension TFogOptionsExt on Pointer<TFogOptions> {
@@ -10680,18 +10751,423 @@ typedef PickCallbackFunction =
 typedef DartPickCallbackFunction =
     void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
 
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
   }
 }
 
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
 
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
+  }
+}
+
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
+  }
+}
+
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
+
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
+  }
+}
+
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
+  }
+}
+
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
+
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
+  }
+}
+
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  }
+}
+
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
+  }
+}
+
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
+
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
+  }
+}
+
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
+  }
+}
+
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
+
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  }
+}
+
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
+  }
+}
+
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
+
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
+  }
+}
+
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
+  }
+}
+
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
+
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
+  }
+}
+
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
+  }
+}
+
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
+
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
   }
 }
 
@@ -10708,59 +11184,6 @@ final class TVertexBufferBuilder extends Struct {
   static Pointer<TVertexBufferBuilder> stackAlloc() {
     return Pointer<TVertexBufferBuilder>(NativeLibrary.instance.stackAlloc<TVertexBufferBuilder>(0));
   }
-}
-
-sealed class TVertexBufferStorageMode {
-  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
-  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
-  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
-}
-
-sealed class TVertexAttribute {
-  static const TVERTEX_ATTRIBUTE_POSITION = 0;
-  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
-  static const TVERTEX_ATTRIBUTE_COLOR = 2;
-  static const TVERTEX_ATTRIBUTE_UV0 = 3;
-  static const TVERTEX_ATTRIBUTE_UV1 = 4;
-  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
-  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
-  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
-  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
-  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
-  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
-  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
-  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
-  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
-  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
-}
-
-sealed class TVertexAttributeType {
-  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
-  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
-  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
-  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
-  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
-  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
-  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
 extension TVertexBufferExt on Pointer<TVertexBuffer> {
@@ -10793,54 +11216,84 @@ final class TBufferObject extends Struct {
   }
 }
 
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
   }
 }
 
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
   }
 }
 
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
 
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
   }
 }
 
-extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
-  TBufferObjectBuilder toDart() {
-    return TBufferObjectBuilder(this);
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
   }
 }
 
-final class TBufferObjectBuilder extends Struct {
-  Pointer<TBufferObjectBuilder> get address => super.address.cast();
-  TBufferObjectBuilder(super.address);
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
 
-  static Pointer<TBufferObjectBuilder> stackAlloc() {
-    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
   }
+}
+
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
+  }
+}
+
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
+
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+  }
+}
+
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
+  }
+}
+
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
+
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
+  }
+}
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
 }
 
 extension double4x4Ext on Pointer<double4x4> {
@@ -10895,6 +11348,21 @@ final class double4x4 extends Struct {
 
   static Pointer<double4x4> stackAlloc() {
     return Pointer<double4x4>(NativeLibrary.instance.stackAlloc<double4x4>(128));
+  }
+}
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
+  }
+}
+
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
+
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
   }
 }
 
@@ -10973,361 +11441,80 @@ final class Aabb3 extends Struct {
   }
 }
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
 }
 
-extension double3Ext on Pointer<double3> {
-  double3 toDart() {
-    return double3(this);
-  }
-}
-
-final class double3 extends Struct {
-  Pointer<double3> get address => super.address.cast();
-  double get x {
-    final addr = Pointer<double3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set x(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
-  }
-
-  double get y {
-    final addr = Pointer<double3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set y(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
-  }
-
-  double get z {
-    final addr = Pointer<double3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set z(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
-  }
-
-  double3(super.address);
-
-  static Pointer<double3> stackAlloc() {
-    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
   }
 }
 
-extension TShadowOptionsExt on Pointer<TShadowOptions> {
-  TShadowOptions toDart() {
-    return TShadowOptions(this);
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
+
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
   }
 }
 
-final class TShadowOptions extends Struct {
-  Pointer<TShadowOptions> get address => super.address.cast();
-  int get mapSize {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set mapSize(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
-  }
-
-  int get shadowCascades {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set shadowCascades(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
-  }
-
-  Array<Float32> get cascadeSplitPositions {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float32>((numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
-  }
-
-  set cascadeSplitPositions(Array<Float32> val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 5), val.internal.addr.addr.toJS, '*');
-  }
-
-  double get constantBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constantBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
-  }
-
-  double get normalBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set normalBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
-  }
-
-  double get shadowFar {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFar(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
-  }
-
-  double get shadowNearHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowNearHint(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
-  }
-
-  double get shadowFarHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFarHint(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
-  }
-
-  bool get stable {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set stable(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 37), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  bool get lispsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set lispsm(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get polygonOffsetConstant {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetConstant(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
-  }
-
-  double get polygonOffsetSlope {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetSlope(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
-  }
-
-  bool get screenSpaceContactShadows {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set screenSpaceContactShadows(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 47), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  int get stepCount {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set stepCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
-  }
-
-  double get maxShadowDistance {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxShadowDistance(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
-  }
-
-  bool get vsmElvsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set vsmElvsm(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 53), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get vsmBlurWidth {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set vsmBlurWidth(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
-  }
-
-  double get shadowBulbRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowBulbRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
-  }
-
-  double get penumbraScale {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set penumbraScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
-  }
-
-  double get penumbraRatioScale {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set penumbraRatioScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
-  }
-
-  double get maxPenumbraRatio {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxPenumbraRatio(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
-  }
-
-  double get maxSearchRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxSearchRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
-  }
-
-  double get transformX {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformX(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
-  }
-
-  double get transformY {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformY(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
-  }
-
-  double get transformZ {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformZ(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
-  }
-
-  double get transformW {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformW(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
-  }
-
-  TShadowOptions(super.address);
-
-  static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
   }
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
+
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
   }
 }
 
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
-
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
   }
 }
 
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
+
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
   }
 }
 
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
+extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
+  TBufferObjectBuilder toDart() {
+    return TBufferObjectBuilder(this);
+  }
+}
 
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+final class TBufferObjectBuilder extends Struct {
+  Pointer<TBufferObjectBuilder> get address => super.address.cast();
+  TBufferObjectBuilder(super.address);
+
+  static Pointer<TBufferObjectBuilder> stackAlloc() {
+    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
   }
 }
 
@@ -11346,103 +11533,6 @@ final class TSceneAsset extends Struct {
   }
 }
 
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
-  }
-}
-
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
-
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
-  }
-}
-
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
-  }
-}
-
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
-
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
-  }
-}
-
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
-  }
-}
-
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
-
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
-  }
-}
-
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
-}
-
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
-  }
-}
-
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
-
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
-  }
-}
-
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
-  }
-}
-
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
-
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
-  }
-}
-
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
   TRenderableBuilder toDart() {
     return TRenderableBuilder(this);
@@ -11456,16 +11546,6 @@ final class TRenderableBuilder extends Struct {
   static Pointer<TRenderableBuilder> stackAlloc() {
     return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
   }
-}
-
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
 extension TMeshDataExt on Pointer<TMeshData> {
@@ -11483,63 +11563,33 @@ final class TMeshData extends Struct {
   }
 }
 
-typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
+sealed class TIntentAction {
+  static const INTENT_ACTION_MOVE_FORWARD = 0;
+  static const INTENT_ACTION_MOVE_BACKWARD = 1;
+  static const INTENT_ACTION_MOVE_LEFT = 2;
+  static const INTENT_ACTION_MOVE_RIGHT = 3;
+  static const INTENT_ACTION_JUMP = 4;
+  static const INTENT_ACTION_SPRINT = 5;
+  static const INTENT_ACTION_CUSTOM1 = 6;
+  static const INTENT_ACTION_CUSTOM2 = 7;
+  static const INTENT_ACTION_CUSTOM3 = 8;
+  static const INTENT_ACTION_CUSTOM4 = 9;
+  static const INTENT_ACTION_CUSTOM5 = 10;
+  static const INTENT_ACTION_CUSTOM6 = 11;
+  static const INTENT_ACTION_CUSTOM7 = 12;
+  static const INTENT_ACTION_CUSTOM8 = 13;
+  static const INTENT_ACTION_CUSTOM9 = 14;
+  static const INTENT_ACTION_CUSTOM10 = 15;
+  static const INTENT_ACTION_CROUCH = 16;
+  static const INTENT_ACTION_INTERACT = 17;
+  static const INTENT_ACTION_USE_ITEM = 18;
+  static const INTENT_ACTION_RELOAD = 19;
+  static const INTENT_ACTION_ALT_FIRE = 20;
 }
 
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
-  }
-}
-
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
-
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
-  }
-}
-
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
-  }
-}
-
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
-
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
-  }
+sealed class TMovementSpace {
+  static const MOVEMENT_SPACE_WORLD = 0;
+  static const MOVEMENT_SPACE_OBJECT = 1;
 }
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
@@ -11602,59 +11652,35 @@ extension StructAllocator on Struct {
       case TTextureSampler:
         final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
-      case TLinearImage:
-        final ptr = TLinearImage.stackAlloc();
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
         return ptr.toDart() as T;
-      case TKtx1Bundle:
-        final ptr = TKtx1Bundle.stackAlloc();
+      case double3:
+        final ptr = double3.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderer:
-        final ptr = TRenderer.stackAlloc();
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
         return ptr.toDart() as T;
-      case TSwapChain:
-        final ptr = TSwapChain.stackAlloc();
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
         return ptr.toDart() as T;
-      case TView:
-        final ptr = TView.stackAlloc();
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
-        return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TTransformManager:
-        final ptr = TTransformManager.stackAlloc();
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableManager:
         final ptr = TRenderableManager.stackAlloc();
         return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TEntityManager:
-        final ptr = TEntityManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFence:
-        final ptr = TFence.stackAlloc();
-        return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
-      case TDebugRegistry:
-        final ptr = TDebugRegistry.stackAlloc();
-        return ptr.toDart() as T;
       case TViewport:
         final ptr = TViewport.stackAlloc();
+        return ptr.toDart() as T;
+      case TView:
+        final ptr = TView.stackAlloc();
         return ptr.toDart() as T;
       case TToneMapper:
         final ptr = TToneMapper.stackAlloc();
@@ -11662,11 +11688,23 @@ extension StructAllocator on Struct {
       case TColorGradingBuilder:
         final ptr = TColorGradingBuilder.stackAlloc();
         return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
+        return ptr.toDart() as T;
       case TSoftShadowOptions:
         final ptr = TSoftShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TVsmShadowOptions:
         final ptr = TVsmShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
+        return ptr.toDart() as T;
+      case TScene:
+        final ptr = TScene.stackAlloc();
         return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
@@ -11680,8 +11718,32 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
+      case TSurfaceOrientationBuilder:
+        final ptr = TSurfaceOrientationBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientation:
+        final ptr = TSurfaceOrientation.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
+      case TLinearImage:
+        final ptr = TLinearImage.stackAlloc();
+        return ptr.toDart() as T;
+      case TKtx1Bundle:
+        final ptr = TKtx1Bundle.stackAlloc();
+        return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
         return ptr.toDart() as T;
       case TVertexBufferBuilder:
         final ptr = TVertexBufferBuilder.stackAlloc();
@@ -11692,62 +11754,50 @@ extension StructAllocator on Struct {
       case TBufferObject:
         final ptr = TBufferObject.stackAlloc();
         return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TBufferObjectBuilder:
-        final ptr = TBufferObjectBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
-        return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
-        return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
         return ptr.toDart() as T;
       case TRenderManager:
         final ptr = TRenderManager.stackAlloc();
         return ptr.toDart() as T;
+      case TRenderer:
+        final ptr = TRenderer.stackAlloc();
+        return ptr.toDart() as T;
       case TAnimationManager:
         final ptr = TAnimationManager.stackAlloc();
         return ptr.toDart() as T;
+      case TSwapChain:
+        final ptr = TSwapChain.stackAlloc();
+        return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
+      case TTransformManager:
+        final ptr = TTransformManager.stackAlloc();
+        return ptr.toDart() as T;
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
+        return ptr.toDart() as T;
+      case TEntityManager:
+        final ptr = TEntityManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFence:
+        final ptr = TFence.stackAlloc();
+        return ptr.toDart() as T;
+      case TDebugRegistry:
+        final ptr = TDebugRegistry.stackAlloc();
+        return ptr.toDart() as T;
+      case TBufferObjectBuilder:
+        final ptr = TBufferObjectBuilder.stackAlloc();
+        return ptr.toDart() as T;
       case TSceneAsset:
         final ptr = TSceneAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableBuilder:
         final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TMeshData:
         final ptr = TMeshData.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientationBuilder:
-        final ptr = TSurfaceOrientationBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientation:
-        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -132,192 +132,148 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external int _MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance);
   external int _Material_getBlendingMode(Pointer<TMaterial> material);
-  external Pointer<TTexture> _Texture_build(
-    Pointer<TEngine> engine,
-    int width,
-    int height,
-    int depth,
-    int levels,
-    int tUsage,
-    int import1,
-    int sampler,
-    int format,
-  );
-  external void _Texture_setExternalImage(
+  external int _LightManager_createLight(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<Void> externalImage,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
   );
-  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
-  external int _Texture_loadImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<TLinearImage> tImage,
-    int bufferFormat,
-    int pixelDataType,
-    int level,
+  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
   );
-  external int _Texture_setImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    int level,
-    Pointer<Uint8> data,
-    size_t size,
-    int x_offset,
-    int y_offset,
-    int z_offset,
-    int width,
-    int height,
-    int depth,
-    int bufferFormat,
-    int pixelDataType,
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
   );
-  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getFormat(Pointer<TTexture> tTexture);
-  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
-  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
-  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
-  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
-  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
-  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
-  external Pointer<TTexture> _Ktx1Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TKtx1Bundle> tBundle,
-    int requestId,
-    VoidCallback onTextureUploadComplete,
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
   );
-  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
-  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
-  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
-  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
-  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
-  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTextureSampler> _TextureSampler_create();
-  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
-    int minFilter,
-    int magFilter,
-    int wrapS,
-    int wrapT,
-    int wrapR,
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
   );
-  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
-  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
-  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
-  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
-  external Pointer<TEngine> _Engine_create(
-    int backend,
-    Pointer<Void> platform,
-    Pointer<Void> sharedContext,
-    int stereoscopicEyeCount,
-    bool disableHandleUseAfterFreeCheck,
-  );
-  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
-  external void _Engine_destroy(Pointer<TEngine> tEngine);
-  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
-  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
-  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
-    Pointer<TEngine> tEngine,
-    int width,
-    int height,
-    JSBigInt flags,
-  );
-  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
-  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
-  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
-  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
-  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
-  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
-  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
-  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
-  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
-  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
-  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
-  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
-  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
-  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
-  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
-  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
-  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
-  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
-  external void _Engine_execute(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Engine_buildMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> materialData,
-    size_t length,
-  );
-  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
-  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
-  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
-  external Pointer<TSkybox> _Engine_buildSkybox(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    bool showSun,
-    double intensity,
-    int priority,
-  );
-  external Pointer<TSkybox> _Engine_buildColoredSkybox(
-    Pointer<TEngine> tEngine,
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
     double r,
     double g,
     double b,
-    double a,
-    bool showSun,
-    double intensity,
-    int priority,
   );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
+  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
+  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
+  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
+  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
+  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
+  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
+  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
+  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<TTexture> tIrradianceTexture,
-    double intensity,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
   );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
+  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<Float32> irradianceHarmonics,
-    double intensity,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
   );
-  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
-  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
-  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
-  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
-  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
-  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
-  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
-  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
-  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
-  external int _DebugRegistry_setProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    double value,
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
   );
-  external int _DebugRegistry_getProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Bool> outValue,
-  );
-  external int _DebugRegistry_getProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Int32> outValue,
-  );
-  external int _DebugRegistry_getProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Float32> outValue,
-  );
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
+  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
   external void _View_getViewport(Pointer<TViewport> TViewport_out, Pointer<TView> view);
   external Pointer<TToneMapper> _ToneMapper_createLinear(Pointer<TEngine> tEngine);
   external Pointer<TToneMapper> _ToneMapper_createACES(Pointer<TEngine> tEngine);
@@ -454,6 +410,168 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _View_pick(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
   external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
   external Pointer<Char> _View_getName(Pointer<TView> tView);
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
+  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_normals(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> normals,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_positions(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> positions,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_triangles_uint(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint32> triangles,
+  );
+  external void _SurfaceOrientationBuilder_triangles_ushort(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Uint16> triangles,
+  );
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
+  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
+  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
+  external void _SurfaceOrientation_getQuats_float4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Float32> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_getQuats_half4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Uint16> out,
+    size_t quatCount,
+    size_t stride,
+  );
+  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
+  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
+  external Pointer<TTexture> _Texture_build(
+    Pointer<TEngine> engine,
+    int width,
+    int height,
+    int depth,
+    int levels,
+    int tUsage,
+    int import1,
+    int sampler,
+    int format,
+  );
+  external void _Texture_setExternalImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<Void> externalImage,
+  );
+  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
+  external int _Texture_loadImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<TLinearImage> tImage,
+    int bufferFormat,
+    int pixelDataType,
+    int level,
+  );
+  external int _Texture_setImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    int level,
+    Pointer<Uint8> data,
+    size_t size,
+    int x_offset,
+    int y_offset,
+    int z_offset,
+    int width,
+    int height,
+    int depth,
+    int bufferFormat,
+    int pixelDataType,
+  );
+  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getFormat(Pointer<TTexture> tTexture);
+  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
+  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
+  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
+  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
+  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
+  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
+  external Pointer<TTexture> _Ktx1Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TKtx1Bundle> tBundle,
+    int requestId,
+    VoidCallback onTextureUploadComplete,
+  );
+  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
+  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
+  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
+  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
+  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
+  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
+  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
+  external Pointer<TTextureSampler> _TextureSampler_create();
+  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
+    int minFilter,
+    int magFilter,
+    int wrapS,
+    int wrapT,
+    int wrapR,
+  );
+  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
+  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
+  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
+  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
+  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+  external void _FrameScheduler_stop();
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _Gizmo_dummy(int t);
+  external Pointer<TGizmo> _Gizmo_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> assetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+  );
+  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
     bool doubleSided,
@@ -495,6 +613,23 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     bool hasIOR,
     bool hasVolume,
   );
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
+  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
+  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
   external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
   external void _VertexBufferBuilder_bufferCount(Pointer<TVertexBufferBuilder> builder, int count);
   external void _VertexBufferBuilder_vertexCount(Pointer<TVertexBufferBuilder> builder, int count);
@@ -530,38 +665,95 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TBufferObject> bufferObject,
   );
   external void _VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer);
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
-  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
+  external Pointer<TRenderTarget> _RenderTarget_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
   );
-  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
-  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
+  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
+  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
+  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
+  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
+  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
   );
-  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
-  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
-  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
-  external Pointer<TBufferObject> _BufferObjectBuilder_build(
-    Pointer<TBufferObjectBuilder> builder,
-    Pointer<TEngine> engine,
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
   );
-  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
-  external void _BufferObject_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TBufferObject> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
+  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
   );
-  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
+  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
+  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
+  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
+  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
+  );
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<double4x4> tModelMatrixPtr);
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
   external void _TransformManager_getLocalTransform(
     Pointer<double4x4> double4x4_out,
     Pointer<TTransformManager> tTransformManager,
@@ -604,124 +796,161 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external void _TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
   external void _TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
-  external int _LightManager_createLight(
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
+  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
+  external Pointer<TEngine> _Engine_create(
+    int backend,
+    Pointer<Void> platform,
+    Pointer<Void> sharedContext,
+    int stereoscopicEyeCount,
+    bool disableHandleUseAfterFreeCheck,
+  );
+  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
+  external void _Engine_destroy(Pointer<TEngine> tEngine);
+  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
+  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
+  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
     Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
+    int width,
+    int height,
+    JSBigInt flags,
   );
-  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
+  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
+  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
+  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
+  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
+  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
+  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
+  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
+  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
+  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
+  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
+  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
+  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
+  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
+  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
+  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
+  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
+  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
+  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
+  external void _Engine_execute(Pointer<TEngine> tEngine);
+  external Pointer<TMaterial> _Engine_buildMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> materialData,
+    size_t length,
   );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
+  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
+  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
+  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
+  external Pointer<TSkybox> _Engine_buildSkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    bool showSun,
+    double intensity,
+    int priority,
   );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TSkybox> _Engine_buildColoredSkybox(
+    Pointer<TEngine> tEngine,
     double r,
     double g,
     double b,
+    double a,
+    bool showSun,
+    double intensity,
+    int priority,
   );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<TTexture> tIrradianceTexture,
     double intensity,
   );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<Float32> irradianceHarmonics,
+    double intensity,
   );
-  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
-  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
+  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
+  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
+  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
+  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
+  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
+  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
+  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
+  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
+  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
+  external int _DebugRegistry_setProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    double value,
   );
-  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
+  external int _DebugRegistry_getProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Bool> outValue,
   );
-  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
-  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
+  external int _DebugRegistry_getProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Int32> outValue,
   );
-  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
-  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
+  external int _DebugRegistry_getProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Float32> outValue,
   );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
+  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
+  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
+  external Pointer<TBufferObject> _BufferObjectBuilder_build(
+    Pointer<TBufferObjectBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
+  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
+  external void _BufferObject_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TBufferObject> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
   );
-  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
-  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
-  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
+  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
   external Pointer<Void> _RenderThread_create();
   external Pointer<Void> _RenderThread_createForCanvas(Pointer<Char> canvasSelector);
   external void _RenderThread_destroy(Pointer<Void> renderThread);
@@ -1791,238 +2020,43 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    int vertexBufferStorageMode,
-    Pointer<Aabb3> boundingBoxPtr,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
+  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
     Pointer<TFilamentAsset> tFilamentAsset,
-    int requiredGeometryCapabilities,
   );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
-  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
-  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
+  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
   );
-  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
-  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
-  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
-  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
-  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
-  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
+
+  /// Returns the visibility mask bits.
+  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
+
+  /// Returns the skybox intensity in lux.
+  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
+
+  /// Returns the environment texture, or nullptr for a color-only skybox.
+  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
   external void _MeshData_dispose(Pointer<TMeshData> meshData);
   external int _GltfParser_parseBuffer(
     Pointer<Uint8> data,
     size_t length,
     Pointer<Char> meshName,
     Pointer<TMeshData> outMeshData,
-  );
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
-  );
-  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
-  );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
-  );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
-  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
-  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-  external void _FrameScheduler_stop();
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external void _Gizmo_dummy(int t);
-  external Pointer<TGizmo> _Gizmo_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> assetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-  );
-  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
-  external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
-  external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
-  );
-  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
-  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
-  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
-  external int _AnimationManager_addGltfAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_removeGltfAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external void _AnimationManager_addMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-  );
-  external void _AnimationManager_removeMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-  );
-  external int _AnimationManager_addBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_removeBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-  );
-  external int _AnimationManager_setMorphAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    Pointer<Uint32> morphIndices,
-    int numMorphTargets,
-    int numFrames,
-    double frameLengthInMs,
-  );
-  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
-  external void _AnimationManager_resetToRestPose(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_addBoneAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> frameData,
-    int numFrames,
-    double frameLengthInMs,
-    double fadeOutInSecs,
-    double fadeInInSecs,
-    double maxDelta,
-    bool loop,
-  );
-  external void _AnimationManager_getRestLocalTransforms(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    Pointer<Float32> out,
-    int numBones,
-  );
-  external void _AnimationManager_getInverseBindMatrix(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> out,
-  );
-  external int _AnimationManager_playGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-    bool loop,
-    bool reverse,
-    bool replaceActive,
-    double crossfade,
-    double startOffset,
-    double speed,
-  );
-  external int _AnimationManager_stopGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int index,
-  );
-  external double _AnimationManager_getGltfAnimationDuration(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int animationIndex,
-  );
-  external int _AnimationManager_getGltfAnimationCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external void _AnimationManager_getGltfAnimationName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_getMorphTargetNameCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-  );
-  external void _AnimationManager_getMorphTargetName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_updateBoneMatrices(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_setMorphTargetWeights(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    int numWeights,
-  );
-  external int _AnimationManager_setGltfAnimationTime(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int animationIndex,
-    double timeInSeconds,
   );
   external void _RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
   external int _RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
@@ -2238,215 +2272,181 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t bonesPerVertex,
   );
   external int _RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, EntityId entity);
-  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
-  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    int vertexBufferStorageMode,
+    Pointer<Aabb3> boundingBoxPtr,
   );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix);
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
-  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
-  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
-  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
-  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
-
-  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
-
-  /// Returns the visibility mask bits.
-  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
-
-  /// Returns the skybox intensity in lux.
-  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
-
-  /// Returns the environment texture, or nullptr for a color-only skybox.
-  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
-  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
-  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
-  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
     Pointer<TFilamentAsset> tFilamentAsset,
+    int requiredGeometryCapabilities,
   );
-  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
+  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
+  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
   );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
-  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
-  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
+  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
+  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
+  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
+  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
+  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
+  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
+  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
+  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
+  external int _AnimationManager_addGltfAnimationComponent(
     Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
+  external int _AnimationManager_removeGltfAnimationComponent(
     Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
+  external void _AnimationManager_addMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
   );
-  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
-  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
-  external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
-  external void _SurfaceOrientationBuilder_normals(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> normals,
-    size_t stride,
+  external void _AnimationManager_removeMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
   );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
+  external int _AnimationManager_addBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
+  external int _AnimationManager_removeBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
   );
-  external void _SurfaceOrientationBuilder_positions(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> positions,
-    size_t stride,
+  external int _AnimationManager_setMorphAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    Pointer<Uint32> morphIndices,
+    int numMorphTargets,
+    int numFrames,
+    double frameLengthInMs,
   );
-  external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
-  external void _SurfaceOrientationBuilder_triangles_uint(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint32> triangles,
+  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
+  external void _AnimationManager_resetToRestPose(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
   );
-  external void _SurfaceOrientationBuilder_triangles_ushort(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Uint16> triangles,
+  external int _AnimationManager_addBoneAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> frameData,
+    int numFrames,
+    double frameLengthInMs,
+    double fadeOutInSecs,
+    double fadeInInSecs,
+    double maxDelta,
+    bool loop,
   );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
-  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
-  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
-  external void _SurfaceOrientation_getQuats_float4(
-    Pointer<TSurfaceOrientation> orientation,
+  external void _AnimationManager_getRestLocalTransforms(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
     Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
+    int numBones,
   );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
-    size_t quatCount,
-    size_t stride,
+  external void _AnimationManager_getInverseBindMatrix(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> out,
   );
-  external void _SurfaceOrientation_getQuats_half4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Uint16> out,
-    size_t quatCount,
-    size_t stride,
+  external int _AnimationManager_playGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+    bool loop,
+    bool reverse,
+    bool replaceActive,
+    double crossfade,
+    double startOffset,
+    double speed,
   );
-  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
+  external int _AnimationManager_stopGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int index,
+  );
+  external double _AnimationManager_getGltfAnimationDuration(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int animationIndex,
+  );
+  external int _AnimationManager_getGltfAnimationCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external void _AnimationManager_getGltfAnimationName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_getMorphTargetNameCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+  );
+  external void _AnimationManager_getMorphTargetName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_updateBoneMatrices(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external int _AnimationManager_setMorphTargetWeights(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    int numWeights,
+  );
+  external int _AnimationManager_setGltfAnimationTime(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int animationIndex,
+    double timeInSeconds,
+  );
   external void _MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor);
   external void _MovementIntentExecutor_process(
     Pointer<TMovementIntentExecutor> executor,
@@ -2833,587 +2833,341 @@ int Material_getBlendingMode(Pointer<TMaterial> material) {
   return result;
 }
 
-Pointer<TTexture> Texture_build(
-  Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import1,
-  int sampler,
-  int format,
-) {
-  final result = GeneratedBindings.instance._Texture_build(
-    engine.cast(),
-    width,
-    height,
-    depth,
-    levels,
-    tUsage,
-    import1,
-    sampler,
-    format,
-  );
-  return Pointer<TTexture>(result);
-}
-
-void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
-  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
-  return result;
-}
-
-Dartsize_t Texture_getLevels(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
-  return result;
-}
-
-bool Texture_loadImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-) {
-  final result = GeneratedBindings.instance._Texture_loadImage(
+int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
     tEngine.cast(),
-    tTexture.cast(),
-    tImage.cast(),
-    bufferFormat,
-    pixelDataType,
-    level,
+    tLightManager.cast(),
+    tLightTtype,
   );
+  return result;
+}
+
+void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
   return result == 1;
 }
 
-bool Texture_setImage(
+int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
+  return double3_out.toDart();
+}
+
+void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
+  return result;
+}
+
+double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+  return result;
+}
+
+double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+  return result;
+}
+
+bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+  return result == 1;
+}
+
+void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
+  return result;
+}
+
+void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+    lambda,
+  );
+  return result;
+}
+
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
+  return result;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
+  return result;
+}
+
+void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
+  return result;
+}
+
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
+  return result;
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
+  return Pointer<Void>(result);
+}
+
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
   Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  int level,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+    tEngine.cast(),
+    tMaterialProvider.cast(),
+    tNameComponentManager.cast(),
+  );
+  return Pointer<TGltfAssetLoader>(result);
+}
+
+void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
+  return result;
+}
+
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dartsize_t size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
+  Dart__darwin_size_t length,
+  int numInstances,
 ) {
-  final result = GeneratedBindings.instance._Texture_setImage(
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
     tEngine.cast(),
-    tTexture.cast(),
-    level,
+    tAssetLoader.cast(),
     data,
-    size,
-    x_offset,
-    y_offset,
-    z_offset,
-    width,
-    height,
-    depth,
-    bufferFormat,
-    pixelDataType,
+    length,
+    numInstances,
   );
-  return result == 1;
+  return Pointer<TFilamentAsset>(result);
 }
 
-int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getFormat(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
-  return result;
-}
-
-int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
-  return result;
-}
-
-void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
-  return result;
-}
-
-Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dartsize_t length) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
-  return Pointer<TKtx1Bundle>(result);
-}
-
-void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
-  return result;
-}
-
-bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
-  return result == 1;
-}
-
-void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
-  return result;
-}
-
-Pointer<TTexture> Ktx1Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  DartVoidCallback onTextureUploadComplete,
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
 ) {
-  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
-    tEngine.cast(),
-    tBundle.cast(),
-    requestId,
-    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
+    tRenderableManager.cast(),
+    tAsset.cast(),
   );
-  return Pointer<TTexture>(result);
+  return Pointer<TMaterialInstance>(result);
 }
 
-Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dartsize_t size) {
-  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
-  return Pointer<TTexture>(result);
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
 }
 
-Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
-  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dartsize_t length, Pointer<Char> name, bool alpha) {
-  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
-  return Pointer<Float32>(result);
-}
-
-void Image_destroy(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
   return result;
 }
 
-int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
-  return result;
-}
-
-int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
-  return result;
-}
-
-int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
-  return result;
-}
-
-Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_create() {
-  final result = GeneratedBindings.instance._TextureSampler_create();
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
-    minFilter,
-    magFilter,
-    wrapS,
-    wrapT,
-    wrapR,
-  );
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
-  return Pointer<TTextureSampler>(result);
-}
-
-void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
-  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
-  return result;
-}
-
-void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
-  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
-  return result;
-}
-
-void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
-  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
-  return result;
-}
-
-Pointer<TEngine> Engine_create(
-  int backend,
-  Pointer<Void> platform,
-  Pointer<Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-) {
-  final result = GeneratedBindings.instance._Engine_create(
-    backend,
-    platform,
-    sharedContext,
-    stereoscopicEyeCount,
-    disableHandleUseAfterFreeCheck,
-  );
-  return Pointer<TEngine>(result);
-}
-
-int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
-  return result;
-}
-
-void Engine_destroy(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
-  return result;
-}
-
-Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
-  return Pointer<TRenderer>(result);
-}
-
-void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
-  return result;
-}
-
-Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
-    tEngine.cast(),
-    width,
-    height,
-    flags.toJSBigInt,
-  );
-  return Pointer<TSwapChain>(result);
-}
-
-void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
-  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
-  return result;
-}
-
-void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
-  return result;
-}
-
-void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
-  return result;
-}
-
-void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
-  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
-  return result;
-}
-
-Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
-  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
-  return Pointer<TView>(result);
-}
-
-Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
-  return Pointer<TTransformManager>(result);
-}
-
-Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
-  return Pointer<TRenderableManager>(result);
-}
-
-Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
-  return Pointer<TLightManager>(result);
-}
-
-Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
-  return Pointer<TEntityManager>(result);
-}
-
-void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
-  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
-  return result;
-}
-
-Dartsize_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
-  return result;
-}
-
-void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
-  return result;
-}
-
-Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
-  return Pointer<TFence>(result);
-}
-
-void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
-  return result;
-}
-
-void Engine_flushAndWait(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
-  return result;
-}
-
-void Engine_execute(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
-  return result;
-}
-
-Pointer<TMaterial> Engine_buildMaterial(Pointer<TEngine> tEngine, Pointer<Uint8> materialData, Dartsize_t length) {
-  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
-  return Pointer<TMaterial>(result);
-}
-
-void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
-  return result;
-}
-
-void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
-  return result;
-}
-
-Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TSkybox> Engine_buildSkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildSkybox(
-    tEngine.cast(),
-    tTexture.cast(),
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TSkybox> Engine_buildColoredSkybox(
-  Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
-    tEngine.cast(),
-    r,
-    g,
-    b,
-    a,
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    tIrradianceTexture.cast(),
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<Float32> irradianceHarmonics,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    irradianceHarmonics,
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
-  return result;
-}
-
-void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
-  return result;
-}
-
-DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
-  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
-  return result;
-}
-
-void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
-  return result;
-}
-
-void Fence_waitAndDestroy(Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
-  return result;
-}
-
-Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
-  return Pointer<TDebugRegistry>(result);
-}
-
-bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
-  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Bool> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Int32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Float32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
+  return Pointer<PointerClass<Char>>(result);
 }
 
 TViewport View_getViewport(Pointer<TView> view) {
@@ -3893,6 +3647,503 @@ Pointer<Char> View_getName(Pointer<TView> tView) {
   return Pointer<Char>(result);
 }
 
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
+  return result;
+}
+
+Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
+  return Pointer<Char>(result);
+}
+
+Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
+  return Pointer<TSurfaceOrientationBuilder>(result);
+}
+
+void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dart__darwin_size_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_normals(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> normals,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_positions(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> positions,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, Dart__darwin_size_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_uint(Pointer<TSurfaceOrientationBuilder> builder, Pointer<Uint32> triangles) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
+  return result;
+}
+
+void SurfaceOrientationBuilder_triangles_ushort(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Uint16> triangles,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
+  return Pointer<TSurfaceOrientation>(result);
+}
+
+void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dart__darwin_size_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
+  return result;
+}
+
+void SurfaceOrientation_getQuats_float4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Float32> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_getQuats_half4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Uint16> out,
+  Dart__darwin_size_t quatCount,
+  Dart__darwin_size_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
+    orientation.cast(),
+    out,
+    quatCount,
+    stride,
+  );
+  return result;
+}
+
+void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
+  return result;
+}
+
+void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
+  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+  return result;
+}
+
+Pointer<TTexture> Texture_build(
+  Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import1,
+  int sampler,
+  int format,
+) {
+  final result = GeneratedBindings.instance._Texture_build(
+    engine.cast(),
+    width,
+    height,
+    depth,
+    levels,
+    tUsage,
+    import1,
+    sampler,
+    format,
+  );
+  return Pointer<TTexture>(result);
+}
+
+void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
+  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
+  return result;
+}
+
+Dart__darwin_size_t Texture_getLevels(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
+  return result;
+}
+
+bool Texture_loadImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+) {
+  final result = GeneratedBindings.instance._Texture_loadImage(
+    tEngine.cast(),
+    tTexture.cast(),
+    tImage.cast(),
+    bufferFormat,
+    pixelDataType,
+    level,
+  );
+  return result == 1;
+}
+
+bool Texture_setImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  int level,
+  Pointer<Uint8> data,
+  Dart__darwin_size_t size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+) {
+  final result = GeneratedBindings.instance._Texture_setImage(
+    tEngine.cast(),
+    tTexture.cast(),
+    level,
+    data,
+    size,
+    x_offset,
+    y_offset,
+    z_offset,
+    width,
+    height,
+    depth,
+    bufferFormat,
+    pixelDataType,
+  );
+  return result == 1;
+}
+
+int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getFormat(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
+  return result;
+}
+
+int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
+  return result;
+}
+
+void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
+  return result;
+}
+
+Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dart__darwin_size_t length) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
+  return Pointer<TKtx1Bundle>(result);
+}
+
+void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
+  return result;
+}
+
+bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
+  return result == 1;
+}
+
+void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
+  return result;
+}
+
+Pointer<TTexture> Ktx1Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  DartVoidCallback onTextureUploadComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
+    tEngine.cast(),
+    tBundle.cast(),
+    requestId,
+    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dart__darwin_size_t size) {
+  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
+  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dart__darwin_size_t length, Pointer<Char> name, bool alpha) {
+  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
+  return Pointer<TLinearImage>(result);
+}
+
+Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
+  return Pointer<Float32>(result);
+}
+
+void Image_destroy(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+  return result;
+}
+
+int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
+  return result;
+}
+
+int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
+  return result;
+}
+
+int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
+  return result;
+}
+
+Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_create() {
+  final result = GeneratedBindings.instance._TextureSampler_create();
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
+    minFilter,
+    magFilter,
+    wrapS,
+    wrapT,
+    wrapR,
+  );
+  return Pointer<TTextureSampler>(result);
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
+  return Pointer<TTextureSampler>(result);
+}
+
+void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
+  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
+  return result;
+}
+
+void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
+  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
+  return result;
+}
+
+void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
+  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
+  return result;
+}
+
+void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
+    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+Pointer<TGizmo> Gizmo_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> assetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+) {
+  final result = GeneratedBindings.instance._Gizmo_create(
+    tEngine.cast(),
+    assetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+  );
+  return Pointer<TGizmo>(result);
+}
+
+void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
+  final result = GeneratedBindings.instance._Gizmo_pick(
+    tGizmo.cast(),
+    x,
+    y,
+    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
+  );
+  return result;
+}
+
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
+  return result;
+}
+
+void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
+  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
+  return result;
+}
+
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   Pointer<TMaterialProvider> provider,
   bool doubleSided,
@@ -3978,6 +4229,58 @@ Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   return Pointer<TMaterialInstance>(result);
 }
 
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
+}
+
+void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
+  return result;
+}
+
+void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
+  return result;
+}
+
+Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
+  return result;
+}
+
+Dart__darwin_size_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
+  return result;
+}
+
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dart__darwin_size_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
+  return result;
+}
+
 Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
   final result = GeneratedBindings.instance._VertexBufferBuilder_create();
   return Pointer<TVertexBufferBuilder>(result);
@@ -4037,7 +4340,7 @@ void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
   return result;
 }
 
-Dartsize_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
+Dart__darwin_size_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
   final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(buffer.cast());
   return result;
 }
@@ -4047,7 +4350,7 @@ void VertexBuffer_setBufferAt(
   Pointer<TVertexBuffer> buffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
 ) {
   final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
@@ -4081,97 +4384,286 @@ void VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer
   return result;
 }
 
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
+Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
+  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
+  return Pointer<TRenderTarget>(result);
 }
 
-void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
+void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
   return result;
 }
 
-void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
   return result;
 }
 
-Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
   return result;
 }
 
-Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
   return result;
 }
 
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
+Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
+  return Pointer<TSkybox>(result);
+}
+
+void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
+  return result;
+}
+
+Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
 ) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
   );
   return result;
 }
 
-void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
-  return result;
-}
-
-Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
-  return Pointer<TBufferObjectBuilder>(result);
-}
-
-void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
-  return result;
-}
-
-Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TBufferObject>(result);
-}
-
-void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
-  return result;
-}
-
-void BufferObject_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TBufferObject> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
 ) {
-  final result = GeneratedBindings.instance._BufferObject_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
+  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
   );
   return result;
 }
 
-void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
-  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
+void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
+  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
+  return result;
+}
+
+void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
+  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
+  return result;
+}
+
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
+  return result;
+}
+
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
+  return result;
+}
+
+void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
+  return result;
+}
+
+void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
+  return result;
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
+    camera.cast(),
+    projectionMatrixPtr.cast(),
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setModelMatrix(Pointer<TCamera> camera, double4x4 tModelMatrix) {
+  final tModelMatrixPtr = tModelMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrixPtr.cast());
+  return result;
+}
+
+void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
+  return result;
+}
+
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
   return result;
 }
 
@@ -4303,259 +4795,454 @@ void TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager>
   return result;
 }
 
-int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+  );
+  return result;
+}
+
+bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+  return result;
+}
+
+void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dart__darwin_size_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+  );
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+    tRenderer.cast(),
+    headRoomRatio,
+    scaleRate,
+    history,
+    interval,
+  );
+  return result;
+}
+
+Pointer<TEngine> Engine_create(
+  int backend,
+  Pointer<Void> platform,
+  Pointer<Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+) {
+  final result = GeneratedBindings.instance._Engine_create(
+    backend,
+    platform,
+    sharedContext,
+    stereoscopicEyeCount,
+    disableHandleUseAfterFreeCheck,
+  );
+  return Pointer<TEngine>(result);
+}
+
+int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
+  return result;
+}
+
+void Engine_destroy(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
+  return result;
+}
+
+Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
+  return Pointer<TRenderer>(result);
+}
+
+void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
+  return result;
+}
+
+Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
     tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
+    width,
+    height,
+    flags.toJSBigInt,
   );
+  return Pointer<TSwapChain>(result);
+}
+
+void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
+  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
   return result;
 }
 
-void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
+void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
   return result;
 }
 
-bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
+void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
   return result;
 }
 
-bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
+  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
   return result;
 }
 
-double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
+Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
 }
 
-void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
+  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
   return result;
 }
 
-double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
+Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
+  return Pointer<TView>(result);
 }
 
-void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
+  return Pointer<TTransformManager>(result);
+}
+
+Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
+  return Pointer<TRenderableManager>(result);
+}
+
+Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
+  return Pointer<TLightManager>(result);
+}
+
+Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
+  return Pointer<TEntityManager>(result);
+}
+
+void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
+  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
   return result;
 }
 
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
+Dart__darwin_size_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
+  return result;
+}
+
+void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
+  return result;
+}
+
+Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
+  return Pointer<TFence>(result);
+}
+
+void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
+  return result;
+}
+
+void Engine_flushAndWait(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
+  return result;
+}
+
+void Engine_execute(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
+  return result;
+}
+
+Pointer<TMaterial> Engine_buildMaterial(
+  Pointer<TEngine> tEngine,
+  Pointer<Uint8> materialData,
+  Dart__darwin_size_t length,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
-  );
+  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
+  return Pointer<TMaterial>(result);
+}
+
+void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
   return result;
 }
 
-double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
   return result;
 }
 
-void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
-  return result;
+Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
+  return Pointer<TScene>(result);
 }
 
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
+Pointer<TSkybox> Engine_buildSkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
+  final result = GeneratedBindings.instance._Engine_buildSkybox(
+    tEngine.cast(),
+    tTexture.cast(),
+    showSun,
+    intensity,
+    priority,
   );
-  return result;
+  return Pointer<TSkybox>(result);
 }
 
-double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
-  return result;
-}
-
-double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
+Pointer<TSkybox> Engine_buildColoredSkybox(
+  Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
 ) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
+  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
+    tEngine.cast(),
+    r,
+    g,
+    b,
+    a,
+    showSun,
+    intensity,
+    priority,
   );
+  return Pointer<TSkybox>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    tIrradianceTexture.cast(),
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<Float32> irradianceHarmonics,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    irradianceHarmonics,
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
   return result;
 }
 
-double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
   return result;
 }
 
-void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
+  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
   return result;
 }
 
-double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
   return result;
 }
 
-void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
+void Fence_waitAndDestroy(Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
   return result;
 }
 
-double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
-  return result;
+Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
+  return Pointer<TDebugRegistry>(result);
 }
 
-void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
-  return result;
-}
-
-bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
+bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
+  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
   return result == 1;
 }
 
-void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
   return result == 1;
 }
 
-void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
-  return result;
+bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
+  return result == 1;
 }
 
-void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
-  return result;
+bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
+  return result == 1;
 }
 
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
+bool DebugRegistry_getProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Bool> outValue,
 ) {
-  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
-    splitPositions,
-    cascades,
-    near,
-    far,
-    lambda,
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Int32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Float32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
+  return Pointer<TBufferObjectBuilder>(result);
+}
+
+void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
+  return result;
+}
+
+Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TBufferObject>(result);
+}
+
+void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
+  return result;
+}
+
+void BufferObject_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TBufferObject> buffer,
+  Pointer<Void> data,
+  Dart__darwin_size_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._BufferObject_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
   );
   return result;
 }
 
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
+void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
+  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
   return result;
 }
 
@@ -4792,7 +5479,7 @@ void Engine_createViewRenderThread(
 void Engine_buildMaterialRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> materialData,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
@@ -5012,7 +5699,7 @@ void Ktx1Reader_createTextureRenderThread(
 void Ktx2Reader_createTextureRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
   Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Ktx2Reader_createTextureRenderThread(
@@ -5258,7 +5945,7 @@ void Renderer_readPixelsRenderThread(
   int tPixelBufferFormat,
   int tPixelDataType,
   Pointer<Uint8> out,
-  Dartsize_t outLength,
+  Dart__darwin_size_t outLength,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -6136,7 +6823,7 @@ void Image_createEmptyRenderThread(
 
 void Image_decodeRenderThread(
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   Pointer<Char> name,
   bool alpha,
   Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
@@ -6212,7 +6899,7 @@ void Texture_setImageRenderThread(
   Pointer<TTexture> tTexture,
   int level,
   Pointer<Uint8> data,
-  Dartsize_t size,
+  Dart__darwin_size_t size,
   int x_offset,
   int y_offset,
   int z_offset,
@@ -6519,7 +7206,7 @@ void GltfResourceLoader_addResourceDataRenderThread(
   Pointer<TGltfResourceLoader> tGltfResourceLoader,
   Pointer<Char> uri,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -6567,7 +7254,7 @@ void GltfAssetLoader_loadRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TGltfAssetLoader> tAssetLoader,
   Pointer<Uint8> data,
-  Dartsize_t length,
+  Dart__darwin_size_t length,
   int numInstances,
   Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
 ) {
@@ -6754,7 +7441,7 @@ void VertexBuffer_setBufferAtRenderThread(
   Pointer<TVertexBuffer> tBuffer,
   int bufferIndex,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -6808,7 +7495,7 @@ void BufferObject_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TBufferObject> tBuffer,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -6872,7 +7559,7 @@ void IndexBuffer_setBufferRenderThread(
   Pointer<TEngine> tEngine,
   Pointer<TIndexBuffer> tBuffer,
   Pointer<Void> data,
-  Dartsize_t sizeInBytes,
+  Dart__darwin_size_t sizeInBytes,
   int byteOffset,
   int requestId,
   DartVoidCallback onComplete,
@@ -7016,8 +7703,8 @@ void RenderableManager_setMorphWeightsRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> weights,
-  Dartsize_t count,
-  Dartsize_t offset,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7037,8 +7724,8 @@ void RenderableManager_setBonesFromMat4RenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7058,8 +7745,8 @@ void RenderableManager_setBonesFromBoneRenderThread(
   Pointer<TRenderableManager> tRenderableManager,
   DartEntityId entityId,
   Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
   int requestId,
   DartVoidCallback onComplete,
 ) {
@@ -7081,8 +7768,8 @@ void RenderableManager_setGeometryAtNonIndexedRenderThread(
   int primitiveIndex,
   int type,
   Pointer<TVertexBuffer> tVertices,
-  Dartsize_t offset,
-  Dartsize_t count,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
   Pointer<NativeFunction<void Function(bool)>> callback,
 ) {
   final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexedRenderThread(
@@ -7164,6 +7851,681 @@ void LightManager_setShadowOptionsRenderThread(
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
+  return result;
+}
+
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
+  return Pointer<TGltfResourceLoader>(result);
+}
+
+void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
+  return result;
+}
+
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
+  return result;
+}
+
+double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dart__darwin_size_t length,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
+  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
+  return result;
+}
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
+  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
+  return result;
+}
+
+/// Returns the visibility mask bits.
+int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
+  return result;
+}
+
+/// Returns the skybox intensity in lux.
+double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
+  return result;
+}
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
+  return Pointer<TTexture>(result);
+}
+
+void MeshData_dispose(Pointer<TMeshData> meshData) {
+  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
+  return result;
+}
+
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dart__darwin_size_t length,
+  Pointer<Char> meshName,
+  Pointer<TMeshData> outMeshData,
+) {
+  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
+  return result;
+}
+
+void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
+  return result == 1;
+}
+
+bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+Dart__darwin_size_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
+  return result;
+}
+
+bool RenderableManager_setMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  Pointer<TMaterialInstance> tMaterialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    tMaterialInstance.cast(),
+  );
+  return result == 1;
+}
+
+Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+void RenderableManager_clearMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return result;
+}
+
+bool RenderableManager_setGeometryAtNonIndexed(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result == 1;
+}
+
+Dart__darwin_size_t RenderableManager_getPrimitiveCount(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+Aabb3 RenderableManager_getAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+void RenderableManager_setAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Aabb3 aabb,
+) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
+    tRenderableManager.cast(),
+    entityId,
+    aabbPtr.cast(),
+  );
+  return result;
+}
+
+Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAabb(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+void RenderableManager_setLayerMask(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int select,
+  int values,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
+    tRenderableManager.cast(),
+    entityId,
+    select,
+    values,
+  );
+  return result;
+}
+
+int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setVisibilityLayer(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int layer,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
+    tRenderableManager.cast(),
+    entityId,
+    layer,
+  );
+  return result;
+}
+
+void RenderableManager_setPriority(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setPriority(
+    tRenderableManager.cast(),
+    entityId,
+    priority,
+  );
+  return result;
+}
+
+int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
+  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
+  return result;
+}
+
+void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
+  return result;
+}
+
+bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setFogEnabled(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool RenderableManager_getLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+  );
+  return result == 1;
+}
+
+void RenderableManager_setCastShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool castShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
+    tRenderableManager.cast(),
+    entityId,
+    castShadows,
+  );
+  return result;
+}
+
+bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setReceiveShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool receiveShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
+    tRenderableManager.cast(),
+    entityId,
+    receiveShadows,
+  );
+  return result;
+}
+
+bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setScreenSpaceContactShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setBlendOrderAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dart__darwin_size_t primitiveIndex,
+  int order,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    order,
+  );
+  return result;
+}
+
+void RenderableManager_setGlobalBlendOrderEnabledAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dart__darwin_size_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setMorphWeights(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> weights,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
+    tRenderableManager.cast(),
+    entityId,
+    weights,
+    count,
+    offset,
+  );
+  return result;
+}
+
+Dart__darwin_size_t RenderableManager_getMorphTargetCount(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+void RenderableManager_setBonesFromMat4(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> transforms,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
+    tRenderableManager.cast(),
+    entityId,
+    transforms,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+void RenderableManager_setBonesFromBone(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> bones,
+  Dart__darwin_size_t boneCount,
+  Dart__darwin_size_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
+    tRenderableManager.cast(),
+    entityId,
+    bones,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+Pointer<TRenderableBuilder> RenderableBuilder_create(Dart__darwin_size_t primitiveCount) {
+  final result = GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
+  return Pointer<TRenderableBuilder>(result);
+}
+
+void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
+  final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
+  return result;
+}
+
+void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
+  return result;
+}
+
+void RenderableBuilder_material(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  Pointer<TMaterialInstance> materialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_material(
+    builder.cast(),
+    primitiveIndex,
+    materialInstance.cast(),
+  );
+  return result;
+}
+
+void RenderableBuilder_geometry(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Pointer<TIndexBuffer> indices,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_geometry(
+    builder.cast(),
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    indices.cast(),
+    offset,
+    count,
+  );
+  return result;
+}
+
+void RenderableBuilder_geometryNonIndexed(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dart__darwin_size_t offset,
+  Dart__darwin_size_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_geometryNonIndexed(
+    builder.cast(),
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result;
+}
+
+void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
+  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
+  return result;
+}
+
+void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
+  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
+  return result;
+}
+
+void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
+  return result;
+}
+
+void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
+  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
+  return result;
+}
+
+void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dart__darwin_size_t primitiveIndex, int order) {
+  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
+  return result;
+}
+
+void RenderableBuilder_globalBlendOrderEnabled(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_globalBlendOrderEnabled(
+    builder.cast(),
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dart__darwin_size_t instanceCount) {
+  final result = GeneratedBindings.instance._RenderableBuilder_instances(builder.cast(), instanceCount);
+  return result;
+}
+
+void RenderableBuilder_skinningFromMat4(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t boneCount,
+  Pointer<Float32> transforms,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
+  return result;
+}
+
+void RenderableBuilder_skinningFromBone(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t boneCount,
+  Pointer<Float32> bones,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(builder.cast(), boneCount, bones);
+  return result;
+}
+
+void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_boneIndicesAndWeights(
+  Pointer<TRenderableBuilder> builder,
+  Dart__darwin_size_t primitiveIndex,
+  Pointer<Float32> indicesAndWeights,
+  Dart__darwin_size_t count,
+  Dart__darwin_size_t bonesPerVertex,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
+    builder.cast(),
+    primitiveIndex,
+    indicesAndWeights,
+    count,
+    bonesPerVertex,
+  );
+  return result;
+}
+
+int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
+  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
   return result;
 }
 
@@ -7253,7 +8615,7 @@ Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
   return Pointer<Int32>(result);
 }
 
-Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+Dart__darwin_size_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
   return result;
 }
@@ -7263,7 +8625,7 @@ Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
   return Pointer<Int32>(result);
 }
 
-Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+Dart__darwin_size_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(tSceneAsset.cast());
   return result;
 }
@@ -7273,7 +8635,7 @@ Pointer<TSceneAsset> SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, in
   return Pointer<TSceneAsset>(result);
 }
 
-Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
+Dart__darwin_size_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
   final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(tSceneAsset.cast());
   return result;
 }
@@ -7337,199 +8699,23 @@ void SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShadin
   return result;
 }
 
-void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Pointer<Int32> out) {
+void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dart__darwin_size_t skinIndex, Pointer<Int32> out) {
   final result = GeneratedBindings.instance._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
   return result;
 }
 
-Dartsize_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex) {
+Dart__darwin_size_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dart__darwin_size_t skinIndex) {
   final result = GeneratedBindings.instance._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
   return result;
 }
 
-Pointer<Char> SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Dartsize_t boneIndex) {
+Pointer<Char> SceneAsset_getBoneName(
+  Pointer<TSceneAsset> tSceneAsset,
+  Dart__darwin_size_t skinIndex,
+  Dart__darwin_size_t boneIndex,
+) {
   final result = GeneratedBindings.instance._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
   return Pointer<Char>(result);
-}
-
-void MeshData_dispose(Pointer<TMeshData> meshData) {
-  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  Pointer<Char> meshName,
-  Pointer<TMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
-  return result;
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
-    tEngine.cast(),
-    tMaterialProvider.cast(),
-    tNameComponentManager.cast(),
-  );
-  return Pointer<TGltfAssetLoader>(result);
-}
-
-void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
-  return result;
-}
-
-Pointer<TFilamentAsset> GltfAssetLoader_load(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  int numInstances,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    data,
-    length,
-    numInstances,
-  );
-  return Pointer<TFilamentAsset>(result);
-}
-
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
-    tRenderableManager.cast(),
-    tAsset.cast(),
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
-}
-
-int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
-  return result;
-}
-
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
-  return Pointer<PointerClass<Char>>(result);
-}
-
-void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
-    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
-  return result;
-}
-
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
-  return result;
-}
-
-Pointer<TGizmo> Gizmo_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> assetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-) {
-  final result = GeneratedBindings.instance._Gizmo_create(
-    tEngine.cast(),
-    assetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
-  );
-  return Pointer<TGizmo>(result);
-}
-
-void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
-  final result = GeneratedBindings.instance._Gizmo_pick(
-    tGizmo.cast(),
-    x,
-    y,
-    callback as Pointer<NativeFunction<GizmoPickCallbackFunction>>,
-  );
-  return result;
-}
-
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
-  return result;
-}
-
-void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
-  final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
-  return result;
-}
-
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
-  return result;
-}
-
-Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
-  return Pointer<Char>(result);
-}
-
-Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
-  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
-  return Pointer<TRenderTarget>(result);
-}
-
-void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
-  return result;
 }
 
 Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
@@ -7858,1180 +9044,6 @@ bool AnimationManager_setGltfAnimationTime(
   return result == 1;
 }
 
-void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
-  return result == 1;
-}
-
-bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-Dartsize_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
-  return result;
-}
-
-bool RenderableManager_setMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  Pointer<TMaterialInstance> tMaterialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    tMaterialInstance.cast(),
-  );
-  return result == 1;
-}
-
-Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-void RenderableManager_clearMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return result;
-}
-
-bool RenderableManager_setGeometryAtNonIndexed(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dartsize_t offset,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result == 1;
-}
-
-Dartsize_t RenderableManager_getPrimitiveCount(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-Aabb3 RenderableManager_getAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Aabb3 aabb,
-) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
-    tRenderableManager.cast(),
-    entityId,
-    aabbPtr.cast(),
-  );
-  return result;
-}
-
-Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAabb(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setLayerMask(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int select,
-  int values,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
-    tRenderableManager.cast(),
-    entityId,
-    select,
-    values,
-  );
-  return result;
-}
-
-int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setVisibilityLayer(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int layer,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
-    tRenderableManager.cast(),
-    entityId,
-    layer,
-  );
-  return result;
-}
-
-void RenderableManager_setPriority(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setPriority(
-    tRenderableManager.cast(),
-    entityId,
-    priority,
-  );
-  return result;
-}
-
-int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
-  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
-  return result;
-}
-
-void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
-  return result;
-}
-
-bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setFogEnabled(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool RenderableManager_getLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-  );
-  return result == 1;
-}
-
-void RenderableManager_setCastShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool castShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
-    tRenderableManager.cast(),
-    entityId,
-    castShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setReceiveShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool receiveShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
-    tRenderableManager.cast(),
-    entityId,
-    receiveShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setScreenSpaceContactShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setBlendOrderAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dartsize_t primitiveIndex,
-  int order,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    order,
-  );
-  return result;
-}
-
-void RenderableManager_setGlobalBlendOrderEnabledAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dartsize_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setMorphWeights(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> weights,
-  Dartsize_t count,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
-    tRenderableManager.cast(),
-    entityId,
-    weights,
-    count,
-    offset,
-  );
-  return result;
-}
-
-Dartsize_t RenderableManager_getMorphTargetCount(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setBonesFromMat4(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
-    tRenderableManager.cast(),
-    entityId,
-    transforms,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-void RenderableManager_setBonesFromBone(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
-    tRenderableManager.cast(),
-    entityId,
-    bones,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-Pointer<TRenderableBuilder> RenderableBuilder_create(Dartsize_t primitiveCount) {
-  final result = GeneratedBindings.instance._RenderableBuilder_create(primitiveCount);
-  return Pointer<TRenderableBuilder>(result);
-}
-
-void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
-  final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
-  return result;
-}
-
-void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
-  return result;
-}
-
-void RenderableBuilder_material(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_material(
-    builder.cast(),
-    primitiveIndex,
-    materialInstance.cast(),
-  );
-  return result;
-}
-
-void RenderableBuilder_geometry(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Pointer<TIndexBuffer> indices,
-  Dartsize_t offset,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_geometry(
-    builder.cast(),
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    indices.cast(),
-    offset,
-    count,
-  );
-  return result;
-}
-
-void RenderableBuilder_geometryNonIndexed(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dartsize_t offset,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_geometryNonIndexed(
-    builder.cast(),
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result;
-}
-
-void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
-  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
-  return result;
-}
-
-void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
-  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
-  return result;
-}
-
-void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
-  return result;
-}
-
-void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
-  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
-  return result;
-}
-
-void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dartsize_t primitiveIndex, int order) {
-  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
-  return result;
-}
-
-void RenderableBuilder_globalBlendOrderEnabled(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_globalBlendOrderEnabled(
-    builder.cast(),
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dartsize_t instanceCount) {
-  final result = GeneratedBindings.instance._RenderableBuilder_instances(builder.cast(), instanceCount);
-  return result;
-}
-
-void RenderableBuilder_skinningFromMat4(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
-  Pointer<Float32> transforms,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
-  return result;
-}
-
-void RenderableBuilder_skinningFromBone(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
-  Pointer<Float32> bones,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromBone(builder.cast(), boneCount, bones);
-  return result;
-}
-
-void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_boneIndicesAndWeights(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  Pointer<Float32> indicesAndWeights,
-  Dartsize_t count,
-  Dartsize_t bonesPerVertex,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
-    builder.cast(),
-    primitiveIndex,
-    indicesAndWeights,
-    count,
-    bonesPerVertex,
-  );
-  return result;
-}
-
-int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
-  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
-  return result;
-}
-
-void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
-  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
-  return result;
-}
-
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
-  return result;
-}
-
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
-  return result;
-}
-
-void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
-  return result;
-}
-
-void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
-    camera.cast(),
-    projectionMatrixPtr.cast(),
-    near,
-    far,
-  );
-  return result;
-}
-
-void Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix) {
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrix);
-  return result;
-}
-
-void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
-  return result;
-}
-
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
-  return result;
-}
-
-Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
-  return Pointer<TSkybox>(result);
-}
-
-void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
-  return result;
-}
-
-void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
-  return result;
-}
-
-void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
-  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
-  return result;
-}
-
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
-  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
-  return result;
-}
-
-/// Returns the visibility mask bits.
-int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
-  return result;
-}
-
-/// Returns the skybox intensity in lux.
-double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
-  return result;
-}
-
-/// Returns the environment texture, or nullptr for a color-only skybox.
-Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
-  return Pointer<TTexture>(result);
-}
-
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
-  );
-  return result;
-}
-
-bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
-  return result;
-}
-
-void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dartsize_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
-  );
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-    tRenderer.cast(),
-    headRoomRatio,
-    scaleRate,
-    history,
-    interval,
-  );
-  return result;
-}
-
-void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
-  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
-  return result;
-}
-
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
-  return Pointer<TGltfResourceLoader>(result);
-}
-
-void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
-  return result;
-}
-
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
-  return result;
-}
-
-double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
-  return result;
-}
-
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
-  );
-  return result;
-}
-
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
-  return result;
-}
-
-void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
-  return Pointer<Void>(result);
-}
-
-Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
-  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
-  return result;
-}
-
-Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_create();
-  return Pointer<TSurfaceOrientationBuilder>(result);
-}
-
-void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_normals(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> normals,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_normals(builder.cast(), normals, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_positions(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> positions,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangleCount(builder.cast(), count);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_uint(Pointer<TSurfaceOrientationBuilder> builder, Pointer<Uint32> triangles) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_uint(builder.cast(), triangles);
-  return result;
-}
-
-void SurfaceOrientationBuilder_triangles_ushort(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Uint16> triangles,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_triangles_ushort(builder.cast(), triangles);
-  return result;
-}
-
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dartsize_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
-  return result;
-}
-
-void SurfaceOrientation_getQuats_float4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Float32> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_half4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Uint16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_half4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
-  return result;
-}
-
 void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
   final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(executor.cast());
   return result;
@@ -9311,455 +9323,6 @@ sealed class TBlendingMode {
   static const BLENDING_MODE_CUSTOM = 7;
 }
 
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-typedef size_t = int;
-typedef Dartsize_t = int;
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
-  }
-}
-
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
-
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
-  }
-}
-
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
-
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
-}
-
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
-
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
-
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
-
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
-
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
-}
-
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
-  }
-}
-
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
-
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
-  }
-}
-
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
-  }
-}
-
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
-
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
-  }
-}
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
-  }
-}
-
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
-
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
-  }
-}
-
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
-  }
-}
-
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
-
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
-  }
-}
-
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
-}
-
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
-
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
-
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
-  }
-}
-
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
-}
-
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
-  }
-}
-
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
-
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
-
-typedef EntityId = int;
-typedef DartEntityId = int;
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
-  }
-}
-
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
-
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
-  }
-}
-
-extension TRenderableManagerExt on Pointer<TRenderableManager> {
-  TRenderableManager toDart() {
-    return TRenderableManager(this);
-  }
-}
-
-final class TRenderableManager extends Struct {
-  Pointer<TRenderableManager> get address => super.address.cast();
-  TRenderableManager(super.address);
-
-  static Pointer<TRenderableManager> stackAlloc() {
-    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
-  }
-}
-
 extension TLightManagerExt on Pointer<TLightManager> {
   TLightManager toDart() {
     return TLightManager(this);
@@ -9775,78 +9338,413 @@ final class TLightManager extends Struct {
   }
 }
 
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+typedef EntityId = int;
+typedef DartEntityId = int;
+
+extension double3Ext on Pointer<double3> {
+  double3 toDart() {
+    return double3(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class double3 extends Struct {
+  Pointer<double3> get address => super.address.cast();
+  double get x {
+    final addr = Pointer<double3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  set x(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
+  }
+
+  double get y {
+    final addr = Pointer<double3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set y(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
+  }
+
+  double get z {
+    final addr = Pointer<double3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set z(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
+  }
+
+  double3(super.address);
+
+  static Pointer<double3> stackAlloc() {
+    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
   }
 }
 
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
+extension TShadowOptionsExt on Pointer<TShadowOptions> {
+  TShadowOptions toDart() {
+    return TShadowOptions(this);
   }
 }
 
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
+final class TShadowOptions extends Struct {
+  Pointer<TShadowOptions> get address => super.address.cast();
+  int get mapSize {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
 
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  set mapSize(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
+  }
+
+  int get shadowCascades {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set shadowCascades(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
+  }
+
+  Array<Float32> get cascadeSplitPositions {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float32>((numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
+  }
+
+  set cascadeSplitPositions(Array<Float32> val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 5), val.internal.addr.addr.toJS, '*');
+  }
+
+  double get constantBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set constantBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
+  }
+
+  double get normalBias {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set normalBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
+  }
+
+  double get shadowFar {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFar(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
+  }
+
+  double get shadowNearHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowNearHint(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
+  }
+
+  double get shadowFarHint {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowFarHint(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
+  }
+
+  bool get stable {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set stable(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 37), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  bool get lispsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set lispsm(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get polygonOffsetConstant {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetConstant(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
+  }
+
+  double get polygonOffsetSlope {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set polygonOffsetSlope(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
+  }
+
+  bool get screenSpaceContactShadows {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set screenSpaceContactShadows(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 47), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  int get stepCount {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set stepCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
+  }
+
+  double get maxShadowDistance {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxShadowDistance(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
+  }
+
+  bool get vsmElvsm {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set vsmElvsm(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 53), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get vsmBlurWidth {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set vsmBlurWidth(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
+  }
+
+  double get shadowBulbRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowBulbRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
+  }
+
+  double get penumbraScale {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
+  }
+
+  double get penumbraRatioScale {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraRatioScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
+  }
+
+  double get maxPenumbraRatio {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxPenumbraRatio(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
+  }
+
+  double get maxSearchRadius {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxSearchRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
+  }
+
+  double get transformX {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformX(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
+  }
+
+  double get transformY {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformY(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
+  }
+
+  double get transformZ {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformZ(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
+  }
+
+  double get transformW {
+    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set transformW(double val) {
+    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
+  }
+
+  TShadowOptions(super.address);
+
+  static Pointer<TShadowOptions> stackAlloc() {
+    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
   }
 }
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
   }
 }
 
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
 
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
   }
 }
 
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
+extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
+  TGltfAssetLoader toDart() {
+    return TGltfAssetLoader(this);
   }
 }
 
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
+final class TGltfAssetLoader extends Struct {
+  Pointer<TGltfAssetLoader> get address => super.address.cast();
+  TGltfAssetLoader(super.address);
 
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
+  static Pointer<TGltfAssetLoader> stackAlloc() {
+    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
   }
 }
 
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
   }
 }
 
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
 
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
+  }
+}
+
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
+  }
+}
+
+typedef size_t = __darwin_size_t;
+typedef __darwin_size_t = int;
+typedef Dart__darwin_size_t = int;
+
+extension TRenderableManagerExt on Pointer<TRenderableManager> {
+  TRenderableManager toDart() {
+    return TRenderableManager(this);
+  }
+}
+
+final class TRenderableManager extends Struct {
+  Pointer<TRenderableManager> get address => super.address.cast();
+  TRenderableManager(super.address);
+
+  static Pointer<TRenderableManager> stackAlloc() {
+    return Pointer<TRenderableManager>(NativeLibrary.instance.stackAlloc<TRenderableManager>(0));
   }
 }
 
@@ -9905,6 +9803,21 @@ final class TViewport extends Struct {
   }
 }
 
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
 extension TToneMapperExt on Pointer<TToneMapper> {
   TToneMapper toDart() {
     return TToneMapper(this);
@@ -9935,6 +9848,21 @@ final class TColorGradingBuilder extends Struct {
   }
 }
 
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
+  }
+}
+
 sealed class TQualityLevel {
   static const LOW = 0;
   static const MEDIUM = 1;
@@ -9950,6 +9878,21 @@ sealed class TLutFormat {
 sealed class TBlendMode {
   static const OPAQUE = 0;
   static const TRANSLUCENT = 1;
+}
+
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
+  }
+}
+
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
+
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
+  }
 }
 
 /// Options for DPCF and PCSS Shadowing.
@@ -10083,6 +10026,36 @@ final class TVsmShadowOptions extends Struct {
 
   static Pointer<TVsmShadowOptions> stackAlloc() {
     return Pointer<TVsmShadowOptions>(NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
+  }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
+  }
+}
+
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
+
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
   }
 }
 
@@ -10679,18 +10652,433 @@ typedef PickCallbackFunction =
 typedef DartPickCallbackFunction =
     void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
 
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
+extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
+  TSurfaceOrientationBuilder toDart() {
+    return TSurfaceOrientationBuilder(this);
   }
 }
 
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
+final class TSurfaceOrientationBuilder extends Struct {
+  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
+  TSurfaceOrientationBuilder(super.address);
 
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
+  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
+    return Pointer<TSurfaceOrientationBuilder>(NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
+  }
+}
+
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
+  }
+}
+
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
+
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
+  }
+}
+
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
+  }
+}
+
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
+
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
+  }
+}
+
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  }
+}
+
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
+  }
+}
+
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
+
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
+  }
+}
+
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+extension TGizmoExt on Pointer<TGizmo> {
+  TGizmo toDart() {
+    return TGizmo(this);
+  }
+}
+
+final class TGizmo extends Struct {
+  Pointer<TGizmo> get address => super.address.cast();
+  TGizmo(super.address);
+
+  static Pointer<TGizmo> stackAlloc() {
+    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
+  }
+}
+
+extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
+  TGltfResourceLoader toDart() {
+    return TGltfResourceLoader(this);
+  }
+}
+
+final class TGltfResourceLoader extends Struct {
+  Pointer<TGltfResourceLoader> get address => super.address.cast();
+  TGltfResourceLoader(super.address);
+
+  static Pointer<TGltfResourceLoader> stackAlloc() {
+    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
+  }
+}
+
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
+}
+
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
+  }
+}
+
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
+
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
+  }
+}
+
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
+extension TIndexBufferExt on Pointer<TIndexBuffer> {
+  TIndexBuffer toDart() {
+    return TIndexBuffer(this);
+  }
+}
+
+final class TIndexBuffer extends Struct {
+  Pointer<TIndexBuffer> get address => super.address.cast();
+  TIndexBuffer(super.address);
+
+  static Pointer<TIndexBuffer> stackAlloc() {
+    return Pointer<TIndexBuffer>(NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
   }
 }
 
@@ -10792,53 +11180,78 @@ final class TBufferObject extends Struct {
   }
 }
 
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
   }
 }
 
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TIndexBufferExt on Pointer<TIndexBuffer> {
-  TIndexBuffer toDart() {
-    return TIndexBuffer(this);
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
   }
 }
 
-final class TIndexBuffer extends Struct {
-  Pointer<TIndexBuffer> get address => super.address.cast();
-  TIndexBuffer(super.address);
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
 
-  static Pointer<TIndexBuffer> stackAlloc() {
-    return Pointer<TIndexBuffer>(NativeLibrary.instance.stackAlloc<TIndexBuffer>(0));
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
   }
 }
 
-extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
-  TBufferObjectBuilder toDart() {
-    return TBufferObjectBuilder(this);
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
   }
 }
 
-final class TBufferObjectBuilder extends Struct {
-  Pointer<TBufferObjectBuilder> get address => super.address.cast();
-  TBufferObjectBuilder(super.address);
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
 
-  static Pointer<TBufferObjectBuilder> stackAlloc() {
-    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  }
+}
+
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
+  }
+}
+
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
+
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+  }
+}
+
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
+  }
+}
+
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
+
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
   }
 }
 
@@ -10894,6 +11307,26 @@ final class double4x4 extends Struct {
 
   static Pointer<double4x4> stackAlloc() {
     return Pointer<double4x4>(NativeLibrary.instance.stackAlloc<double4x4>(128));
+  }
+}
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
+  }
+}
+
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
+
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
   }
 }
 
@@ -10972,361 +11405,80 @@ final class Aabb3 extends Struct {
   }
 }
 
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
 }
 
-extension double3Ext on Pointer<double3> {
-  double3 toDart() {
-    return double3(this);
-  }
-}
-
-final class double3 extends Struct {
-  Pointer<double3> get address => super.address.cast();
-  double get x {
-    final addr = Pointer<double3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set x(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
-  }
-
-  double get y {
-    final addr = Pointer<double3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set y(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
-  }
-
-  double get z {
-    final addr = Pointer<double3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set z(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
-  }
-
-  double3(super.address);
-
-  static Pointer<double3> stackAlloc() {
-    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
   }
 }
 
-extension TShadowOptionsExt on Pointer<TShadowOptions> {
-  TShadowOptions toDart() {
-    return TShadowOptions(this);
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
+
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
   }
 }
 
-final class TShadowOptions extends Struct {
-  Pointer<TShadowOptions> get address => super.address.cast();
-  int get mapSize {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set mapSize(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 0), val.toJS, 'i32');
-  }
-
-  int get shadowCascades {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set shadowCascades(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 4), val.toJS, 'i8');
-  }
-
-  Array<Float32> get cascadeSplitPositions {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 5);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float32>((numElements: 3, addr: Pointer<Float32>(this.address.addr + 5)));
-  }
-
-  set cascadeSplitPositions(Array<Float32> val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 5), val.internal.addr.addr.toJS, '*');
-  }
-
-  double get constantBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 17);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constantBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 17), val.toJS, 'float');
-  }
-
-  double get normalBias {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 21);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set normalBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 21), val.toJS, 'float');
-  }
-
-  double get shadowFar {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 25);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFar(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 25), val.toJS, 'float');
-  }
-
-  double get shadowNearHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 29);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowNearHint(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 29), val.toJS, 'float');
-  }
-
-  double get shadowFarHint {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 33);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowFarHint(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 33), val.toJS, 'float');
-  }
-
-  bool get stable {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set stable(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 37), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  bool get lispsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set lispsm(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get polygonOffsetConstant {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 39);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetConstant(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 39), val.toJS, 'float');
-  }
-
-  double get polygonOffsetSlope {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 43);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set polygonOffsetSlope(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 43), val.toJS, 'float');
-  }
-
-  bool get screenSpaceContactShadows {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 47);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set screenSpaceContactShadows(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 47), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  int get stepCount {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 48);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set stepCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 48), val.toJS, 'i8');
-  }
-
-  double get maxShadowDistance {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 49);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxShadowDistance(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 49), val.toJS, 'float');
-  }
-
-  bool get vsmElvsm {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 53);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set vsmElvsm(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 53), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get vsmBlurWidth {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 54);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set vsmBlurWidth(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 54), val.toJS, 'float');
-  }
-
-  double get shadowBulbRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 58);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowBulbRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 58), val.toJS, 'float');
-  }
-
-  double get penumbraScale {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 62);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set penumbraScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 62), val.toJS, 'float');
-  }
-
-  double get penumbraRatioScale {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 66);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set penumbraRatioScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 66), val.toJS, 'float');
-  }
-
-  double get maxPenumbraRatio {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 70);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxPenumbraRatio(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 70), val.toJS, 'float');
-  }
-
-  double get maxSearchRadius {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 74);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set maxSearchRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 74), val.toJS, 'float');
-  }
-
-  double get transformX {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 78);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformX(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 78), val.toJS, 'float');
-  }
-
-  double get transformY {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 82);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformY(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 82), val.toJS, 'float');
-  }
-
-  double get transformZ {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 86);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformZ(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 86), val.toJS, 'float');
-  }
-
-  double get transformW {
-    final addr = Pointer<TShadowOptions>(this.address.addr + 90);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set transformW(double val) {
-    NativeLibrary.instance.setValue(Pointer<TShadowOptions>(this.address.addr + 90), val.toJS, 'float');
-  }
-
-  TShadowOptions(super.address);
-
-  static Pointer<TShadowOptions> stackAlloc() {
-    return Pointer<TShadowOptions>(NativeLibrary.instance.stackAlloc<TShadowOptions>(94));
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
   }
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
+
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
   }
 }
 
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
-
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
   }
 }
 
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
+
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
   }
 }
 
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
+extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
+  TBufferObjectBuilder toDart() {
+    return TBufferObjectBuilder(this);
+  }
+}
 
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+final class TBufferObjectBuilder extends Struct {
+  Pointer<TBufferObjectBuilder> get address => super.address.cast();
+  TBufferObjectBuilder(super.address);
+
+  static Pointer<TBufferObjectBuilder> stackAlloc() {
+    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
   }
 }
 
@@ -11342,51 +11494,6 @@ final class TSceneAsset extends Struct {
 
   static Pointer<TSceneAsset> stackAlloc() {
     return Pointer<TSceneAsset>(NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
-  }
-}
-
-extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
-  TGltfAssetLoader toDart() {
-    return TGltfAssetLoader(this);
-  }
-}
-
-final class TGltfAssetLoader extends Struct {
-  Pointer<TGltfAssetLoader> get address => super.address.cast();
-  TGltfAssetLoader(super.address);
-
-  static Pointer<TGltfAssetLoader> stackAlloc() {
-    return Pointer<TGltfAssetLoader>(NativeLibrary.instance.stackAlloc<TGltfAssetLoader>(0));
-  }
-}
-
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
-  }
-}
-
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
-
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
-  }
-}
-
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
-  }
-}
-
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
-
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
   }
 }
 
@@ -11407,41 +11514,6 @@ sealed class TPrimitiveType {
   static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
-extension TGltfResourceLoaderExt on Pointer<TGltfResourceLoader> {
-  TGltfResourceLoader toDart() {
-    return TGltfResourceLoader(this);
-  }
-}
-
-final class TGltfResourceLoader extends Struct {
-  Pointer<TGltfResourceLoader> get address => super.address.cast();
-  TGltfResourceLoader(super.address);
-
-  static Pointer<TGltfResourceLoader> stackAlloc() {
-    return Pointer<TGltfResourceLoader>(NativeLibrary.instance.stackAlloc<TGltfResourceLoader>(0));
-  }
-}
-
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-extension TGizmoExt on Pointer<TGizmo> {
-  TGizmo toDart() {
-    return TGizmo(this);
-  }
-}
-
-final class TGizmo extends Struct {
-  Pointer<TGizmo> get address => super.address.cast();
-  TGizmo(super.address);
-
-  static Pointer<TGizmo> stackAlloc() {
-    return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
-  }
-}
-
 extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
   TRenderableBuilder toDart() {
     return TRenderableBuilder(this);
@@ -11455,16 +11527,6 @@ final class TRenderableBuilder extends Struct {
   static Pointer<TRenderableBuilder> stackAlloc() {
     return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
   }
-}
-
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
 extension TMeshDataExt on Pointer<TMeshData> {
@@ -11482,63 +11544,14 @@ final class TMeshData extends Struct {
   }
 }
 
-typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
-
-extension TSurfaceOrientationBuilderExt on Pointer<TSurfaceOrientationBuilder> {
-  TSurfaceOrientationBuilder toDart() {
-    return TSurfaceOrientationBuilder(this);
-  }
-}
-
-final class TSurfaceOrientationBuilder extends Struct {
-  Pointer<TSurfaceOrientationBuilder> get address => super.address.cast();
-  TSurfaceOrientationBuilder(super.address);
-
-  static Pointer<TSurfaceOrientationBuilder> stackAlloc() {
-    return Pointer<TSurfaceOrientationBuilder>(NativeLibrary.instance.stackAlloc<TSurfaceOrientationBuilder>(0));
-  }
-}
-
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
-  }
-}
-
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
-
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
-  }
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
 extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
@@ -11601,59 +11614,35 @@ extension StructAllocator on Struct {
       case TTextureSampler:
         final ptr = TTextureSampler.stackAlloc();
         return ptr.toDart() as T;
-      case TLinearImage:
-        final ptr = TLinearImage.stackAlloc();
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
         return ptr.toDart() as T;
-      case TKtx1Bundle:
-        final ptr = TKtx1Bundle.stackAlloc();
+      case double3:
+        final ptr = double3.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TRenderer:
-        final ptr = TRenderer.stackAlloc();
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
         return ptr.toDart() as T;
-      case TSwapChain:
-        final ptr = TSwapChain.stackAlloc();
+      case TGltfAssetLoader:
+        final ptr = TGltfAssetLoader.stackAlloc();
         return ptr.toDart() as T;
-      case TView:
-        final ptr = TView.stackAlloc();
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
-        return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TTransformManager:
-        final ptr = TTransformManager.stackAlloc();
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableManager:
         final ptr = TRenderableManager.stackAlloc();
         return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TEntityManager:
-        final ptr = TEntityManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFence:
-        final ptr = TFence.stackAlloc();
-        return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
-      case TDebugRegistry:
-        final ptr = TDebugRegistry.stackAlloc();
-        return ptr.toDart() as T;
       case TViewport:
         final ptr = TViewport.stackAlloc();
+        return ptr.toDart() as T;
+      case TView:
+        final ptr = TView.stackAlloc();
         return ptr.toDart() as T;
       case TToneMapper:
         final ptr = TToneMapper.stackAlloc();
@@ -11661,11 +11650,23 @@ extension StructAllocator on Struct {
       case TColorGradingBuilder:
         final ptr = TColorGradingBuilder.stackAlloc();
         return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
+        return ptr.toDart() as T;
       case TSoftShadowOptions:
         final ptr = TSoftShadowOptions.stackAlloc();
         return ptr.toDart() as T;
       case TVsmShadowOptions:
         final ptr = TVsmShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
+        return ptr.toDart() as T;
+      case TScene:
+        final ptr = TScene.stackAlloc();
         return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
@@ -11679,8 +11680,32 @@ extension StructAllocator on Struct {
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
+      case TSurfaceOrientationBuilder:
+        final ptr = TSurfaceOrientationBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientation:
+        final ptr = TSurfaceOrientation.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
+      case TLinearImage:
+        final ptr = TLinearImage.stackAlloc();
+        return ptr.toDart() as T;
+      case TKtx1Bundle:
+        final ptr = TKtx1Bundle.stackAlloc();
+        return ptr.toDart() as T;
+      case TGizmo:
+        final ptr = TGizmo.stackAlloc();
+        return ptr.toDart() as T;
+      case TGltfResourceLoader:
+        final ptr = TGltfResourceLoader.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
         return ptr.toDart() as T;
       case TVertexBufferBuilder:
         final ptr = TVertexBufferBuilder.stackAlloc();
@@ -11691,62 +11716,50 @@ extension StructAllocator on Struct {
       case TBufferObject:
         final ptr = TBufferObject.stackAlloc();
         return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TBufferObjectBuilder:
-        final ptr = TBufferObjectBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
-        return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
-        return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
         return ptr.toDart() as T;
       case TRenderManager:
         final ptr = TRenderManager.stackAlloc();
         return ptr.toDart() as T;
+      case TRenderer:
+        final ptr = TRenderer.stackAlloc();
+        return ptr.toDart() as T;
       case TAnimationManager:
         final ptr = TAnimationManager.stackAlloc();
         return ptr.toDart() as T;
+      case TSwapChain:
+        final ptr = TSwapChain.stackAlloc();
+        return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
+        return ptr.toDart() as T;
+      case TTransformManager:
+        final ptr = TTransformManager.stackAlloc();
+        return ptr.toDart() as T;
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
+        return ptr.toDart() as T;
+      case TEntityManager:
+        final ptr = TEntityManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFence:
+        final ptr = TFence.stackAlloc();
+        return ptr.toDart() as T;
+      case TDebugRegistry:
+        final ptr = TDebugRegistry.stackAlloc();
+        return ptr.toDart() as T;
+      case TBufferObjectBuilder:
+        final ptr = TBufferObjectBuilder.stackAlloc();
+        return ptr.toDart() as T;
       case TSceneAsset:
         final ptr = TSceneAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfAssetLoader:
-        final ptr = TGltfAssetLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TGltfResourceLoader:
-        final ptr = TGltfResourceLoader.stackAlloc();
-        return ptr.toDart() as T;
-      case TGizmo:
-        final ptr = TGizmo.stackAlloc();
         return ptr.toDart() as T;
       case TRenderableBuilder:
         final ptr = TRenderableBuilder.stackAlloc();
         return ptr.toDart() as T;
       case TMeshData:
         final ptr = TMeshData.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientationBuilder:
-        final ptr = TSurfaceOrientationBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientation:
-        final ptr = TSurfaceOrientation.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
@@ -180,8 +180,7 @@ class FFICamera extends Camera<Pointer<TCamera>> {
   /// Reused native-path scratch so repeated camera updates do not allocate.
   /// Backed by Dart heap memory (GC-managed, no explicit free); never touched
   /// on web, which allocates each call transiently on the wasm stack.
-  late final double4x4 _modelMatrixScratch =
-      matrix4ToDouble4x4(Matrix4.identity());
+  late final double4x4 _modelMatrixScratch = matrix4ToDouble4x4(Matrix4.identity());
 
   @override
   Future setModelMatrix(Matrix4 matrix) async {
@@ -194,10 +193,7 @@ class FFICamera extends Camera<Pointer<TCamera>> {
       Camera_setModelMatrix(camera, matrix4ToDouble4x4(matrix));
       stackRestore(stackPtr);
     } else {
-      Camera_setModelMatrix(
-        camera,
-        matrix4ToDouble4x4(matrix, out: _modelMatrixScratch),
-      );
+      Camera_setModelMatrix(camera, matrix4ToDouble4x4(matrix, out: _modelMatrixScratch));
     }
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
@@ -179,10 +179,18 @@ class FFICamera extends Camera<Pointer<TCamera>> {
   ///
   @override
   Future setModelMatrix(Matrix4 matrix) async {
-    // Filament's Camera::setModelMatrix delegates to its entity's transform.
-    // Use the existing by-value binding to avoid the typed-data .address
-    // trampoline, which can be missing when native test kernels are loaded.
-    _app.transformManager.setTransform(_entity, matrix);
+    // By-value matrix binding, matching Camera_setCustomProjectionWithCulling
+    // and TransformManager_setTransform; a raw double* argument would require
+    // the typed-data .address trampoline, which is not available in all
+    // module builds.
+    late Pointer stackPtr;
+    if (FILAMENT_WASM) {
+      stackPtr = stackSave();
+    }
+    Camera_setModelMatrix(camera, matrix4ToDouble4x4(matrix));
+    if (FILAMENT_WASM) {
+      stackRestore(stackPtr);
+    }
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
@@ -179,15 +179,10 @@ class FFICamera extends Camera<Pointer<TCamera>> {
   ///
   @override
   Future setModelMatrix(Matrix4 matrix) async {
-    late Pointer stackPtr;
-    if (FILAMENT_WASM) {
-      stackPtr = stackSave();
-    }
-    Camera_setModelMatrix(camera, matrix.storage.address);
-    if (FILAMENT_WASM) {
-      stackRestore(stackPtr);
-      matrix.storage.free();
-    }
+    // Filament's Camera::setModelMatrix delegates to its entity's transform.
+    // Use the existing by-value binding to avoid the typed-data .address
+    // trampoline, which can be missing when native test kernels are loaded.
+    _app.transformManager.setTransform(_entity, matrix);
   }
 
   @override

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_camera.dart
@@ -177,19 +177,27 @@ class FFICamera extends Camera<Pointer<TCamera>> {
   ///
   ///
   ///
+  /// Reused native-path scratch so repeated camera updates do not allocate.
+  /// Backed by Dart heap memory (GC-managed, no explicit free); never touched
+  /// on web, which allocates each call transiently on the wasm stack.
+  late final double4x4 _modelMatrixScratch =
+      matrix4ToDouble4x4(Matrix4.identity());
+
   @override
   Future setModelMatrix(Matrix4 matrix) async {
     // By-value matrix binding, matching Camera_setCustomProjectionWithCulling
     // and TransformManager_setTransform; a raw double* argument would require
     // the typed-data .address trampoline, which is not available in all
     // module builds.
-    late Pointer stackPtr;
     if (FILAMENT_WASM) {
-      stackPtr = stackSave();
-    }
-    Camera_setModelMatrix(camera, matrix4ToDouble4x4(matrix));
-    if (FILAMENT_WASM) {
+      final stackPtr = stackSave();
+      Camera_setModelMatrix(camera, matrix4ToDouble4x4(matrix));
       stackRestore(stackPtr);
+    } else {
+      Camera_setModelMatrix(
+        camera,
+        matrix4ToDouble4x4(matrix, out: _modelMatrixScratch),
+      );
     }
   }
 

--- a/thermion_dart/lib/src/utils/src/matrix.dart
+++ b/thermion_dart/lib/src/utils/src/matrix.dart
@@ -22,12 +22,12 @@ Matrix4 double4x4ToMatrix4(double4x4 mat) {
   ]);
 }
 
-double4x4 matrix4ToDouble4x4(Matrix4 mat) {
-  final out = StructAllocator.create<double4x4>();
-  Array<Float64> col1 = out.col1;
-  Array<Float64> col2 = out.col2;
-  Array<Float64> col3 = out.col3;
-  Array<Float64> col4 = out.col4;
+double4x4 matrix4ToDouble4x4(Matrix4 mat, {double4x4? out}) {
+  final result = out ?? StructAllocator.create<double4x4>();
+  Array<Float64> col1 = result.col1;
+  Array<Float64> col2 = result.col2;
+  Array<Float64> col3 = result.col3;
+  Array<Float64> col4 = result.col4;
 
   for (int i = 0; i < 4; i++) {
     col1[i] = mat.storage[i];
@@ -36,5 +36,5 @@ double4x4 matrix4ToDouble4x4(Matrix4 mat) {
     col4[i] = mat.storage[i + 12];
   }
 
-  return out;
+  return result;
 }

--- a/thermion_dart/native/include/c_api/TCamera.h
+++ b/thermion_dart/native/include/c_api/TCamera.h
@@ -49,7 +49,7 @@ EMSCRIPTEN_KEEPALIVE void Camera_setCustomProjectionWithCulling(
     double near,
     double far
 );
-EMSCRIPTEN_KEEPALIVE void Camera_setModelMatrix(TCamera* camera, double *tModelMatrix);
+EMSCRIPTEN_KEEPALIVE void Camera_setModelMatrix(TCamera* camera, double4x4 tModelMatrix);
 EMSCRIPTEN_KEEPALIVE void Camera_setLensProjection(TCamera *camera, double near, double far, double aspect, double focalLength);
 EMSCRIPTEN_KEEPALIVE EntityId Camera_getEntity(TCamera* camera);
 EMSCRIPTEN_KEEPALIVE void Camera_setProjection(TCamera *const tCamera, TProjection projection, double left, double right,

--- a/thermion_dart/native/src/c_api/TCamera.cpp
+++ b/thermion_dart/native/src/c_api/TCamera.cpp
@@ -69,10 +69,9 @@ namespace thermion
             return camera->getSensitivity();
         }
 
-        EMSCRIPTEN_KEEPALIVE void Camera_setModelMatrix(TCamera *tCamera, double *tModelMatrix) {
+        EMSCRIPTEN_KEEPALIVE void Camera_setModelMatrix(TCamera *tCamera, double4x4 tModelMatrix) {
             auto *camera = reinterpret_cast<Camera *>(tCamera);
-            auto modelMatrix = convert_double_to_mat4f(tModelMatrix);
-            camera->setModelMatrix(modelMatrix);
+            camera->setModelMatrix(convert_double4x4_to_mat4(tModelMatrix));
         }
 
 

--- a/thermion_dart/pubspec.yaml
+++ b/thermion_dart/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   path: ^1.9.0
   crypto: ^3.0.0
   image: ^4.3.0
-  ffigen_js: ^0.0.14-pre
+  ffigen_js: ^0.0.15-pre
   
 dev_dependencies:
   ffigen: ^18.1.0

--- a/thermion_dart/test/camera_tests.dart
+++ b/thermion_dart/test/camera_tests.dart
@@ -37,6 +37,35 @@ void main() async {
     });
   });
 
+  test('model matrix updates preserve every element and caller storage', () async {
+    final camera = await FilamentApp.instance!.createCamera();
+    try {
+      // Include nonzero storage offsets and non-translation elements. Camera
+      // updates use column-major matrices and must not free the caller's data.
+      final backing = Float64List(20);
+      backing[0] = 123;
+      backing[19] = 456;
+      final storage = Float64List.sublistView(backing, 2, 18);
+      final matrix = Matrix4.fromFloat64List(storage);
+      for (var update = 0; update < 8; update++) {
+        matrix.setIdentity();
+        matrix.setTranslation(Vector3(update + 0.25, -2.5, 3.75));
+        matrix.rotateY(0.2 * update);
+        final expected = matrix.storage.toList();
+        await camera.setModelMatrix(matrix);
+        final actual = await camera.getModelMatrix();
+        for (var i = 0; i < 16; i++) {
+          expect(actual.storage[i], closeTo(expected[i], 1e-6), reason: 'update $update, element $i');
+        }
+        expect(matrix.storage, orderedEquals(expected));
+        expect(backing[0], 123);
+        expect(backing[19], 456);
+      }
+    } finally {
+      await camera.destroy();
+    }
+  });
+
   test('get/set exposure (aperture, shutter speed, sensitivity)', () async {
     await testHelper.withViewer((viewer) async {
       final camera = await viewer.getActiveCamera();


### PR DESCRIPTION
Extracted from #301 (frame scheduling / render task lifetimes).

## Problem
`Camera_setModelMatrix` was the only camera matrix binding taking a raw `double*`. On web, passing a `Float64List` by pointer requires a per-function typed-data trampoline (`Camera_setModelMatrix#PT`) that is not present in all module builds — the direct call fails at runtime there. Every sibling binding avoids this: `Camera_getModelMatrix` returns `double4x4` by value, and both `Camera_setCustomProjectionWithCulling` and `TransformManager_setTransform` take `double4x4` by value.

## Fix
`Camera_setModelMatrix` now takes `double4x4` by value, so the Dart side is a pass-through — `Camera_setModelMatrix(camera, ...)` — with no pointer glue on any platform. The C implementation converts through `convert_double4x4_to_mat4` (double precision), matching the convention of the other by-value matrix bindings.

Camera updates run per input event, so the implementation reuses a per-camera scratch `double4x4` on native (Dart-heap-backed via `Struct.create`, GC-managed, no explicit free, zero per-call allocation) and a transient wasm-stack allocation on web (inside the `stackSave` window, also zero GC pressure). `matrix4ToDouble4x4` gains an optional `out` parameter; measured **10.4 ns/call** on native with zero allocations (down from 19.4 ns with a fresh struct per call).

## Web bindings fix (drive-by, required)
Regenerating the web bindings revealed `ffigen_js` dropped enums that no included function signature referenced by type — `TSceneAssetGeometryCapability` (used only as bitmask constants in `ffi_asset.dart`) was missing and the package did not compile for web (this also breaks `develop`'s web build at HEAD). Root-cause fixed in **ffigen_js `fix/root-enum-decl-emission`** (to be published as `0.0.15-pre`): root-level `EnumDecl` cursors now go through the type extractor instead of the macro-deferral path, matching upstream `ffigen`; structs/unions keep the dependency-only behavior. Eighteen enums now emit standalone, matching the native bindings.

## Validation
- Native (macOS/Metal): all 13 tests in `camera_tests.dart` pass, including the new round-trip test (non-translation elements, nonzero storage offsets, caller-buffer preservation) which exercises scratch-reuse overwrites.
- Web (Chrome, COOP/COEP via `tool/web_test_runner.dart`, wasm module built from this branch): 8/13 pass — including every model-matrix test (set/round-trip, target-entity matrix, `lookAt`/`getPosition`). The suite previously could not even load on web due to the missing enum. The 5 failures are pre-existing and unrelated to this change: four hit a test-harness `capture()` limitation ("multiple swapchains registered", `ffi_filament_app.dart:936`) and one is a `frustum.containsVector3` web-platform discrepancy (projection/frustum code is untouched by this PR).
- `dart analyze`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
