### PR TITLE
fix: preserve double precision in convert_double4x4_to_mat4

### DIFF
--- a/thermion_dart/native/include/MathUtils.hpp
+++ b/thermion_dart/native/include/MathUtils.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include <cstddef>
+#include <cstring>
+#include <type_traits>
 #include <math/mat4.h>
 #include <math/mat3.h>
 #include "c_api/APIBoundaryTypes.h"
@@ -24,24 +27,31 @@ static filament::math::mat3f convert_double_to_mat3f(double* data)
         filament::math::float3{static_cast<float>(data[6]), static_cast<float>(data[7]), static_cast<float>(data[8])}};
 }
 
-// Helper function to convert filament::math::mat4 to double4x4
+// Both types store four consecutive columns of doubles. Copy their object
+// representations without narrowing values or aliasing unrelated C++ types.
+// Guard size/type assumptions here; matrix tests check column ordering too.
+static_assert(std::is_same_v<filament::math::mat4::value_type, double>);
+static_assert(std::is_trivially_copyable_v<filament::math::mat4>);
+static_assert(std::is_trivially_copyable_v<double4x4>);
+static_assert(std::is_standard_layout_v<double4x4>);
+static_assert(sizeof(filament::math::mat4) == 16 * sizeof(double));
+static_assert(sizeof(double4x4) == sizeof(filament::math::mat4));
+static_assert(offsetof(double4x4, col1) == 0);
+static_assert(offsetof(double4x4, col2) == 4 * sizeof(double));
+static_assert(offsetof(double4x4, col3) == 8 * sizeof(double));
+static_assert(offsetof(double4x4, col4) == 12 * sizeof(double));
+
 static double4x4 convert_mat4_to_double4x4(const filament::math::mat4 &mat)
 {
-    return double4x4 {
-        {mat[0][0], mat[0][1], mat[0][2], mat[0][3]},
-        {mat[1][0], mat[1][1], mat[1][2], mat[1][3]},
-        {mat[2][0], mat[2][1], mat[2][2], mat[2][3]},
-        {mat[3][0], mat[3][1], mat[3][2], mat[3][3]},
-    };
+    double4x4 result;
+    std::memcpy(&result, &mat, sizeof(result));
+    return result;
 }
 
-// Helper function to convert double4x4 to filament::math::mat4
 static filament::math::mat4 convert_double4x4_to_mat4(const double4x4 &d_mat)
 {
-    return filament::math::mat4{
-        filament::math::float4{float(d_mat.col1[0]), float(d_mat.col1[1]), float(d_mat.col1[2]), float(d_mat.col1[3])},
-        filament::math::float4{float(d_mat.col2[0]), float(d_mat.col2[1]), float(d_mat.col2[2]), float(d_mat.col2[3])},
-        filament::math::float4{float(d_mat.col3[0]), float(d_mat.col3[1]), float(d_mat.col3[2]), float(d_mat.col3[3])},
-        filament::math::float4{float(d_mat.col4[0]), float(d_mat.col4[1]), float(d_mat.col4[2]), float(d_mat.col4[3])}};
+    filament::math::mat4 result(filament::math::mat4::NO_INIT);
+    std::memcpy(&result, &d_mat, sizeof(result));
+    return result;
 }
 }


### PR DESCRIPTION
This PR preserves exact double values when converting between `double4x4` and `mat4` (previously `convert_double4x4_to_mat4` narrowed every matrix element to float before constructing Filament's double-precision `mat4`). 
