### PR TITLE
chore: sort generated bindings

### DIFF
--- a/thermion_dart/ffigen/native.yaml
+++ b/thermion_dart/ffigen/native.yaml
@@ -1,4 +1,5 @@
 output: '../lib/src/bindings/src/thermion_dart_ffi.g.dart'
+sort: true
 headers:
   entry-points:
     - '../native/include/c_api/*.h'

--- a/thermion_dart/ffigen/web.yaml
+++ b/thermion_dart/ffigen/web.yaml
@@ -1,4 +1,5 @@
 output: '../lib/src/bindings/src/thermion_dart_js_interop.g.dart'
+sort: true
 headers:
   entry-points:
     - '../native/web/include/ThermionWebApi.h'

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -7,61 +7,498 @@ library;
 
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Uint64>()
-external int TSWAP_CHAIN_CONFIG_TRANSPARENT;
-
-@ffi.Native<ffi.Uint64>()
-external int TSWAP_CHAIN_CONFIG_READABLE;
-
-@ffi.Native<ffi.Uint64>()
-external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
-
-@ffi.Native<ffi.Uint64>()
-external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
-
-@ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TViewport View_getViewport(ffi.Pointer<TView> view);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createLinear(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createACES(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGX(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(ffi.Pointer<TEngine> tEngine, int look);
-
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float, ffi.Float, ffi.Float)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
-  ffi.Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external bool AnimationManager_addBoneAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+  ffi.Pointer<ffi.Float> frameData,
+  int numFrames,
+  double frameLengthInMs,
+  double fadeOutInSecs,
+  double fadeInInSecs,
+  double maxDelta,
+  bool loop,
 );
 
-@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_addBoneAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_addGltfAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
 
-@ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+external void AnimationManager_addMorphAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+external bool AnimationManager_clearMorphAnimation(ffi.Pointer<TAnimationManager> tAnimationManager, int entityId);
+
+@ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TAnimationManager> AnimationManager_create(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>>,
+  )
+>(isLeaf: true)
+external void AnimationManager_createRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void AnimationManager_destroy(ffi.Pointer<TAnimationManager> tAnimationManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void AnimationManager_destroyRenderThread(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int AnimationManager_getGltfAnimationCount(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external double AnimationManager_getGltfAnimationDuration(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int animationIndex,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Char>, ffi.Int)
+>(isLeaf: true)
+external void AnimationManager_getGltfAnimationName(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  ffi.Pointer<ffi.Char> outPtr,
+  int index,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)
+>(isLeaf: true)
+external void AnimationManager_getInverseBindMatrix(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int skinIndex,
+  int boneIndex,
+  ffi.Pointer<ffi.Float> out,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId, ffi.Pointer<ffi.Char>, ffi.Int)
+>(isLeaf: true)
+external void AnimationManager_getMorphTargetName(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int childEntity,
+  ffi.Pointer<ffi.Char> outPtr,
+  int index,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
+external int AnimationManager_getMorphTargetNameCount(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int childEntity,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)
+>(isLeaf: true)
+external void AnimationManager_getRestLocalTransforms(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int skinIndex,
+  ffi.Pointer<ffi.Float> out,
+  int numBones,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external bool AnimationManager_playGltfAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int index,
+  bool loop,
+  bool reverse,
+  bool replaceActive,
+  double crossfade,
+  double startOffset,
+  double speed,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_removeBoneAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_removeGltfAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
+external void AnimationManager_removeMorphAnimationComponent(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void AnimationManager_resetToRestPose(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void AnimationManager_resetToRestPoseRenderThread(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Float)>(
+  isLeaf: true,
+)
+external bool AnimationManager_setGltfAnimationTime(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int animationIndex,
+  double timeInSeconds,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Int,
+    ffi.Float,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void AnimationManager_setGltfAnimationTimeRenderThread(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int animationIndex,
+  double timeInSeconds,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TAnimationManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Pointer<ffi.Uint32>,
+    ffi.Int,
+    ffi.Int,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external bool AnimationManager_setMorphAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> morphData,
+  ffi.Pointer<ffi.Uint32> morphIndices,
+  int numMorphTargets,
+  int numFrames,
+  double frameLengthInMs,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
+external bool AnimationManager_setMorphTargetWeights(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> morphData,
+  int numWeights,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
+external void AnimationManager_setMorphTargetWeightsRenderThread(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> morphData,
+  int numWeights,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external bool AnimationManager_stopGltfAnimation(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  int index,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(isLeaf: true)
+external void AnimationManager_update(ffi.Pointer<TAnimationManager> tAnimationManager, int frameTimeInNanos);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool AnimationManager_updateBoneMatrices(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TAnimationManager>,
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
+external void AnimationManager_updateBoneMatricesRenderThread(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  ffi.Pointer<TSceneAsset> sceneAsset,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void AnimationManager_updateRenderThread(
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int frameTimeInNanos,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TBufferObject> Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TBufferObject> BufferObjectBuilder_build(
+  ffi.Pointer<TBufferObjectBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TBufferObjectBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>>,
+  )
+>(isLeaf: true)
+external void BufferObjectBuilder_buildRenderThread(
+  ffi.Pointer<TBufferObjectBuilder> tBuilder,
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TBufferObjectBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TBufferObjectBuilder> BufferObjectBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>)>(isLeaf: true)
+external void BufferObjectBuilder_destroy(ffi.Pointer<TBufferObjectBuilder> builder);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Uint32)>(isLeaf: true)
+external void BufferObjectBuilder_size(ffi.Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>)>(isLeaf: true)
+external void BufferObject_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TBufferObject> buffer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void BufferObject_destroyRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TBufferObject> tBuffer,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)
+>(isLeaf: true)
+external void BufferObject_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TBufferObject> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TBufferObject>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void BufferObject_setBufferRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TBufferObject> tBuffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getAperture(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getCullingProjectionMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external int Camera_getEntity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
+external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void Camera_getFrustum(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> out);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getNear(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
+external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(isLeaf: true)
+external void Camera_lookAt(ffi.Pointer<TCamera> camera, double3 eye, double3 focus, double3 up);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setCustomProjectionWithCulling(
+  ffi.Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void Camera_setExposure(ffi.Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
+external void Camera_setFocusDistance(ffi.Pointer<TCamera> camera, double focusDistance);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setLensProjection(
+  ffi.Pointer<TCamera> camera,
+  double near,
+  double far,
+  double aspect,
+  double focalLength,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void Camera_setModelMatrix(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> tModelMatrix);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TCamera>,
+    ffi.UnsignedInt,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+  )
+>(isLeaf: true)
+external void Camera_setProjection(
+  ffi.Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double, ffi.Bool)>(
+  isLeaf: true,
+)
+external void Camera_setProjectionFromFov(
+  ffi.Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Camera_setProjectionMatrix(
+  ffi.Pointer<TCamera> camera,
+  ffi.Pointer<ffi.Double> matrix,
+  double near,
+  double far,
+);
 
 @ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
 external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
@@ -69,48 +506,18 @@ external ffi.Pointer<TColorGrading> ColorGradingBuilder_build(
   ffi.Pointer<TEngine> engine,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
-external void ColorGradingBuilder_destroy(ffi.Pointer<TColorGradingBuilder> builder);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void ColorGrading_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TColorGrading> colorGrading);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void ColorGradingBuilder_quality(ffi.Pointer<TColorGradingBuilder> builder, int level);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void ColorGradingBuilder_format(ffi.Pointer<TColorGradingBuilder> builder, int format);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(isLeaf: true)
-external void ColorGradingBuilder_dimensions(ffi.Pointer<TColorGradingBuilder> builder, int dim);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
-external void ColorGradingBuilder_toneMapper(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  ffi.Pointer<TToneMapper> toneMapper,
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_buildRenderThread(
+  ffi.Pointer<TColorGradingBuilder> tBuilder,
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>> onComplete,
 );
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_exposure(ffi.Pointer<TColorGradingBuilder> builder, double exposure);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_nightAdaptation(ffi.Pointer<TColorGradingBuilder> builder, double adaptation);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_whiteBalance(
-  ffi.Pointer<TColorGradingBuilder> builder,
-  double temperature,
-  double tint,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_contrast(ffi.Pointer<TColorGradingBuilder> builder, double contrast);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_vibrance(ffi.Pointer<TColorGradingBuilder> builder, double vibrance);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
-external void ColorGradingBuilder_saturation(ffi.Pointer<TColorGradingBuilder> builder, double saturation);
 
 @ffi.Native<
   ffi.Void Function(
@@ -138,6 +545,80 @@ external void ColorGradingBuilder_channelMixer(
   double outBlueG,
   double outBlueB,
 );
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_contrast(ffi.Pointer<TColorGradingBuilder> builder, double contrast);
+
+@ffi.Native<ffi.Pointer<TColorGradingBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TColorGradingBuilder> ColorGradingBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>)>(
+  isLeaf: true,
+)
+external void ColorGradingBuilder_createRenderThread(
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>> onComplete,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TColorGradingBuilder>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+  )
+>(isLeaf: true)
+external void ColorGradingBuilder_curves(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double shadowGammaR,
+  double shadowGammaG,
+  double shadowGammaB,
+  double midPointR,
+  double midPointG,
+  double midPointB,
+  double highlightScaleR,
+  double highlightScaleG,
+  double highlightScaleB,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>(isLeaf: true)
+external void ColorGradingBuilder_destroy(ffi.Pointer<TColorGradingBuilder> builder);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void ColorGradingBuilder_destroyRenderThread(
+  ffi.Pointer<TColorGradingBuilder> tBuilder,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint8)>(isLeaf: true)
+external void ColorGradingBuilder_dimensions(ffi.Pointer<TColorGradingBuilder> builder, int dim);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_exposure(ffi.Pointer<TColorGradingBuilder> builder, double exposure);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_format(ffi.Pointer<TColorGradingBuilder> builder, int format);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
+external void ColorGradingBuilder_gamutMapping(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
+external void ColorGradingBuilder_luminanceScaling(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_nightAdaptation(ffi.Pointer<TColorGradingBuilder> builder, double adaptation);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void ColorGradingBuilder_quality(ffi.Pointer<TColorGradingBuilder> builder, int level);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_saturation(ffi.Pointer<TColorGradingBuilder> builder, double saturation);
 
 @ffi.Native<
   ffi.Void Function(
@@ -207,155 +688,608 @@ external void ColorGradingBuilder_slopeOffsetPower(
   double powerB,
 );
 
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_curves(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Pointer<TToneMapper>)>(isLeaf: true)
+external void ColorGradingBuilder_toneMapper(
   ffi.Pointer<TColorGradingBuilder> builder,
-  double shadowGammaR,
-  double shadowGammaG,
-  double shadowGammaB,
-  double midPointR,
-  double midPointG,
-  double midPointB,
-  double highlightScaleR,
-  double highlightScaleG,
-  double highlightScaleB,
+  ffi.Pointer<TToneMapper> toneMapper,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
-external void ColorGradingBuilder_luminanceScaling(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_vibrance(ffi.Pointer<TColorGradingBuilder> builder, double vibrance);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Bool)>(isLeaf: true)
-external void ColorGradingBuilder_gamutMapping(ffi.Pointer<TColorGradingBuilder> builder, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Float, ffi.Float)>(isLeaf: true)
+external void ColorGradingBuilder_whiteBalance(
+  ffi.Pointer<TColorGradingBuilder> builder,
+  double temperature,
+  double tint,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void View_setColorGrading(ffi.Pointer<TView> tView, ffi.Pointer<TColorGrading> tColorGrading);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void ColorGrading_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TColorGrading> colorGrading);
 
-@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TColorGrading> View_getColorGrading(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Bool>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Bool> outValue,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
-external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Float> outValue,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
-external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int>)>(isLeaf: true)
+external bool DebugRegistry_getProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  ffi.Pointer<ffi.Int> outValue,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external void View_setRenderTarget(ffi.Pointer<TView> view, ffi.Pointer<TRenderTarget> renderTarget);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external bool DebugRegistry_hasProperty(ffi.Pointer<TDebugRegistry> tDebugRegistry, ffi.Pointer<ffi.Char> name);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrustumCullingEnabled(ffi.Pointer<TView> view, bool enabled);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
+external bool DebugRegistry_setProperty_bool(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  bool value,
+);
 
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getVisibleRenderableCount(ffi.Pointer<TView> view);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Float)>(isLeaf: true)
+external bool DebugRegistry_setProperty_float(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  double value,
+);
 
-@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TRenderTarget> View_getRenderTarget(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
+external bool DebugRegistry_setProperty_int(
+  ffi.Pointer<TDebugRegistry> tDebugRegistry,
+  ffi.Pointer<ffi.Char> name,
+  int value,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
+@ffi.Native<
+  ffi.Pointer<TSkybox> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Uint8,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
+  )
+>(isLeaf: true)
+external void Engine_buildColoredSkyboxRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
-external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
+@ffi.Native<
+  ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)
+>(isLeaf: true)
+external ffi.Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<ffi.Float> irradianceHarmonics,
+  double intensity,
+);
 
-@ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
-external int View_getShadowType(ffi.Pointer<TView> tView);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<ffi.Float>,
+    ffi.Float,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>,
+  )
+>(isLeaf: true)
+external void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<ffi.Float> harmonics,
+  double intensity,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(isLeaf: true)
-external void View_setSoftShadowOptions(ffi.Pointer<TView> tView, TSoftShadowOptions options);
+@ffi.Native<
+  ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)
+>(isLeaf: true)
+external ffi.Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+);
 
-@ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTexture>,
+    ffi.Float,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>,
+  )
+>(isLeaf: true)
+external void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tReflectionsTexture,
+  ffi.Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(isLeaf: true)
-external void View_setVsmShadowOptions(ffi.Pointer<TView> tView, TVsmShadowOptions options);
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Engine_buildMaterial(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> materialData,
+  int length,
+);
 
-@ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
+  )
+>(isLeaf: true)
+external void Engine_buildMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> materialData,
+  int length,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(isLeaf: true)
-external void View_setBloom(ffi.Pointer<TView> tView, bool enabled, double strength);
+@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Bool, ffi.Float, ffi.Uint8)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TSkybox> Engine_buildSkybox(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
-external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Bool,
+    ffi.Float,
+    ffi.Uint8,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
+  )
+>(isLeaf: true)
+external void Engine_buildSkyboxRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
-external void View_setAntiAliasing(ffi.Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
+@ffi.Native<
+  ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)
+>(isLeaf: true)
+external ffi.Pointer<TEngine> Engine_create(
+  int backend,
+  ffi.Pointer<ffi.Void> platform,
+  ffi.Pointer<ffi.Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(isLeaf: true)
-external void View_setLayerEnabled(ffi.Pointer<TView> tView, int layer, bool visible);
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
+external ffi.Pointer<TCamera> Engine_createCamera(ffi.Pointer<TEngine> tEngine, int entityId);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(isLeaf: true)
-external void View_setCamera(ffi.Pointer<TView> tView, ffi.Pointer<TCamera> tCamera);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    EntityId,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>,
+  )
+>(isLeaf: true)
+external void Engine_createCameraRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>> onComplete,
+);
 
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TFence> Engine_createFence(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>)
+>(isLeaf: true)
+external void Engine_createFenceRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setStencilBufferEnabled(ffi.Pointer<TView> tView, bool enabled);
+@ffi.Native<ffi.Pointer<TSwapChain> Function(ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  int flags,
+);
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
+  )
+>(isLeaf: true)
+external void Engine_createHeadlessSwapChainRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  int flags,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Void>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>,
+  )
+>(isLeaf: true)
+external void Engine_createRenderThread(
+  int backend,
+  ffi.Pointer<ffi.Void> platform,
+  ffi.Pointer<ffi.Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>> onComplete,
+);
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TRenderer> Engine_createRenderer(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void View_setScene(ffi.Pointer<TView> tView, ffi.Pointer<TScene> tScene);
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>)
+>(isLeaf: true)
+external void Engine_createRendererRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setFrontFaceWindingInverted(ffi.Pointer<TView> tView, bool inverted);
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TScene> Engine_createScene(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(isLeaf: true)
-external void View_setAmbientOcclusionOptions(ffi.Pointer<TView> tView, TAmbientOcclusionOptions options);
+@ffi.Native<ffi.Pointer<TSwapChain> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
+external ffi.Pointer<TSwapChain> Engine_createSwapChain(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Void> window,
+  int flags,
+);
 
-@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(ffi.Pointer<TView> tView);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
+  )
+>(isLeaf: true)
+external void Engine_createSwapChainRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Void> window,
+  int flags,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
-external void View_setFogOptions(ffi.Pointer<TView> tView, TFogOptions tFogOptions);
+@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TView> Engine_createView(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
-external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>)
+>(isLeaf: true)
+external void Engine_createViewRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
-external void View_setTransparentPickingEnabled(ffi.Pointer<TView> tView, bool enabled);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_destroy(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
-external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(isLeaf: true)
+external void Engine_destroyCamera(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TCamera> tCamera);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
-external void View_pick(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyCameraRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TCamera> tCamera,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external void View_setName(ffi.Pointer<TView> tView, ffi.Pointer<ffi.Char> name);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void Engine_destroyColorGrading(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TColorGrading> tColorGrading);
 
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyColorGradingRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TColorGrading> tColorGrading,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
-external void Gizmo_dummy(int t);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(isLeaf: true)
+external void Engine_destroyFence(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TFence> tFence);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyFenceRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TFence> tFence,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Engine_destroyIndirectLight(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TIndirectLight> tIndirectLight);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void Engine_destroyIndirectLightRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(isLeaf: true)
+external void Engine_destroyMaterial(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TMaterial> tMaterial);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void Engine_destroyMaterialInstance(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void Engine_destroyMaterialInstanceRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterial> tMaterial,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Engine_destroyRenderer(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderer> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyRendererRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void Engine_destroyScene(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroySceneRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TScene> tScene,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(isLeaf: true)
+external void Engine_destroySkybox(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TSkybox> tSkybox);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroySkyboxRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSkybox> tSkybox,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void Engine_destroySwapChain(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TSwapChain> tSwapChain);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroySwapChainRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
+external void Engine_destroyTexture(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TTexture> tTexture);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyTextureRenderThread(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TTexture> tTexture,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(isLeaf: true)
+external void Engine_destroyView(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_destroyViewRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TView> tView,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_execute(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_executeRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Engine_flushAndWait(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Engine_flushAndWaitRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
+external ffi.Pointer<TCamera> Engine_getCameraComponent(ffi.Pointer<TEngine> tEngine, int entityId);
+
+@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TEntityManager> Engine_getEntityManager(ffi.Pointer<TEngine> engine);
+
+@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TLightManager> Engine_getLightManager(ffi.Pointer<TEngine> engine);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getMaxAutomaticInstances(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(ffi.Pointer<TEngine> engine);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external int Engine_getSupportedFeatureLevel(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TTransformManager> Engine_getTransformManager(ffi.Pointer<TEngine> engine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
+external void Engine_setAutomaticInstancingEnabled(ffi.Pointer<TEngine> tEngine, bool enabled);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
+external int EntityManager_createEntity(ffi.Pointer<TEntityManager> tEntityManager);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEntityManager>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)
+>(isLeaf: true)
+external void EntityManager_createEntityRenderThread(
+  ffi.Pointer<TEntityManager> tEntityManager,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(isLeaf: true)
+external void EntityManager_destroyEntity(ffi.Pointer<TEntityManager> tEntityManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void EntityManager_destroyEntityRenderThread(
+  ffi.Pointer<TEntityManager> tEntityManager,
+  int entityId,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
+external void Fence_waitAndDestroy(ffi.Pointer<TFence> tFence);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Fence_waitAndDestroyRenderThread(ffi.Pointer<TFence> tFence, int requestId, VoidCallback onComplete);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void FilamentAsset_getEntities(ffi.Pointer<TFilamentAsset> filamentAsset, ffi.Pointer<EntityId> out);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getEntityCount(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getResourceUriCount(ffi.Pointer<TFilamentAsset> tFilamentAsset);
+
+@ffi.Native<ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(ffi.Pointer<TFilamentAsset> tFilamentAsset);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external int FilamentAsset_getWireframe(ffi.Pointer<TFilamentAsset> filamentAsset);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)
+>(isLeaf: true)
+external void FilamentAsset_getWireframeRenderThread(
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
+
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void FrameScheduler_setTargetFps(int fps);
+
+@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+
+@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
+external void FrameScheduler_startWithPort(int port, int targetFps);
+
+@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
+external int FrameScheduler_steadyClockUs();
+
+@ffi.Native<ffi.Void Function()>()
+external void FrameScheduler_stop();
 
 @ffi.Native<
   ffi.Pointer<TGizmo> Function(
@@ -378,65 +1312,707 @@ external ffi.Pointer<TGizmo> Gizmo_create(
   int tGizmoType,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32, GizmoPickCallback)>(isLeaf: true)
-external void Gizmo_pick(ffi.Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TView>,
+    ffi.Pointer<TMaterial>,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>,
+  )
+>(isLeaf: true)
+external void Gizmo_createRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>> callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.UnsignedInt)>(isLeaf: true)
+external void Gizmo_dummy(int t);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.UnsignedInt)>(isLeaf: true)
 external void Gizmo_highlight(ffi.Pointer<TGizmo> tGizmo, int axis);
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>, ffi.Uint32, ffi.Uint32, GizmoPickCallback)>(isLeaf: true)
+external void Gizmo_pick(ffi.Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TGizmo>)>(isLeaf: true)
 external void Gizmo_unhighlight(ffi.Pointer<TGizmo> tGizmo);
 
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> Material_createInstance(ffi.Pointer<TMaterial> tMaterial);
+@ffi.Native<
+  ffi.Pointer<TGltfAssetLoader> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Pointer<TNameComponentManager>,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+);
 
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TMaterialProvider>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>>,
+  )
+>(isLeaf: true)
+external void GltfAssetLoader_createRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TMaterialProvider> tMaterialProvider,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>> callback,
+);
 
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createImageMaterial(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external void GltfAssetLoader_destroy(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
 
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createGridMaterial(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void GltfAssetLoader_destroyRenderThread(
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createGizmoMaterial(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, ffi.Pointer<TFilamentAsset>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  ffi.Pointer<TFilamentAsset> tAsset,
+);
 
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createSilhouetteMaterial(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
+external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
 
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createEdgeOutlineMaterial(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<
+  ffi.Pointer<TFilamentAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+);
 
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createWireframeMaterial(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>,
+  )
+>(isLeaf: true)
+external void GltfAssetLoader_loadRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int numInstances,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>> callback,
+);
 
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createTranslationAxisMaterial(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Pointer<TMeshData>)>(
+  isLeaf: true,
+)
+external int GltfParser_parseBuffer(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> meshName,
+  ffi.Pointer<TMeshData> outMeshData,
+);
 
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(ffi.Pointer<TEngine> tEngine);
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Uint8>, ffi.Size)
+>(isLeaf: true)
+external void GltfResourceLoader_addResourceData(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.Char> uri,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+);
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external bool Material_hasParameter(ffi.Pointer<TMaterial> tMaterial, ffi.Pointer<ffi.Char> propertyName);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void GltfResourceLoader_addResourceDataRenderThread(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.Char> uri,
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_asyncBeginLoad(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
+external void GltfResourceLoader_asyncBeginLoadRenderThread(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
+);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external double GltfResourceLoader_asyncGetLoadProgress(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>)
+>(isLeaf: true)
+external void GltfResourceLoader_asyncGetLoadProgressRenderThread(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>> callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_asyncUpdateLoad(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_asyncUpdateLoadRenderThread(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
+
+@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>>,
+  )
+>(isLeaf: true)
+external void GltfResourceLoader_createRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>> callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
+external void GltfResourceLoader_destroy(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void GltfResourceLoader_destroyRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfResourceLoader> tResourceLoader,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external bool GltfResourceLoader_loadResources(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
+external void GltfResourceLoader_loadResourcesRenderThread(
+  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
+);
+
+@ffi.Native<ffi.Pointer<TLinearImage> Function(ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+external ffi.Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>,
+  )
+>(isLeaf: true)
+external void Image_createEmptyRenderThread(
+  int width,
+  int height,
+  int channel,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Bool)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TLinearImage> Image_decode(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> name,
+  bool alpha,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.Char>,
+    ffi.Bool,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>,
+  )
+>(isLeaf: true)
+external void Image_decodeRenderThread(
+  ffi.Pointer<ffi.Uint8> data,
+  int length,
+  ffi.Pointer<ffi.Char> name,
+  bool alpha,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external void Image_destroy(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Image_destroyRenderThread(ffi.Pointer<TLinearImage> tLinearImage, int requestId, VoidCallback onComplete);
+
+@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external ffi.Pointer<ffi.Float> Image_getBytes(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TLinearImage>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>,
+  )
+>(isLeaf: true)
+external void Image_getBytesRenderThread(
+  ffi.Pointer<TLinearImage> tLinearImage,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>> onComplete,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getChannels(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
+>(isLeaf: true)
+external void Image_getChannelsRenderThread(
+  ffi.Pointer<TLinearImage> tLinearImage,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getHeight(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
+>(isLeaf: true)
+external void Image_getHeightRenderThread(
+  ffi.Pointer<TLinearImage> tLinearImage,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
+external int Image_getWidth(ffi.Pointer<TLinearImage> tLinearImage);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
+>(isLeaf: true)
+external void Image_getWidthRenderThread(
+  ffi.Pointer<TLinearImage> tLinearImage,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
+external void IndexBufferBuilder_bufferType(ffi.Pointer<TIndexBufferBuilder> builder, int indexType);
+
+@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
+  ffi.Pointer<TIndexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TIndexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>,
+  )
+>(isLeaf: true)
+external void IndexBufferBuilder_buildRenderThread(
+  ffi.Pointer<TIndexBufferBuilder> tBuilder,
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
+external void IndexBufferBuilder_destroy(ffi.Pointer<TIndexBufferBuilder> builder);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(isLeaf: true)
+external void IndexBufferBuilder_indexCount(ffi.Pointer<TIndexBufferBuilder> builder, int count);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external void IndexBuffer_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TIndexBuffer> buffer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void IndexBuffer_destroyRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TIndexBuffer> tBuffer,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
+external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)
+>(isLeaf: true)
+external void IndexBuffer_setBuffer(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TIndexBuffer> buffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void IndexBuffer_setBufferRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TIndexBuffer> tBuffer,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
+external void IndirectLight_setRotation(ffi.Pointer<TIndirectLight> tIndirectLight, ffi.Pointer<ffi.Double> rotation);
+
+@ffi.Native<ffi.Pointer<TKtx1Bundle> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(ffi.Pointer<ffi.Uint8> ktxData, int length);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external void Ktx1Bundle_destroy(ffi.Pointer<TKtx1Bundle> tBundle);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void Ktx1Bundle_getSphericalHarmonics(ffi.Pointer<TKtx1Bundle> tBundle, ffi.Pointer<ffi.Float> harmonics);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
+external bool Ktx1Bundle_isCubemap(ffi.Pointer<TKtx1Bundle> tBundle);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>, ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  VoidCallback onTextureUploadComplete,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TKtx1Bundle>,
+    ffi.Uint32,
+    VoidCallback,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
+external void Ktx1Reader_createTextureRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  VoidCallback onTextureUploadComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
+external void Ktx2Reader_createTextureRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computeLogSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
+external void LightManager_computePracticalSplits(
+  ffi.Pointer<ffi.Float> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
+external void LightManager_computeUniformSplits(ffi.Pointer<ffi.Float> splitPositions, int cascades);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>, ffi.UnsignedInt)>(isLeaf: true)
+external int LightManager_createLight(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TLightManager> tLightManager,
+  int tLightTtype,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external void LightManager_destroyLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getColor(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getDirection(ffi.Pointer<TLightManager> tLightManager, int light);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getIntensity(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool LightManager_getLightChannel(ffi.Pointer<TLightManager> tLightManager, int entity, int channel);
+
+@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double3 LightManager_getPosition(ffi.Pointer<TLightManager> tLightManager, int light);
+
+@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external TShadowOptions LightManager_getShadowOptions(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSpotLightInnerCone(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSpotLightOuterCone(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunAngularRadius(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external double LightManager_getSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external int LightManager_getType(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_hasComponent(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isDirectional(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isPointLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
+external bool LightManager_isSpotLight(ffi.Pointer<TLightManager> tLightManager, int entity);
+
+@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external double LightManager_rgbToColorTemperature(double r, double g, double b);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setColor(ffi.Pointer<TLightManager> tLightManager, int entity, double r, double g, double b);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setColorTemperature(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double colorTemperature,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setDirection(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double falloff);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensity(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityCandela(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setIntensityWatts(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double watts,
+  double efficiency,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void LightManager_setLightChannel(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setPosition(
+  ffi.Pointer<TLightManager> tLightManager,
+  int light,
+  double x,
+  double y,
+  double z,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void LightManager_setShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void LightManager_setShadowCasterRenderThread(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entityId,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
+external void LightManager_setShadowOptions(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  TShadowOptions options,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void LightManager_setShadowOptionsRenderThread(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entityId,
+  TShadowOptions options,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
+external void LightManager_setSpotLightCone(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double inner,
+  double outer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunAngularRadius(
+  ffi.Pointer<TLightManager> tLightManager,
+  int entity,
+  double angularRadius,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double haloFalloff);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
+external void LightManager_setSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity, double haloSize);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external int MaterialInstance_getTransparencyMode(ffi.Pointer<TMaterialInstance> materialInstance);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
 external bool MaterialInstance_isStencilWriteEnabled(ffi.Pointer<TMaterialInstance> materialInstance);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
-external void MaterialInstance_setStencilWrite(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setCullingMode(ffi.Pointer<TMaterialInstance> materialInstance, int culling);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
-external void MaterialInstance_setDoubleSided(ffi.Pointer<TMaterialInstance> materialInstance, bool doubleSided);
+external void MaterialInstance_setDepthCulling(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
+external void MaterialInstance_setDepthFunc(ffi.Pointer<TMaterialInstance> materialInstance, int depthFunc);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
 external void MaterialInstance_setDepthWrite(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
-external void MaterialInstance_setDepthCulling(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
+external void MaterialInstance_setDoubleSided(ffi.Pointer<TMaterialInstance> materialInstance, bool doubleSided);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
+external void MaterialInstance_setParameterBool(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  bool value,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Double)>(isLeaf: true)
 external void MaterialInstance_setParameterFloat(
@@ -495,6 +2071,13 @@ external void MaterialInstance_setParameterFloat4(
   double z,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
+external void MaterialInstance_setParameterInt(
+  ffi.Pointer<TMaterialInstance> materialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  int value,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Double>)>(
   isLeaf: true,
 )
@@ -513,20 +2096,6 @@ external void MaterialInstance_setParameterMat4(
   ffi.Pointer<ffi.Double> matrix,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
-external void MaterialInstance_setParameterInt(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  int value,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
-external void MaterialInstance_setParameterBool(
-  ffi.Pointer<TMaterialInstance> materialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  bool value,
-);
-
 @ffi.Native<
   ffi.Void Function(
     ffi.Pointer<TMaterialInstance>,
@@ -542,13 +2111,29 @@ external void MaterialInstance_setParameterTexture(
   ffi.Pointer<TTextureSampler> sampler,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt)>(isLeaf: true)
-external void MaterialInstance_setDepthFunc(ffi.Pointer<TMaterialInstance> materialInstance, int depthFunc);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterialInstance>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TTextureSampler>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void MaterialInstance_setParameterTextureRenderThread(
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+  ffi.Pointer<ffi.Char> propertyName,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TTextureSampler> tSampler,
+  int requestId,
+  VoidCallback onComplete,
+);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external void MaterialInstance_setStencilOpStencilFail(
+external void MaterialInstance_setStencilCompareFunction(
   ffi.Pointer<TMaterialInstance> materialInstance,
-  int op,
+  int func,
   int face,
 );
 
@@ -563,11 +2148,14 @@ external void MaterialInstance_setStencilOpDepthStencilPass(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external void MaterialInstance_setStencilCompareFunction(
+external void MaterialInstance_setStencilOpStencilFail(
   ffi.Pointer<TMaterialInstance> materialInstance,
-  int func,
+  int op,
   int face,
 );
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(isLeaf: true)
+external void MaterialInstance_setStencilReadMask(ffi.Pointer<TMaterialInstance> materialInstance, int mask);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8, ffi.UnsignedInt)>(isLeaf: true)
 external void MaterialInstance_setStencilReferenceValue(
@@ -576,8 +2164,8 @@ external void MaterialInstance_setStencilReferenceValue(
   int face,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(isLeaf: true)
-external void MaterialInstance_setStencilReadMask(ffi.Pointer<TMaterialInstance> materialInstance, int mask);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Bool)>(isLeaf: true)
+external void MaterialInstance_setStencilWrite(ffi.Pointer<TMaterialInstance> materialInstance, bool enabled);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TMaterialInstance>, ffi.Uint8)>(isLeaf: true)
 external void MaterialInstance_setStencilWriteMask(ffi.Pointer<TMaterialInstance> materialInstance, int mask);
@@ -586,731 +2174,6 @@ external void MaterialInstance_setStencilWriteMask(ffi.Pointer<TMaterialInstance
 external void MaterialInstance_setTransparencyMode(
   ffi.Pointer<TMaterialInstance> materialInstance,
   int transparencyMode,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external int MaterialInstance_getTransparencyMode(ffi.Pointer<TMaterialInstance> materialInstance);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
-external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
-
-@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
-external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
-external void NameComponentManager_destroy(ffi.Pointer<TNameComponentManager> tNameComponentManager);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> NameComponentManager_getName(
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  int entity,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    Aabb3,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tVertexBuffer,
-  ffi.Pointer<TIndexBuffer> tIndexBuffer,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  int vertexBufferStorageMode,
-  Aabb3 boundingBox,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  int requiredGeometryCapabilities,
-);
-
-@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void SceneAsset_addToScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void SceneAsset_removeFromScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getChildEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getChildEntities(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<EntityId> out);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getCameraEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external ffi.Pointer<EntityId> SceneAsset_getLightEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getLightEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(ffi.Pointer<TSceneAsset> tSceneAsset, int index);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<
-  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)
->(isLeaf: true)
-external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
-  ffi.Pointer<TSceneAsset> asset,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int SceneAsset_getGeometryCapabilities(ffi.Pointer<TSceneAsset> asset);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool SceneAsset_supportsFlatShading(ffi.Pointer<TSceneAsset> asset);
-
-@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int primitiveIndex,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external int SceneAsset_getVertexBufferStorageMode(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-
-@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int SceneAsset_getPrimitiveOffsetForEntity(ffi.Pointer<TSceneAsset> tSceneAsset, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void SceneAsset_releaseSourceData(ffi.Pointer<TSceneAsset> tSceneAsset);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
-external void SceneAsset_setFlatShading(ffi.Pointer<TSceneAsset> tSceneAsset, bool flatShading);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void SceneAsset_getBones(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex, ffi.Pointer<EntityId> out);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
-external int SceneAsset_getBoneCount(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex);
-
-@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void Camera_setExposure(ffi.Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getAperture(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getShutterSpeed(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getSensitivity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getModelMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getViewMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double4x4 Camera_getCullingProjectionMatrix(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void Camera_getFrustum(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> out);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setProjectionMatrix(
-  ffi.Pointer<TCamera> camera,
-  ffi.Pointer<ffi.Double> matrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double, ffi.Bool)>(
-  isLeaf: true,
-)
-external void Camera_setProjectionFromFov(
-  ffi.Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocalLength(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double3, double3, double3)>(isLeaf: true)
-external void Camera_lookAt(ffi.Pointer<TCamera> camera, double3 eye, double3 focus, double3 up);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getNear(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getCullingFar(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TCamera>, ffi.Bool)>(isLeaf: true)
-external double Camera_getFov(ffi.Pointer<TCamera> camera, bool horizontal);
-
-@ffi.Native<ffi.Double Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external double Camera_getFocusDistance(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Float)>(isLeaf: true)
-external void Camera_setFocusDistance(ffi.Pointer<TCamera> camera, double focusDistance);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, double4x4, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setCustomProjectionWithCulling(
-  ffi.Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void Camera_setModelMatrix(ffi.Pointer<TCamera> camera, ffi.Pointer<ffi.Double> tModelMatrix);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TCamera>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Camera_setLensProjection(
-  ffi.Pointer<TCamera> camera,
-  double near,
-  double far,
-  double aspect,
-  double focalLength,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TCamera>)>(isLeaf: true)
-external int Camera_getEntity(ffi.Pointer<TCamera> camera);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TCamera>,
-    ffi.UnsignedInt,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-  )
->(isLeaf: true)
-external void Camera_setProjection(
-  ffi.Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMeshData>)>(isLeaf: true)
-external void MeshData_dispose(ffi.Pointer<TMeshData> meshData);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Pointer<TMeshData>)>(
-  isLeaf: true,
-)
-external int GltfParser_parseBuffer(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> meshName,
-  ffi.Pointer<TMeshData> outMeshData,
-);
-
-@ffi.Native<
-  ffi.Pointer<TTexture> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint8,
-    ffi.Uint16,
-    ffi.IntPtr,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TTexture> Texture_build(
-  ffi.Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import$,
-  int sampler,
-  int format,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void Texture_setExternalImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<ffi.Void> externalImage,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getLevels(ffi.Pointer<TTexture> tTexture);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TLinearImage>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Int,
-  )
->(isLeaf: true)
-external bool Texture_loadImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Uint32,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external bool Texture_setImage(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
-external int Texture_getWidth(ffi.Pointer<TTexture> tTexture, int level);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
-external int Texture_getHeight(ffi.Pointer<TTexture> tTexture, int level);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
-external int Texture_getDepth(ffi.Pointer<TTexture> tTexture, int level);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>)>(isLeaf: true)
-external int Texture_getFormat(ffi.Pointer<TTexture> tTexture);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
-external int Texture_getUsage(ffi.Pointer<TTexture> tTexture, int level);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Texture_generateMipMaps(ffi.Pointer<TTexture> tTexture, ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TKtx1Bundle> Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TKtx1Bundle> Ktx1Bundle_create(ffi.Pointer<ffi.Uint8> ktxData, int length);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void Ktx1Bundle_getSphericalHarmonics(ffi.Pointer<TKtx1Bundle> tBundle, ffi.Pointer<ffi.Float> harmonics);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external bool Ktx1Bundle_isCubemap(ffi.Pointer<TKtx1Bundle> tBundle);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TKtx1Bundle>)>(isLeaf: true)
-external void Ktx1Bundle_destroy(ffi.Pointer<TKtx1Bundle> tBundle);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>, ffi.Pointer<TKtx1Bundle>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TTexture> Ktx1Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  VoidCallback onTextureUploadComplete,
-);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TTexture> Ktx2Reader_createTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-);
-
-@ffi.Native<ffi.Pointer<TLinearImage> Function(ffi.Uint32, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
-external ffi.Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel);
-
-@ffi.Native<ffi.Pointer<TLinearImage> Function(ffi.Pointer<ffi.Uint8>, ffi.Size, ffi.Pointer<ffi.Char>, ffi.Bool)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TLinearImage> Image_decode(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> name,
-  bool alpha,
-);
-
-@ffi.Native<ffi.Pointer<ffi.Float> Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external ffi.Pointer<ffi.Float> Image_getBytes(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external void Image_destroy(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getWidth(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getHeight(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TLinearImage>)>(isLeaf: true)
-external int Image_getChannels(ffi.Pointer<TLinearImage> tLinearImage);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getColorTexture(ffi.Pointer<TRenderTarget> tRenderTarget);
-
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(ffi.Pointer<TRenderTarget> tRenderTarget);
-
-@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_create();
-
-@ffi.Native<
-  ffi.Pointer<TTextureSampler> Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-  )
->(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-);
-
-@ffi.Native<ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setMinFilter(ffi.Pointer<TTextureSampler> sampler, int filter);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setMagFilter(ffi.Pointer<TTextureSampler> sampler, int filter);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setWrapModeS(ffi.Pointer<TTextureSampler> sampler, int mode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setWrapModeT(ffi.Pointer<TTextureSampler> sampler, int mode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setWrapModeR(ffi.Pointer<TTextureSampler> sampler, int mode);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(isLeaf: true)
-external void TextureSampler_setAnisotropy(ffi.Pointer<TTextureSampler> sampler, double anisotropy);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
-external void TextureSampler_setCompareMode(ffi.Pointer<TTextureSampler> sampler, int mode, int func);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
-external void TextureSampler_destroy(ffi.Pointer<TTextureSampler> sampler);
-
-@ffi.Native<
-  ffi.Pointer<TEngine> Function(ffi.UnsignedInt, ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>, ffi.Uint8, ffi.Bool)
->(isLeaf: true)
-external ffi.Pointer<TEngine> Engine_create(
-  int backend,
-  ffi.Pointer<ffi.Void> platform,
-  ffi.Pointer<ffi.Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getSupportedFeatureLevel(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_destroy(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TRenderer> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TRenderer> Engine_createRenderer(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Engine_destroyRenderer(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderer> tRenderer);
-
-@ffi.Native<ffi.Pointer<TSwapChain> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Void>, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Void> window,
-  int flags,
-);
-
-@ffi.Native<ffi.Pointer<TSwapChain> Function(ffi.Pointer<TEngine>, ffi.Uint32, ffi.Uint32, ffi.Uint64)>(isLeaf: true)
-external ffi.Pointer<TSwapChain> Engine_createHeadlessSwapChain(
-  ffi.Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  int flags,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
-external void Engine_destroySwapChain(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TSwapChain> tSwapChain);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>)>(isLeaf: true)
-external void Engine_destroyView(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>)>(isLeaf: true)
-external void Engine_destroyScene(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
-external void Engine_destroyColorGrading(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TColorGrading> tColorGrading);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
-external ffi.Pointer<TCamera> Engine_createCamera(ffi.Pointer<TEngine> tEngine, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>)>(isLeaf: true)
-external void Engine_destroyCamera(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TCamera> tCamera);
-
-@ffi.Native<ffi.Pointer<TView> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TView> Engine_createView(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
-external ffi.Pointer<TCamera> Engine_getCameraComponent(ffi.Pointer<TEngine> tEngine, int entityId);
-
-@ffi.Native<ffi.Pointer<TTransformManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TTransformManager> Engine_getTransformManager(ffi.Pointer<TEngine> engine);
-
-@ffi.Native<ffi.Pointer<TRenderableManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TRenderableManager> Engine_getRenderableManager(ffi.Pointer<TEngine> engine);
-
-@ffi.Native<ffi.Pointer<TLightManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TLightManager> Engine_getLightManager(ffi.Pointer<TEngine> engine);
-
-@ffi.Native<ffi.Pointer<TEntityManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TEntityManager> Engine_getEntityManager(ffi.Pointer<TEngine> engine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Bool)>(isLeaf: true)
-external void Engine_setAutomaticInstancingEnabled(ffi.Pointer<TEngine> tEngine, bool enabled);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external int Engine_getMaxAutomaticInstances(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>)>(isLeaf: true)
-external void Engine_destroyTexture(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TTexture> tTexture);
-
-@ffi.Native<ffi.Pointer<TFence> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TFence> Engine_createFence(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>)>(isLeaf: true)
-external void Engine_destroyFence(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TFence> tFence);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_flushAndWait(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external void Engine_execute(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
-external ffi.Pointer<TMaterial> Engine_buildMaterial(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> materialData,
-  int length,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>)>(isLeaf: true)
-external void Engine_destroyMaterial(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TMaterial> tMaterial);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external void Engine_destroyMaterialInstance(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-);
-
-@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TScene> Engine_createScene(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Bool, ffi.Float, ffi.Uint8)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TSkybox> Engine_buildSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-);
-
-@ffi.Native<
-  ffi.Pointer<TSkybox> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Uint8,
-  )
->(isLeaf: true)
-external ffi.Pointer<TSkybox> Engine_buildColoredSkybox(
-  ffi.Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>, ffi.Float)
->(isLeaf: true)
-external ffi.Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-);
-
-@ffi.Native<
-  ffi.Pointer<TIndirectLight> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Float>, ffi.Float)
->(isLeaf: true)
-external ffi.Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<ffi.Float> irradianceHarmonics,
-  double intensity,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>)>(isLeaf: true)
-external void Engine_destroySkybox(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TSkybox> tSkybox);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Engine_destroyIndirectLight(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TIndirectLight> tIndirectLight);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TEntityManager>)>(isLeaf: true)
-external int EntityManager_createEntity(ffi.Pointer<TEntityManager> tEntityManager);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId)>(isLeaf: true)
-external void EntityManager_destroyEntity(ffi.Pointer<TEntityManager> tEntityManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>)>(isLeaf: true)
-external void Fence_waitAndDestroy(ffi.Pointer<TFence> tFence);
-
-@ffi.Native<ffi.Pointer<TDebugRegistry> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TDebugRegistry> Engine_getDebugRegistry(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external bool DebugRegistry_hasProperty(ffi.Pointer<TDebugRegistry> tDebugRegistry, ffi.Pointer<ffi.Char> name);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Bool)>(isLeaf: true)
-external bool DebugRegistry_setProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  bool value,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Int)>(isLeaf: true)
-external bool DebugRegistry_setProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  int value,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Float)>(isLeaf: true)
-external bool DebugRegistry_setProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  double value,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Bool>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_bool(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Bool> outValue,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Int>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_int(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Int> outValue,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TDebugRegistry>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external bool DebugRegistry_getProperty_float(
-  ffi.Pointer<TDebugRegistry> tDebugRegistry,
-  ffi.Pointer<ffi.Char> name,
-  ffi.Pointer<ffi.Float> outValue,
 );
 
 @ffi.Native<
@@ -1396,1427 +2259,6 @@ external ffi.Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
   bool hasSheen,
   bool hasIOR,
   bool hasVolume,
-);
-
-@ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(isLeaf: true)
-external void VertexBufferBuilder_bufferCount(ffi.Pointer<TVertexBufferBuilder> builder, int count);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(isLeaf: true)
-external void VertexBufferBuilder_vertexCount(ffi.Pointer<TVertexBufferBuilder> builder, int count);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Bool)>(isLeaf: true)
-external void VertexBufferBuilder_enableBufferObjects(ffi.Pointer<TVertexBufferBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
-external int VertexBufferBuilder_getStorageMode(ffi.Pointer<TVertexBufferBuilder> builder);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.UnsignedInt,
-    ffi.Uint8,
-    ffi.UnsignedInt,
-    ffi.Uint32,
-    ffi.Uint8,
-  )
->(isLeaf: true)
-external void VertexBufferBuilder_attribute(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  int bufferIndex,
-  int attributeType,
-  int byteOffset,
-  int byteStride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void VertexBufferBuilder_normalized(ffi.Pointer<TVertexBufferBuilder> builder, int attribute, bool normalize);
-
-@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TVertexBuffer> VertexBufferBuilder_build(
-  ffi.Pointer<TVertexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
-external void VertexBufferBuilder_destroy(ffi.Pointer<TVertexBufferBuilder> builder);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external int VertexBuffer_getVertexCount(ffi.Pointer<TVertexBuffer> buffer);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-  )
->(isLeaf: true)
-external void VertexBuffer_setBufferAt(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TVertexBuffer> buffer,
-  int bufferIndex,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>, ffi.Uint8, ffi.Pointer<TBufferObject>)>(
-  isLeaf: true,
-)
-external void VertexBuffer_setBufferObjectAt(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TVertexBuffer> buffer,
-  int bufferIndex,
-  ffi.Pointer<TBufferObject> bufferObject,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
-external void VertexBuffer_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TVertexBuffer> buffer);
-
-@ffi.Native<ffi.Pointer<TIndexBufferBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TIndexBufferBuilder> IndexBufferBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Uint32)>(isLeaf: true)
-external void IndexBufferBuilder_indexCount(ffi.Pointer<TIndexBufferBuilder> builder, int count);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>, ffi.UnsignedInt)>(isLeaf: true)
-external void IndexBufferBuilder_bufferType(ffi.Pointer<TIndexBufferBuilder> builder, int indexType);
-
-@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TIndexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TIndexBuffer> IndexBufferBuilder_build(
-  ffi.Pointer<TIndexBufferBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndexBufferBuilder>)>(isLeaf: true)
-external void IndexBufferBuilder_destroy(ffi.Pointer<TIndexBufferBuilder> builder);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external int IndexBuffer_getIndexCount(ffi.Pointer<TIndexBuffer> buffer);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)
->(isLeaf: true)
-external void IndexBuffer_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TIndexBuffer> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>)>(isLeaf: true)
-external void IndexBuffer_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TIndexBuffer> buffer);
-
-@ffi.Native<ffi.Pointer<TBufferObjectBuilder> Function()>(isLeaf: true)
-external ffi.Pointer<TBufferObjectBuilder> BufferObjectBuilder_create();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Uint32)>(isLeaf: true)
-external void BufferObjectBuilder_size(ffi.Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
-
-@ffi.Native<ffi.Pointer<TBufferObject> Function(ffi.Pointer<TBufferObjectBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TBufferObject> BufferObjectBuilder_build(
-  ffi.Pointer<TBufferObjectBuilder> builder,
-  ffi.Pointer<TEngine> engine,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TBufferObjectBuilder>)>(isLeaf: true)
-external void BufferObjectBuilder_destroy(ffi.Pointer<TBufferObjectBuilder> builder);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>, ffi.Pointer<ffi.Void>, ffi.Size, ffi.Uint32)
->(isLeaf: true)
-external void BufferObject_setBuffer(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TBufferObject> buffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>)>(isLeaf: true)
-external void BufferObject_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TBufferObject> buffer);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external double4x4 TransformManager_getLocalTransform(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
-
-@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external double4x4 TransformManager_getWorldTransform(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4)>(isLeaf: true)
-external void TransformManager_setTransform(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  double4x4 transform,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(isLeaf: true)
-external bool TransformManager_transformToUnitCube(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  Aabb3 boundingBox,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId, ffi.Bool)>(isLeaf: true)
-external void TransformManager_setParent(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int child,
-  int parent,
-  bool preserveScaling,
-);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external int TransformManager_getParent(ffi.Pointer<TTransformManager> tTransformManager, int child);
-
-@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external int TransformManager_getAncestor(ffi.Pointer<TTransformManager> tTransformManager, int childEntityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external void TransformManager_createComponent(ffi.Pointer<TTransformManager> tTransformManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external void TransformManager_removeComponent(ffi.Pointer<TTransformManager> tTransformManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external bool TransformManager_hasComponent(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external bool TransformManager_empty(ffi.Pointer<TTransformManager> tTransformManager);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external int TransformManager_getComponentCount(ffi.Pointer<TTransformManager> tTransformManager);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
-external int TransformManager_getChildCount(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Pointer<EntityId>, ffi.Int)>(isLeaf: true)
-external void TransformManager_getChildren(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  ffi.Pointer<EntityId> children,
-  int count,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external void TransformManager_openLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
-external void TransformManager_commitLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TEngine>, ffi.Pointer<TLightManager>, ffi.UnsignedInt)>(isLeaf: true)
-external int LightManager_createLight(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TLightManager> tLightManager,
-  int tLightTtype,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external void LightManager_destroyLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_hasComponent(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external int LightManager_getType(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isDirectional(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isPointLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isSpotLight(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setPosition(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getPosition(ffi.Pointer<TLightManager> tLightManager, int light);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setDirection(
-  ffi.Pointer<TLightManager> tLightManager,
-  int light,
-  double x,
-  double y,
-  double z,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getDirection(ffi.Pointer<TLightManager> tLightManager, int light);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setColor(ffi.Pointer<TLightManager> tLightManager, int entity, double r, double g, double b);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setColorTemperature(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double colorTemperature,
-);
-
-@ffi.Native<double3 Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double3 LightManager_getColor(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensity(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityCandela(ffi.Pointer<TLightManager> tLightManager, int entity, double intensity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setIntensityWatts(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double watts,
-  double efficiency,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getIntensity(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double)>(isLeaf: true)
-external void LightManager_setFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double falloff);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Double, ffi.Double)>(isLeaf: true)
-external void LightManager_setSpotLightCone(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double inner,
-  double outer,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSpotLightOuterCone(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSpotLightInnerCone(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunAngularRadius(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  double angularRadius,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunAngularRadius(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity, double haloSize);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunHaloSize(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Float)>(isLeaf: true)
-external void LightManager_setSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity, double haloFalloff);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external double LightManager_getSunHaloFalloff(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void LightManager_setShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity, bool enabled);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external bool LightManager_isShadowCaster(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions)>(isLeaf: true)
-external void LightManager_setShadowOptions(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  TShadowOptions options,
-);
-
-@ffi.Native<TShadowOptions Function(ffi.Pointer<TLightManager>, EntityId)>(isLeaf: true)
-external TShadowOptions LightManager_getShadowOptions(ffi.Pointer<TLightManager> tLightManager, int entity);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void LightManager_setLightChannel(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entity,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TLightManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
-external bool LightManager_getLightChannel(ffi.Pointer<TLightManager> tLightManager, int entity, int channel);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8)>(isLeaf: true)
-external void LightManager_computeUniformSplits(ffi.Pointer<ffi.Float> splitPositions, int cascades);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computeLogSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Float>, ffi.Uint8, ffi.Float, ffi.Float, ffi.Float)>(isLeaf: true)
-external void LightManager_computePracticalSplits(
-  ffi.Pointer<ffi.Float> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-);
-
-@ffi.Native<ffi.Double Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external double LightManager_rgbToColorTemperature(double r, double g, double b);
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
-external ffi.Pointer<ffi.Void> RenderThread_create();
-
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Char>)>(isLeaf: true)
-external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(ffi.Pointer<ffi.Char> canvasSelector);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void RenderThread_destroy(ffi.Pointer<ffi.Void> renderThread);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)>(isLeaf: true)
-external void RenderThread_addTask(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> task);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderManager>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Pointer<ffi.Pointer<TView>>,
-    ffi.Uint8,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void RenderManager_setRenderableRenderThread(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  ffi.Pointer<ffi.Pointer<TView>> tViews,
-  int numViews,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void RenderManager_renderRenderThread(
-  ffi.Pointer<TRenderManager> tRenderManager,
-  int frameTimeInNanos,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void RenderManager_addAnimationManagerRenderThread(
-  ffi.Pointer<TRenderManager> tRenderManager,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void RenderManager_removeAnimationManagerRenderThread(
-  ffi.Pointer<TRenderManager> tRenderManager,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void RenderManager_removeSwapChainRenderThread(
-  ffi.Pointer<TRenderManager> tRenderManager,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>>,
-  )
->(isLeaf: true)
-external void AnimationManager_createRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TAnimationManager>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void AnimationManager_destroyRenderThread(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Void>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>>,
-  )
->(isLeaf: true)
-external void Engine_createRenderThread(
-  int backend,
-  ffi.Pointer<ffi.Void> platform,
-  ffi.Pointer<ffi.Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TEngine>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>>)
->(isLeaf: true)
-external void Engine_createRendererRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderer>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyRendererRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
-  )
->(isLeaf: true)
-external void Engine_createSwapChainRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Void> window,
-  int flags,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>>,
-  )
->(isLeaf: true)
-external void Engine_createHeadlessSwapChainRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  int flags,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSwapChain>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    EntityId,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>>,
-  )
->(isLeaf: true)
-external void Engine_createCameraRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  int entityId,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TCamera>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TCamera>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyCameraRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TCamera> tCamera,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>>)
->(isLeaf: true)
-external void Engine_createViewRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TView>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>,
-  )
->(isLeaf: true)
-external void Engine_buildMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> materialData,
-  int length,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSwapChain>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroySwapChainRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyViewRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TView> tView,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroySceneRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TScene> tScene,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TColorGrading>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyColorGradingRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TColorGrading> tColorGrading,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterial>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterial> tMaterial,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TMaterialInstance>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void Engine_destroyMaterialInstanceRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TSkybox>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroySkyboxRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TSkybox> tSkybox,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndirectLight>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void Engine_destroyIndirectLightRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint8,
-    ffi.Uint16,
-    ffi.IntPtr,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
-external void Texture_buildRenderThread(
-  ffi.Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import$,
-  int sampler,
-  int format,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Void>, ffi.Uint32, VoidCallback)
->(isLeaf: true)
-external void Texture_setExternalImageRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<ffi.Void> externalImage,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Texture_generateMipMapsRenderThread(
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TEngine> tEngine,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TKtx1Bundle>,
-    ffi.Uint32,
-    VoidCallback,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
-external void Ktx1Reader_createTextureRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  VoidCallback onTextureUploadComplete,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
-external void Ktx2Reader_createTextureRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyTextureRenderThread(
-  ffi.Pointer<TEngine> engine,
-  ffi.Pointer<TTexture> tTexture,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>>)
->(isLeaf: true)
-external void Engine_createFenceRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFence>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Fence_waitAndDestroyRenderThread(ffi.Pointer<TFence> tFence, int requestId, VoidCallback onComplete);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TFence>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_destroyFenceRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TFence> tFence,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_flushAndWaitRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Engine_executeRenderThread(ffi.Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Uint8,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
-  )
->(isLeaf: true)
-external void Engine_buildSkyboxRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Uint8,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>>,
-  )
->(isLeaf: true)
-external void Engine_buildColoredSkyboxRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSkybox>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTexture>,
-    ffi.Float,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>,
-  )
->(isLeaf: true)
-external void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<ffi.Float>,
-    ffi.Float,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>>,
-  )
->(isLeaf: true)
-external void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tReflectionsTexture,
-  ffi.Pointer<ffi.Float> harmonics,
-  double intensity,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void Renderer_setClearOptionsRenderThread(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Pointer<TSwapChain>,
-    ffi.Uint64,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
-external void Renderer_beginFrameRenderThread(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Renderer_endFrameRenderThread(ffi.Pointer<TRenderer> tRenderer, int requestId, VoidCallback onComplete);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Renderer_renderRenderThread(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Renderer_renderStandaloneViewRenderThread(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TView> tView,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<TRenderTarget>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void Renderer_readPixelsRenderThread(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterial>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>,
-  )
->(isLeaf: true)
-external void Material_createInstanceRenderThread(
-  ffi.Pointer<TMaterial> tMaterial,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TMaterialInstance>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TTextureSampler>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void MaterialInstance_setParameterTextureRenderThread(
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-  ffi.Pointer<ffi.Char> propertyName,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TTextureSampler> tSampler,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
-external void Material_createImageMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
-external void Material_createGizmoMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
-external void Material_createBoneOverlayMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
-external void Material_createSilhouetteMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
-external void Material_createEdgeOutlineMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
-external void Material_createWireframeMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
->(isLeaf: true)
-external void Material_createTranslationAxisMaterialRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>>)>(
-  isLeaf: true,
-)
-external void ColorGradingBuilder_createRenderThread(
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TColorGradingBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>>,
-  )
->(isLeaf: true)
-external void ColorGradingBuilder_buildRenderThread(
-  ffi.Pointer<TColorGradingBuilder> tBuilder,
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TColorGrading>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TColorGradingBuilder>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void ColorGradingBuilder_destroyRenderThread(
-  ffi.Pointer<TColorGradingBuilder> tBuilder,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
-external void ToneMapper_createLinearRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
-external void ToneMapper_createACESRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
-external void ToneMapper_createACESLegacyRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
-external void ToneMapper_createFilmicRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
-external void ToneMapper_createPBRNeutralRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
-external void ToneMapper_createAGXRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>,
-  )
->(isLeaf: true)
-external void ToneMapper_createAGXWithLookRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  int look,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>,
-  )
->(isLeaf: true)
-external void ToneMapper_createGenericRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
->(isLeaf: true)
-external void ToneMapper_createDisplayRangeRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void ToneMapper_destroyRenderThread(
-  ffi.Pointer<TToneMapper> tToneMapper,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
-external void View_pickRenderThread(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setColorGradingRenderThread(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TColorGrading> tColorGrading,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Double, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setBloomRenderThread(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  double strength,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setCameraRenderThread(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TCamera> tCamera,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>)
->(isLeaf: true)
-external void View_getNameRenderThread(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setNameRenderThread(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<ffi.Char> name,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setViewportRenderThread(
-  ffi.Pointer<TView> tView,
-  int width,
-  int height,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setRenderTargetRenderThread(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setAntiAliasingRenderThread(
-  ffi.Pointer<TView> tView,
-  bool msaa,
-  bool fxaa,
-  bool taa,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setPostProcessingRenderThread(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setFrustumCullingEnabledRenderThread(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setStencilBufferEnabledRenderThread(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setDitheringEnabledRenderThread(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setRenderQualityRenderThread(
-  ffi.Pointer<TView> tView,
-  int qualityLevel,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setSceneRenderThread(
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TScene> tScene,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setLayerEnabledRenderThread(
-  ffi.Pointer<TView> tView,
-  int layer,
-  bool visible,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setBlendModeRenderThread(
-  ffi.Pointer<TView> tView,
-  int blendMode,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setFogOptionsRenderThread(
-  ffi.Pointer<TView> tView,
-  TFogOptions tFogOptions,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setAmbientOcclusionOptionsRenderThread(
-  ffi.Pointer<TView> tView,
-  TAmbientOcclusionOptions options,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setFrontFaceWindingInvertedRenderThread(
-  ffi.Pointer<TView> tView,
-  bool inverted,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setShadowsEnabledRenderThread(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setShadowTypeRenderThread(
-  ffi.Pointer<TView> tView,
-  int shadowType,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setSoftShadowOptionsRenderThread(
-  ffi.Pointer<TView> tView,
-  TSoftShadowOptions options,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setVsmShadowOptionsRenderThread(
-  ffi.Pointer<TView> tView,
-  TVsmShadowOptions options,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void View_setTransparentPickingEnabledRenderThread(
-  ffi.Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void SceneAsset_destroyRenderThread(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
-  )
->(isLeaf: true)
-external void SceneAsset_createFromFilamentAssetRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  int requiredGeometryCapabilities,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    Aabb3,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
-  )
->(isLeaf: true)
-external void SceneAsset_createFromBuffersRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tVertexBuffer,
-  ffi.Pointer<TIndexBuffer> tIndexBuffer,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  int vertexBufferStorageMode,
-  Aabb3 boundingBox,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> callback,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
-  )
->(isLeaf: true)
-external void SceneAsset_createInstanceRenderThread(
-  ffi.Pointer<TSceneAsset> asset,
-  ffi.Pointer<ffi.Pointer<TMaterialInstance>> tMaterialInstances,
-  int materialInstanceCount,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void SceneAsset_releaseSourceDataRenderThread(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void SceneAsset_setFlatShadingRenderThread(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
-  int requestId,
-  VoidCallback onComplete,
 );
 
 @ffi.Native<
@@ -2906,198 +2348,252 @@ external void MaterialProvider_createMaterialInstanceRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>> callback,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void AnimationManager_updateRenderThread(
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createBoneOverlayMaterial(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
+external void Material_createBoneOverlayMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createEdgeOutlineMaterial(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
+external void Material_createEdgeOutlineMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createGizmoMaterial(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
+external void Material_createGizmoMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createGridMaterial(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createImageMaterial(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
+external void Material_createImageMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> Material_createInstance(ffi.Pointer<TMaterial> tMaterial);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TMaterial>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>>,
+  )
+>(isLeaf: true)
+external void Material_createInstanceRenderThread(
+  ffi.Pointer<TMaterial> tMaterial,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterialInstance>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createSilhouetteMaterial(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
+external void Material_createSilhouetteMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createTranslationAxisMaterial(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
+external void Material_createTranslationAxisMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TMaterial> Material_createWireframeMaterial(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>>)
+>(isLeaf: true)
+external void Material_createWireframeMaterialRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TMaterial>)>> onComplete,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
+external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
+external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external bool Material_hasParameter(ffi.Pointer<TMaterial> tMaterial, ffi.Pointer<ffi.Char> propertyName);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMeshData>)>(isLeaf: true)
+external void MeshData_dispose(ffi.Pointer<TMeshData> meshData);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
+external void MovementIntentExecutor_destroy(ffi.Pointer<TMovementIntentExecutor> executor);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>, ffi.Pointer<TMovementIntent>, ffi.Uint64)>(
+  isLeaf: true,
+)
+external void MovementIntentExecutor_process(
+  ffi.Pointer<TMovementIntentExecutor> executor,
+  ffi.Pointer<TMovementIntent> intent,
+  int deltaTimeInNanos,
+);
+
+@ffi.Native<ffi.Pointer<TNameComponentManager> Function()>(isLeaf: true)
+external ffi.Pointer<TNameComponentManager> NameComponentManager_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TNameComponentManager>)>(isLeaf: true)
+external void NameComponentManager_destroy(ffi.Pointer<TNameComponentManager> tNameComponentManager);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TNameComponentManager>, EntityId)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> NameComponentManager_getName(
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  int entity,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
+external void Pipeline_registerMovementIntentExecutor(ffi.Pointer<TMovementIntentExecutor> executor);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_addAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
   ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void RenderManager_addAnimationManagerRenderThread(
+  ffi.Pointer<TRenderManager> tRenderManager,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_attachToRenderThread(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Pointer<TRenderManager> Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
+external ffi.Pointer<TRenderManager> RenderManager_create(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TRenderer> tRenderer,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_detachFromRenderThread(ffi.Pointer<TRenderManager> tRenderManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
+external void RenderManager_removeAnimationManager(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void RenderManager_removeAnimationManagerRenderThread(
+  ffi.Pointer<TRenderManager> tRenderManager,
+  ffi.Pointer<TAnimationManager> tAnimationManager,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
+external void RenderManager_removeSwapChain(ffi.Pointer<TRenderManager> tRenderer, ffi.Pointer<TSwapChain> swapChain);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void RenderManager_removeSwapChainRenderThread(
+  ffi.Pointer<TRenderManager> tRenderManager,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(isLeaf: true)
+external void RenderManager_render(ffi.Pointer<TRenderManager> tRenderer, int frameTimeInNanos);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void RenderManager_renderRenderThread(
+  ffi.Pointer<TRenderManager> tRenderManager,
   int frameTimeInNanos,
   int requestId,
   VoidCallback onComplete,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
+external void RenderManager_requestRender(ffi.Pointer<TRenderManager> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(isLeaf: true)
+external void RenderManager_setPaused(ffi.Pointer<TRenderManager> tRenderer, bool paused);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)
+>(isLeaf: true)
+external void RenderManager_setRenderable(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> swapChain,
+  ffi.Pointer<ffi.Pointer<TView>> views,
+  int numViews,
+);
+
 @ffi.Native<
   ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Float,
+    ffi.Pointer<TRenderManager>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Pointer<ffi.Pointer<TView>>,
+    ffi.Uint8,
     ffi.Uint32,
     VoidCallback,
   )
 >(isLeaf: true)
-external void AnimationManager_setGltfAnimationTimeRenderThread(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int animationIndex,
-  double timeInSeconds,
+external void RenderManager_setRenderableRenderThread(
+  ffi.Pointer<TRenderManager> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  ffi.Pointer<ffi.Pointer<TView>> tViews,
+  int numViews,
   int requestId,
   VoidCallback onComplete,
 );
 
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
-external void AnimationManager_updateBoneMatricesRenderThread(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TAnimationManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
-external void AnimationManager_setMorphTargetWeightsRenderThread(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> morphData,
-  int numWeights,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>,
-  )
->(isLeaf: true)
-external void Image_createEmptyRenderThread(
-  int width,
-  int height,
-  int channel,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Pointer<ffi.Char>,
-    ffi.Bool,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>>,
-  )
->(isLeaf: true)
-external void Image_decodeRenderThread(
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  ffi.Pointer<ffi.Char> name,
-  bool alpha,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TLinearImage>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TLinearImage>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>>,
-  )
->(isLeaf: true)
-external void Image_getBytesRenderThread(
-  ffi.Pointer<TLinearImage> tLinearImage,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Float>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Image_destroyRenderThread(ffi.Pointer<TLinearImage> tLinearImage, int requestId, VoidCallback onComplete);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
->(isLeaf: true)
-external void Image_getWidthRenderThread(
-  ffi.Pointer<TLinearImage> tLinearImage,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
->(isLeaf: true)
-external void Image_getHeightRenderThread(
-  ffi.Pointer<TLinearImage> tLinearImage,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TLinearImage>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>>)
->(isLeaf: true)
-external void Image_getChannelsRenderThread(
-  ffi.Pointer<TLinearImage> tLinearImage,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Uint32)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Pointer<TLinearImage>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Int,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
-external void Texture_loadImageRenderThread(
+@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(
+  isLeaf: true,
+)
+external ffi.Pointer<TRenderTarget> RenderTarget_create(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  ffi.Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TTexture>,
-    ffi.Uint32,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
-external void Texture_setImageRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> tTexture,
-  int level,
-  ffi.Pointer<ffi.Uint8> data,
-  int size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderTarget>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
-  )
->(isLeaf: true)
-external void RenderTarget_getColorTextureRenderThread(
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+  ffi.Pointer<TTexture> color,
+  ffi.Pointer<TTexture> depth,
 );
 
 @ffi.Native<
@@ -3115,6 +2611,9 @@ external void RenderTarget_createRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TRenderTarget>)>> onComplete,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void RenderTarget_destroy(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderTarget> tRenderTarget);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>, ffi.Uint32, VoidCallback)>(isLeaf: true)
 external void RenderTarget_destroyRenderThread(
   ffi.Pointer<TEngine> tEngine,
@@ -3123,472 +2622,54 @@ external void RenderTarget_destroyRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>)>(
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getColorTexture(ffi.Pointer<TRenderTarget> tRenderTarget);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderTarget>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
+external void RenderTarget_getColorTextureRenderThread(
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external ffi.Pointer<TTexture> RenderTarget_getDepthTexture(ffi.Pointer<TRenderTarget> tRenderTarget);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>)>(isLeaf: true)
+external void RenderThread_addTask(ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> task);
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function()>(isLeaf: true)
+external ffi.Pointer<ffi.Void> RenderThread_create();
+
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(ffi.Pointer<ffi.Char> canvasSelector);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void RenderThread_destroy(ffi.Pointer<ffi.Void> renderThread);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
+external void RenderableBuilder_blendOrder(ffi.Pointer<TRenderableBuilder> builder, int primitiveIndex, int order);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
   isLeaf: true,
 )
-external void TextureSampler_createRenderThread(
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
+external void RenderableBuilder_boneIndicesAndWeights(
+  ffi.Pointer<TRenderableBuilder> builder,
+  int primitiveIndex,
+  ffi.Pointer<ffi.Float> indicesAndWeights,
+  int count,
+  int bonesPerVertex,
 );
 
-@ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>,
-  )
->(isLeaf: true)
-external void TextureSampler_createWithFilteringRenderThread(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, Aabb3)>(isLeaf: true)
+external void RenderableBuilder_boundingBox(ffi.Pointer<TRenderableBuilder> builder, Aabb3 aabb);
 
-@ffi.Native<
-  ffi.Void Function(
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>,
-  )
->(isLeaf: true)
-external void TextureSampler_createWithComparisonRenderThread(
-  int compareMode,
-  int compareFunc,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TextureSampler_setMinFilterRenderThread(
-  ffi.Pointer<TTextureSampler> sampler,
-  int filter,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TextureSampler_setMagFilterRenderThread(
-  ffi.Pointer<TTextureSampler> sampler,
-  int filter,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TextureSampler_setWrapModeSRenderThread(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TextureSampler_setWrapModeTRenderThread(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TextureSampler_setWrapModeRRenderThread(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TextureSampler_setAnisotropyRenderThread(
-  ffi.Pointer<TTextureSampler> sampler,
-  double anisotropy,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.UnsignedInt, ffi.Uint32, VoidCallback)
->(isLeaf: true)
-external void TextureSampler_setCompareModeRenderThread(
-  ffi.Pointer<TTextureSampler> sampler,
-  int mode,
-  int func,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TextureSampler_destroyRenderThread(
-  ffi.Pointer<TTextureSampler> sampler,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void AnimationManager_resetToRestPoseRenderThread(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>>,
-  )
->(isLeaf: true)
-external void GltfAssetLoader_createRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>> callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void GltfAssetLoader_destroyRenderThread(
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>>,
-  )
->(isLeaf: true)
-external void GltfResourceLoader_createRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>> callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void GltfResourceLoader_destroyRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfResourceLoader> tResourceLoader,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
-external void GltfResourceLoader_loadResourcesRenderThread(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<ffi.Char>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void GltfResourceLoader_addResourceDataRenderThread(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.Char> uri,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TFilamentAsset>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
-external void GltfResourceLoader_asyncBeginLoadRenderThread(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoadRenderThread(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>>)
->(isLeaf: true)
-external void GltfResourceLoader_asyncGetLoadProgressRenderThread(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Float)>> callback,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>>,
-  )
->(isLeaf: true)
-external void GltfAssetLoader_loadRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int numInstances,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TFilamentAsset>)>> callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Scene_addFilamentAssetRenderThread(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TFilamentAsset> tAsset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)
->(isLeaf: true)
-external void FilamentAsset_getWireframeRenderThread(
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Scene_addEntityRenderThread(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Scene_removeEntityRenderThread(
-  ffi.Pointer<TScene> tScene,
-  int entityId,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void SceneAsset_addToSceneRenderThread(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void SceneAsset_removeFromSceneRenderThread(
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  ffi.Pointer<TScene> tScene,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Scene_setSkyboxRenderThread(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TSkybox> tSkybox,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void Scene_setIndirectLightRenderThread(
-  ffi.Pointer<TScene> tScene,
-  ffi.Pointer<TIndirectLight> tIndirectLight,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
-    ffi.Pointer<TGltfResourceLoader>,
-    ffi.Pointer<TNameComponentManager>,
-    ffi.Pointer<TView>,
-    ffi.Pointer<TMaterial>,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>>,
-  )
->(isLeaf: true)
-external void Gizmo_createRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
-  ffi.Pointer<TView> tView,
-  ffi.Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TGizmo>)>> callback,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TVertexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>,
-  )
->(isLeaf: true)
-external void VertexBufferBuilder_buildRenderThread(
-  ffi.Pointer<TVertexBufferBuilder> tBuilder,
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void VertexBuffer_destroyRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tBuffer,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void VertexBuffer_setBufferAtRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tBuffer,
-  int bufferIndex,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Uint8,
-    ffi.Pointer<TBufferObject>,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void VertexBuffer_setBufferObjectAtRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TVertexBuffer> tBuffer,
-  int bufferIndex,
-  ffi.Pointer<TBufferObject> tBufferObject,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TBufferObjectBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>>,
-  )
->(isLeaf: true)
-external void BufferObjectBuilder_buildRenderThread(
-  ffi.Pointer<TBufferObjectBuilder> tBuilder,
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TBufferObject>)>> onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TBufferObject>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void BufferObject_setBufferRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TBufferObject> tBuffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TBufferObject>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void BufferObject_destroyRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TBufferObject> tBuffer,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TIndexBufferBuilder>,
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>>,
-  )
->(isLeaf: true)
-external void IndexBufferBuilder_buildRenderThread(
-  ffi.Pointer<TIndexBufferBuilder> tBuilder,
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndexBuffer>)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TIndexBuffer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void IndexBuffer_destroyRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TIndexBuffer> tBuffer,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TIndexBuffer>,
-    ffi.Pointer<ffi.Void>,
-    ffi.Size,
-    ffi.Uint32,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void IndexBuffer_setBufferRenderThread(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TIndexBuffer> tBuffer,
-  ffi.Pointer<ffi.Void> data,
-  int sizeInBytes,
-  int byteOffset,
-  int requestId,
-  VoidCallback onComplete,
-);
+@ffi.Native<ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
+external int RenderableBuilder_build(ffi.Pointer<TRenderableBuilder> builder, ffi.Pointer<TEngine> engine, int entity);
 
 @ffi.Native<
   ffi.Void Function(
@@ -3605,549 +2686,26 @@ external void RenderableBuilder_buildRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>> onComplete,
 );
 
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TEntityManager>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>>)
->(isLeaf: true)
-external void EntityManager_createEntityRenderThread(
-  ffi.Pointer<TEntityManager> tEntityManager,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(EntityId)>> onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEntityManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void EntityManager_destroyEntityRenderThread(
-  ffi.Pointer<TEntityManager> tEntityManager,
-  int entityId,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void TransformManager_setTransformRenderThread(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  double4x4 transform,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void TransformManager_setParentRenderThread(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int child,
-  int parent,
-  bool preserveScaling,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TransformManager_createComponentRenderThread(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void TransformManager_removeComponentRenderThread(
-  ffi.Pointer<TTransformManager> tTransformManager,
-  int entityId,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void RenderableManager_destroyEntityRenderThread(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void RenderableManager_setMorphWeightsRenderThread(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> weights,
-  int count,
-  int offset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void RenderableManager_setBonesFromMat4RenderThread(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> transforms,
-  int boneCount,
-  int offset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
-  )
->(isLeaf: true)
-external void RenderableManager_setBonesFromBoneRenderThread(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> bones,
-  int boneCount,
-  int offset,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Int,
-    ffi.Uint8,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Size,
-    ffi.Size,
-    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
-  )
->(isLeaf: true)
-external void RenderableManager_setGeometryAtNonIndexedRenderThread(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  int type,
-  ffi.Pointer<TVertexBuffer> tVertices,
-  int offset,
-  int count,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void RenderableManager_setCastShadowsRenderThread(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void RenderableManager_setReceiveShadowsRenderThread(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
-external void LightManager_setShadowCasterRenderThread(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entityId,
-  bool enabled,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TLightManager>, EntityId, TShadowOptions, ffi.Uint32, VoidCallback)>(
-  isLeaf: true,
-)
-external void LightManager_setShadowOptionsRenderThread(
-  ffi.Pointer<TLightManager> tLightManager,
-  int entityId,
-  TShadowOptions options,
-  int requestId,
-  VoidCallback onComplete,
-);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Double,
-    ffi.Uint8,
-    ffi.Bool,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external void Renderer_setClearOptions(
-  ffi.Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)>(isLeaf: true)
-external bool Renderer_beginFrame(
-  ffi.Pointer<TRenderer> tRenderer,
-  ffi.Pointer<TSwapChain> tSwapChain,
-  int frameTimeInNanos,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
-external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
-external void Renderer_render(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
-external void Renderer_renderStandaloneView(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
-
-@ffi.Native<
-  ffi.Void Function(
-    ffi.Pointer<TRenderer>,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Uint32,
-    ffi.Pointer<TRenderTarget>,
-    ffi.UnsignedInt,
-    ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
-    ffi.Size,
-  )
->(isLeaf: true)
-external void Renderer_readPixels(
-  ffi.Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  ffi.Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
-  int outLength,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void Renderer_setFrameInterval(
-  ffi.Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-);
-
-@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TRenderTarget> RenderTarget_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TTexture> color,
-  ffi.Pointer<TTexture> depth,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
-external void RenderTarget_destroy(ffi.Pointer<TEngine> tEngine, ffi.Pointer<TRenderTarget> tRenderTarget);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
-external void Skybox_setColor(ffi.Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
-
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void Skybox_setLayerMask(ffi.Pointer<TSkybox> tSkybox, int select, int values);
-
-/// Returns the visibility mask bits.
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external int Skybox_getLayerMask(ffi.Pointer<TSkybox> tSkybox);
-
-/// Returns the skybox intensity in lux.
-@ffi.Native<ffi.Float Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external double Skybox_getIntensity(ffi.Pointer<TSkybox> tSkybox);
-
-/// Returns the environment texture, or nullptr for a color-only skybox.
-@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
-external ffi.Pointer<TTexture> Skybox_getTexture(ffi.Pointer<TSkybox> tSkybox);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external void RenderableManager_destroyEntity(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_hasComponent(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
-external bool RenderableManager_empty(ffi.Pointer<TRenderableManager> tRenderableManager);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_isRenderable(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
-external int RenderableManager_getComponentCount(ffi.Pointer<TRenderableManager> tRenderableManager);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int, ffi.Pointer<TMaterialInstance>)>(
-  isLeaf: true,
-)
-external bool RenderableManager_setMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  ffi.Pointer<TMaterialInstance> tMaterialInstance,
-);
-
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
-external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
-external void RenderableManager_clearMaterialInstanceAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TRenderableManager>,
-    EntityId,
-    ffi.Int,
-    ffi.Uint8,
-    ffi.Pointer<TVertexBuffer>,
-    ffi.Size,
-    ffi.Size,
-  )
->(isLeaf: true)
-external bool RenderableManager_setGeometryAtNonIndexed(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  int type,
-  ffi.Pointer<TVertexBuffer> vertices,
-  int offset,
-  int count,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external int RenderableManager_getPrimitiveCount(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external Aabb3 RenderableManager_getAxisAlignedBoundingBox(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, Aabb3)>(isLeaf: true)
-external void RenderableManager_setAxisAlignedBoundingBox(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  Aabb3 aabb,
-);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external Aabb3 RenderableManager_getAabb(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external Aabb3 RenderableManager_getBoundingBox(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setLayerMask(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int select,
-  int values,
-);
-
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external int RenderableManager_getLayerMask(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setVisibilityLayer(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int layer,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setPriority(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int priority,
-);
-
-@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external int RenderableManager_getPriority(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
-external void RenderableManager_setChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setCulling(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_getCulling(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setFogEnabled(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_getFogEnabled(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setLightChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-  bool enable,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
-external bool RenderableManager_getLightChannel(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int channel,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setCastShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool castShadows,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_isShadowCaster(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setReceiveShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool receiveShadows,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external bool RenderableManager_isShadowReceiver(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setScreenSpaceContactShadows(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size, ffi.Uint16)>(isLeaf: true)
-external void RenderableManager_setBlendOrderAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  int order,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size, ffi.Bool)>(isLeaf: true)
-external void RenderableManager_setGlobalBlendOrderEnabledAt(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  int primitiveIndex,
-  bool enabled,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void RenderableManager_setMorphWeights(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> weights,
-  int count,
-  int offset,
-);
-
-@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
-external int RenderableManager_getMorphTargetCount(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void RenderableManager_setBonesFromMat4(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> transforms,
-  int boneCount,
-  int offset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void RenderableManager_setBonesFromBone(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> bones,
-  int boneCount,
-  int offset,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_castShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(isLeaf: true)
+external void RenderableBuilder_channel(ffi.Pointer<TRenderableBuilder> builder, int channel);
 
 @ffi.Native<ffi.Pointer<TRenderableBuilder> Function(ffi.Size)>(isLeaf: true)
 external ffi.Pointer<TRenderableBuilder> RenderableBuilder_create(int primitiveCount);
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_culling(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>)>(isLeaf: true)
 external void RenderableBuilder_destroy(ffi.Pointer<TRenderableBuilder> builder);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, Aabb3)>(isLeaf: true)
-external void RenderableBuilder_boundingBox(ffi.Pointer<TRenderableBuilder> builder, Aabb3 aabb);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_enableSkinningBuffers(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
-external void RenderableBuilder_material(
-  ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  ffi.Pointer<TMaterialInstance> materialInstance,
-);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_fog(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
 
 @ffi.Native<
   ffi.Void Function(
@@ -4189,36 +2747,6 @@ external void RenderableBuilder_geometryNonIndexed(
   int count,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(isLeaf: true)
-external void RenderableBuilder_priority(ffi.Pointer<TRenderableBuilder> builder, int priority);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(isLeaf: true)
-external void RenderableBuilder_channel(ffi.Pointer<TRenderableBuilder> builder, int channel);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_culling(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_castShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_receiveShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_fog(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_lightChannel(ffi.Pointer<TRenderableBuilder> builder, int channel, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
-external void RenderableBuilder_layerMask(ffi.Pointer<TRenderableBuilder> builder, int select, int values);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_screenSpaceContactShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
-external void RenderableBuilder_blendOrder(ffi.Pointer<TRenderableBuilder> builder, int primitiveIndex, int order);
-
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Bool)>(isLeaf: true)
 external void RenderableBuilder_globalBlendOrderEnabled(
   ffi.Pointer<TRenderableBuilder> builder,
@@ -4229,12 +2757,27 @@ external void RenderableBuilder_globalBlendOrderEnabled(
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size)>(isLeaf: true)
 external void RenderableBuilder_instances(ffi.Pointer<TRenderableBuilder> builder, int instanceCount);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>)>(isLeaf: true)
-external void RenderableBuilder_skinningFromMat4(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void RenderableBuilder_layerMask(ffi.Pointer<TRenderableBuilder> builder, int select, int values);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_lightChannel(ffi.Pointer<TRenderableBuilder> builder, int channel, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<TMaterialInstance>)>(isLeaf: true)
+external void RenderableBuilder_material(
   ffi.Pointer<TRenderableBuilder> builder,
-  int boneCount,
-  ffi.Pointer<ffi.Float> transforms,
+  int primitiveIndex,
+  ffi.Pointer<TMaterialInstance> materialInstance,
 );
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Uint8)>(isLeaf: true)
+external void RenderableBuilder_priority(ffi.Pointer<TRenderableBuilder> builder, int priority);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_receiveShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
+external void RenderableBuilder_screenSpaceContactShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>)>(isLeaf: true)
 external void RenderableBuilder_skinningFromBone(
@@ -4243,31 +2786,845 @@ external void RenderableBuilder_skinningFromBone(
   ffi.Pointer<ffi.Float> bones,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
-external void RenderableBuilder_enableSkinningBuffers(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void RenderableBuilder_boneIndicesAndWeights(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Pointer<ffi.Float>)>(isLeaf: true)
+external void RenderableBuilder_skinningFromMat4(
   ffi.Pointer<TRenderableBuilder> builder,
-  int primitiveIndex,
-  ffi.Pointer<ffi.Float> indicesAndWeights,
-  int count,
-  int bonesPerVertex,
+  int boneCount,
+  ffi.Pointer<ffi.Float> transforms,
 );
 
-@ffi.Native<ffi.Int Function(ffi.Pointer<TRenderableBuilder>, ffi.Pointer<TEngine>, EntityId)>(isLeaf: true)
-external int RenderableBuilder_build(ffi.Pointer<TRenderableBuilder> builder, ffi.Pointer<TEngine> engine, int entity);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
+external void RenderableManager_clearMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TIndirectLight>, ffi.Pointer<ffi.Double>)>(isLeaf: true)
-external void IndirectLight_setRotation(ffi.Pointer<TIndirectLight> tIndirectLight, ffi.Pointer<ffi.Double> rotation);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external void RenderableManager_destroyEntity(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void RenderableManager_destroyEntityRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
+external bool RenderableManager_empty(ffi.Pointer<TRenderableManager> tRenderableManager);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external Aabb3 RenderableManager_getAabb(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external Aabb3 RenderableManager_getAxisAlignedBoundingBox(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external Aabb3 RenderableManager_getBoundingBox(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>)>(isLeaf: true)
+external int RenderableManager_getComponentCount(ffi.Pointer<TRenderableManager> tRenderableManager);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_getCulling(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_getFogEnabled(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external int RenderableManager_getLayerMask(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt)>(isLeaf: true)
+external bool RenderableManager_getLightChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+);
+
+@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external int RenderableManager_getMorphTargetCount(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external int RenderableManager_getPrimitiveCount(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external int RenderableManager_getPriority(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_hasComponent(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_isRenderable(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_isShadowCaster(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId)>(isLeaf: true)
+external bool RenderableManager_isShadowReceiver(ffi.Pointer<TRenderableManager> tRenderableManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, Aabb3)>(isLeaf: true)
+external void RenderableManager_setAxisAlignedBoundingBox(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  Aabb3 aabb,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size, ffi.Uint16)>(isLeaf: true)
+external void RenderableManager_setBlendOrderAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  int order,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void RenderableManager_setBonesFromBone(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> bones,
+  int boneCount,
+  int offset,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void RenderableManager_setBonesFromBoneRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> bones,
+  int boneCount,
+  int offset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void RenderableManager_setBonesFromMat4(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> transforms,
+  int boneCount,
+  int offset,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void RenderableManager_setBonesFromMat4RenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> transforms,
+  int boneCount,
+  int offset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setCastShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool castShadows,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void RenderableManager_setCastShadowsRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setCulling(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setFogEnabled(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Int,
+    ffi.Uint8,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Size,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external bool RenderableManager_setGeometryAtNonIndexed(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  int type,
+  ffi.Pointer<TVertexBuffer> vertices,
+  int offset,
+  int count,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Int,
+    ffi.Uint8,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
+external void RenderableManager_setGeometryAtNonIndexedRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  int type,
+  ffi.Pointer<TVertexBuffer> tVertices,
+  int offset,
+  int count,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Size, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setGlobalBlendOrderEnabledAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setLayerMask(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int select,
+  int values,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setLightChannel(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int channel,
+  bool enable,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Int, ffi.Pointer<TMaterialInstance>)>(
+  isLeaf: true,
+)
+external bool RenderableManager_setMaterialInstanceAt(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int primitiveIndex,
+  ffi.Pointer<TMaterialInstance> tMaterialInstance,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
+  isLeaf: true,
+)
+external void RenderableManager_setMorphWeights(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> weights,
+  int count,
+  int offset,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderableManager>,
+    EntityId,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void RenderableManager_setMorphWeightsRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  ffi.Pointer<ffi.Float> weights,
+  int count,
+  int offset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setPriority(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int priority,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setReceiveShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool receiveShadows,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void RenderableManager_setReceiveShadowsRenderThread(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Bool)>(isLeaf: true)
+external void RenderableManager_setScreenSpaceContactShadows(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  bool enabled,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableManager>, EntityId, ffi.Uint8)>(isLeaf: true)
+external void RenderableManager_setVisibilityLayer(
+  ffi.Pointer<TRenderableManager> tRenderableManager,
+  int entityId,
+  int layer,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TRenderer>, ffi.Pointer<TSwapChain>, ffi.Uint64)>(isLeaf: true)
+external bool Renderer_beginFrame(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Pointer<TSwapChain>,
+    ffi.Uint64,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
+external void Renderer_beginFrameRenderThread(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TSwapChain> tSwapChain,
+  int frameTimeInNanos,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
+external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Renderer_endFrameRenderThread(ffi.Pointer<TRenderer> tRenderer, int requestId, VoidCallback onComplete);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<TRenderTarget>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external void Renderer_readPixels(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<TRenderTarget>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void Renderer_readPixelsRenderThread(
+  ffi.Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  ffi.Pointer<ffi.Uint8> out,
+  int outLength,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
+external void Renderer_render(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Renderer_renderRenderThread(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)
+external void Renderer_renderStandaloneView(ffi.Pointer<TRenderer> tRenderer, ffi.Pointer<TView> tView);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Renderer_renderStandaloneViewRenderThread(
+  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TView> tView,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+  )
+>(isLeaf: true)
+external void Renderer_setClearOptions(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderer>,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Double,
+    ffi.Uint8,
+    ffi.Bool,
+    ffi.Bool,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void Renderer_setClearOptionsRenderThread(
+  ffi.Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Float, ffi.Float, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void Renderer_setFrameInterval(
+  ffi.Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void SceneAsset_addToScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void SceneAsset_addToSceneRenderThread(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    Aabb3,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tVertexBuffer,
+  ffi.Pointer<TIndexBuffer> tIndexBuffer,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  int vertexBufferStorageMode,
+  Aabb3 boundingBox,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Pointer<TIndexBuffer>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    Aabb3,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
+  )
+>(isLeaf: true)
+external void SceneAsset_createFromBuffersRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tVertexBuffer,
+  ffi.Pointer<TIndexBuffer> tIndexBuffer,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  int vertexBufferStorageMode,
+  Aabb3 boundingBox,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> callback,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  int requiredGeometryCapabilities,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Pointer<TNameComponentManager>,
+    ffi.Pointer<TFilamentAsset>,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
+  )
+>(isLeaf: true)
+external void SceneAsset_createFromFilamentAssetRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+  ffi.Pointer<TFilamentAsset> tFilamentAsset,
+  int requiredGeometryCapabilities,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> onComplete,
+);
+
+@ffi.Native<
+  ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Pointer<TMaterialInstance>>, ffi.Int)
+>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_createInstance(
+  ffi.Pointer<TSceneAsset> asset,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TSceneAsset>,
+    ffi.Pointer<ffi.Pointer<TMaterialInstance>>,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>>,
+  )
+>(isLeaf: true)
+external void SceneAsset_createInstanceRenderThread(
+  ffi.Pointer<TSceneAsset> asset,
+  ffi.Pointer<ffi.Pointer<TMaterialInstance>> tMaterialInstances,
+  int materialInstanceCount,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TSceneAsset>)>> callback,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_destroy(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void SceneAsset_destroyRenderThread(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>, ffi.Size)>(isLeaf: true)
+external int SceneAsset_getBoneCount(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex);
+
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Size)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> SceneAsset_getBoneName(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Size, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getBones(ffi.Pointer<TSceneAsset> tSceneAsset, int skinIndex, ffi.Pointer<EntityId> out);
+
+@ffi.Native<Aabb3 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external Aabb3 SceneAsset_getBoundingBox(ffi.Pointer<TSceneAsset> asset);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getCameraEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getCameraEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
+external void SceneAsset_getChildEntities(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<EntityId> out);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getChildEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getEntity(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Pointer<TFilamentAsset> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getGeometryCapabilities(ffi.Pointer<TSceneAsset> asset);
+
+@ffi.Native<ffi.Pointer<TIndexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+
+@ffi.Native<ffi.Pointer<TSceneAsset> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TSceneAsset> SceneAsset_getInstance(ffi.Pointer<TSceneAsset> tSceneAsset, int index);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getInstanceCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Pointer<EntityId> Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external ffi.Pointer<EntityId> SceneAsset_getLightEntities(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getLightEntityCount(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
+external int SceneAsset_getPrimitiveOffsetForEntity(ffi.Pointer<TSceneAsset> tSceneAsset, int entity);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external int SceneAsset_getType(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int primitiveIndex,
+);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
+external int SceneAsset_getVertexBufferStorageMode(ffi.Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external void SceneAsset_releaseSourceData(ffi.Pointer<TSceneAsset> tSceneAsset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void SceneAsset_releaseSourceDataRenderThread(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void SceneAsset_removeFromScene(ffi.Pointer<TSceneAsset> tSceneAsset, ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void SceneAsset_removeFromSceneRenderThread(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  ffi.Pointer<TScene> tScene,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool)>(isLeaf: true)
+external void SceneAsset_setFlatShading(ffi.Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSceneAsset>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void SceneAsset_setFlatShadingRenderThread(
+  ffi.Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TSceneAsset>)>(isLeaf: true)
+external bool SceneAsset_supportsFlatShading(ffi.Pointer<TSceneAsset> asset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Scene_addEntityRenderThread(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
+external void Scene_addFilamentAsset(ffi.Pointer<TScene> tScene, ffi.Pointer<TFilamentAsset> asset);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Scene_addFilamentAssetRenderThread(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TFilamentAsset> tAsset,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TScene>)>(isLeaf: true)
+external ffi.Pointer<TSkybox> Scene_getSkybox(ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
+external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Scene_removeEntityRenderThread(
+  ffi.Pointer<TScene> tScene,
+  int entityId,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
+external void Scene_setIndirectLight(ffi.Pointer<TScene> tScene, ffi.Pointer<TIndirectLight> tIndirectLight);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Scene_setIndirectLightRenderThread(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TIndirectLight> tIndirectLight,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(isLeaf: true)
+external void Scene_setSkybox(ffi.Pointer<TScene> tScene, ffi.Pointer<TSkybox> skybox);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Scene_setSkyboxRenderThread(
+  ffi.Pointer<TScene> tScene,
+  ffi.Pointer<TSkybox> tSkybox,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+/// Returns the skybox intensity in lux.
+@ffi.Native<ffi.Float Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external double Skybox_getIntensity(ffi.Pointer<TSkybox> tSkybox);
+
+/// Returns the visibility mask bits.
+@ffi.Native<ffi.Uint8 Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external int Skybox_getLayerMask(ffi.Pointer<TSkybox> tSkybox);
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+@ffi.Native<ffi.Pointer<TTexture> Function(ffi.Pointer<TSkybox>)>(isLeaf: true)
+external ffi.Pointer<TTexture> Skybox_getTexture(ffi.Pointer<TSkybox> tSkybox);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
+external void Skybox_setColor(ffi.Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSkybox>, ffi.Uint8, ffi.Uint8)>(isLeaf: true)
+external void Skybox_setLayerMask(ffi.Pointer<TSkybox> tSkybox, int select, int values);
+
+@ffi.Native<ffi.Pointer<TSurfaceOrientation> Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+);
 
 @ffi.Native<ffi.Pointer<TSurfaceOrientationBuilder> Function()>(isLeaf: true)
 external ffi.Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create();
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_vertexCount(ffi.Pointer<TSurfaceOrientationBuilder> builder, int count);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
+external void SurfaceOrientationBuilder_destroy(ffi.Pointer<TSurfaceOrientationBuilder> builder);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
 external void SurfaceOrientationBuilder_normals(
@@ -4277,23 +3634,16 @@ external void SurfaceOrientationBuilder_normals(
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_tangents(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> tangents,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
-external void SurfaceOrientationBuilder_uvs(
-  ffi.Pointer<TSurfaceOrientationBuilder> builder,
-  ffi.Pointer<ffi.Float> uvs,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
 external void SurfaceOrientationBuilder_positions(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
   ffi.Pointer<ffi.Float> positions,
+  int stride,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_tangents(
+  ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> tangents,
   int stride,
 );
 
@@ -4312,16 +3662,18 @@ external void SurfaceOrientationBuilder_triangles_ushort(
   ffi.Pointer<ffi.Uint16> triangles,
 );
 
-@ffi.Native<ffi.Pointer<TSurfaceOrientation> Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
-external ffi.Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Pointer<ffi.Float>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_uvs(
   ffi.Pointer<TSurfaceOrientationBuilder> builder,
+  ffi.Pointer<ffi.Float> uvs,
+  int stride,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>)>(isLeaf: true)
-external void SurfaceOrientationBuilder_destroy(ffi.Pointer<TSurfaceOrientationBuilder> builder);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
+external void SurfaceOrientationBuilder_vertexCount(ffi.Pointer<TSurfaceOrientationBuilder> builder, int count);
 
-@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external int SurfaceOrientation_getVertexCount(ffi.Pointer<TSurfaceOrientation> orientation);
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external void SurfaceOrientation_destroy(ffi.Pointer<TSurfaceOrientation> orientation);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Float>, ffi.Size, ffi.Size)>(
   isLeaf: true,
@@ -4329,16 +3681,6 @@ external int SurfaceOrientation_getVertexCount(ffi.Pointer<TSurfaceOrientation> 
 external void SurfaceOrientation_getQuats_float4(
   ffi.Pointer<TSurfaceOrientation> orientation,
   ffi.Pointer<ffi.Float> out,
-  int quatCount,
-  int stride,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>, ffi.Size, ffi.Size)>(
-  isLeaf: true,
-)
-external void SurfaceOrientation_getQuats_short4(
-  ffi.Pointer<TSurfaceOrientation> orientation,
-  ffi.Pointer<ffi.Int16> out,
   int quatCount,
   int stride,
 );
@@ -4353,433 +3695,642 @@ external void SurfaceOrientation_getQuats_half4(
   int stride,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
-external void SurfaceOrientation_destroy(ffi.Pointer<TSurfaceOrientation> orientation);
-
-@ffi.Native<ffi.Pointer<TAnimationManager> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TAnimationManager> AnimationManager_create(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void AnimationManager_destroy(ffi.Pointer<TAnimationManager> tAnimationManager);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Uint64)>(isLeaf: true)
-external void AnimationManager_update(ffi.Pointer<TAnimationManager> tAnimationManager, int frameTimeInNanos);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_addGltfAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_removeGltfAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
-external void AnimationManager_addMorphAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
-external void AnimationManager_removeMorphAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_addBoneAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_removeBoneAnimationComponent(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    EntityId,
-    ffi.Pointer<ffi.Float>,
-    ffi.Pointer<ffi.Uint32>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Float,
-  )
->(isLeaf: true)
-external bool AnimationManager_setMorphAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> morphData,
-  ffi.Pointer<ffi.Uint32> morphIndices,
-  int numMorphTargets,
-  int numFrames,
-  double frameLengthInMs,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId)>(isLeaf: true)
-external bool AnimationManager_clearMorphAnimation(ffi.Pointer<TAnimationManager> tAnimationManager, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external void AnimationManager_resetToRestPose(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Int,
-    ffi.Pointer<ffi.Float>,
-    ffi.Int,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-    ffi.Bool,
-  )
->(isLeaf: true)
-external bool AnimationManager_addBoneAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-  ffi.Pointer<ffi.Float> frameData,
-  int numFrames,
-  double frameLengthInMs,
-  double fadeOutInSecs,
-  double fadeInInSecs,
-  double maxDelta,
-  bool loop,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Pointer<ffi.Float>, ffi.Int)
->(isLeaf: true)
-external void AnimationManager_getRestLocalTransforms(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int skinIndex,
-  ffi.Pointer<ffi.Float> out,
-  int numBones,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Int, ffi.Pointer<ffi.Float>)
->(isLeaf: true)
-external void AnimationManager_getInverseBindMatrix(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int skinIndex,
-  int boneIndex,
-  ffi.Pointer<ffi.Float> out,
-);
-
-@ffi.Native<
-  ffi.Bool Function(
-    ffi.Pointer<TAnimationManager>,
-    ffi.Pointer<TSceneAsset>,
-    ffi.Int,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Bool,
-    ffi.Float,
-    ffi.Float,
-    ffi.Float,
-  )
->(isLeaf: true)
-external bool AnimationManager_playGltfAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int index,
-  bool loop,
-  bool reverse,
-  bool replaceActive,
-  double crossfade,
-  double startOffset,
-  double speed,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external bool AnimationManager_stopGltfAnimation(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int index,
-);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int)>(isLeaf: true)
-external double AnimationManager_getGltfAnimationDuration(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int animationIndex,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external int AnimationManager_getGltfAnimationCount(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Pointer<ffi.Char>, ffi.Int)
->(isLeaf: true)
-external void AnimationManager_getGltfAnimationName(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  ffi.Pointer<ffi.Char> outPtr,
-  int index,
-);
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId)>(isLeaf: true)
-external int AnimationManager_getMorphTargetNameCount(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int childEntity,
-);
-
-@ffi.Native<
-  ffi.Void Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, EntityId, ffi.Pointer<ffi.Char>, ffi.Int)
->(isLeaf: true)
-external void AnimationManager_getMorphTargetName(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-  int childEntity,
-  ffi.Pointer<ffi.Char> outPtr,
-  int index,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>)>(isLeaf: true)
-external bool AnimationManager_updateBoneMatrices(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> sceneAsset,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, EntityId, ffi.Pointer<ffi.Float>, ffi.Int)>(isLeaf: true)
-external bool AnimationManager_setMorphTargetWeights(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  int entityId,
-  ffi.Pointer<ffi.Float> morphData,
-  int numWeights,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TAnimationManager>, ffi.Pointer<TSceneAsset>, ffi.Int, ffi.Float)>(
+@ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>, ffi.Pointer<ffi.Int16>, ffi.Size, ffi.Size)>(
   isLeaf: true,
 )
-external bool AnimationManager_setGltfAnimationTime(
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-  ffi.Pointer<TSceneAsset> tSceneAsset,
-  int animationIndex,
-  double timeInSeconds,
+external void SurfaceOrientation_getQuats_short4(
+  ffi.Pointer<TSurfaceOrientation> orientation,
+  ffi.Pointer<ffi.Int16> out,
+  int quatCount,
+  int stride,
 );
 
+@ffi.Native<ffi.Size Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
+external int SurfaceOrientation_getVertexCount(ffi.Pointer<TSurfaceOrientation> orientation);
+
+@ffi.Native<ffi.Uint64>()
+external int TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
+
+@ffi.Native<ffi.Uint64>()
+external int TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
+
+@ffi.Native<ffi.Uint64>()
+external int TSWAP_CHAIN_CONFIG_READABLE;
+
+@ffi.Native<ffi.Uint64>()
+external int TSWAP_CHAIN_CONFIG_TRANSPARENT;
+
+@ffi.Native<ffi.Pointer<TTextureSampler> Function()>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_create();
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>)>(
+  isLeaf: true,
+)
+external void TextureSampler_createRenderThread(
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TTextureSampler> Function(ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc);
+
 @ffi.Native<
-  ffi.Pointer<TGltfAssetLoader> Function(
-    ffi.Pointer<TEngine>,
-    ffi.Pointer<TMaterialProvider>,
-    ffi.Pointer<TNameComponentManager>,
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>,
   )
 >(isLeaf: true)
-external ffi.Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TMaterialProvider> tMaterialProvider,
-  ffi.Pointer<TNameComponentManager> tNameComponentManager,
+external void TextureSampler_createWithComparisonRenderThread(
+  int compareMode,
+  int compareFunc,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external void GltfAssetLoader_destroy(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
+@ffi.Native<
+  ffi.Pointer<TTextureSampler> Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+);
 
 @ffi.Native<
-  ffi.Pointer<TFilamentAsset> Function(
+  ffi.Void Function(
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>>,
+  )
+>(isLeaf: true)
+external void TextureSampler_createWithFilteringRenderThread(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTextureSampler>)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>)>(isLeaf: true)
+external void TextureSampler_destroy(ffi.Pointer<TTextureSampler> sampler);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TextureSampler_destroyRenderThread(
+  ffi.Pointer<TTextureSampler> sampler,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double)>(isLeaf: true)
+external void TextureSampler_setAnisotropy(ffi.Pointer<TTextureSampler> sampler, double anisotropy);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.Double, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TextureSampler_setAnisotropyRenderThread(
+  ffi.Pointer<TTextureSampler> sampler,
+  double anisotropy,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setCompareMode(ffi.Pointer<TTextureSampler> sampler, int mode, int func);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.UnsignedInt, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
+external void TextureSampler_setCompareModeRenderThread(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+  int func,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setMagFilter(ffi.Pointer<TTextureSampler> sampler, int filter);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TextureSampler_setMagFilterRenderThread(
+  ffi.Pointer<TTextureSampler> sampler,
+  int filter,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setMinFilter(ffi.Pointer<TTextureSampler> sampler, int filter);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TextureSampler_setMinFilterRenderThread(
+  ffi.Pointer<TTextureSampler> sampler,
+  int filter,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setWrapModeR(ffi.Pointer<TTextureSampler> sampler, int mode);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TextureSampler_setWrapModeRRenderThread(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setWrapModeS(ffi.Pointer<TTextureSampler> sampler, int mode);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TextureSampler_setWrapModeSRenderThread(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt)>(isLeaf: true)
+external void TextureSampler_setWrapModeT(ffi.Pointer<TTextureSampler> sampler, int mode);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTextureSampler>, ffi.UnsignedInt, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TextureSampler_setWrapModeTRenderThread(
+  ffi.Pointer<TTextureSampler> sampler,
+  int mode,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<
+  ffi.Pointer<TTexture> Function(
     ffi.Pointer<TEngine>,
-    ffi.Pointer<TGltfAssetLoader>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint8,
+    ffi.Uint16,
+    ffi.IntPtr,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TTexture> Texture_build(
+  ffi.Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import$,
+  int sampler,
+  int format,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint8,
+    ffi.Uint16,
+    ffi.IntPtr,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>>,
+  )
+>(isLeaf: true)
+external void Texture_buildRenderThread(
+  ffi.Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import$,
+  int sampler,
+  int format,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TTexture>)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external void Texture_generateMipMaps(ffi.Pointer<TTexture> tTexture, ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTexture>, ffi.Pointer<TEngine>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void Texture_generateMipMapsRenderThread(
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TEngine> tEngine,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
+external int Texture_getDepth(ffi.Pointer<TTexture> tTexture, int level);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>)>(isLeaf: true)
+external int Texture_getFormat(ffi.Pointer<TTexture> tTexture);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
+external int Texture_getHeight(ffi.Pointer<TTexture> tTexture, int level);
+
+@ffi.Native<ffi.Size Function(ffi.Pointer<TTexture>)>(isLeaf: true)
+external int Texture_getLevels(ffi.Pointer<TTexture> tTexture);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
+external int Texture_getUsage(ffi.Pointer<TTexture> tTexture, int level);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TTexture>, ffi.Uint32)>(isLeaf: true)
+external int Texture_getWidth(ffi.Pointer<TTexture> tTexture, int level);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TLinearImage>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Int,
+  )
+>(isLeaf: true)
+external bool Texture_loadImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+);
+
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Pointer<TLinearImage>,
+    ffi.UnsignedInt,
+    ffi.UnsignedInt,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
+>(isLeaf: true)
+external void Texture_loadImageRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void Texture_setExternalImage(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<ffi.Void> externalImage,
+);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<ffi.Void>, ffi.Uint32, VoidCallback)
+>(isLeaf: true)
+external void Texture_setExternalImageRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TTexture> tTexture,
+  ffi.Pointer<ffi.Void> externalImage,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<
+  ffi.Bool Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Uint32,
     ffi.Pointer<ffi.Uint8>,
     ffi.Size,
     ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
   )
 >(isLeaf: true)
-external ffi.Pointer<TFilamentAsset> GltfAssetLoader_load(
+external bool Texture_setImage(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfAssetLoader> tAssetLoader,
+  ffi.Pointer<TTexture> tTexture,
+  int level,
   ffi.Pointer<ffi.Uint8> data,
-  int length,
-  int numInstances,
+  int size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
 );
-
-@ffi.Native<ffi.Pointer<TMaterialInstance> Function(ffi.Pointer<TRenderableManager>, ffi.Pointer<TFilamentAsset>)>(
-  isLeaf: true,
-)
-external ffi.Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  ffi.Pointer<TRenderableManager> tRenderableManager,
-  ffi.Pointer<TFilamentAsset> tAsset,
-);
-
-@ffi.Native<ffi.Pointer<TMaterialProvider> Function(ffi.Pointer<TGltfAssetLoader>)>(isLeaf: true)
-external ffi.Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(ffi.Pointer<TGltfAssetLoader> tAssetLoader);
-
-@ffi.Native<ffi.Int32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getResourceUriCount(ffi.Pointer<TFilamentAsset> tFilamentAsset);
-
-@ffi.Native<ffi.Pointer<ffi.Pointer<ffi.Char>> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Pointer<ffi.Char>> FilamentAsset_getResourceUris(ffi.Pointer<TFilamentAsset> tFilamentAsset);
-
-@ffi.Native<ffi.Pointer<TGltfResourceLoader> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
-external ffi.Pointer<TGltfResourceLoader> GltfResourceLoader_create(ffi.Pointer<TEngine> tEngine);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_destroy(
-  ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external bool GltfResourceLoader_asyncBeginLoad(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external void GltfResourceLoader_asyncUpdateLoad(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
-
-@ffi.Native<ffi.Float Function(ffi.Pointer<TGltfResourceLoader>)>(isLeaf: true)
-external double GltfResourceLoader_asyncGetLoadProgress(ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader);
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Uint8>, ffi.Size)
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TTexture>,
+    ffi.Uint32,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Uint32,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>,
+  )
 >(isLeaf: true)
-external void GltfResourceLoader_addResourceData(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<ffi.Char> uri,
-  ffi.Pointer<ffi.Uint8> data,
-  int length,
-);
-
-@ffi.Native<ffi.Bool Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external bool GltfResourceLoader_loadResources(
-  ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  ffi.Pointer<TFilamentAsset> tFilamentAsset,
-);
-
-@ffi.Native<ffi.Pointer<TRenderManager> Function(ffi.Pointer<TEngine>, ffi.Pointer<TRenderer>)>(isLeaf: true)
-external ffi.Pointer<TRenderManager> RenderManager_create(
+external void Texture_setImageRenderThread(
   ffi.Pointer<TEngine> tEngine,
-  ffi.Pointer<TRenderer> tRenderer,
+  ffi.Pointer<TTexture> tTexture,
+  int level,
+  ffi.Pointer<ffi.Uint8> data,
+  int size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACES(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_addAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TAnimationManager>)>(isLeaf: true)
-external void RenderManager_removeAnimationManager(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TAnimationManager> tAnimationManager,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint64)>(isLeaf: true)
-external void RenderManager_render(ffi.Pointer<TRenderManager> tRenderer, int frameTimeInNanos);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createACESLegacy(ffi.Pointer<TEngine> tEngine);
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>, ffi.Pointer<ffi.Pointer<TView>>, ffi.Uint8)
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
 >(isLeaf: true)
-external void RenderManager_setRenderable(
-  ffi.Pointer<TRenderManager> tRenderer,
-  ffi.Pointer<TSwapChain> swapChain,
-  ffi.Pointer<ffi.Pointer<TView>> views,
-  int numViews,
+external void ToneMapper_createACESLegacyRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Pointer<TSwapChain>)>(isLeaf: true)
-external void RenderManager_removeSwapChain(ffi.Pointer<TRenderManager> tRenderer, ffi.Pointer<TSwapChain> swapChain);
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
+external void ToneMapper_createACESRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(ffi.Pointer<TRenderManager> tRenderer);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGX(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_attachToRenderThread(ffi.Pointer<TRenderManager> tRenderer);
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
+external void ToneMapper_createAGXRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_detachFromRenderThread(ffi.Pointer<TRenderManager> tRenderManager);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Int)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createAGXWithLook(ffi.Pointer<TEngine> tEngine, int look);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(isLeaf: true)
-external void RenderManager_setPaused(ffi.Pointer<TRenderManager> tRenderer, bool paused);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Int,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>,
+  )
+>(isLeaf: true)
+external void ToneMapper_createAGXWithLookRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  int look,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+);
 
-@ffi.Native<ffi.Uint32 Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getEntityCount(ffi.Pointer<TFilamentAsset> filamentAsset);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createDisplayRange(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TFilamentAsset>, ffi.Pointer<EntityId>)>(isLeaf: true)
-external void FilamentAsset_getEntities(ffi.Pointer<TFilamentAsset> filamentAsset, ffi.Pointer<EntityId> out);
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
+external void ToneMapper_createDisplayRangeRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+);
 
-@ffi.Native<EntityId Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external int FilamentAsset_getWireframe(ffi.Pointer<TFilamentAsset> filamentAsset);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createFilmic(ffi.Pointer<TEngine> tEngine);
 
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external ffi.Pointer<ffi.Void> FilamentAsset_getSourceAsset(ffi.Pointer<TFilamentAsset> filamentAsset);
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
+external void ToneMapper_createFilmicRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_addEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, EntityId)>(isLeaf: true)
-external void Scene_removeEntity(ffi.Pointer<TScene> tScene, int entityId);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TSkybox>)>(isLeaf: true)
-external void Scene_setSkybox(ffi.Pointer<TScene> tScene, ffi.Pointer<TSkybox> skybox);
-
-@ffi.Native<ffi.Pointer<TSkybox> Function(ffi.Pointer<TScene>)>(isLeaf: true)
-external ffi.Pointer<TSkybox> Scene_getSkybox(ffi.Pointer<TScene> tScene);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TIndirectLight>)>(isLeaf: true)
-external void Scene_setIndirectLight(ffi.Pointer<TScene> tScene, ffi.Pointer<TIndirectLight> tIndirectLight);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TScene>, ffi.Pointer<TFilamentAsset>)>(isLeaf: true)
-external void Scene_addFilamentAsset(ffi.Pointer<TScene> tScene, ffi.Pointer<TFilamentAsset> asset);
-
-@ffi.Native<ffi.Void Function(FrameTickCallback, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-
-@ffi.Native<ffi.Void Function()>()
-external void FrameScheduler_stop();
-
-@ffi.Native<ffi.Int Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int FrameScheduler_initDartApi(ffi.Pointer<ffi.Void> data);
-
-@ffi.Native<ffi.Void Function(ffi.Int64, ffi.Int)>(isLeaf: true)
-external void FrameScheduler_startWithPort(int port, int targetFps);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void FrameScheduler_setTargetFps(int fps);
-
-@ffi.Native<ffi.Int64 Function()>(isLeaf: true)
-external int FrameScheduler_steadyClockUs();
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
-external void MovementIntentExecutor_destroy(ffi.Pointer<TMovementIntentExecutor> executor);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>, ffi.Pointer<TMovementIntent>, ffi.Uint64)>(
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>, ffi.Float, ffi.Float, ffi.Float, ffi.Float)>(
   isLeaf: true,
 )
-external void MovementIntentExecutor_process(
-  ffi.Pointer<TMovementIntentExecutor> executor,
-  ffi.Pointer<TMovementIntent> intent,
-  int deltaTimeInNanos,
+external ffi.Pointer<TToneMapper> ToneMapper_createGeneric(
+  ffi.Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TMovementIntentExecutor>)>(isLeaf: true)
-external void Pipeline_registerMovementIntentExecutor(ffi.Pointer<TMovementIntentExecutor> executor);
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Float,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>,
+  )
+>(isLeaf: true)
+external void ToneMapper_createGenericRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+);
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void TransformPipeline_setEngine(ffi.Pointer<ffi.Void> enginePtr);
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createLinear(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
+external void ToneMapper_createLinearRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+);
+
+@ffi.Native<ffi.Pointer<TToneMapper> Function(ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TToneMapper> ToneMapper_createPBRNeutral(ffi.Pointer<TEngine> tEngine);
+
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>>)
+>(isLeaf: true)
+external void ToneMapper_createPBRNeutralRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TToneMapper>)>> onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>)>(isLeaf: true)
+external void ToneMapper_destroy(ffi.Pointer<TToneMapper> toneMapper);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TToneMapper>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void ToneMapper_destroyRenderThread(
+  ffi.Pointer<TToneMapper> tToneMapper,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external void TransformManager_commitLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external void TransformManager_createComponent(ffi.Pointer<TTransformManager> tTransformManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TransformManager_createComponentRenderThread(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external bool TransformManager_empty(ffi.Pointer<TTransformManager> tTransformManager);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external int TransformManager_getAncestor(ffi.Pointer<TTransformManager> tTransformManager, int childEntityId);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external int TransformManager_getChildCount(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Pointer<EntityId>, ffi.Int)>(isLeaf: true)
+external void TransformManager_getChildren(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  ffi.Pointer<EntityId> children,
+  int count,
+);
+
+@ffi.Native<ffi.Int Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external int TransformManager_getComponentCount(ffi.Pointer<TTransformManager> tTransformManager);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external double4x4 TransformManager_getLocalTransform(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+
+@ffi.Native<EntityId Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external int TransformManager_getParent(ffi.Pointer<TTransformManager> tTransformManager, int child);
+
+@ffi.Native<double4x4 Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external double4x4 TransformManager_getWorldTransform(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external bool TransformManager_hasComponent(ffi.Pointer<TTransformManager> tTransformManager, int entityId);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>)>(isLeaf: true)
+external void TransformManager_openLocalTransformTransaction(ffi.Pointer<TTransformManager> tTransformManager);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId)>(isLeaf: true)
+external void TransformManager_removeComponent(ffi.Pointer<TTransformManager> tTransformManager, int entity);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void TransformManager_removeComponentRenderThread(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId, ffi.Bool)>(isLeaf: true)
+external void TransformManager_setParent(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int child,
+  int parent,
+  bool preserveScaling,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, EntityId, ffi.Bool, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void TransformManager_setParentRenderThread(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int child,
+  int parent,
+  bool preserveScaling,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4)>(isLeaf: true)
+external void TransformManager_setTransform(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  double4x4 transform,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TTransformManager>, EntityId, double4x4, ffi.Uint32, VoidCallback)>(
+  isLeaf: true,
+)
+external void TransformManager_setTransformRenderThread(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  double4x4 transform,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TTransformManager>, EntityId, Aabb3)>(isLeaf: true)
+external bool TransformManager_transformToUnitCube(
+  ffi.Pointer<TTransformManager> tTransformManager,
+  int entityId,
+  Aabb3 boundingBox,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Float)>(isLeaf: true)
+external void TransformPipeline_addKeyBinding(int logicalKey, int intentAction, double value);
+
+@ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Float)>(isLeaf: true)
+external void TransformPipeline_addMouseButtonBinding(int mouseButton, int intentAction, double value);
+
+@ffi.Native<ffi.Void Function()>(isLeaf: true)
+external void TransformPipeline_cleanup();
+
+@ffi.Native<ffi.Void Function()>(isLeaf: true)
+external void TransformPipeline_clearKeyBindings();
+
+@ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Int, ffi.Int)>(isLeaf: true)
+external void TransformPipeline_onKeyEvent(int eventType, int logicalKey, int physicalKey, int synthesized);
 
 @ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Double, ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
 external void TransformPipeline_onMouseEvent(
@@ -4791,14 +4342,8 @@ external void TransformPipeline_onMouseEvent(
   double deltaY,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Int, ffi.Int)>(isLeaf: true)
-external void TransformPipeline_onKeyEvent(int eventType, int logicalKey, int physicalKey, int synthesized);
-
 @ffi.Native<ffi.Void Function(ffi.Double, ffi.Double, ffi.Double)>(isLeaf: true)
 external void TransformPipeline_onScrollEvent(double localX, double localY, double delta);
-
-@ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_update(double deltaTime);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
 external void TransformPipeline_registerPipelineStage(
@@ -4806,174 +4351,490 @@ external void TransformPipeline_registerPipelineStage(
   ffi.Pointer<ffi.Char> name,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void TransformPipeline_unregisterPipelineStage(ffi.Pointer<ffi.Void> pipelineStageHandle);
-
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
-external void TransformPipeline_cleanup();
-
-@ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Float)>(isLeaf: true)
-external void TransformPipeline_addKeyBinding(int logicalKey, int intentAction, double value);
+@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
+external void TransformPipeline_removeKeyBindingsForAction(int intentAction);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
 external void TransformPipeline_removeKeyBindingsForKey(int logicalKey);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
-external void TransformPipeline_removeKeyBindingsForAction(int intentAction);
-
-@ffi.Native<ffi.Void Function()>(isLeaf: true)
-external void TransformPipeline_clearKeyBindings();
-
-@ffi.Native<ffi.Void Function(ffi.Int, ffi.Int, ffi.Float)>(isLeaf: true)
-external void TransformPipeline_addMouseButtonBinding(int mouseButton, int intentAction, double value);
-
-@ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
 external void TransformPipeline_removeMouseButtonBindings(int mouseButton);
 
-@ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
-external void TransformPipeline_setMouseSensitivity(double sensitivity);
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void TransformPipeline_setEngine(ffi.Pointer<ffi.Void> enginePtr);
 
 @ffi.Native<ffi.Void Function(ffi.Int)>(isLeaf: true)
 external void TransformPipeline_setInvertMouseY(int invert);
 
-typedef VoidCallbackFunction = ffi.Void Function(ffi.Int32 requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-typedef VoidCallback = ffi.Pointer<ffi.NativeFunction<VoidCallbackFunction>>;
-typedef EntityId = ffi.Int32;
-typedef DartEntityId = int;
+@ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
+external void TransformPipeline_setMouseSensitivity(double sensitivity);
 
-final class TCamera extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external void TransformPipeline_unregisterPipelineStage(ffi.Pointer<ffi.Void> pipelineStageHandle);
 
-final class TEngine extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Float)>(isLeaf: true)
+external void TransformPipeline_update(double deltaTime);
 
-final class TEntityManager extends ffi.Opaque {}
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.UnsignedInt,
+    ffi.Uint8,
+    ffi.UnsignedInt,
+    ffi.Uint32,
+    ffi.Uint8,
+  )
+>(isLeaf: true)
+external void VertexBufferBuilder_attribute(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  int bufferIndex,
+  int attributeType,
+  int byteOffset,
+  int byteStride,
+);
 
-final class TViewer extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint8)>(isLeaf: true)
+external void VertexBufferBuilder_bufferCount(ffi.Pointer<TVertexBufferBuilder> builder, int count);
 
-final class TSceneManager extends ffi.Opaque {}
+@ffi.Native<ffi.Pointer<TVertexBuffer> Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Pointer<TEngine>)>(isLeaf: true)
+external ffi.Pointer<TVertexBuffer> VertexBufferBuilder_build(
+  ffi.Pointer<TVertexBufferBuilder> builder,
+  ffi.Pointer<TEngine> engine,
+);
 
-final class TLightManager extends ffi.Opaque {}
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TVertexBufferBuilder>,
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>>,
+  )
+>(isLeaf: true)
+external void VertexBufferBuilder_buildRenderThread(
+  ffi.Pointer<TVertexBufferBuilder> tBuilder,
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TVertexBuffer>)>> onComplete,
+);
 
-final class TRenderManager extends ffi.Opaque {}
+@ffi.Native<ffi.Pointer<TVertexBufferBuilder> Function()>(isLeaf: true)
+external ffi.Pointer<TVertexBufferBuilder> VertexBufferBuilder_create();
 
-final class TRenderer extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
+external void VertexBufferBuilder_destroy(ffi.Pointer<TVertexBufferBuilder> builder);
 
-final class TFence extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Bool)>(isLeaf: true)
+external void VertexBufferBuilder_enableBufferObjects(ffi.Pointer<TVertexBufferBuilder> builder, bool enabled);
 
-final class TRenderTarget extends ffi.Opaque {}
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TVertexBufferBuilder>)>(isLeaf: true)
+external int VertexBufferBuilder_getStorageMode(ffi.Pointer<TVertexBufferBuilder> builder);
 
-final class TSwapChain extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.UnsignedInt, ffi.Bool)>(isLeaf: true)
+external void VertexBufferBuilder_normalized(ffi.Pointer<TVertexBufferBuilder> builder, int attribute, bool normalize);
 
-final class TView extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TVertexBufferBuilder>, ffi.Uint32)>(isLeaf: true)
+external void VertexBufferBuilder_vertexCount(ffi.Pointer<TVertexBufferBuilder> builder, int count);
 
-final class TGizmo extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
+external void VertexBuffer_destroy(ffi.Pointer<TEngine> engine, ffi.Pointer<TVertexBuffer> buffer);
 
-final class TScene extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void VertexBuffer_destroyRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tBuffer,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-final class TSkybox extends ffi.Opaque {}
+@ffi.Native<ffi.Size Function(ffi.Pointer<TVertexBuffer>)>(isLeaf: true)
+external int VertexBuffer_getVertexCount(ffi.Pointer<TVertexBuffer> buffer);
 
-final class TIndirectLight extends ffi.Opaque {}
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+  )
+>(isLeaf: true)
+external void VertexBuffer_setBufferAt(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TVertexBuffer> buffer,
+  int bufferIndex,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+);
 
-final class TTransformManager extends ffi.Opaque {}
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<ffi.Void>,
+    ffi.Size,
+    ffi.Uint32,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void VertexBuffer_setBufferAtRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tBuffer,
+  int bufferIndex,
+  ffi.Pointer<ffi.Void> data,
+  int sizeInBytes,
+  int byteOffset,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-final class TAnimationManager extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TEngine>, ffi.Pointer<TVertexBuffer>, ffi.Uint8, ffi.Pointer<TBufferObject>)>(
+  isLeaf: true,
+)
+external void VertexBuffer_setBufferObjectAt(
+  ffi.Pointer<TEngine> engine,
+  ffi.Pointer<TVertexBuffer> buffer,
+  int bufferIndex,
+  ffi.Pointer<TBufferObject> bufferObject,
+);
 
-final class TSceneAsset extends ffi.Opaque {}
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TEngine>,
+    ffi.Pointer<TVertexBuffer>,
+    ffi.Uint8,
+    ffi.Pointer<TBufferObject>,
+    ffi.Uint32,
+    VoidCallback,
+  )
+>(isLeaf: true)
+external void VertexBuffer_setBufferObjectAtRenderThread(
+  ffi.Pointer<TEngine> tEngine,
+  ffi.Pointer<TVertexBuffer> tBuffer,
+  int bufferIndex,
+  ffi.Pointer<TBufferObject> tBufferObject,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-final class TNameComponentManager extends ffi.Opaque {}
+@ffi.Native<TAmbientOcclusionOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TAmbientOcclusionOptions View_getAmbientOcclusionOptions(ffi.Pointer<TView> tView);
 
-final class TMaterial extends ffi.Opaque {}
+@ffi.Native<ffi.Pointer<TCamera> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TCamera> View_getCamera(ffi.Pointer<TView> tView);
 
-final class TMaterialInstance extends ffi.Opaque {}
+@ffi.Native<ffi.Pointer<TColorGrading> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TColorGrading> View_getColorGrading(ffi.Pointer<TView> tView);
 
-final class TMaterialProvider extends ffi.Opaque {}
+@ffi.Native<TFogOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TFogOptions View_getFogOptions(ffi.Pointer<TView> tView);
 
-final class TRenderableManager extends ffi.Opaque {}
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<ffi.Char> View_getName(ffi.Pointer<TView> tView);
 
-final class TRenderableInstance extends ffi.Opaque {}
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>)
+>(isLeaf: true)
+external void View_getNameRenderThread(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>> onComplete,
+);
 
-final class TTexture extends ffi.Opaque {}
+@ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TRenderTarget> View_getRenderTarget(ffi.Pointer<TView> tView);
 
-final class TTextureSampler extends ffi.Opaque {}
+@ffi.Native<ffi.Pointer<TScene> Function(ffi.Pointer<TView>)>(isLeaf: true)
+external ffi.Pointer<TScene> View_getScene(ffi.Pointer<TView> tView);
 
-final class TLinearImage extends ffi.Opaque {}
+@ffi.Native<ffi.Int Function(ffi.Pointer<TView>)>(isLeaf: true)
+external int View_getShadowType(ffi.Pointer<TView> tView);
 
-final class TGltfAssetLoader extends ffi.Opaque {}
+@ffi.Native<TSoftShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TSoftShadowOptions View_getSoftShadowOptions(ffi.Pointer<TView> tView);
 
-final class TGltfResourceLoader extends ffi.Opaque {}
+@ffi.Native<TViewport Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TViewport View_getViewport(ffi.Pointer<TView> view);
 
-final class TFilamentAsset extends ffi.Opaque {}
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<TView>)>(isLeaf: true)
+external int View_getVisibleRenderableCount(ffi.Pointer<TView> view);
 
-final class TColorGrading extends ffi.Opaque {}
+@ffi.Native<TVsmShadowOptions Function(ffi.Pointer<TView>)>(isLeaf: true)
+external TVsmShadowOptions View_getVsmShadowOptions(ffi.Pointer<TView> tView);
 
-final class TKtx1Bundle extends ffi.Opaque {}
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isDitheringEnabled(ffi.Pointer<TView> tView);
 
-final class TDebugRegistry extends ffi.Opaque {}
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isStencilBufferEnabled(ffi.Pointer<TView> tView);
 
-final class TRenderableBuilder extends ffi.Opaque {}
+@ffi.Native<ffi.Bool Function(ffi.Pointer<TView>)>(isLeaf: true)
+external bool View_isTransparentPickingEnabled(ffi.Pointer<TView> tView);
 
-final class TVertexBuffer extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
+external void View_pick(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
 
-final class TIndexBuffer extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, PickCallback)>(isLeaf: true)
+external void View_pickRenderThread(ffi.Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
 
-final class TVertexBufferBuilder extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions)>(isLeaf: true)
+external void View_setAmbientOcclusionOptions(ffi.Pointer<TView> tView, TAmbientOcclusionOptions options);
 
-final class TIndexBufferBuilder extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TAmbientOcclusionOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setAmbientOcclusionOptionsRenderThread(
+  ffi.Pointer<TView> tView,
+  TAmbientOcclusionOptions options,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-final class TBufferObject extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool)>(isLeaf: true)
+external void View_setAntiAliasing(ffi.Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
 
-final class TBufferObjectBuilder extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Bool, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setAntiAliasingRenderThread(
+  ffi.Pointer<TView> tView,
+  bool msaa,
+  bool fxaa,
+  bool taa,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-final class TSurfaceOrientation extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
+external void View_setBlendMode(ffi.Pointer<TView> view, int blendMode);
 
-final class TSurfaceOrientationBuilder extends ffi.Opaque {}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setBlendModeRenderThread(
+  ffi.Pointer<TView> tView,
+  int blendMode,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-final class double3 extends ffi.Struct {
-  @ffi.Double()
-  external double x;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Float)>(isLeaf: true)
+external void View_setBloom(ffi.Pointer<TView> tView, bool enabled, double strength);
 
-  @ffi.Double()
-  external double y;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Double, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setBloomRenderThread(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  double strength,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-  @ffi.Double()
-  external double z;
-}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>)>(isLeaf: true)
+external void View_setCamera(ffi.Pointer<TView> tView, ffi.Pointer<TCamera> tCamera);
 
-final class double3x3 extends ffi.Struct {
-  external double3 col1;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TCamera>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setCameraRenderThread(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TCamera> tCamera,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-  external double3 col2;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>)>(isLeaf: true)
+external void View_setColorGrading(ffi.Pointer<TView> tView, ffi.Pointer<TColorGrading> tColorGrading);
 
-  external double3 col3;
-}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TColorGrading>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setColorGradingRenderThread(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TColorGrading> tColorGrading,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-final class double4 extends ffi.Struct {
-  @ffi.Double()
-  external double x;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setDitheringEnabled(ffi.Pointer<TView> tView, bool enabled);
 
-  @ffi.Double()
-  external double y;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setDitheringEnabledRenderThread(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-  @ffi.Double()
-  external double z;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions)>(isLeaf: true)
+external void View_setFogOptions(ffi.Pointer<TView> tView, TFogOptions tFogOptions);
 
-  @ffi.Double()
-  external double w;
-}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TFogOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setFogOptionsRenderThread(
+  ffi.Pointer<TView> tView,
+  TFogOptions tFogOptions,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-final class double4x4 extends ffi.Struct {
-  @ffi.Array.multi([4])
-  external ffi.Array<ffi.Double> col1;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrontFaceWindingInverted(ffi.Pointer<TView> tView, bool inverted);
 
-  @ffi.Array.multi([4])
-  external ffi.Array<ffi.Double> col2;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setFrontFaceWindingInvertedRenderThread(
+  ffi.Pointer<TView> tView,
+  bool inverted,
+  int requestId,
+  VoidCallback onComplete,
+);
 
-  @ffi.Array.multi([4])
-  external ffi.Array<ffi.Double> col3;
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setFrustumCullingEnabled(ffi.Pointer<TView> view, bool enabled);
 
-  @ffi.Array.multi([4])
-  external ffi.Array<ffi.Double> col4;
-}
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setFrustumCullingEnabledRenderThread(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool)>(isLeaf: true)
+external void View_setLayerEnabled(ffi.Pointer<TView> tView, int layer, bool visible);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setLayerEnabledRenderThread(
+  ffi.Pointer<TView> tView,
+  int layer,
+  bool visible,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external void View_setName(ffi.Pointer<TView> tView, ffi.Pointer<ffi.Char> name);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<ffi.Char>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setNameRenderThread(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<ffi.Char> name,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setPostProcessing(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setPostProcessingRenderThread(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.UnsignedInt)>(isLeaf: true)
+external void View_setRenderQuality(ffi.Pointer<TView> tView, int qualityLevel);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setRenderQualityRenderThread(
+  ffi.Pointer<TView> tView,
+  int qualityLevel,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>)>(isLeaf: true)
+external void View_setRenderTarget(ffi.Pointer<TView> view, ffi.Pointer<TRenderTarget> renderTarget);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TRenderTarget>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setRenderTargetRenderThread(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TRenderTarget> tRenderTarget,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>)>(isLeaf: true)
+external void View_setScene(ffi.Pointer<TView> tView, ffi.Pointer<TScene> tScene);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Pointer<TScene>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setSceneRenderThread(
+  ffi.Pointer<TView> tView,
+  ffi.Pointer<TScene> tScene,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int)>(isLeaf: true)
+external void View_setShadowType(ffi.Pointer<TView> tView, int shadowType);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Int, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setShadowTypeRenderThread(
+  ffi.Pointer<TView> tView,
+  int shadowType,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setShadowsEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setShadowsEnabledRenderThread(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions)>(isLeaf: true)
+external void View_setSoftShadowOptions(ffi.Pointer<TView> tView, TSoftShadowOptions options);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TSoftShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setSoftShadowOptionsRenderThread(
+  ffi.Pointer<TView> tView,
+  TSoftShadowOptions options,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setStencilBufferEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setStencilBufferEnabledRenderThread(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool)>(isLeaf: true)
+external void View_setTransparentPickingEnabled(ffi.Pointer<TView> tView, bool enabled);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Bool, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setTransparentPickingEnabledRenderThread(
+  ffi.Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32)>(isLeaf: true)
+external void View_setViewport(ffi.Pointer<TView> view, int width, int height);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, ffi.Uint32, ffi.Uint32, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setViewportRenderThread(
+  ffi.Pointer<TView> tView,
+  int width,
+  int height,
+  int requestId,
+  VoidCallback onComplete,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions)>(isLeaf: true)
+external void View_setVsmShadowOptions(ffi.Pointer<TView> tView, TVsmShadowOptions options);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<TView>, TVsmShadowOptions, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void View_setVsmShadowOptionsRenderThread(
+  ffi.Pointer<TView> tView,
+  TVsmShadowOptions options,
+  int requestId,
+  VoidCallback onComplete,
+);
 
 final class Aabb2 extends ffi.Struct {
   @ffi.Float()
@@ -5009,310 +4870,41 @@ final class Aabb3 extends ffi.Struct {
   external double halfExtentZ;
 }
 
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
-}
-
-sealed class TVertexBufferStorageMode {
-  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
-  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
-  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
-}
-
-sealed class TSceneAssetGeometryCapability {
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_NONE = 0;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_BARYCENTRICS = 1;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_WRITABLE_VERTICES = 2;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_ACCESSIBLE_GEOMETRY_BUFFERS = 4;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_PRESERVED_TOPOLOGY = 8;
-  static const SCENE_ASSET_GEOMETRY_CAPABILITY_UNIQUE_TRIANGLE_CORNERS = 16;
-}
-
-sealed class TFeatureLevel {
-  static const FEATURE_LEVEL_0 = 0;
-  static const FEATURE_LEVEL_1 = 1;
-  static const FEATURE_LEVEL_2 = 2;
-  static const FEATURE_LEVEL_3 = 3;
-}
-
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
-}
-
-sealed class TVertexAttribute {
-  static const TVERTEX_ATTRIBUTE_POSITION = 0;
-  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
-  static const TVERTEX_ATTRIBUTE_COLOR = 2;
-  static const TVERTEX_ATTRIBUTE_UV0 = 3;
-  static const TVERTEX_ATTRIBUTE_UV1 = 4;
-  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
-  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
-  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
-  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
-  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
-  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
-  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
-  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
-  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
-  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
-}
-
-sealed class TVertexAttributeType {
-  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
-  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
-  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
-  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
-  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
-  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
-  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
-}
-
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-final class TViewport extends ffi.Struct {
-  @ffi.Int32()
-  external int left;
-
-  @ffi.Int32()
-  external int bottom;
-
-  @ffi.Uint32()
-  external int width;
-
-  @ffi.Uint32()
-  external int height;
-}
-
-/// Copied from FogOptions in View.h
-final class TFogOptions extends ffi.Struct {
-  @ffi.Float()
-  external double distance;
-
-  @ffi.Float()
-  external double cutOffDistance;
-
-  @ffi.Float()
-  external double maximumOpacity;
-
-  @ffi.Float()
-  external double height;
-
-  @ffi.Float()
-  external double heightFalloff;
-
-  @ffi.Float()
-  external double density;
-
-  @ffi.Float()
-  external double inScatteringStart;
-
-  @ffi.Float()
-  external double inScatteringSize;
-
-  external ffi.Pointer<TTexture> skyColor;
-
-  @ffi.Float()
-  external double linearColorR;
-
-  @ffi.Float()
-  external double linearColorG;
-
-  @ffi.Float()
-  external double linearColorB;
-
-  @ffi.Bool()
-  external bool fogColorFromIbl;
-
-  @ffi.Bool()
-  external bool enabled;
-}
-
-final class TToneMapper extends ffi.Opaque {}
-
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
-}
-
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
-}
-
-sealed class TLutFormat {
-  static const INTEGER = 0;
-  static const FLOAT = 1;
-}
-
-final class TColorGradingBuilder extends ffi.Opaque {}
-
-/// Options for DPCF and PCSS Shadowing.
-final class TSoftShadowOptions extends ffi.Struct {
-  @ffi.Float()
-  external double penumbraScale;
-
-  @ffi.Float()
-  external double penumbraRatioScale;
-
-  @ffi.Float()
-  external double maxPenumbraRatio;
-
-  @ffi.Float()
-  external double maxSearchRadius;
-}
-
-/// Options for VSM Shadowing.
-final class TVsmShadowOptions extends ffi.Struct {
-  @ffi.Uint8()
-  external int anisotropy;
-
-  @ffi.Bool()
-  external bool mipmapping;
-
-  @ffi.Uint8()
-  external int msaaSamples;
-
-  @ffi.Bool()
-  external bool highPrecision;
-
-  @ffi.Float()
-  external double minVarianceScale;
-
-  @ffi.Float()
-  external double lightBleedReduction;
-}
-
-/// Screen Space Cone Tracing (SSCT) options
-/// Ambient shadows from dominant light
-final class TSsct extends ffi.Struct {
-  /// !< full cone angle in radian, between 0 and pi/2
-  @ffi.Float()
-  external double lightConeRad;
-
-  /// !< how far shadows can be cast
-  @ffi.Float()
-  external double shadowDistance;
-
-  /// !< max distance for contact
-  @ffi.Float()
-  external double contactDistanceMax;
-
-  /// !< intensity
-  @ffi.Float()
-  external double intensity;
-
-  /// !< light direction X
-  @ffi.Float()
-  external double lightDirectionX;
-
-  /// !< light direction Y
-  @ffi.Float()
-  external double lightDirectionY;
-
-  /// !< light direction Z
-  @ffi.Float()
-  external double lightDirectionZ;
-
-  /// !< depth bias in world units (mitigate self shadowing)
-  @ffi.Float()
-  external double depthBias;
-
-  /// !< depth slope bias (mitigate self shadowing)
-  @ffi.Float()
-  external double depthSlopeBias;
-
-  /// !< tracing sample count, between 1 and 255
-  @ffi.Uint8()
-  external int sampleCount;
-
-  /// !< # of rays to trace, between 1 and 255
-  @ffi.Uint8()
-  external int rayCount;
-
-  /// !< enables or disables SSCT
-  @ffi.Bool()
-  external bool enabled;
-}
-
-sealed class TAmbientOcclusionType {
-  static const SAO = 0;
-  static const GTAO = 1;
-}
-
-/// Ground Truth-based Ambient Occlusion (GTAO) options
-final class TGtao extends ffi.Struct {
-  /// !< number of slices; higher values reduce noise
-  @ffi.Uint8()
-  external int sampleSliceCount;
-
-  /// !< integration steps per slice; higher values reduce bias
-  @ffi.Uint8()
-  external int sampleStepsPerSlice;
-
-  /// !< ignored when visibility bitmasks are enabled
-  @ffi.Float()
-  external double thicknessHeuristic;
-
-  /// !< enables visibility bitmasks mode
-  @ffi.Bool()
-  external bool useVisibilityBitmasks;
-
-  /// !< world-space thickness used by visibility bitmasks
-  @ffi.Float()
-  external double constThickness;
-
-  /// !< increases thickness with distance
-  @ffi.Bool()
-  external bool linearThickness;
-}
+typedef EntityId = ffi.Int32;
+typedef DartEntityId = int;
+typedef FilamentRenderCallback = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
+typedef FilamentRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> owner);
+typedef DartFilamentRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> owner);
+typedef FrameTickCallback = ffi.Pointer<ffi.NativeFunction<FrameTickCallbackFunction>>;
+typedef FrameTickCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(int frameTimeNanos);
+typedef GizmoPickCallback = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction =
+    ffi.Void Function(ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+
+const int JUMP_INTENT_MASK = 4;
+
+const int MAX_CUSTOM_INTENTS = 16;
+
+const int MOVEMENT_INTENT_MASK = 1;
+
+typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
+typedef PickCallbackFunction =
+    ffi.Void Function(
+      ffi.Uint32 requestId,
+      EntityId entityId,
+      ffi.Float depth,
+      ffi.Float fragX,
+      ffi.Float fragY,
+      ffi.Float fragZ,
+    );
+typedef DartPickCallbackFunction =
+    void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
+
+const int ROTATION_INTENT_MASK = 2;
+
+const int SPRINT_INTENT_MASK = 8;
 
 /// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
 final class TAmbientOcclusionOptions extends ffi.Struct {
@@ -5373,18 +4965,125 @@ final class TAmbientOcclusionOptions extends ffi.Struct {
   external int aoType;
 }
 
-typedef PickCallbackFunction =
-    ffi.Void Function(
-      ffi.Uint32 requestId,
-      EntityId entityId,
-      ffi.Float depth,
-      ffi.Float fragX,
-      ffi.Float fragY,
-      ffi.Float fragZ,
-    );
-typedef DartPickCallbackFunction =
-    void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
-typedef PickCallback = ffi.Pointer<ffi.NativeFunction<PickCallbackFunction>>;
+sealed class TAmbientOcclusionType {
+  static const SAO = 0;
+  static const GTAO = 1;
+}
+
+final class TAnimationManager extends ffi.Opaque {}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
+}
+
+sealed class TBlendingMode {
+  static const BLENDING_MODE_OPAQUE = 0;
+  static const BLENDING_MODE_TRANSPARENT = 1;
+  static const BLENDING_MODE_ADD = 2;
+  static const BLENDING_MODE_MASKED = 3;
+  static const BLENDING_MODE_FADE = 4;
+  static const BLENDING_MODE_MULTIPLY = 5;
+  static const BLENDING_MODE_SCREEN = 6;
+  static const BLENDING_MODE_CUSTOM = 7;
+}
+
+final class TBufferObject extends ffi.Opaque {}
+
+final class TBufferObjectBuilder extends ffi.Opaque {}
+
+final class TCamera extends ffi.Opaque {}
+
+final class TColorGrading extends ffi.Opaque {}
+
+final class TColorGradingBuilder extends ffi.Opaque {}
+
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
+final class TDebugRegistry extends ffi.Opaque {}
+
+final class TEngine extends ffi.Opaque {}
+
+final class TEntityManager extends ffi.Opaque {}
+
+sealed class TFeatureLevel {
+  static const FEATURE_LEVEL_0 = 0;
+  static const FEATURE_LEVEL_1 = 1;
+  static const FEATURE_LEVEL_2 = 2;
+  static const FEATURE_LEVEL_3 = 3;
+}
+
+final class TFence extends ffi.Opaque {}
+
+final class TFilamentAsset extends ffi.Opaque {}
+
+/// Copied from FogOptions in View.h
+final class TFogOptions extends ffi.Struct {
+  @ffi.Float()
+  external double distance;
+
+  @ffi.Float()
+  external double cutOffDistance;
+
+  @ffi.Float()
+  external double maximumOpacity;
+
+  @ffi.Float()
+  external double height;
+
+  @ffi.Float()
+  external double heightFalloff;
+
+  @ffi.Float()
+  external double density;
+
+  @ffi.Float()
+  external double inScatteringStart;
+
+  @ffi.Float()
+  external double inScatteringSize;
+
+  external ffi.Pointer<TTexture> skyColor;
+
+  @ffi.Float()
+  external double linearColorR;
+
+  @ffi.Float()
+  external double linearColorG;
+
+  @ffi.Float()
+  external double linearColorB;
+
+  @ffi.Bool()
+  external bool fogColorFromIbl;
+
+  @ffi.Bool()
+  external bool enabled;
+}
+
+final class TGizmo extends ffi.Opaque {}
 
 sealed class TGizmoAxis {
   static const X = 0;
@@ -5400,90 +5099,103 @@ sealed class TGizmoPickResultType {
   static const None = 4;
 }
 
-typedef GizmoPickCallbackFunction =
-    ffi.Void Function(ffi.UnsignedInt resultType, ffi.Float x, ffi.Float y, ffi.Float z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef GizmoPickCallback = ffi.Pointer<ffi.NativeFunction<GizmoPickCallbackFunction>>;
-
-sealed class TSamplerCompareFunc {
-  /// !< Less or equal
-  static const LE = 0;
-
-  /// !< Greater or equal
-  static const GE = 1;
-
-  /// !< Strictly less than
-  static const L = 2;
-
-  /// !< Strictly greater than
-  static const G = 3;
-
-  /// !< Equal
-  static const E = 4;
-
-  /// !< Not equal
-  static const NE = 5;
-
-  /// !< Always. Depth / stencil testing is deactivated.
-  static const A = 6;
-
-  /// !< Never. The depth / stencil test always fails.
-  static const N = 7;
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
 }
 
-sealed class TStencilOperation {
-  static const KEEP = 0;
-  static const ZERO = 1;
-  static const REPLACE = 2;
-  static const INCR = 3;
-  static const INCR_WRAP = 4;
-  static const DECR = 5;
-  static const DECR_WRAP = 6;
-  static const INVERT = 7;
+final class TGltfAssetLoader extends ffi.Opaque {}
+
+final class TGltfResourceLoader extends ffi.Opaque {}
+
+/// Ground Truth-based Ambient Occlusion (GTAO) options
+final class TGtao extends ffi.Struct {
+  /// !< number of slices; higher values reduce noise
+  @ffi.Uint8()
+  external int sampleSliceCount;
+
+  /// !< integration steps per slice; higher values reduce bias
+  @ffi.Uint8()
+  external int sampleStepsPerSlice;
+
+  /// !< ignored when visibility bitmasks are enabled
+  @ffi.Float()
+  external double thicknessHeuristic;
+
+  /// !< enables visibility bitmasks mode
+  @ffi.Bool()
+  external bool useVisibilityBitmasks;
+
+  /// !< world-space thickness used by visibility bitmasks
+  @ffi.Float()
+  external double constThickness;
+
+  /// !< increases thickness with distance
+  @ffi.Bool()
+  external bool linearThickness;
 }
 
-sealed class TStencilFace {
-  static const STENCIL_FACE_FRONT = 1;
-  static const STENCIL_FACE_BACK = 2;
-  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+final class TIndexBuffer extends ffi.Opaque {}
+
+final class TIndexBufferBuilder extends ffi.Opaque {}
+
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
 }
 
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
+final class TIndirectLight extends ffi.Opaque {}
+
+final class TInputHandler extends ffi.Opaque {}
+
+sealed class TIntentAction {
+  static const INTENT_ACTION_MOVE_FORWARD = 0;
+  static const INTENT_ACTION_MOVE_BACKWARD = 1;
+  static const INTENT_ACTION_MOVE_LEFT = 2;
+  static const INTENT_ACTION_MOVE_RIGHT = 3;
+  static const INTENT_ACTION_JUMP = 4;
+  static const INTENT_ACTION_SPRINT = 5;
+  static const INTENT_ACTION_CUSTOM1 = 6;
+  static const INTENT_ACTION_CUSTOM2 = 7;
+  static const INTENT_ACTION_CUSTOM3 = 8;
+  static const INTENT_ACTION_CUSTOM4 = 9;
+  static const INTENT_ACTION_CUSTOM5 = 10;
+  static const INTENT_ACTION_CUSTOM6 = 11;
+  static const INTENT_ACTION_CUSTOM7 = 12;
+  static const INTENT_ACTION_CUSTOM8 = 13;
+  static const INTENT_ACTION_CUSTOM9 = 14;
+  static const INTENT_ACTION_CUSTOM10 = 15;
+  static const INTENT_ACTION_CROUCH = 16;
+  static const INTENT_ACTION_INTERACT = 17;
+  static const INTENT_ACTION_USE_ITEM = 18;
+  static const INTENT_ACTION_RELOAD = 19;
+  static const INTENT_ACTION_ALT_FIRE = 20;
 }
 
-sealed class TTransparencyMode {
-  /// ! the transparent object is drawn honoring the raster state
-  static const DEFAULT = 0;
+final class TKtx1Bundle extends ffi.Opaque {}
 
-  /// the transparent object is first drawn in the depth buffer,
-  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
-  static const TWO_PASSES_ONE_SIDE = 1;
+final class TLightManager extends ffi.Opaque {}
 
-  /// the transparent object is drawn twice in the color buffer,
-  /// first with back faces only, then with front faces; the culling
-  /// mode is ignored. Can be combined with two-sided lighting
-  static const TWO_PASSES_TWO_SIDES = 2;
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
 }
 
-sealed class TBlendingMode {
-  static const BLENDING_MODE_OPAQUE = 0;
-  static const BLENDING_MODE_TRANSPARENT = 1;
-  static const BLENDING_MODE_ADD = 2;
-  static const BLENDING_MODE_MASKED = 3;
-  static const BLENDING_MODE_FADE = 4;
-  static const BLENDING_MODE_MULTIPLY = 5;
-  static const BLENDING_MODE_SCREEN = 6;
-  static const BLENDING_MODE_CUSTOM = 7;
+final class TLinearImage extends ffi.Opaque {}
+
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
 }
 
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
-}
+final class TMaterial extends ffi.Opaque {}
+
+final class TMaterialInstance extends ffi.Opaque {}
+
+final class TMaterialProvider extends ffi.Opaque {}
 
 final class TMeshData extends ffi.Struct {
   external ffi.Pointer<ffi.Char> name;
@@ -5514,14 +5226,415 @@ final class TMeshData extends ffi.Struct {
   external int primitiveType;
 }
 
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
+final class TMovementIntent extends ffi.Struct {
+  @ffi.Float()
+  external double movementDirectionX;
+
+  @ffi.Float()
+  external double movementDirectionY;
+
+  @ffi.Float()
+  external double movementDirectionZ;
+
+  @ffi.Float()
+  external double movementSpeed;
+
+  @ffi.Float()
+  external double mouseDeltaX;
+
+  @ffi.Float()
+  external double mouseDeltaY;
+
+  @ffi.Uint32()
+  external int intentStates;
+
+  @ffi.Float()
+  external double deltaTime;
+
+  @ffi.Array.multi([16])
+  external ffi.Array<ffi.Int> customIntentActions;
+
+  @ffi.Array.multi([16])
+  external ffi.Array<ffi.Float> customIntentValues;
+
+  @ffi.Int()
+  external int customIntentCount;
 }
+
+final class TMovementIntentCalculator extends ffi.Opaque {}
+
+final class TMovementIntentExecutor extends ffi.Opaque {}
+
+sealed class TMovementSpace {
+  static const MOVEMENT_SPACE_WORLD = 0;
+  static const MOVEMENT_SPACE_OBJECT = 1;
+}
+
+final class TNameComponentManager extends ffi.Opaque {}
+
+/// ! Pixel Data Format
+sealed class TPixelDataFormat {
+  /// !< One Red channel, float
+  static const PIXELDATAFORMAT_R = 0;
+
+  /// !< One Red channel, integer
+  static const PIXELDATAFORMAT_R_INTEGER = 1;
+
+  /// !< Two Red and Green channels, float
+  static const PIXELDATAFORMAT_RG = 2;
+
+  /// !< Two Red and Green channels, integer
+  static const PIXELDATAFORMAT_RG_INTEGER = 3;
+
+  /// !< Three Red, Green and Blue channels, float
+  static const PIXELDATAFORMAT_RGB = 4;
+
+  /// !< Three Red, Green and Blue channels, integer
+  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
+
+  /// !< Four Red, Green, Blue and Alpha channels, float
+  static const PIXELDATAFORMAT_RGBA = 6;
+
+  /// !< Four Red, Green, Blue and Alpha channels, integer
+  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
+  static const PIXELDATAFORMAT_UNUSED = 8;
+
+  /// !< Depth, 16-bit or 24-bits usually
+  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
+
+  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
+  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
+  static const PIXELDATAFORMAT_ALPHA = 11;
+}
+
+sealed class TPixelDataType {
+  /// !< unsigned byte
+  static const PIXELDATATYPE_UBYTE = 0;
+
+  /// !< signed byte
+  static const PIXELDATATYPE_BYTE = 1;
+
+  /// !< unsigned short (16-bit)
+  static const PIXELDATATYPE_USHORT = 2;
+
+  /// !< signed short (16-bit)
+  static const PIXELDATATYPE_SHORT = 3;
+
+  /// !< unsigned int (32-bit)
+  static const PIXELDATATYPE_UINT = 4;
+
+  /// !< signed int (32-bit)
+  static const PIXELDATATYPE_INT = 5;
+
+  /// !< half-float (16-bit float)
+  static const PIXELDATATYPE_HALF = 6;
+
+  /// !< float (32-bits float)
+  static const PIXELDATATYPE_FLOAT = 7;
+
+  /// !< compressed pixels, @see CompressedPixelDataType
+  static const PIXELDATATYPE_COMPRESSED = 8;
+
+  /// !< three low precision floating-point numbers
+  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
+
+  /// !< unsigned int (16-bit), encodes 3 RGB channels
+  static const PIXELDATATYPE_USHORT_565 = 10;
+
+  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
+  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+}
+
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
+
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
+
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
+
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
+
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
+}
+
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
+}
+
+final class TRenderManager extends ffi.Opaque {}
+
+final class TRenderTarget extends ffi.Opaque {}
+
+final class TRenderableBuilder extends ffi.Opaque {}
+
+final class TRenderableInstance extends ffi.Opaque {}
+
+final class TRenderableManager extends ffi.Opaque {}
+
+final class TRenderer extends ffi.Opaque {}
+
+sealed class TSamplerCompareFunc {
+  /// !< Less or equal
+  static const LE = 0;
+
+  /// !< Greater or equal
+  static const GE = 1;
+
+  /// !< Strictly less than
+  static const L = 2;
+
+  /// !< Strictly greater than
+  static const G = 3;
+
+  /// !< Equal
+  static const E = 4;
+
+  /// !< Not equal
+  static const NE = 5;
+
+  /// !< Always. Depth / stencil testing is deactivated.
+  static const A = 6;
+
+  /// !< Never. The depth / stencil test always fails.
+  static const N = 7;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+final class TScene extends ffi.Opaque {}
+
+final class TSceneAsset extends ffi.Opaque {}
+
+sealed class TSceneAssetGeometryCapability {
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_NONE = 0;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_BARYCENTRICS = 1;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_WRITABLE_VERTICES = 2;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_ACCESSIBLE_GEOMETRY_BUFFERS = 4;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_PRESERVED_TOPOLOGY = 8;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_UNIQUE_TRIANGLE_CORNERS = 16;
+}
+
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
+}
+
+final class TSceneManager extends ffi.Opaque {}
+
+final class TShadowOptions extends ffi.Struct {
+  @ffi.Uint32()
+  external int mapSize;
+
+  @ffi.Uint8()
+  external int shadowCascades;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.Float> cascadeSplitPositions;
+
+  @ffi.Float()
+  external double constantBias;
+
+  @ffi.Float()
+  external double normalBias;
+
+  @ffi.Float()
+  external double shadowFar;
+
+  @ffi.Float()
+  external double shadowNearHint;
+
+  @ffi.Float()
+  external double shadowFarHint;
+
+  @ffi.Bool()
+  external bool stable;
+
+  @ffi.Bool()
+  external bool lispsm;
+
+  @ffi.Float()
+  external double polygonOffsetConstant;
+
+  @ffi.Float()
+  external double polygonOffsetSlope;
+
+  @ffi.Bool()
+  external bool screenSpaceContactShadows;
+
+  @ffi.Uint8()
+  external int stepCount;
+
+  @ffi.Float()
+  external double maxShadowDistance;
+
+  @ffi.Bool()
+  external bool vsmElvsm;
+
+  @ffi.Float()
+  external double vsmBlurWidth;
+
+  @ffi.Float()
+  external double shadowBulbRadius;
+
+  @ffi.Float()
+  external double penumbraScale;
+
+  @ffi.Float()
+  external double penumbraRatioScale;
+
+  @ffi.Float()
+  external double maxPenumbraRatio;
+
+  @ffi.Float()
+  external double maxSearchRadius;
+
+  @ffi.Float()
+  external double transformX;
+
+  @ffi.Float()
+  external double transformY;
+
+  @ffi.Float()
+  external double transformZ;
+
+  @ffi.Float()
+  external double transformW;
+}
+
+final class TSkybox extends ffi.Opaque {}
+
+/// Options for DPCF and PCSS Shadowing.
+final class TSoftShadowOptions extends ffi.Struct {
+  @ffi.Float()
+  external double penumbraScale;
+
+  @ffi.Float()
+  external double penumbraRatioScale;
+
+  @ffi.Float()
+  external double maxPenumbraRatio;
+
+  @ffi.Float()
+  external double maxSearchRadius;
+}
+
+/// Screen Space Cone Tracing (SSCT) options
+/// Ambient shadows from dominant light
+final class TSsct extends ffi.Struct {
+  /// !< full cone angle in radian, between 0 and pi/2
+  @ffi.Float()
+  external double lightConeRad;
+
+  /// !< how far shadows can be cast
+  @ffi.Float()
+  external double shadowDistance;
+
+  /// !< max distance for contact
+  @ffi.Float()
+  external double contactDistanceMax;
+
+  /// !< intensity
+  @ffi.Float()
+  external double intensity;
+
+  /// !< light direction X
+  @ffi.Float()
+  external double lightDirectionX;
+
+  /// !< light direction Y
+  @ffi.Float()
+  external double lightDirectionY;
+
+  /// !< light direction Z
+  @ffi.Float()
+  external double lightDirectionZ;
+
+  /// !< depth bias in world units (mitigate self shadowing)
+  @ffi.Float()
+  external double depthBias;
+
+  /// !< depth slope bias (mitigate self shadowing)
+  @ffi.Float()
+  external double depthSlopeBias;
+
+  /// !< tracing sample count, between 1 and 255
+  @ffi.Uint8()
+  external int sampleCount;
+
+  /// !< # of rays to trace, between 1 and 255
+  @ffi.Uint8()
+  external int rayCount;
+
+  /// !< enables or disables SSCT
+  @ffi.Bool()
+  external bool enabled;
+}
+
+sealed class TStencilFace {
+  static const STENCIL_FACE_FRONT = 1;
+  static const STENCIL_FACE_BACK = 2;
+  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+}
+
+sealed class TStencilOperation {
+  static const KEEP = 0;
+  static const ZERO = 1;
+  static const REPLACE = 2;
+  static const INCR = 3;
+  static const INCR_WRAP = 4;
+  static const DECR = 5;
+  static const DECR_WRAP = 6;
+  static const INVERT = 7;
+}
+
+final class TSurfaceOrientation extends ffi.Opaque {}
+
+final class TSurfaceOrientationBuilder extends ffi.Opaque {}
+
+final class TSwapChain extends ffi.Opaque {}
+
+final class TTexture extends ffi.Opaque {}
 
 sealed class TTextureFormat {
   static const TEXTUREFORMAT_R8 = 0;
@@ -5635,77 +5748,15 @@ sealed class TTextureFormat {
   static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
 }
 
-/// ! Pixel Data Format
-sealed class TPixelDataFormat {
-  /// !< One Red channel, float
-  static const PIXELDATAFORMAT_R = 0;
+final class TTextureSampler extends ffi.Opaque {}
 
-  /// !< One Red channel, integer
-  static const PIXELDATAFORMAT_R_INTEGER = 1;
-
-  /// !< Two Red and Green channels, float
-  static const PIXELDATAFORMAT_RG = 2;
-
-  /// !< Two Red and Green channels, integer
-  static const PIXELDATAFORMAT_RG_INTEGER = 3;
-
-  /// !< Three Red, Green and Blue channels, float
-  static const PIXELDATAFORMAT_RGB = 4;
-
-  /// !< Three Red, Green and Blue channels, integer
-  static const PIXELDATAFORMAT_RGB_INTEGER = 5;
-
-  /// !< Four Red, Green, Blue and Alpha channels, float
-  static const PIXELDATAFORMAT_RGBA = 6;
-
-  /// !< Four Red, Green, Blue and Alpha channels, integer
-  static const PIXELDATAFORMAT_RGBA_INTEGER = 7;
-  static const PIXELDATAFORMAT_UNUSED = 8;
-
-  /// !< Depth, 16-bit or 24-bits usually
-  static const PIXELDATAFORMAT_DEPTH_COMPONENT = 9;
-
-  /// !< Two Depth (24-bits) + Stencil (8-bits) channels
-  static const PIXELDATAFORMAT_DEPTH_STENCIL = 10;
-  static const PIXELDATAFORMAT_ALPHA = 11;
-}
-
-sealed class TPixelDataType {
-  /// !< unsigned byte
-  static const PIXELDATATYPE_UBYTE = 0;
-
-  /// !< signed byte
-  static const PIXELDATATYPE_BYTE = 1;
-
-  /// !< unsigned short (16-bit)
-  static const PIXELDATATYPE_USHORT = 2;
-
-  /// !< signed short (16-bit)
-  static const PIXELDATATYPE_SHORT = 3;
-
-  /// !< unsigned int (32-bit)
-  static const PIXELDATATYPE_UINT = 4;
-
-  /// !< signed int (32-bit)
-  static const PIXELDATATYPE_INT = 5;
-
-  /// !< half-float (16-bit float)
-  static const PIXELDATATYPE_HALF = 6;
-
-  /// !< float (32-bits float)
-  static const PIXELDATATYPE_FLOAT = 7;
-
-  /// !< compressed pixels, @see CompressedPixelDataType
-  static const PIXELDATATYPE_COMPRESSED = 8;
-
-  /// !< three low precision floating-point numbers
-  static const PIXELDATATYPE_UINT_10F_11F_11F_REV = 9;
-
-  /// !< unsigned int (16-bit), encodes 3 RGB channels
-  static const PIXELDATATYPE_USHORT_565 = 10;
-
-  /// !< unsigned normalized 10 bits RGB, 2 bits alpha
-  static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
 }
 
 sealed class TTextureUsage {
@@ -5745,225 +5796,173 @@ sealed class TTextureUsage {
   static const TEXTURE_USAGE_DEFAULT = 24;
 }
 
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
+final class TToneMapper extends ffi.Opaque {}
+
+final class TTransformManager extends ffi.Opaque {}
+
+sealed class TTransparencyMode {
+  /// ! the transparent object is drawn honoring the raster state
+  static const DEFAULT = 0;
+
+  /// the transparent object is first drawn in the depth buffer,
+  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
+  static const TWO_PASSES_ONE_SIDE = 1;
+
+  /// the transparent object is drawn twice in the color buffer,
+  /// first with back faces only, then with front faces; the culling
+  /// mode is ignored. Can be combined with two-sided lighting
+  static const TWO_PASSES_TWO_SIDES = 2;
 }
 
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+sealed class TVertexAttribute {
+  static const TVERTEX_ATTRIBUTE_POSITION = 0;
+  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
+  static const TVERTEX_ATTRIBUTE_COLOR = 2;
+  static const TVERTEX_ATTRIBUTE_UV0 = 3;
+  static const TVERTEX_ATTRIBUTE_UV1 = 4;
+  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
+  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
+  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
+  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
+  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
+  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
+  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
+  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
+  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
+  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
 }
 
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
+sealed class TVertexAttributeType {
+  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
+  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
+  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
+  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
+  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
+  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
+  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
 }
 
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+final class TVertexBuffer extends ffi.Opaque {}
+
+final class TVertexBufferBuilder extends ffi.Opaque {}
+
+sealed class TVertexBufferStorageMode {
+  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
+  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
+  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
 }
 
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
+final class TView extends ffi.Opaque {}
 
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
+final class TViewer extends ffi.Opaque {}
 
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
+final class TViewport extends ffi.Struct {
+  @ffi.Int32()
+  external int left;
 
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
-}
-
-final class TShadowOptions extends ffi.Struct {
-  @ffi.Uint32()
-  external int mapSize;
-
-  @ffi.Uint8()
-  external int shadowCascades;
-
-  @ffi.Array.multi([3])
-  external ffi.Array<ffi.Float> cascadeSplitPositions;
-
-  @ffi.Float()
-  external double constantBias;
-
-  @ffi.Float()
-  external double normalBias;
-
-  @ffi.Float()
-  external double shadowFar;
-
-  @ffi.Float()
-  external double shadowNearHint;
-
-  @ffi.Float()
-  external double shadowFarHint;
-
-  @ffi.Bool()
-  external bool stable;
-
-  @ffi.Bool()
-  external bool lispsm;
-
-  @ffi.Float()
-  external double polygonOffsetConstant;
-
-  @ffi.Float()
-  external double polygonOffsetSlope;
-
-  @ffi.Bool()
-  external bool screenSpaceContactShadows;
-
-  @ffi.Uint8()
-  external int stepCount;
-
-  @ffi.Float()
-  external double maxShadowDistance;
-
-  @ffi.Bool()
-  external bool vsmElvsm;
-
-  @ffi.Float()
-  external double vsmBlurWidth;
-
-  @ffi.Float()
-  external double shadowBulbRadius;
-
-  @ffi.Float()
-  external double penumbraScale;
-
-  @ffi.Float()
-  external double penumbraRatioScale;
-
-  @ffi.Float()
-  external double maxPenumbraRatio;
-
-  @ffi.Float()
-  external double maxSearchRadius;
-
-  @ffi.Float()
-  external double transformX;
-
-  @ffi.Float()
-  external double transformY;
-
-  @ffi.Float()
-  external double transformZ;
-
-  @ffi.Float()
-  external double transformW;
-}
-
-typedef FilamentRenderCallbackFunction = ffi.Void Function(ffi.Pointer<ffi.Void> owner);
-typedef DartFilamentRenderCallbackFunction = void Function(ffi.Pointer<ffi.Void> owner);
-typedef FilamentRenderCallback = ffi.Pointer<ffi.NativeFunction<FilamentRenderCallbackFunction>>;
-typedef FrameTickCallbackFunction = ffi.Void Function(ffi.Uint64 frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(int frameTimeNanos);
-typedef FrameTickCallback = ffi.Pointer<ffi.NativeFunction<FrameTickCallbackFunction>>;
-
-final class TMovementIntentCalculator extends ffi.Opaque {}
-
-sealed class TIntentAction {
-  static const INTENT_ACTION_MOVE_FORWARD = 0;
-  static const INTENT_ACTION_MOVE_BACKWARD = 1;
-  static const INTENT_ACTION_MOVE_LEFT = 2;
-  static const INTENT_ACTION_MOVE_RIGHT = 3;
-  static const INTENT_ACTION_JUMP = 4;
-  static const INTENT_ACTION_SPRINT = 5;
-  static const INTENT_ACTION_CUSTOM1 = 6;
-  static const INTENT_ACTION_CUSTOM2 = 7;
-  static const INTENT_ACTION_CUSTOM3 = 8;
-  static const INTENT_ACTION_CUSTOM4 = 9;
-  static const INTENT_ACTION_CUSTOM5 = 10;
-  static const INTENT_ACTION_CUSTOM6 = 11;
-  static const INTENT_ACTION_CUSTOM7 = 12;
-  static const INTENT_ACTION_CUSTOM8 = 13;
-  static const INTENT_ACTION_CUSTOM9 = 14;
-  static const INTENT_ACTION_CUSTOM10 = 15;
-  static const INTENT_ACTION_CROUCH = 16;
-  static const INTENT_ACTION_INTERACT = 17;
-  static const INTENT_ACTION_USE_ITEM = 18;
-  static const INTENT_ACTION_RELOAD = 19;
-  static const INTENT_ACTION_ALT_FIRE = 20;
-}
-
-final class TMovementIntent extends ffi.Struct {
-  @ffi.Float()
-  external double movementDirectionX;
-
-  @ffi.Float()
-  external double movementDirectionY;
-
-  @ffi.Float()
-  external double movementDirectionZ;
-
-  @ffi.Float()
-  external double movementSpeed;
-
-  @ffi.Float()
-  external double mouseDeltaX;
-
-  @ffi.Float()
-  external double mouseDeltaY;
+  @ffi.Int32()
+  external int bottom;
 
   @ffi.Uint32()
-  external int intentStates;
+  external int width;
+
+  @ffi.Uint32()
+  external int height;
+}
+
+/// Options for VSM Shadowing.
+final class TVsmShadowOptions extends ffi.Struct {
+  @ffi.Uint8()
+  external int anisotropy;
+
+  @ffi.Bool()
+  external bool mipmapping;
+
+  @ffi.Uint8()
+  external int msaaSamples;
+
+  @ffi.Bool()
+  external bool highPrecision;
 
   @ffi.Float()
-  external double deltaTime;
+  external double minVarianceScale;
 
-  @ffi.Array.multi([16])
-  external ffi.Array<ffi.Int> customIntentActions;
-
-  @ffi.Array.multi([16])
-  external ffi.Array<ffi.Float> customIntentValues;
-
-  @ffi.Int()
-  external int customIntentCount;
+  @ffi.Float()
+  external double lightBleedReduction;
 }
 
-final class TMovementIntentExecutor extends ffi.Opaque {}
-
-sealed class TMovementSpace {
-  static const MOVEMENT_SPACE_WORLD = 0;
-  static const MOVEMENT_SPACE_OBJECT = 1;
-}
-
-final class TInputHandler extends ffi.Opaque {}
+typedef VoidCallback = ffi.Pointer<ffi.NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = ffi.Void Function(ffi.Int32 requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
 
 const int __bool_true_false_are_defined = 1;
 
-const int true$ = 1;
+final class double3 extends ffi.Struct {
+  @ffi.Double()
+  external double x;
+
+  @ffi.Double()
+  external double y;
+
+  @ffi.Double()
+  external double z;
+}
+
+final class double3x3 extends ffi.Struct {
+  external double3 col1;
+
+  external double3 col2;
+
+  external double3 col3;
+}
+
+final class double4 extends ffi.Struct {
+  @ffi.Double()
+  external double x;
+
+  @ffi.Double()
+  external double y;
+
+  @ffi.Double()
+  external double z;
+
+  @ffi.Double()
+  external double w;
+}
+
+final class double4x4 extends ffi.Struct {
+  @ffi.Array.multi([4])
+  external ffi.Array<ffi.Double> col1;
+
+  @ffi.Array.multi([4])
+  external ffi.Array<ffi.Double> col2;
+
+  @ffi.Array.multi([4])
+  external ffi.Array<ffi.Double> col3;
+
+  @ffi.Array.multi([4])
+  external ffi.Array<ffi.Double> col4;
+}
 
 const int false$ = 0;
 
-const int MAX_CUSTOM_INTENTS = 16;
-
-const int MOVEMENT_INTENT_MASK = 1;
-
-const int ROTATION_INTENT_MASK = 2;
-
-const int JUMP_INTENT_MASK = 4;
-
-const int SPRINT_INTENT_MASK = 8;
+const int true$ = 1;

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -19,52 +19,273 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     NativeLibrary.instance = lib as NativeLibrary;
   }
 
-  external void _Thermion_setCanvasElementSize(Pointer<Char> name, int width, int height);
-  external void _Thermion_destroyCanvas(Pointer<Char> canvasSelector);
-  external int _Thermion_createGLContext(Pointer<Char> canvasSelector);
-  external int _Thermion_getGLContext();
-  external Pointer<Int32> _TSWAP_CHAIN_CONFIG_TRANSPARENT;
-  external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
-  external Pointer<Int32> _TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
-  external Pointer<Int32> _TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
-  external void _View_getViewport(Pointer<TViewport> TViewport_out, Pointer<TView> view);
-  external Pointer<TToneMapper> _ToneMapper_createLinear(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createACES(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createACESLegacy(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createFilmic(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createAGX(Pointer<TEngine> tEngine);
-  external Pointer<TToneMapper> _ToneMapper_createAGXWithLook(Pointer<TEngine> tEngine, int look);
-  external Pointer<TToneMapper> _ToneMapper_createGeneric(
-    Pointer<TEngine> tEngine,
-    double contrast,
-    double midGrayIn,
-    double midGrayOut,
-    double hdrMax,
+  external int _AnimationManager_addBoneAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> frameData,
+    int numFrames,
+    double frameLengthInMs,
+    double fadeOutInSecs,
+    double fadeInInSecs,
+    double maxDelta,
+    bool loop,
   );
-  external Pointer<TToneMapper> _ToneMapper_createDisplayRange(Pointer<TEngine> tEngine);
-  external void _ToneMapper_destroy(Pointer<TToneMapper> toneMapper);
-  external Pointer<TColorGradingBuilder> _ColorGradingBuilder_create();
+  external int _AnimationManager_addBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_addGltfAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _AnimationManager_addMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+  );
+  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
+  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
+  external void _AnimationManager_createRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TAnimationManager>)>> onComplete,
+  );
+  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
+  external void _AnimationManager_destroyRenderThread(
+    Pointer<TAnimationManager> tAnimationManager,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _AnimationManager_getGltfAnimationCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external double _AnimationManager_getGltfAnimationDuration(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int animationIndex,
+  );
+  external void _AnimationManager_getGltfAnimationName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external void _AnimationManager_getInverseBindMatrix(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    int boneIndex,
+    Pointer<Float32> out,
+  );
+  external void _AnimationManager_getMorphTargetName(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+    Pointer<Char> outPtr,
+    int index,
+  );
+  external int _AnimationManager_getMorphTargetNameCount(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    EntityId childEntity,
+  );
+  external void _AnimationManager_getRestLocalTransforms(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int skinIndex,
+    Pointer<Float32> out,
+    int numBones,
+  );
+  external int _AnimationManager_playGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int index,
+    bool loop,
+    bool reverse,
+    bool replaceActive,
+    double crossfade,
+    double startOffset,
+    double speed,
+  );
+  external int _AnimationManager_removeBoneAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external int _AnimationManager_removeGltfAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+  );
+  external void _AnimationManager_removeMorphAnimationComponent(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+  );
+  external void _AnimationManager_resetToRestPose(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external void _AnimationManager_resetToRestPoseRenderThread(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _AnimationManager_setGltfAnimationTime(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int animationIndex,
+    double timeInSeconds,
+  );
+  external void _AnimationManager_setGltfAnimationTimeRenderThread(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> tSceneAsset,
+    int animationIndex,
+    double timeInSeconds,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _AnimationManager_setMorphAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    Pointer<Uint32> morphIndices,
+    int numMorphTargets,
+    int numFrames,
+    double frameLengthInMs,
+  );
+  external int _AnimationManager_setMorphTargetWeights(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    int numWeights,
+  );
+  external void _AnimationManager_setMorphTargetWeightsRenderThread(
+    Pointer<TAnimationManager> tAnimationManager,
+    EntityId entityId,
+    Pointer<Float32> morphData,
+    int numWeights,
+    Pointer<NativeFunction<void Function(bool)>> callback,
+  );
+  external int _AnimationManager_stopGltfAnimation(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    int index,
+  );
+  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
+  external int _AnimationManager_updateBoneMatrices(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+  );
+  external void _AnimationManager_updateBoneMatricesRenderThread(
+    Pointer<TAnimationManager> tAnimationManager,
+    Pointer<TSceneAsset> sceneAsset,
+    Pointer<NativeFunction<void Function(bool)>> callback,
+  );
+  external void _AnimationManager_updateRenderThread(
+    Pointer<TAnimationManager> tAnimationManager,
+    JSBigInt frameTimeInNanos,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external Pointer<TBufferObject> _BufferObjectBuilder_build(
+    Pointer<TBufferObjectBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _BufferObjectBuilder_buildRenderThread(
+    Pointer<TBufferObjectBuilder> tBuilder,
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TBufferObject>)>> onComplete,
+  );
+  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
+  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
+  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
+  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
+  external void _BufferObject_destroyRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TBufferObject> tBuffer,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _BufferObject_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TBufferObject> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _BufferObject_setBufferRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TBufferObject> tBuffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external double _Camera_getAperture(Pointer<TCamera> camera);
+  external double _Camera_getCullingFar(Pointer<TCamera> camera);
+  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
+  external double _Camera_getFocalLength(Pointer<TCamera> camera);
+  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
+  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
+  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
+  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external double _Camera_getNear(Pointer<TCamera> camera);
+  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external double _Camera_getSensitivity(Pointer<TCamera> camera);
+  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
+  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
+  external void _Camera_lookAt(
+    Pointer<TCamera> camera,
+    Pointer<double3> eyePtr,
+    Pointer<double3> focusPtr,
+    Pointer<double3> upPtr,
+  );
+  external void _Camera_setCustomProjectionWithCulling(
+    Pointer<TCamera> camera,
+    Pointer<double4x4> projectionMatrixPtr,
+    double near,
+    double far,
+  );
+  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
+  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
+  external void _Camera_setLensProjection(
+    Pointer<TCamera> camera,
+    double near,
+    double far,
+    double aspect,
+    double focalLength,
+  );
+  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix);
+  external void _Camera_setProjection(
+    Pointer<TCamera> tCamera,
+    int projection,
+    double left,
+    double right,
+    double bottom,
+    double top,
+    double near,
+    double far,
+  );
+  external void _Camera_setProjectionFromFov(
+    Pointer<TCamera> camera,
+    double fovInDegrees,
+    double aspect,
+    double near,
+    double far,
+    bool horizontal,
+  );
+  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
   external Pointer<TColorGrading> _ColorGradingBuilder_build(
     Pointer<TColorGradingBuilder> builder,
     Pointer<TEngine> engine,
   );
-  external void _ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder);
-  external void _ColorGrading_destroy(Pointer<TEngine> engine, Pointer<TColorGrading> colorGrading);
-  external void _ColorGradingBuilder_quality(Pointer<TColorGradingBuilder> builder, int level);
-  external void _ColorGradingBuilder_format(Pointer<TColorGradingBuilder> builder, int format);
-  external void _ColorGradingBuilder_dimensions(Pointer<TColorGradingBuilder> builder, int dim);
-  external void _ColorGradingBuilder_toneMapper(Pointer<TColorGradingBuilder> builder, Pointer<TToneMapper> toneMapper);
-  external void _ColorGradingBuilder_exposure(Pointer<TColorGradingBuilder> builder, double exposure);
-  external void _ColorGradingBuilder_nightAdaptation(Pointer<TColorGradingBuilder> builder, double adaptation);
-  external void _ColorGradingBuilder_whiteBalance(
-    Pointer<TColorGradingBuilder> builder,
-    double temperature,
-    double tint,
+  external void _ColorGradingBuilder_buildRenderThread(
+    Pointer<TColorGradingBuilder> tBuilder,
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TColorGrading>)>> onComplete,
   );
-  external void _ColorGradingBuilder_contrast(Pointer<TColorGradingBuilder> builder, double contrast);
-  external void _ColorGradingBuilder_vibrance(Pointer<TColorGradingBuilder> builder, double vibrance);
-  external void _ColorGradingBuilder_saturation(Pointer<TColorGradingBuilder> builder, double saturation);
   external void _ColorGradingBuilder_channelMixer(
     Pointer<TColorGradingBuilder> builder,
     double outRedR,
@@ -77,6 +298,37 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     double outBlueG,
     double outBlueB,
   );
+  external void _ColorGradingBuilder_contrast(Pointer<TColorGradingBuilder> builder, double contrast);
+  external Pointer<TColorGradingBuilder> _ColorGradingBuilder_create();
+  external void _ColorGradingBuilder_createRenderThread(
+    Pointer<NativeFunction<void Function(PointerClass<TColorGradingBuilder>)>> onComplete,
+  );
+  external void _ColorGradingBuilder_curves(
+    Pointer<TColorGradingBuilder> builder,
+    double shadowGammaR,
+    double shadowGammaG,
+    double shadowGammaB,
+    double midPointR,
+    double midPointG,
+    double midPointB,
+    double highlightScaleR,
+    double highlightScaleG,
+    double highlightScaleB,
+  );
+  external void _ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder);
+  external void _ColorGradingBuilder_destroyRenderThread(
+    Pointer<TColorGradingBuilder> tBuilder,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _ColorGradingBuilder_dimensions(Pointer<TColorGradingBuilder> builder, int dim);
+  external void _ColorGradingBuilder_exposure(Pointer<TColorGradingBuilder> builder, double exposure);
+  external void _ColorGradingBuilder_format(Pointer<TColorGradingBuilder> builder, int format);
+  external void _ColorGradingBuilder_gamutMapping(Pointer<TColorGradingBuilder> builder, bool enabled);
+  external void _ColorGradingBuilder_luminanceScaling(Pointer<TColorGradingBuilder> builder, bool enabled);
+  external void _ColorGradingBuilder_nightAdaptation(Pointer<TColorGradingBuilder> builder, double adaptation);
+  external void _ColorGradingBuilder_quality(Pointer<TColorGradingBuilder> builder, int level);
+  external void _ColorGradingBuilder_saturation(Pointer<TColorGradingBuilder> builder, double saturation);
   external void _ColorGradingBuilder_shadowsMidtonesHighlights(
     Pointer<TColorGradingBuilder> builder,
     double shadowsR,
@@ -108,62 +360,296 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     double powerG,
     double powerB,
   );
-  external void _ColorGradingBuilder_curves(
+  external void _ColorGradingBuilder_toneMapper(Pointer<TColorGradingBuilder> builder, Pointer<TToneMapper> toneMapper);
+  external void _ColorGradingBuilder_vibrance(Pointer<TColorGradingBuilder> builder, double vibrance);
+  external void _ColorGradingBuilder_whiteBalance(
     Pointer<TColorGradingBuilder> builder,
-    double shadowGammaR,
-    double shadowGammaG,
-    double shadowGammaB,
-    double midPointR,
-    double midPointG,
-    double midPointB,
-    double highlightScaleR,
-    double highlightScaleG,
-    double highlightScaleB,
+    double temperature,
+    double tint,
   );
-  external void _ColorGradingBuilder_luminanceScaling(Pointer<TColorGradingBuilder> builder, bool enabled);
-  external void _ColorGradingBuilder_gamutMapping(Pointer<TColorGradingBuilder> builder, bool enabled);
-  external void _View_setColorGrading(Pointer<TView> tView, Pointer<TColorGrading> tColorGrading);
-  external Pointer<TColorGrading> _View_getColorGrading(Pointer<TView> tView);
-  external void _View_setBlendMode(Pointer<TView> view, int blendMode);
-  external void _View_setViewport(Pointer<TView> view, int width, int height);
-  external void _View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget);
-  external void _View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled);
-  external int _View_getVisibleRenderableCount(Pointer<TView> view);
-  external Pointer<TRenderTarget> _View_getRenderTarget(Pointer<TView> tView);
-  external void _View_setPostProcessing(Pointer<TView> tView, bool enabled);
-  external void _View_setShadowsEnabled(Pointer<TView> tView, bool enabled);
-  external void _View_setShadowType(Pointer<TView> tView, int shadowType);
-  external int _View_getShadowType(Pointer<TView> tView);
-  external void _View_setSoftShadowOptions(Pointer<TView> tView, Pointer<TSoftShadowOptions> optionsPtr);
-  external void _View_getSoftShadowOptions(Pointer<TSoftShadowOptions> TSoftShadowOptions_out, Pointer<TView> tView);
-  external void _View_setVsmShadowOptions(Pointer<TView> tView, Pointer<TVsmShadowOptions> optionsPtr);
-  external void _View_getVsmShadowOptions(Pointer<TVsmShadowOptions> TVsmShadowOptions_out, Pointer<TView> tView);
-  external void _View_setBloom(Pointer<TView> tView, bool enabled, double strength);
-  external void _View_setRenderQuality(Pointer<TView> tView, int qualityLevel);
-  external void _View_setAntiAliasing(Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
-  external void _View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible);
-  external void _View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera);
-  external Pointer<TScene> _View_getScene(Pointer<TView> tView);
-  external Pointer<TCamera> _View_getCamera(Pointer<TView> tView);
-  external void _View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled);
-  external int _View_isStencilBufferEnabled(Pointer<TView> tView);
-  external void _View_setDitheringEnabled(Pointer<TView> tView, bool enabled);
-  external int _View_isDitheringEnabled(Pointer<TView> tView);
-  external void _View_setScene(Pointer<TView> tView, Pointer<TScene> tScene);
-  external void _View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted);
-  external void _View_setAmbientOcclusionOptions(Pointer<TView> tView, Pointer<TAmbientOcclusionOptions> optionsPtr);
-  external void _View_getAmbientOcclusionOptions(
-    Pointer<TAmbientOcclusionOptions> TAmbientOcclusionOptions_out,
+  external void _ColorGrading_destroy(Pointer<TEngine> engine, Pointer<TColorGrading> colorGrading);
+  external int _DebugRegistry_getProperty_bool(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Bool> outValue,
+  );
+  external int _DebugRegistry_getProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Float32> outValue,
+  );
+  external int _DebugRegistry_getProperty_int(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    Pointer<Int32> outValue,
+  );
+  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
+  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
+  external int _DebugRegistry_setProperty_float(
+    Pointer<TDebugRegistry> tDebugRegistry,
+    Pointer<Char> name,
+    double value,
+  );
+  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
+  external Pointer<TSkybox> _Engine_buildColoredSkybox(
+    Pointer<TEngine> tEngine,
+    double r,
+    double g,
+    double b,
+    double a,
+    bool showSun,
+    double intensity,
+    int priority,
+  );
+  external void _Engine_buildColoredSkyboxRenderThread(
+    Pointer<TEngine> tEngine,
+    double r,
+    double g,
+    double b,
+    double a,
+    bool showSun,
+    double intensity,
+    int priority,
+    Pointer<NativeFunction<void Function(PointerClass<TSkybox>)>> onComplete,
+  );
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<Float32> irradianceHarmonics,
+    double intensity,
+  );
+  external void _Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<Float32> harmonics,
+    double intensity,
+    Pointer<NativeFunction<void Function(PointerClass<TIndirectLight>)>> onComplete,
+  );
+  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<TTexture> tIrradianceTexture,
+    double intensity,
+  );
+  external void _Engine_buildIndirectLightFromIrradianceTextureRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tReflectionsTexture,
+    Pointer<TTexture> tIrradianceTexture,
+    double intensity,
+    Pointer<NativeFunction<void Function(PointerClass<TIndirectLight>)>> onComplete,
+  );
+  external Pointer<TMaterial> _Engine_buildMaterial(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> materialData,
+    size_t length,
+  );
+  external void _Engine_buildMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> materialData,
+    size_t length,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
+  );
+  external Pointer<TSkybox> _Engine_buildSkybox(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    bool showSun,
+    double intensity,
+    int priority,
+  );
+  external void _Engine_buildSkyboxRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    bool showSun,
+    double intensity,
+    int priority,
+    Pointer<NativeFunction<void Function(PointerClass<TSkybox>)>> onComplete,
+  );
+  external Pointer<TEngine> _Engine_create(
+    int backend,
+    Pointer<Void> platform,
+    Pointer<Void> sharedContext,
+    int stereoscopicEyeCount,
+    bool disableHandleUseAfterFreeCheck,
+  );
+  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
+  external void _Engine_createCameraRenderThread(
+    Pointer<TEngine> tEngine,
+    EntityId entityId,
+    Pointer<NativeFunction<void Function(PointerClass<TCamera>)>> onComplete,
+  );
+  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
+  external void _Engine_createFenceRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TFence>)>> onComplete,
+  );
+  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
+    Pointer<TEngine> tEngine,
+    int width,
+    int height,
+    JSBigInt flags,
+  );
+  external void _Engine_createHeadlessSwapChainRenderThread(
+    Pointer<TEngine> tEngine,
+    int width,
+    int height,
+    JSBigInt flags,
+    Pointer<NativeFunction<void Function(PointerClass<TSwapChain>)>> onComplete,
+  );
+  external void _Engine_createRenderThread(
+    int backend,
+    Pointer<Void> platform,
+    Pointer<Void> sharedContext,
+    int stereoscopicEyeCount,
+    bool disableHandleUseAfterFreeCheck,
+    Pointer<NativeFunction<void Function(PointerClass<TEngine>)>> onComplete,
+  );
+  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
+  external void _Engine_createRendererRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TRenderer>)>> onComplete,
+  );
+  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
+  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
+  external void _Engine_createSwapChainRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<Void> window,
+    JSBigInt flags,
+    Pointer<NativeFunction<void Function(PointerClass<TSwapChain>)>> onComplete,
+  );
+  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
+  external void _Engine_createViewRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TView>)>> onComplete,
+  );
+  external void _Engine_destroy(Pointer<TEngine> tEngine);
+  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
+  external void _Engine_destroyCameraRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TCamera> tCamera,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
+  external void _Engine_destroyColorGradingRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TColorGrading> tColorGrading,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
+  external void _Engine_destroyFenceRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TFence> tFence,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
+  external void _Engine_destroyIndirectLightRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TIndirectLight> tIndirectLight,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
+  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
+  external void _Engine_destroyMaterialInstanceRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialInstance> tMaterialInstance,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterial> tMaterial,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyRenderThread(Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external void _Engine_destroyRendererRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TRenderer> tRenderer,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
+  external void _Engine_destroySceneRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TScene> tScene,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
+  external void _Engine_destroySkyboxRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TSkybox> tSkybox,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
+  external void _Engine_destroySwapChainRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TSwapChain> tSwapChain,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
+  external void _Engine_destroyTextureRenderThread(
+    Pointer<TEngine> engine,
+    Pointer<TTexture> tTexture,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
+  external void _Engine_destroyViewRenderThread(
+    Pointer<TEngine> tEngine,
     Pointer<TView> tView,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external void _View_setFogOptions(Pointer<TView> tView, Pointer<TFogOptions> tFogOptionsPtr);
-  external void _View_getFogOptions(Pointer<TFogOptions> TFogOptions_out, Pointer<TView> tView);
-  external void _View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled);
-  external int _View_isTransparentPickingEnabled(Pointer<TView> tView);
-  external void _View_pick(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
-  external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
-  external Pointer<Char> _View_getName(Pointer<TView> tView);
-  external void _Gizmo_dummy(int t);
+  external void _Engine_execute(Pointer<TEngine> tEngine);
+  external void _Engine_executeRenderThread(Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
+  external void _Engine_flushAndWaitRenderThread(Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
+  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
+  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
+  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
+  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
+  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
+  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
+  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
+  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
+  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
+  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
+  external void _EntityManager_createEntityRenderThread(
+    Pointer<TEntityManager> tEntityManager,
+    Pointer<NativeFunction<void Function(EntityId)>> onComplete,
+  );
+  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
+  external void _EntityManager_destroyEntityRenderThread(
+    Pointer<TEntityManager> tEntityManager,
+    EntityId entityId,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
+  external void _Fence_waitAndDestroyRenderThread(Pointer<TFence> tFence, int requestId, VoidCallback onComplete);
+  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
+  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
+  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
+  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
+  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
+  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
+  external void _FilamentAsset_getWireframeRenderThread(
+    Pointer<TFilamentAsset> tFilamentAsset,
+    Pointer<NativeFunction<void Function(EntityId)>> onComplete,
+  );
+  external int _FrameScheduler_initDartApi(Pointer<Void> data);
+  external void _FrameScheduler_setTargetFps(int fps);
+  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
+  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
+  external JSBigInt _FrameScheduler_steadyClockUs();
+  external void _FrameScheduler_stop();
   external Pointer<TGizmo> _Gizmo_create(
     Pointer<TEngine> tEngine,
     Pointer<TGltfAssetLoader> assetLoader,
@@ -173,26 +659,357 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TMaterial> tMaterial,
     int tGizmoType,
   );
-  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
+  external void _Gizmo_createRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TView> tView,
+    Pointer<TMaterial> tMaterial,
+    int tGizmoType,
+    Pointer<NativeFunction<void Function(PointerClass<TGizmo>)>> callback,
+  );
+  external void _Gizmo_dummy(int t);
   external void _Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis);
+  external void _Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, GizmoPickCallback callback);
   external void _Gizmo_unhighlight(Pointer<TGizmo> tGizmo);
-  external Pointer<TMaterialInstance> _Material_createInstance(Pointer<TMaterial> tMaterial);
-  external int _Material_getFeatureLevel(Pointer<TMaterial> tMaterial);
-  external Pointer<TMaterial> _Material_createImageMaterial(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Material_createGridMaterial(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Material_createGizmoMaterial(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Material_createSilhouetteMaterial(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Material_createEdgeOutlineMaterial(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Material_createWireframeMaterial(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Material_createTranslationAxisMaterial(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Material_createBoneOverlayMaterial(Pointer<TEngine> tEngine);
-  external int _Material_hasParameter(Pointer<TMaterial> tMaterial, Pointer<Char> propertyName);
+  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
+  );
+  external void _GltfAssetLoader_createRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TMaterialProvider> tMaterialProvider,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<NativeFunction<void Function(PointerClass<TGltfAssetLoader>)>> callback,
+  );
+  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
+  external void _GltfAssetLoader_destroyRenderThread(
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
+    Pointer<TRenderableManager> tRenderableManager,
+    Pointer<TFilamentAsset> tAsset,
+  );
+  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
+  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
+  );
+  external void _GltfAssetLoader_loadRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<Uint8> data,
+    size_t length,
+    int numInstances,
+    Pointer<NativeFunction<void Function(PointerClass<TFilamentAsset>)>> callback,
+  );
+  external int _GltfParser_parseBuffer(
+    Pointer<Uint8> data,
+    size_t length,
+    Pointer<Char> meshName,
+    Pointer<TMeshData> outMeshData,
+  );
+  external void _GltfResourceLoader_addResourceData(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
+  );
+  external void _GltfResourceLoader_addResourceDataRenderThread(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<Char> uri,
+    Pointer<Uint8> data,
+    size_t length,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _GltfResourceLoader_asyncBeginLoad(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external void _GltfResourceLoader_asyncBeginLoadRenderThread(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    Pointer<NativeFunction<void Function(bool)>> callback,
+  );
+  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external void _GltfResourceLoader_asyncGetLoadProgressRenderThread(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<NativeFunction<void Function(double)>> callback,
+  );
+  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external void _GltfResourceLoader_asyncUpdateLoadRenderThread(Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
+  external void _GltfResourceLoader_createRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TGltfResourceLoader>)>> callback,
+  );
+  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
+  external void _GltfResourceLoader_destroyRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfResourceLoader> tResourceLoader,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _GltfResourceLoader_loadResources(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+  );
+  external void _GltfResourceLoader_loadResourcesRenderThread(
+    Pointer<TGltfResourceLoader> tGltfResourceLoader,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    Pointer<NativeFunction<void Function(bool)>> callback,
+  );
+  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
+  external void _Image_createEmptyRenderThread(
+    int width,
+    int height,
+    int channel,
+    Pointer<NativeFunction<void Function(PointerClass<TLinearImage>)>> onComplete,
+  );
+  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
+  external void _Image_decodeRenderThread(
+    Pointer<Uint8> data,
+    size_t length,
+    Pointer<Char> name,
+    bool alpha,
+    Pointer<NativeFunction<void Function(PointerClass<TLinearImage>)>> onComplete,
+  );
+  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
+  external void _Image_destroyRenderThread(Pointer<TLinearImage> tLinearImage, int requestId, VoidCallback onComplete);
+  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
+  external void _Image_getBytesRenderThread(
+    Pointer<TLinearImage> tLinearImage,
+    Pointer<NativeFunction<void Function(PointerClass<Float32>)>> onComplete,
+  );
+  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
+  external void _Image_getChannelsRenderThread(
+    Pointer<TLinearImage> tLinearImage,
+    Pointer<NativeFunction<void Function(int)>> onComplete,
+  );
+  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
+  external void _Image_getHeightRenderThread(
+    Pointer<TLinearImage> tLinearImage,
+    Pointer<NativeFunction<void Function(int)>> onComplete,
+  );
+  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
+  external void _Image_getWidthRenderThread(
+    Pointer<TLinearImage> tLinearImage,
+    Pointer<NativeFunction<void Function(int)>> onComplete,
+  );
+  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
+  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
+    Pointer<TIndexBufferBuilder> builder,
+    Pointer<TEngine> engine,
+  );
+  external void _IndexBufferBuilder_buildRenderThread(
+    Pointer<TIndexBufferBuilder> tBuilder,
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TIndexBuffer>)>> onComplete,
+  );
+  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
+  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
+  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
+  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_destroyRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TIndexBuffer> tBuffer,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
+  external void _IndexBuffer_setBuffer(
+    Pointer<TEngine> engine,
+    Pointer<TIndexBuffer> buffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _IndexBuffer_setBufferRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TIndexBuffer> tBuffer,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
+  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
+  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
+  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
+  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
+  external Pointer<TTexture> _Ktx1Reader_createTexture(
+    Pointer<TEngine> tEngine,
+    Pointer<TKtx1Bundle> tBundle,
+    int requestId,
+    VoidCallback onTextureUploadComplete,
+  );
+  external void _Ktx1Reader_createTextureRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TKtx1Bundle> tBundle,
+    int requestId,
+    VoidCallback onTextureUploadComplete,
+    Pointer<NativeFunction<void Function(PointerClass<TTexture>)>> onComplete,
+  );
+  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
+  external void _Ktx2Reader_createTextureRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<Uint8> data,
+    size_t size,
+    Pointer<NativeFunction<void Function(PointerClass<TTexture>)>> onComplete,
+  );
+  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
+  external void _LightManager_computePracticalSplits(
+    Pointer<Float32> splitPositions,
+    int cascades,
+    double near,
+    double far,
+    double lambda,
+  );
+  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
+  external int _LightManager_createLight(
+    Pointer<TEngine> tEngine,
+    Pointer<TLightManager> tLightManager,
+    int tLightTtype,
+  );
+  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external void _LightManager_getColor(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external void _LightManager_getDirection(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
+  external void _LightManager_getPosition(
+    Pointer<double3> double3_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+  );
+  external void _LightManager_getShadowOptions(
+    Pointer<TShadowOptions> TShadowOptions_out,
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+  );
+  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
+  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
+  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
+  external void _LightManager_setColor(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double r,
+    double g,
+    double b,
+  );
+  external void _LightManager_setColorTemperature(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double colorTemperature,
+  );
+  external void _LightManager_setDirection(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
+  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
+  external void _LightManager_setIntensityCandela(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double intensity,
+  );
+  external void _LightManager_setIntensityWatts(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double watts,
+    double efficiency,
+  );
+  external void _LightManager_setLightChannel(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    int channel,
+    bool enable,
+  );
+  external void _LightManager_setPosition(
+    Pointer<TLightManager> tLightManager,
+    EntityId light,
+    double x,
+    double y,
+    double z,
+  );
+  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
+  external void _LightManager_setShadowCasterRenderThread(
+    Pointer<TLightManager> tLightManager,
+    EntityId entityId,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _LightManager_setShadowOptions(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    Pointer<TShadowOptions> optionsPtr,
+  );
+  external void _LightManager_setShadowOptionsRenderThread(
+    Pointer<TLightManager> tLightManager,
+    EntityId entityId,
+    Pointer<TShadowOptions> optionsPtr,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _LightManager_setSpotLightCone(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double inner,
+    double outer,
+  );
+  external void _LightManager_setSunAngularRadius(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double angularRadius,
+  );
+  external void _LightManager_setSunHaloFalloff(
+    Pointer<TLightManager> tLightManager,
+    EntityId entity,
+    double haloFalloff,
+  );
+  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
+  external int _MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance);
   external int _MaterialInstance_isStencilWriteEnabled(Pointer<TMaterialInstance> materialInstance);
-  external void _MaterialInstance_setStencilWrite(Pointer<TMaterialInstance> materialInstance, bool enabled);
   external void _MaterialInstance_setCullingMode(Pointer<TMaterialInstance> materialInstance, int culling);
-  external void _MaterialInstance_setDoubleSided(Pointer<TMaterialInstance> materialInstance, bool doubleSided);
-  external void _MaterialInstance_setDepthWrite(Pointer<TMaterialInstance> materialInstance, bool enabled);
   external void _MaterialInstance_setDepthCulling(Pointer<TMaterialInstance> materialInstance, bool enabled);
+  external void _MaterialInstance_setDepthFunc(Pointer<TMaterialInstance> materialInstance, int depthFunc);
+  external void _MaterialInstance_setDepthWrite(Pointer<TMaterialInstance> materialInstance, bool enabled);
+  external void _MaterialInstance_setDoubleSided(Pointer<TMaterialInstance> materialInstance, bool doubleSided);
+  external void _MaterialInstance_setParameterBool(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    bool value,
+  );
   external void _MaterialInstance_setParameterFloat(
     Pointer<TMaterialInstance> materialInstance,
     Pointer<Char> propertyName,
@@ -225,6 +1042,11 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     double w,
     double z,
   );
+  external void _MaterialInstance_setParameterInt(
+    Pointer<TMaterialInstance> materialInstance,
+    Pointer<Char> propertyName,
+    int value,
+  );
   external void _MaterialInstance_setParameterMat3(
     Pointer<TMaterialInstance> materialInstance,
     Pointer<Char> propertyName,
@@ -235,26 +1057,23 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<Char> propertyName,
     Pointer<Float64> matrix,
   );
-  external void _MaterialInstance_setParameterInt(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    int value,
-  );
-  external void _MaterialInstance_setParameterBool(
-    Pointer<TMaterialInstance> materialInstance,
-    Pointer<Char> propertyName,
-    bool value,
-  );
   external void _MaterialInstance_setParameterTexture(
     Pointer<TMaterialInstance> materialInstance,
     Pointer<Char> propertyName,
     Pointer<TTexture> texture,
     Pointer<TTextureSampler> sampler,
   );
-  external void _MaterialInstance_setDepthFunc(Pointer<TMaterialInstance> materialInstance, int depthFunc);
-  external void _MaterialInstance_setStencilOpStencilFail(
+  external void _MaterialInstance_setParameterTextureRenderThread(
+    Pointer<TMaterialInstance> tMaterialInstance,
+    Pointer<Char> propertyName,
+    Pointer<TTexture> tTexture,
+    Pointer<TTextureSampler> tSampler,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _MaterialInstance_setStencilCompareFunction(
     Pointer<TMaterialInstance> materialInstance,
-    int op,
+    int func,
     int face,
   );
   external void _MaterialInstance_setStencilOpDepthFail(Pointer<TMaterialInstance> materialInstance, int op, int face);
@@ -263,325 +1082,22 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int op,
     int face,
   );
-  external void _MaterialInstance_setStencilCompareFunction(
+  external void _MaterialInstance_setStencilOpStencilFail(
     Pointer<TMaterialInstance> materialInstance,
-    int func,
+    int op,
     int face,
   );
+  external void _MaterialInstance_setStencilReadMask(Pointer<TMaterialInstance> materialInstance, int mask);
   external void _MaterialInstance_setStencilReferenceValue(
     Pointer<TMaterialInstance> materialInstance,
     int value,
     int face,
   );
-  external void _MaterialInstance_setStencilReadMask(Pointer<TMaterialInstance> materialInstance, int mask);
+  external void _MaterialInstance_setStencilWrite(Pointer<TMaterialInstance> materialInstance, bool enabled);
   external void _MaterialInstance_setStencilWriteMask(Pointer<TMaterialInstance> materialInstance, int mask);
   external void _MaterialInstance_setTransparencyMode(
     Pointer<TMaterialInstance> materialInstance,
     int transparencyMode,
-  );
-  external int _MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance);
-  external int _Material_getBlendingMode(Pointer<TMaterial> material);
-  external Pointer<TNameComponentManager> _NameComponentManager_create();
-  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
-  external Pointer<Char> _NameComponentManager_getName(
-    Pointer<TNameComponentManager> tNameComponentManager,
-    EntityId entity,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    int vertexBufferStorageMode,
-    Pointer<Aabb3> boundingBoxPtr,
-  );
-  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TFilamentAsset> tFilamentAsset,
-    int requiredGeometryCapabilities,
-  );
-  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
-  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
-  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
-  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
-  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
-  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
-  external Pointer<TSceneAsset> _SceneAsset_createInstance(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-  );
-  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
-  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
-  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
-  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
-  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
-  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
-  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
-  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
-  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
-  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
-  external void _Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity);
-  external double _Camera_getAperture(Pointer<TCamera> camera);
-  external double _Camera_getShutterSpeed(Pointer<TCamera> camera);
-  external double _Camera_getSensitivity(Pointer<TCamera> camera);
-  external void _Camera_getModelMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getViewMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getCullingProjectionMatrix(Pointer<double4x4> double4x4_out, Pointer<TCamera> camera);
-  external void _Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out);
-  external void _Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far);
-  external void _Camera_setProjectionFromFov(
-    Pointer<TCamera> camera,
-    double fovInDegrees,
-    double aspect,
-    double near,
-    double far,
-    bool horizontal,
-  );
-  external double _Camera_getFocalLength(Pointer<TCamera> camera);
-  external void _Camera_lookAt(
-    Pointer<TCamera> camera,
-    Pointer<double3> eyePtr,
-    Pointer<double3> focusPtr,
-    Pointer<double3> upPtr,
-  );
-  external double _Camera_getNear(Pointer<TCamera> camera);
-  external double _Camera_getCullingFar(Pointer<TCamera> camera);
-  external double _Camera_getFov(Pointer<TCamera> camera, bool horizontal);
-  external double _Camera_getFocusDistance(Pointer<TCamera> camera);
-  external void _Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance);
-  external void _Camera_setCustomProjectionWithCulling(
-    Pointer<TCamera> camera,
-    Pointer<double4x4> projectionMatrixPtr,
-    double near,
-    double far,
-  );
-  external void _Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix);
-  external void _Camera_setLensProjection(
-    Pointer<TCamera> camera,
-    double near,
-    double far,
-    double aspect,
-    double focalLength,
-  );
-  external EntityId _Camera_getEntity(Pointer<TCamera> camera);
-  external void _Camera_setProjection(
-    Pointer<TCamera> tCamera,
-    int projection,
-    double left,
-    double right,
-    double bottom,
-    double top,
-    double near,
-    double far,
-  );
-  external void _MeshData_dispose(Pointer<TMeshData> meshData);
-  external int _GltfParser_parseBuffer(
-    Pointer<Uint8> data,
-    size_t length,
-    Pointer<Char> meshName,
-    Pointer<TMeshData> outMeshData,
-  );
-  external Pointer<TTexture> _Texture_build(
-    Pointer<TEngine> engine,
-    int width,
-    int height,
-    int depth,
-    int levels,
-    int tUsage,
-    int import1,
-    int sampler,
-    int format,
-  );
-  external void _Texture_setExternalImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<Void> externalImage,
-  );
-  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
-  external int _Texture_loadImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<TLinearImage> tImage,
-    int bufferFormat,
-    int pixelDataType,
-    int level,
-  );
-  external int _Texture_setImage(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    int level,
-    Pointer<Uint8> data,
-    size_t size,
-    int x_offset,
-    int y_offset,
-    int z_offset,
-    int width,
-    int height,
-    int depth,
-    int bufferFormat,
-    int pixelDataType,
-  );
-  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
-  external int _Texture_getFormat(Pointer<TTexture> tTexture);
-  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
-  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
-  external Pointer<TKtx1Bundle> _Ktx1Bundle_create(Pointer<Uint8> ktxData, size_t length);
-  external void _Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics);
-  external int _Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle);
-  external void _Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle);
-  external Pointer<TTexture> _Ktx1Reader_createTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TKtx1Bundle> tBundle,
-    int requestId,
-    VoidCallback onTextureUploadComplete,
-  );
-  external Pointer<TTexture> _Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, size_t size);
-  external Pointer<TLinearImage> _Image_createEmpty(int width, int height, int channel);
-  external Pointer<TLinearImage> _Image_decode(Pointer<Uint8> data, size_t length, Pointer<Char> name, bool alpha);
-  external Pointer<Float32> _Image_getBytes(Pointer<TLinearImage> tLinearImage);
-  external void _Image_destroy(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getWidth(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getHeight(Pointer<TLinearImage> tLinearImage);
-  external int _Image_getChannels(Pointer<TLinearImage> tLinearImage);
-  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
-  external Pointer<TTextureSampler> _TextureSampler_create();
-  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
-    int minFilter,
-    int magFilter,
-    int wrapS,
-    int wrapT,
-    int wrapR,
-  );
-  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
-  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
-  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
-  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
-  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
-  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
-  external Pointer<TEngine> _Engine_create(
-    int backend,
-    Pointer<Void> platform,
-    Pointer<Void> sharedContext,
-    int stereoscopicEyeCount,
-    bool disableHandleUseAfterFreeCheck,
-  );
-  external int _Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine);
-  external void _Engine_destroy(Pointer<TEngine> tEngine);
-  external Pointer<TRenderer> _Engine_createRenderer(Pointer<TEngine> tEngine);
-  external void _Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external Pointer<TSwapChain> _Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, JSBigInt flags);
-  external Pointer<TSwapChain> _Engine_createHeadlessSwapChain(
-    Pointer<TEngine> tEngine,
-    int width,
-    int height,
-    JSBigInt flags,
-  );
-  external void _Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain);
-  external void _Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView);
-  external void _Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene);
-  external void _Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading);
-  external Pointer<TCamera> _Engine_createCamera(Pointer<TEngine> tEngine, EntityId entityId);
-  external void _Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera);
-  external Pointer<TView> _Engine_createView(Pointer<TEngine> tEngine);
-  external Pointer<TCamera> _Engine_getCameraComponent(Pointer<TEngine> tEngine, EntityId entityId);
-  external Pointer<TTransformManager> _Engine_getTransformManager(Pointer<TEngine> engine);
-  external Pointer<TRenderableManager> _Engine_getRenderableManager(Pointer<TEngine> engine);
-  external Pointer<TLightManager> _Engine_getLightManager(Pointer<TEngine> engine);
-  external Pointer<TEntityManager> _Engine_getEntityManager(Pointer<TEngine> engine);
-  external void _Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled);
-  external size_t _Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine);
-  external void _Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture);
-  external Pointer<TFence> _Engine_createFence(Pointer<TEngine> tEngine);
-  external void _Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence);
-  external void _Engine_flushAndWait(Pointer<TEngine> tEngine);
-  external void _Engine_execute(Pointer<TEngine> tEngine);
-  external Pointer<TMaterial> _Engine_buildMaterial(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> materialData,
-    size_t length,
-  );
-  external void _Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial);
-  external void _Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance);
-  external Pointer<TScene> _Engine_createScene(Pointer<TEngine> tEngine);
-  external Pointer<TSkybox> _Engine_buildSkybox(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    bool showSun,
-    double intensity,
-    int priority,
-  );
-  external Pointer<TSkybox> _Engine_buildColoredSkybox(
-    Pointer<TEngine> tEngine,
-    double r,
-    double g,
-    double b,
-    double a,
-    bool showSun,
-    double intensity,
-    int priority,
-  );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceTexture(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<TTexture> tIrradianceTexture,
-    double intensity,
-  );
-  external Pointer<TIndirectLight> _Engine_buildIndirectLightFromIrradianceHarmonics(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<Float32> irradianceHarmonics,
-    double intensity,
-  );
-  external void _Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox);
-  external void _Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight);
-  external EntityId _EntityManager_createEntity(Pointer<TEntityManager> tEntityManager);
-  external void _EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, EntityId entityId);
-  external void _Fence_waitAndDestroy(Pointer<TFence> tFence);
-  external Pointer<TDebugRegistry> _Engine_getDebugRegistry(Pointer<TEngine> tEngine);
-  external int _DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name);
-  external int _DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value);
-  external int _DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value);
-  external int _DebugRegistry_setProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    double value,
-  );
-  external int _DebugRegistry_getProperty_bool(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Bool> outValue,
-  );
-  external int _DebugRegistry_getProperty_int(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Int32> outValue,
-  );
-  external int _DebugRegistry_getProperty_float(
-    Pointer<TDebugRegistry> tDebugRegistry,
-    Pointer<Char> name,
-    Pointer<Float32> outValue,
   );
   external Pointer<TMaterialInstance> _MaterialProvider_createMaterialInstance(
     Pointer<TMaterialProvider> provider,
@@ -623,802 +1139,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     bool hasSheen,
     bool hasIOR,
     bool hasVolume,
-  );
-  external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
-  external void _VertexBufferBuilder_bufferCount(Pointer<TVertexBufferBuilder> builder, int count);
-  external void _VertexBufferBuilder_vertexCount(Pointer<TVertexBufferBuilder> builder, int count);
-  external void _VertexBufferBuilder_enableBufferObjects(Pointer<TVertexBufferBuilder> builder, bool enabled);
-  external int _VertexBufferBuilder_getStorageMode(Pointer<TVertexBufferBuilder> builder);
-  external void _VertexBufferBuilder_attribute(
-    Pointer<TVertexBufferBuilder> builder,
-    int attribute,
-    int bufferIndex,
-    int attributeType,
-    int byteOffset,
-    int byteStride,
-  );
-  external void _VertexBufferBuilder_normalized(Pointer<TVertexBufferBuilder> builder, int attribute, bool normalize);
-  external Pointer<TVertexBuffer> _VertexBufferBuilder_build(
-    Pointer<TVertexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder);
-  external size_t _VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer);
-  external void _VertexBuffer_setBufferAt(
-    Pointer<TEngine> engine,
-    Pointer<TVertexBuffer> buffer,
-    int bufferIndex,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _VertexBuffer_setBufferObjectAt(
-    Pointer<TEngine> engine,
-    Pointer<TVertexBuffer> buffer,
-    int bufferIndex,
-    Pointer<TBufferObject> bufferObject,
-  );
-  external void _VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer);
-  external Pointer<TIndexBufferBuilder> _IndexBufferBuilder_create();
-  external void _IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count);
-  external void _IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType);
-  external Pointer<TIndexBuffer> _IndexBufferBuilder_build(
-    Pointer<TIndexBufferBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder);
-  external size_t _IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer);
-  external void _IndexBuffer_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TIndexBuffer> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer);
-  external Pointer<TBufferObjectBuilder> _BufferObjectBuilder_create();
-  external void _BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes);
-  external Pointer<TBufferObject> _BufferObjectBuilder_build(
-    Pointer<TBufferObjectBuilder> builder,
-    Pointer<TEngine> engine,
-  );
-  external void _BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder);
-  external void _BufferObject_setBuffer(
-    Pointer<TEngine> engine,
-    Pointer<TBufferObject> buffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-  );
-  external void _BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer);
-  external void _TransformManager_getLocalTransform(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external void _TransformManager_getWorldTransform(
-    Pointer<double4x4> double4x4_out,
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-  );
-  external void _TransformManager_setTransform(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<double4x4> transformPtr,
-  );
-  external int _TransformManager_transformToUnitCube(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<Aabb3> boundingBoxPtr,
-  );
-  external void _TransformManager_setParent(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId child,
-    EntityId parent,
-    bool preserveScaling,
-  );
-  external EntityId _TransformManager_getParent(Pointer<TTransformManager> tTransformManager, EntityId child);
-  external EntityId _TransformManager_getAncestor(Pointer<TTransformManager> tTransformManager, EntityId childEntityId);
-  external void _TransformManager_createComponent(Pointer<TTransformManager> tTransformManager, EntityId entity);
-  external void _TransformManager_removeComponent(Pointer<TTransformManager> tTransformManager, EntityId entity);
-  external int _TransformManager_hasComponent(Pointer<TTransformManager> tTransformManager, EntityId entityId);
-  external int _TransformManager_empty(Pointer<TTransformManager> tTransformManager);
-  external int _TransformManager_getComponentCount(Pointer<TTransformManager> tTransformManager);
-  external int _TransformManager_getChildCount(Pointer<TTransformManager> tTransformManager, EntityId entityId);
-  external void _TransformManager_getChildren(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<Int32> children,
-    int count,
-  );
-  external void _TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
-  external void _TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
-  external int _LightManager_createLight(
-    Pointer<TEngine> tEngine,
-    Pointer<TLightManager> tLightManager,
-    int tLightTtype,
-  );
-  external void _LightManager_destroyLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_hasComponent(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_getType(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isDirectional(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isPointLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external int _LightManager_isSpotLight(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setPosition(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getPosition(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setDirection(
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-    double x,
-    double y,
-    double z,
-  );
-  external void _LightManager_getDirection(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId light,
-  );
-  external void _LightManager_setColor(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double r,
-    double g,
-    double b,
-  );
-  external void _LightManager_setColorTemperature(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double colorTemperature,
-  );
-  external void _LightManager_getColor(
-    Pointer<double3> double3_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setIntensity(Pointer<TLightManager> tLightManager, EntityId entity, double intensity);
-  external void _LightManager_setIntensityCandela(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double intensity,
-  );
-  external void _LightManager_setIntensityWatts(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double watts,
-    double efficiency,
-  );
-  external double _LightManager_getIntensity(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setFalloff(Pointer<TLightManager> tLightManager, EntityId entity, double falloff);
-  external double _LightManager_getFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSpotLightCone(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double inner,
-    double outer,
-  );
-  external double _LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external double _LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunAngularRadius(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double angularRadius,
-  );
-  external double _LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity, double haloSize);
-  external double _LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setSunHaloFalloff(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    double haloFalloff,
-  );
-  external double _LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity, bool enabled);
-  external int _LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, EntityId entity);
-  external void _LightManager_setShadowOptions(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    Pointer<TShadowOptions> optionsPtr,
-  );
-  external void _LightManager_getShadowOptions(
-    Pointer<TShadowOptions> TShadowOptions_out,
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-  );
-  external void _LightManager_setLightChannel(
-    Pointer<TLightManager> tLightManager,
-    EntityId entity,
-    int channel,
-    bool enable,
-  );
-  external int _LightManager_getLightChannel(Pointer<TLightManager> tLightManager, EntityId entity, int channel);
-  external void _LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades);
-  external void _LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far);
-  external void _LightManager_computePracticalSplits(
-    Pointer<Float32> splitPositions,
-    int cascades,
-    double near,
-    double far,
-    double lambda,
-  );
-  external double _LightManager_rgbToColorTemperature(double r, double g, double b);
-  external Pointer<Void> _RenderThread_create();
-  external Pointer<Void> _RenderThread_createForCanvas(Pointer<Char> canvasSelector);
-  external void _RenderThread_destroy(Pointer<Void> renderThread);
-  external void _RenderThread_addTask(Pointer<NativeFunction<void Function()>> task);
-  external void _RenderManager_setRenderableRenderThread(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    Pointer<PointerClass<TView>> tViews,
-    int numViews,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderManager_renderRenderThread(
-    Pointer<TRenderManager> tRenderManager,
-    JSBigInt frameTimeInNanos,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderManager_addAnimationManagerRenderThread(
-    Pointer<TRenderManager> tRenderManager,
-    Pointer<TAnimationManager> tAnimationManager,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderManager_removeAnimationManagerRenderThread(
-    Pointer<TRenderManager> tRenderManager,
-    Pointer<TAnimationManager> tAnimationManager,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderManager_removeSwapChainRenderThread(
-    Pointer<TRenderManager> tRenderManager,
-    Pointer<TSwapChain> tSwapChain,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _AnimationManager_createRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TAnimationManager>)>> onComplete,
-  );
-  external void _AnimationManager_destroyRenderThread(
-    Pointer<TAnimationManager> tAnimationManager,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_createRenderThread(
-    int backend,
-    Pointer<Void> platform,
-    Pointer<Void> sharedContext,
-    int stereoscopicEyeCount,
-    bool disableHandleUseAfterFreeCheck,
-    Pointer<NativeFunction<void Function(PointerClass<TEngine>)>> onComplete,
-  );
-  external void _Engine_createRendererRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TRenderer>)>> onComplete,
-  );
-  external void _Engine_destroyRendererRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TRenderer> tRenderer,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_createSwapChainRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<Void> window,
-    JSBigInt flags,
-    Pointer<NativeFunction<void Function(PointerClass<TSwapChain>)>> onComplete,
-  );
-  external void _Engine_createHeadlessSwapChainRenderThread(
-    Pointer<TEngine> tEngine,
-    int width,
-    int height,
-    JSBigInt flags,
-    Pointer<NativeFunction<void Function(PointerClass<TSwapChain>)>> onComplete,
-  );
-  external void _Engine_createCameraRenderThread(
-    Pointer<TEngine> tEngine,
-    EntityId entityId,
-    Pointer<NativeFunction<void Function(PointerClass<TCamera>)>> onComplete,
-  );
-  external void _Engine_destroyCameraRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TCamera> tCamera,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_createViewRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TView>)>> onComplete,
-  );
-  external void _Engine_buildMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> materialData,
-    size_t length,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _Engine_destroyRenderThread(Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
-  external void _Engine_destroySwapChainRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TSwapChain> tSwapChain,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_destroyViewRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TView> tView,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_destroySceneRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TScene> tScene,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_destroyColorGradingRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TColorGrading> tColorGrading,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_destroyMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterial> tMaterial,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_destroyMaterialInstanceRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialInstance> tMaterialInstance,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_destroySkyboxRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TSkybox> tSkybox,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_destroyIndirectLightRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TIndirectLight> tIndirectLight,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Texture_buildRenderThread(
-    Pointer<TEngine> engine,
-    int width,
-    int height,
-    int depth,
-    int levels,
-    int tUsage,
-    int import1,
-    int sampler,
-    int format,
-    Pointer<NativeFunction<void Function(PointerClass<TTexture>)>> onComplete,
-  );
-  external void _Texture_setExternalImageRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<Void> externalImage,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Texture_generateMipMapsRenderThread(
-    Pointer<TTexture> tTexture,
-    Pointer<TEngine> tEngine,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Ktx1Reader_createTextureRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TKtx1Bundle> tBundle,
-    int requestId,
-    VoidCallback onTextureUploadComplete,
-    Pointer<NativeFunction<void Function(PointerClass<TTexture>)>> onComplete,
-  );
-  external void _Ktx2Reader_createTextureRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<Uint8> data,
-    size_t size,
-    Pointer<NativeFunction<void Function(PointerClass<TTexture>)>> onComplete,
-  );
-  external void _Engine_destroyTextureRenderThread(
-    Pointer<TEngine> engine,
-    Pointer<TTexture> tTexture,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_createFenceRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TFence>)>> onComplete,
-  );
-  external void _Fence_waitAndDestroyRenderThread(Pointer<TFence> tFence, int requestId, VoidCallback onComplete);
-  external void _Engine_destroyFenceRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TFence> tFence,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Engine_flushAndWaitRenderThread(Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
-  external void _Engine_executeRenderThread(Pointer<TEngine> tEngine, int requestId, VoidCallback onComplete);
-  external void _Engine_buildSkyboxRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    bool showSun,
-    double intensity,
-    int priority,
-    Pointer<NativeFunction<void Function(PointerClass<TSkybox>)>> onComplete,
-  );
-  external void _Engine_buildColoredSkyboxRenderThread(
-    Pointer<TEngine> tEngine,
-    double r,
-    double g,
-    double b,
-    double a,
-    bool showSun,
-    double intensity,
-    int priority,
-    Pointer<NativeFunction<void Function(PointerClass<TSkybox>)>> onComplete,
-  );
-  external void _Engine_buildIndirectLightFromIrradianceTextureRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<TTexture> tIrradianceTexture,
-    double intensity,
-    Pointer<NativeFunction<void Function(PointerClass<TIndirectLight>)>> onComplete,
-  );
-  external void _Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tReflectionsTexture,
-    Pointer<Float32> harmonics,
-    double intensity,
-    Pointer<NativeFunction<void Function(PointerClass<TIndirectLight>)>> onComplete,
-  );
-  external void _Renderer_setClearOptionsRenderThread(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Renderer_beginFrameRenderThread(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-    Pointer<NativeFunction<void Function(bool)>> onComplete,
-  );
-  external void _Renderer_endFrameRenderThread(Pointer<TRenderer> tRenderer, int requestId, VoidCallback onComplete);
-  external void _Renderer_renderRenderThread(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Renderer_renderStandaloneViewRenderThread(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TView> tView,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Renderer_readPixelsRenderThread(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Material_createInstanceRenderThread(
-    Pointer<TMaterial> tMaterial,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterialInstance>)>> onComplete,
-  );
-  external void _MaterialInstance_setParameterTextureRenderThread(
-    Pointer<TMaterialInstance> tMaterialInstance,
-    Pointer<Char> propertyName,
-    Pointer<TTexture> tTexture,
-    Pointer<TTextureSampler> tSampler,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Material_createImageMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _Material_createGizmoMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _Material_createBoneOverlayMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _Material_createSilhouetteMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _Material_createEdgeOutlineMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _Material_createWireframeMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _Material_createTranslationAxisMaterialRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
-  );
-  external void _ColorGradingBuilder_createRenderThread(
-    Pointer<NativeFunction<void Function(PointerClass<TColorGradingBuilder>)>> onComplete,
-  );
-  external void _ColorGradingBuilder_buildRenderThread(
-    Pointer<TColorGradingBuilder> tBuilder,
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TColorGrading>)>> onComplete,
-  );
-  external void _ColorGradingBuilder_destroyRenderThread(
-    Pointer<TColorGradingBuilder> tBuilder,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _ToneMapper_createLinearRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_createACESRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_createACESLegacyRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_createFilmicRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_createPBRNeutralRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_createAGXRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_createAGXWithLookRenderThread(
-    Pointer<TEngine> tEngine,
-    int look,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_createGenericRenderThread(
-    Pointer<TEngine> tEngine,
-    double contrast,
-    double midGrayIn,
-    double midGrayOut,
-    double hdrMax,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_createDisplayRangeRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
-  );
-  external void _ToneMapper_destroyRenderThread(
-    Pointer<TToneMapper> tToneMapper,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_pickRenderThread(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
-  external void _View_setColorGradingRenderThread(
-    Pointer<TView> tView,
-    Pointer<TColorGrading> tColorGrading,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setBloomRenderThread(
-    Pointer<TView> tView,
-    bool enabled,
-    double strength,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setCameraRenderThread(
-    Pointer<TView> tView,
-    Pointer<TCamera> tCamera,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_getNameRenderThread(
-    Pointer<TView> tView,
-    Pointer<NativeFunction<void Function(PointerClass<Char>)>> onComplete,
-  );
-  external void _View_setNameRenderThread(
-    Pointer<TView> tView,
-    Pointer<Char> name,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setViewportRenderThread(
-    Pointer<TView> tView,
-    int width,
-    int height,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setRenderTargetRenderThread(
-    Pointer<TView> tView,
-    Pointer<TRenderTarget> tRenderTarget,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setAntiAliasingRenderThread(
-    Pointer<TView> tView,
-    bool msaa,
-    bool fxaa,
-    bool taa,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setPostProcessingRenderThread(
-    Pointer<TView> tView,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setFrustumCullingEnabledRenderThread(
-    Pointer<TView> tView,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setStencilBufferEnabledRenderThread(
-    Pointer<TView> tView,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setDitheringEnabledRenderThread(
-    Pointer<TView> tView,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setRenderQualityRenderThread(
-    Pointer<TView> tView,
-    int qualityLevel,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setSceneRenderThread(
-    Pointer<TView> tView,
-    Pointer<TScene> tScene,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setLayerEnabledRenderThread(
-    Pointer<TView> tView,
-    int layer,
-    bool visible,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setBlendModeRenderThread(
-    Pointer<TView> tView,
-    int blendMode,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setFogOptionsRenderThread(
-    Pointer<TView> tView,
-    Pointer<TFogOptions> tFogOptionsPtr,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setAmbientOcclusionOptionsRenderThread(
-    Pointer<TView> tView,
-    Pointer<TAmbientOcclusionOptions> optionsPtr,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setFrontFaceWindingInvertedRenderThread(
-    Pointer<TView> tView,
-    bool inverted,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setShadowsEnabledRenderThread(
-    Pointer<TView> tView,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setShadowTypeRenderThread(
-    Pointer<TView> tView,
-    int shadowType,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setSoftShadowOptionsRenderThread(
-    Pointer<TView> tView,
-    Pointer<TSoftShadowOptions> optionsPtr,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setVsmShadowOptionsRenderThread(
-    Pointer<TView> tView,
-    Pointer<TVsmShadowOptions> optionsPtr,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _View_setTransparentPickingEnabledRenderThread(
-    Pointer<TView> tView,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _SceneAsset_destroyRenderThread(
-    Pointer<TSceneAsset> tSceneAsset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _SceneAsset_createFromFilamentAssetRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TFilamentAsset> tFilamentAsset,
-    int requiredGeometryCapabilities,
-    Pointer<NativeFunction<void Function(PointerClass<TSceneAsset>)>> onComplete,
-  );
-  external void _SceneAsset_createFromBuffersRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tVertexBuffer,
-    Pointer<TIndexBuffer> tIndexBuffer,
-    Pointer<PointerClass<TMaterialInstance>> materialInstances,
-    int materialInstanceCount,
-    int tPrimitiveType,
-    int vertexBufferStorageMode,
-    Pointer<Aabb3> boundingBoxPtr,
-    Pointer<NativeFunction<void Function(PointerClass<TSceneAsset>)>> callback,
-  );
-  external void _SceneAsset_createInstanceRenderThread(
-    Pointer<TSceneAsset> asset,
-    Pointer<PointerClass<TMaterialInstance>> tMaterialInstances,
-    int materialInstanceCount,
-    Pointer<NativeFunction<void Function(PointerClass<TSceneAsset>)>> callback,
-  );
-  external void _SceneAsset_releaseSourceDataRenderThread(
-    Pointer<TSceneAsset> tSceneAsset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _SceneAsset_setFlatShadingRenderThread(
-    Pointer<TSceneAsset> tSceneAsset,
-    bool flatShading,
-    int requestId,
-    VoidCallback onComplete,
   );
   external void _MaterialProvider_createMaterialInstanceRenderThread(
     Pointer<TMaterialProvider> tMaterialProvider,
@@ -1462,90 +1182,122 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     bool hasVolume,
     Pointer<NativeFunction<void Function(PointerClass<TMaterialInstance>)>> callback,
   );
-  external void _AnimationManager_updateRenderThread(
+  external Pointer<TMaterial> _Material_createBoneOverlayMaterial(Pointer<TEngine> tEngine);
+  external void _Material_createBoneOverlayMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
+  );
+  external Pointer<TMaterial> _Material_createEdgeOutlineMaterial(Pointer<TEngine> tEngine);
+  external void _Material_createEdgeOutlineMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
+  );
+  external Pointer<TMaterial> _Material_createGizmoMaterial(Pointer<TEngine> tEngine);
+  external void _Material_createGizmoMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
+  );
+  external Pointer<TMaterial> _Material_createGridMaterial(Pointer<TEngine> tEngine);
+  external Pointer<TMaterial> _Material_createImageMaterial(Pointer<TEngine> tEngine);
+  external void _Material_createImageMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
+  );
+  external Pointer<TMaterialInstance> _Material_createInstance(Pointer<TMaterial> tMaterial);
+  external void _Material_createInstanceRenderThread(
+    Pointer<TMaterial> tMaterial,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterialInstance>)>> onComplete,
+  );
+  external Pointer<TMaterial> _Material_createSilhouetteMaterial(Pointer<TEngine> tEngine);
+  external void _Material_createSilhouetteMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
+  );
+  external Pointer<TMaterial> _Material_createTranslationAxisMaterial(Pointer<TEngine> tEngine);
+  external void _Material_createTranslationAxisMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
+  );
+  external Pointer<TMaterial> _Material_createWireframeMaterial(Pointer<TEngine> tEngine);
+  external void _Material_createWireframeMaterialRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TMaterial>)>> onComplete,
+  );
+  external int _Material_getBlendingMode(Pointer<TMaterial> material);
+  external int _Material_getFeatureLevel(Pointer<TMaterial> tMaterial);
+  external int _Material_hasParameter(Pointer<TMaterial> tMaterial, Pointer<Char> propertyName);
+  external void _MeshData_dispose(Pointer<TMeshData> meshData);
+  external void _MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor);
+  external void _MovementIntentExecutor_process(
+    Pointer<TMovementIntentExecutor> executor,
+    Pointer<TMovementIntent> intent,
+    JSBigInt deltaTimeInNanos,
+  );
+  external Pointer<TNameComponentManager> _NameComponentManager_create();
+  external void _NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager);
+  external Pointer<Char> _NameComponentManager_getName(
+    Pointer<TNameComponentManager> tNameComponentManager,
+    EntityId entity,
+  );
+  external void _Pipeline_registerMovementIntentExecutor(Pointer<TMovementIntentExecutor> executor);
+  external void _RenderManager_addAnimationManager(
+    Pointer<TRenderManager> tRenderer,
     Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_addAnimationManagerRenderThread(
+    Pointer<TRenderManager> tRenderManager,
+    Pointer<TAnimationManager> tAnimationManager,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
+  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
+  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
+  external void _RenderManager_removeAnimationManager(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TAnimationManager> tAnimationManager,
+  );
+  external void _RenderManager_removeAnimationManagerRenderThread(
+    Pointer<TRenderManager> tRenderManager,
+    Pointer<TAnimationManager> tAnimationManager,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
+  external void _RenderManager_removeSwapChainRenderThread(
+    Pointer<TRenderManager> tRenderManager,
+    Pointer<TSwapChain> tSwapChain,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
+  external void _RenderManager_renderRenderThread(
+    Pointer<TRenderManager> tRenderManager,
     JSBigInt frameTimeInNanos,
     int requestId,
     VoidCallback onComplete,
   );
-  external void _AnimationManager_setGltfAnimationTimeRenderThread(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int animationIndex,
-    double timeInSeconds,
+  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
+  external void _RenderManager_setRenderable(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> swapChain,
+    Pointer<PointerClass<TView>> views,
+    int numViews,
+  );
+  external void _RenderManager_setRenderableRenderThread(
+    Pointer<TRenderManager> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    Pointer<PointerClass<TView>> tViews,
+    int numViews,
     int requestId,
     VoidCallback onComplete,
   );
-  external void _AnimationManager_updateBoneMatricesRenderThread(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    Pointer<NativeFunction<void Function(bool)>> callback,
-  );
-  external void _AnimationManager_setMorphTargetWeightsRenderThread(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    int numWeights,
-    Pointer<NativeFunction<void Function(bool)>> callback,
-  );
-  external void _Image_createEmptyRenderThread(
-    int width,
-    int height,
-    int channel,
-    Pointer<NativeFunction<void Function(PointerClass<TLinearImage>)>> onComplete,
-  );
-  external void _Image_decodeRenderThread(
-    Pointer<Uint8> data,
-    size_t length,
-    Pointer<Char> name,
-    bool alpha,
-    Pointer<NativeFunction<void Function(PointerClass<TLinearImage>)>> onComplete,
-  );
-  external void _Image_getBytesRenderThread(
-    Pointer<TLinearImage> tLinearImage,
-    Pointer<NativeFunction<void Function(PointerClass<Float32>)>> onComplete,
-  );
-  external void _Image_destroyRenderThread(Pointer<TLinearImage> tLinearImage, int requestId, VoidCallback onComplete);
-  external void _Image_getWidthRenderThread(
-    Pointer<TLinearImage> tLinearImage,
-    Pointer<NativeFunction<void Function(int)>> onComplete,
-  );
-  external void _Image_getHeightRenderThread(
-    Pointer<TLinearImage> tLinearImage,
-    Pointer<NativeFunction<void Function(int)>> onComplete,
-  );
-  external void _Image_getChannelsRenderThread(
-    Pointer<TLinearImage> tLinearImage,
-    Pointer<NativeFunction<void Function(int)>> onComplete,
-  );
-  external void _Texture_loadImageRenderThread(
+  external Pointer<TRenderTarget> _RenderTarget_create(
     Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    Pointer<TLinearImage> tImage,
-    int bufferFormat,
-    int pixelDataType,
-    int level,
-    Pointer<NativeFunction<void Function(bool)>> onComplete,
-  );
-  external void _Texture_setImageRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> tTexture,
-    int level,
-    Pointer<Uint8> data,
-    size_t size,
-    int x_offset,
-    int y_offset,
-    int z_offset,
-    int width,
-    int height,
-    int depth,
-    int bufferFormat,
-    int pixelDataType,
-    Pointer<NativeFunction<void Function(bool)>> onComplete,
-  );
-  external void _RenderTarget_getColorTextureRenderThread(
-    Pointer<TRenderTarget> tRenderTarget,
-    Pointer<NativeFunction<void Function(PointerClass<TTexture>)>> onComplete,
+    Pointer<TTexture> color,
+    Pointer<TTexture> depth,
   );
   external void _RenderTarget_createRenderThread(
     Pointer<TEngine> tEngine,
@@ -1553,591 +1305,46 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TTexture> depth,
     Pointer<NativeFunction<void Function(PointerClass<TRenderTarget>)>> onComplete,
   );
+  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
   external void _RenderTarget_destroyRenderThread(
     Pointer<TEngine> tEngine,
     Pointer<TRenderTarget> tRenderTarget,
     int requestId,
     VoidCallback onComplete,
   );
-  external void _TextureSampler_createRenderThread(
-    Pointer<NativeFunction<void Function(PointerClass<TTextureSampler>)>> onComplete,
+  external Pointer<TTexture> _RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget);
+  external void _RenderTarget_getColorTextureRenderThread(
+    Pointer<TRenderTarget> tRenderTarget,
+    Pointer<NativeFunction<void Function(PointerClass<TTexture>)>> onComplete,
   );
-  external void _TextureSampler_createWithFilteringRenderThread(
-    int minFilter,
-    int magFilter,
-    int wrapS,
-    int wrapT,
-    int wrapR,
-    Pointer<NativeFunction<void Function(PointerClass<TTextureSampler>)>> onComplete,
+  external Pointer<TTexture> _RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget);
+  external void _RenderThread_addTask(Pointer<NativeFunction<void Function()>> task);
+  external Pointer<Void> _RenderThread_create();
+  external Pointer<Void> _RenderThread_createForCanvas(Pointer<Char> canvasSelector);
+  external void _RenderThread_destroy(Pointer<Void> renderThread);
+  external void _RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, size_t primitiveIndex, int order);
+  external void _RenderableBuilder_boneIndicesAndWeights(
+    Pointer<TRenderableBuilder> builder,
+    size_t primitiveIndex,
+    Pointer<Float32> indicesAndWeights,
+    size_t count,
+    size_t bonesPerVertex,
   );
-  external void _TextureSampler_createWithComparisonRenderThread(
-    int compareMode,
-    int compareFunc,
-    Pointer<NativeFunction<void Function(PointerClass<TTextureSampler>)>> onComplete,
-  );
-  external void _TextureSampler_setMinFilterRenderThread(
-    Pointer<TTextureSampler> sampler,
-    int filter,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TextureSampler_setMagFilterRenderThread(
-    Pointer<TTextureSampler> sampler,
-    int filter,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TextureSampler_setWrapModeSRenderThread(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TextureSampler_setWrapModeTRenderThread(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TextureSampler_setWrapModeRRenderThread(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TextureSampler_setAnisotropyRenderThread(
-    Pointer<TTextureSampler> sampler,
-    double anisotropy,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TextureSampler_setCompareModeRenderThread(
-    Pointer<TTextureSampler> sampler,
-    int mode,
-    int func,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TextureSampler_destroyRenderThread(
-    Pointer<TTextureSampler> sampler,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _AnimationManager_resetToRestPoseRenderThread(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _GltfAssetLoader_createRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<NativeFunction<void Function(PointerClass<TGltfAssetLoader>)>> callback,
-  );
-  external void _GltfAssetLoader_destroyRenderThread(
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _GltfResourceLoader_createRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TGltfResourceLoader>)>> callback,
-  );
-  external void _GltfResourceLoader_destroyRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfResourceLoader> tResourceLoader,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _GltfResourceLoader_loadResourcesRenderThread(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-    Pointer<NativeFunction<void Function(bool)>> callback,
-  );
-  external void _GltfResourceLoader_addResourceDataRenderThread(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
-    Pointer<Uint8> data,
-    size_t length,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _GltfResourceLoader_asyncBeginLoadRenderThread(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-    Pointer<NativeFunction<void Function(bool)>> callback,
-  );
-  external void _GltfResourceLoader_asyncUpdateLoadRenderThread(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external void _GltfResourceLoader_asyncGetLoadProgressRenderThread(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<NativeFunction<void Function(double)>> callback,
-  );
-  external void _GltfAssetLoader_loadRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
-    Pointer<NativeFunction<void Function(PointerClass<TFilamentAsset>)>> callback,
-  );
-  external void _Scene_addFilamentAssetRenderThread(
-    Pointer<TScene> tScene,
-    Pointer<TFilamentAsset> tAsset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _FilamentAsset_getWireframeRenderThread(
-    Pointer<TFilamentAsset> tFilamentAsset,
-    Pointer<NativeFunction<void Function(EntityId)>> onComplete,
-  );
-  external void _Scene_addEntityRenderThread(
-    Pointer<TScene> tScene,
-    EntityId entityId,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Scene_removeEntityRenderThread(
-    Pointer<TScene> tScene,
-    EntityId entityId,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _SceneAsset_addToSceneRenderThread(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _SceneAsset_removeFromSceneRenderThread(
-    Pointer<TSceneAsset> tSceneAsset,
-    Pointer<TScene> tScene,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Scene_setSkyboxRenderThread(
-    Pointer<TScene> tScene,
-    Pointer<TSkybox> tSkybox,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Scene_setIndirectLightRenderThread(
-    Pointer<TScene> tScene,
-    Pointer<TIndirectLight> tIndirectLight,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Gizmo_createRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TNameComponentManager> tNameComponentManager,
-    Pointer<TView> tView,
-    Pointer<TMaterial> tMaterial,
-    int tGizmoType,
-    Pointer<NativeFunction<void Function(PointerClass<TGizmo>)>> callback,
-  );
-  external void _VertexBufferBuilder_buildRenderThread(
-    Pointer<TVertexBufferBuilder> tBuilder,
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TVertexBuffer>)>> onComplete,
-  );
-  external void _VertexBuffer_destroyRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tBuffer,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _VertexBuffer_setBufferAtRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tBuffer,
-    int bufferIndex,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _VertexBuffer_setBufferObjectAtRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TVertexBuffer> tBuffer,
-    int bufferIndex,
-    Pointer<TBufferObject> tBufferObject,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _BufferObjectBuilder_buildRenderThread(
-    Pointer<TBufferObjectBuilder> tBuilder,
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TBufferObject>)>> onComplete,
-  );
-  external void _BufferObject_setBufferRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TBufferObject> tBuffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _BufferObject_destroyRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TBufferObject> tBuffer,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _IndexBufferBuilder_buildRenderThread(
-    Pointer<TIndexBufferBuilder> tBuilder,
-    Pointer<TEngine> tEngine,
-    Pointer<NativeFunction<void Function(PointerClass<TIndexBuffer>)>> onComplete,
-  );
-  external void _IndexBuffer_destroyRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TIndexBuffer> tBuffer,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _IndexBuffer_setBufferRenderThread(
-    Pointer<TEngine> tEngine,
-    Pointer<TIndexBuffer> tBuffer,
-    Pointer<Void> data,
-    size_t sizeInBytes,
-    int byteOffset,
-    int requestId,
-    VoidCallback onComplete,
-  );
+  external void _RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Pointer<Aabb3> aabbPtr);
+  external int _RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, EntityId entity);
   external void _RenderableBuilder_buildRenderThread(
     Pointer<TRenderableBuilder> tBuilder,
     Pointer<TEngine> tEngine,
     EntityId entityId,
     Pointer<NativeFunction<void Function(int)>> onComplete,
   );
-  external void _EntityManager_createEntityRenderThread(
-    Pointer<TEntityManager> tEntityManager,
-    Pointer<NativeFunction<void Function(EntityId)>> onComplete,
-  );
-  external void _EntityManager_destroyEntityRenderThread(
-    Pointer<TEntityManager> tEntityManager,
-    EntityId entityId,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TransformManager_setTransformRenderThread(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    Pointer<double4x4> transformPtr,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TransformManager_setParentRenderThread(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId child,
-    EntityId parent,
-    bool preserveScaling,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TransformManager_createComponentRenderThread(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _TransformManager_removeComponentRenderThread(
-    Pointer<TTransformManager> tTransformManager,
-    EntityId entityId,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderableManager_destroyEntityRenderThread(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderableManager_setMorphWeightsRenderThread(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    Pointer<Float32> weights,
-    size_t count,
-    size_t offset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderableManager_setBonesFromMat4RenderThread(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    Pointer<Float32> transforms,
-    size_t boneCount,
-    size_t offset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderableManager_setBonesFromBoneRenderThread(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    Pointer<Float32> bones,
-    size_t boneCount,
-    size_t offset,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderableManager_setGeometryAtNonIndexedRenderThread(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int primitiveIndex,
-    int type,
-    Pointer<TVertexBuffer> tVertices,
-    size_t offset,
-    size_t count,
-    Pointer<NativeFunction<void Function(bool)>> callback,
-  );
-  external void _RenderableManager_setCastShadowsRenderThread(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _RenderableManager_setReceiveShadowsRenderThread(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _LightManager_setShadowCasterRenderThread(
-    Pointer<TLightManager> tLightManager,
-    EntityId entityId,
-    bool enabled,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _LightManager_setShadowOptionsRenderThread(
-    Pointer<TLightManager> tLightManager,
-    EntityId entityId,
-    Pointer<TShadowOptions> optionsPtr,
-    int requestId,
-    VoidCallback onComplete,
-  );
-  external void _Renderer_setClearOptions(
-    Pointer<TRenderer> tRenderer,
-    double clearR,
-    double clearG,
-    double clearB,
-    double clearA,
-    int clearStencil,
-    bool clear,
-    bool discard,
-  );
-  external int _Renderer_beginFrame(
-    Pointer<TRenderer> tRenderer,
-    Pointer<TSwapChain> tSwapChain,
-    JSBigInt frameTimeInNanos,
-  );
-  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
-  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
-  external void _Renderer_readPixels(
-    Pointer<TRenderer> tRenderer,
-    int width,
-    int height,
-    int xOffset,
-    int yOffset,
-    Pointer<TRenderTarget> tRenderTarget,
-    int tPixelBufferFormat,
-    int tPixelDataType,
-    Pointer<Uint8> out,
-    size_t outLength,
-  );
-  external void _Renderer_setFrameInterval(
-    Pointer<TRenderer> tRenderer,
-    double headRoomRatio,
-    double scaleRate,
-    int history,
-    int interval,
-  );
-  external Pointer<TRenderTarget> _RenderTarget_create(
-    Pointer<TEngine> tEngine,
-    Pointer<TTexture> color,
-    Pointer<TTexture> depth,
-  );
-  external void _RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget);
-  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
-
-  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
-
-  /// Returns the visibility mask bits.
-  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
-
-  /// Returns the skybox intensity in lux.
-  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
-
-  /// Returns the environment texture, or nullptr for a color-only skybox.
-  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
-  external void _RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external int _RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external int _RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager);
-  external int _RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external size_t _RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager);
-  external int _RenderableManager_setMaterialInstanceAt(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int primitiveIndex,
-    Pointer<TMaterialInstance> tMaterialInstance,
-  );
-  external Pointer<TMaterialInstance> _RenderableManager_getMaterialInstanceAt(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int primitiveIndex,
-  );
-  external void _RenderableManager_clearMaterialInstanceAt(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int primitiveIndex,
-  );
-  external int _RenderableManager_setGeometryAtNonIndexed(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int primitiveIndex,
-    int type,
-    Pointer<TVertexBuffer> vertices,
-    size_t offset,
-    size_t count,
-  );
-  external size_t _RenderableManager_getPrimitiveCount(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-  );
-  external void _RenderableManager_getAxisAlignedBoundingBox(
-    Pointer<Aabb3> Aabb3_out,
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-  );
-  external void _RenderableManager_setAxisAlignedBoundingBox(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    Pointer<Aabb3> aabbPtr,
-  );
-  external void _RenderableManager_getAabb(
-    Pointer<Aabb3> Aabb3_out,
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-  );
-  external void _RenderableManager_getBoundingBox(
-    Pointer<Aabb3> Aabb3_out,
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-  );
-  external void _RenderableManager_setLayerMask(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int select,
-    int values,
-  );
-  external int _RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external void _RenderableManager_setVisibilityLayer(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int layer,
-  );
-  external void _RenderableManager_setPriority(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int priority,
-  );
-  external int _RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external void _RenderableManager_setChannel(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int channel,
-  );
-  external void _RenderableManager_setCulling(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    bool enabled,
-  );
-  external int _RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external void _RenderableManager_setFogEnabled(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    bool enabled,
-  );
-  external int _RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external void _RenderableManager_setLightChannel(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int channel,
-    bool enable,
-  );
-  external int _RenderableManager_getLightChannel(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    int channel,
-  );
-  external void _RenderableManager_setCastShadows(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    bool castShadows,
-  );
-  external int _RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external void _RenderableManager_setReceiveShadows(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    bool receiveShadows,
-  );
-  external int _RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
-  external void _RenderableManager_setScreenSpaceContactShadows(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    bool enabled,
-  );
-  external void _RenderableManager_setBlendOrderAt(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    size_t primitiveIndex,
-    int order,
-  );
-  external void _RenderableManager_setGlobalBlendOrderEnabledAt(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    size_t primitiveIndex,
-    bool enabled,
-  );
-  external void _RenderableManager_setMorphWeights(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    Pointer<Float32> weights,
-    size_t count,
-    size_t offset,
-  );
-  external size_t _RenderableManager_getMorphTargetCount(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-  );
-  external void _RenderableManager_setBonesFromMat4(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    Pointer<Float32> transforms,
-    size_t boneCount,
-    size_t offset,
-  );
-  external void _RenderableManager_setBonesFromBone(
-    Pointer<TRenderableManager> tRenderableManager,
-    EntityId entityId,
-    Pointer<Float32> bones,
-    size_t boneCount,
-    size_t offset,
-  );
+  external void _RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled);
+  external void _RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel);
   external Pointer<TRenderableBuilder> _RenderableBuilder_create(size_t primitiveCount);
+  external void _RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled);
   external void _RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder);
-  external void _RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Pointer<Aabb3> aabbPtr);
-  external void _RenderableBuilder_material(
-    Pointer<TRenderableBuilder> builder,
-    size_t primitiveIndex,
-    Pointer<TMaterialInstance> materialInstance,
-  );
+  external void _RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled);
+  external void _RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled);
   external void _RenderableBuilder_geometry(
     Pointer<TRenderableBuilder> builder,
     size_t primitiveIndex,
@@ -2155,62 +1362,491 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t offset,
     size_t count,
   );
-  external void _RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority);
-  external void _RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel);
-  external void _RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled);
-  external void _RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled);
-  external void _RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled);
-  external void _RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled);
-  external void _RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled);
-  external void _RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values);
-  external void _RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled);
-  external void _RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, size_t primitiveIndex, int order);
   external void _RenderableBuilder_globalBlendOrderEnabled(
     Pointer<TRenderableBuilder> builder,
     size_t primitiveIndex,
     bool enabled,
   );
   external void _RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, size_t instanceCount);
-  external void _RenderableBuilder_skinningFromMat4(
+  external void _RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values);
+  external void _RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled);
+  external void _RenderableBuilder_material(
     Pointer<TRenderableBuilder> builder,
-    size_t boneCount,
-    Pointer<Float32> transforms,
+    size_t primitiveIndex,
+    Pointer<TMaterialInstance> materialInstance,
   );
+  external void _RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority);
+  external void _RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled);
+  external void _RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled);
   external void _RenderableBuilder_skinningFromBone(
     Pointer<TRenderableBuilder> builder,
     size_t boneCount,
     Pointer<Float32> bones,
   );
-  external void _RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled);
-  external void _RenderableBuilder_boneIndicesAndWeights(
+  external void _RenderableBuilder_skinningFromMat4(
     Pointer<TRenderableBuilder> builder,
-    size_t primitiveIndex,
-    Pointer<Float32> indicesAndWeights,
-    size_t count,
-    size_t bonesPerVertex,
+    size_t boneCount,
+    Pointer<Float32> transforms,
   );
-  external int _RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, EntityId entity);
-  external void _IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation);
+  external void _RenderableManager_clearMaterialInstanceAt(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int primitiveIndex,
+  );
+  external void _RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external void _RenderableManager_destroyEntityRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager);
+  external void _RenderableManager_getAabb(
+    Pointer<Aabb3> Aabb3_out,
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+  );
+  external void _RenderableManager_getAxisAlignedBoundingBox(
+    Pointer<Aabb3> Aabb3_out,
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+  );
+  external void _RenderableManager_getBoundingBox(
+    Pointer<Aabb3> Aabb3_out,
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+  );
+  external size_t _RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager);
+  external int _RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external int _RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external int _RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external int _RenderableManager_getLightChannel(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int channel,
+  );
+  external Pointer<TMaterialInstance> _RenderableManager_getMaterialInstanceAt(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int primitiveIndex,
+  );
+  external size_t _RenderableManager_getMorphTargetCount(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+  );
+  external size_t _RenderableManager_getPrimitiveCount(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+  );
+  external int _RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external int _RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external int _RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external int _RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external int _RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, EntityId entityId);
+  external void _RenderableManager_setAxisAlignedBoundingBox(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    Pointer<Aabb3> aabbPtr,
+  );
+  external void _RenderableManager_setBlendOrderAt(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    size_t primitiveIndex,
+    int order,
+  );
+  external void _RenderableManager_setBonesFromBone(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    Pointer<Float32> bones,
+    size_t boneCount,
+    size_t offset,
+  );
+  external void _RenderableManager_setBonesFromBoneRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    Pointer<Float32> bones,
+    size_t boneCount,
+    size_t offset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderableManager_setBonesFromMat4(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    Pointer<Float32> transforms,
+    size_t boneCount,
+    size_t offset,
+  );
+  external void _RenderableManager_setBonesFromMat4RenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    Pointer<Float32> transforms,
+    size_t boneCount,
+    size_t offset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderableManager_setCastShadows(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool castShadows,
+  );
+  external void _RenderableManager_setCastShadowsRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderableManager_setChannel(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int channel,
+  );
+  external void _RenderableManager_setCulling(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool enabled,
+  );
+  external void _RenderableManager_setFogEnabled(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool enabled,
+  );
+  external int _RenderableManager_setGeometryAtNonIndexed(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int primitiveIndex,
+    int type,
+    Pointer<TVertexBuffer> vertices,
+    size_t offset,
+    size_t count,
+  );
+  external void _RenderableManager_setGeometryAtNonIndexedRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int primitiveIndex,
+    int type,
+    Pointer<TVertexBuffer> tVertices,
+    size_t offset,
+    size_t count,
+    Pointer<NativeFunction<void Function(bool)>> callback,
+  );
+  external void _RenderableManager_setGlobalBlendOrderEnabledAt(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    size_t primitiveIndex,
+    bool enabled,
+  );
+  external void _RenderableManager_setLayerMask(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int select,
+    int values,
+  );
+  external void _RenderableManager_setLightChannel(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int channel,
+    bool enable,
+  );
+  external int _RenderableManager_setMaterialInstanceAt(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int primitiveIndex,
+    Pointer<TMaterialInstance> tMaterialInstance,
+  );
+  external void _RenderableManager_setMorphWeights(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    Pointer<Float32> weights,
+    size_t count,
+    size_t offset,
+  );
+  external void _RenderableManager_setMorphWeightsRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    Pointer<Float32> weights,
+    size_t count,
+    size_t offset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderableManager_setPriority(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int priority,
+  );
+  external void _RenderableManager_setReceiveShadows(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool receiveShadows,
+  );
+  external void _RenderableManager_setReceiveShadowsRenderThread(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _RenderableManager_setScreenSpaceContactShadows(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    bool enabled,
+  );
+  external void _RenderableManager_setVisibilityLayer(
+    Pointer<TRenderableManager> tRenderableManager,
+    EntityId entityId,
+    int layer,
+  );
+  external int _Renderer_beginFrame(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+  );
+  external void _Renderer_beginFrameRenderThread(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TSwapChain> tSwapChain,
+    JSBigInt frameTimeInNanos,
+    Pointer<NativeFunction<void Function(bool)>> onComplete,
+  );
+  external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
+  external void _Renderer_endFrameRenderThread(Pointer<TRenderer> tRenderer, int requestId, VoidCallback onComplete);
+  external void _Renderer_readPixels(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+  );
+  external void _Renderer_readPixelsRenderThread(
+    Pointer<TRenderer> tRenderer,
+    int width,
+    int height,
+    int xOffset,
+    int yOffset,
+    Pointer<TRenderTarget> tRenderTarget,
+    int tPixelBufferFormat,
+    int tPixelDataType,
+    Pointer<Uint8> out,
+    size_t outLength,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_renderRenderThread(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
+  external void _Renderer_renderStandaloneViewRenderThread(
+    Pointer<TRenderer> tRenderer,
+    Pointer<TView> tView,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Renderer_setClearOptions(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+  );
+  external void _Renderer_setClearOptionsRenderThread(
+    Pointer<TRenderer> tRenderer,
+    double clearR,
+    double clearG,
+    double clearB,
+    double clearA,
+    int clearStencil,
+    bool clear,
+    bool discard,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Renderer_setFrameInterval(
+    Pointer<TRenderer> tRenderer,
+    double headRoomRatio,
+    double scaleRate,
+    int history,
+    int interval,
+  );
+  external void _SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external void _SceneAsset_addToSceneRenderThread(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromBuffers(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    int vertexBufferStorageMode,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external void _SceneAsset_createFromBuffersRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tVertexBuffer,
+    Pointer<TIndexBuffer> tIndexBuffer,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+    int tPrimitiveType,
+    int vertexBufferStorageMode,
+    Pointer<Aabb3> boundingBoxPtr,
+    Pointer<NativeFunction<void Function(PointerClass<TSceneAsset>)>> callback,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createFromFilamentAsset(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    int requiredGeometryCapabilities,
+  );
+  external void _SceneAsset_createFromFilamentAssetRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TNameComponentManager> tNameComponentManager,
+    Pointer<TFilamentAsset> tFilamentAsset,
+    int requiredGeometryCapabilities,
+    Pointer<NativeFunction<void Function(PointerClass<TSceneAsset>)>> onComplete,
+  );
+  external Pointer<TSceneAsset> _SceneAsset_createInstance(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> materialInstances,
+    int materialInstanceCount,
+  );
+  external void _SceneAsset_createInstanceRenderThread(
+    Pointer<TSceneAsset> asset,
+    Pointer<PointerClass<TMaterialInstance>> tMaterialInstances,
+    int materialInstanceCount,
+    Pointer<NativeFunction<void Function(PointerClass<TSceneAsset>)>> callback,
+  );
+  external void _SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_destroyRenderThread(
+    Pointer<TSceneAsset> tSceneAsset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external size_t _SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex);
+  external Pointer<Char> _SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, size_t boneIndex);
+  external void _SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, size_t skinIndex, Pointer<Int32> out);
+  external void _SceneAsset_getBoundingBox(Pointer<Aabb3> Aabb3_out, Pointer<TSceneAsset> asset);
+  external Pointer<Int32> _SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out);
+  external int _SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external EntityId _SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TFilamentAsset> _SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset);
+  external Pointer<TIndexBuffer> _SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external Pointer<TSceneAsset> _SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index);
+  external size_t _SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<Int32> _SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset);
+  external size_t _SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset);
+  external int _SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, EntityId entity);
+  external int _SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset);
+  external Pointer<TVertexBuffer> _SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external int _SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex);
+  external void _SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset);
+  external void _SceneAsset_releaseSourceDataRenderThread(
+    Pointer<TSceneAsset> tSceneAsset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene);
+  external void _SceneAsset_removeFromSceneRenderThread(
+    Pointer<TSceneAsset> tSceneAsset,
+    Pointer<TScene> tScene,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading);
+  external void _SceneAsset_setFlatShadingRenderThread(
+    Pointer<TSceneAsset> tSceneAsset,
+    bool flatShading,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset);
+  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_addEntityRenderThread(
+    Pointer<TScene> tScene,
+    EntityId entityId,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
+  external void _Scene_addFilamentAssetRenderThread(
+    Pointer<TScene> tScene,
+    Pointer<TFilamentAsset> tAsset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
+  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
+  external void _Scene_removeEntityRenderThread(
+    Pointer<TScene> tScene,
+    EntityId entityId,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
+  external void _Scene_setIndirectLightRenderThread(
+    Pointer<TScene> tScene,
+    Pointer<TIndirectLight> tIndirectLight,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
+  external void _Scene_setSkyboxRenderThread(
+    Pointer<TScene> tScene,
+    Pointer<TSkybox> tSkybox,
+    int requestId,
+    VoidCallback onComplete,
+  );
+
+  /// Returns the skybox intensity in lux.
+  external double _Skybox_getIntensity(Pointer<TSkybox> tSkybox);
+
+  /// Returns the visibility mask bits.
+  external int _Skybox_getLayerMask(Pointer<TSkybox> tSkybox);
+
+  /// Returns the environment texture, or nullptr for a color-only skybox.
+  external Pointer<TTexture> _Skybox_getTexture(Pointer<TSkybox> tSkybox);
+  external void _Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a);
+
+  /// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+  external void _Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values);
+  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
   external Pointer<TSurfaceOrientationBuilder> _SurfaceOrientationBuilder_create();
-  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
   external void _SurfaceOrientationBuilder_normals(
     Pointer<TSurfaceOrientationBuilder> builder,
     Pointer<Float32> normals,
     size_t stride,
   );
-  external void _SurfaceOrientationBuilder_tangents(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> tangents,
-    size_t stride,
-  );
-  external void _SurfaceOrientationBuilder_uvs(
-    Pointer<TSurfaceOrientationBuilder> builder,
-    Pointer<Float32> uvs,
-    size_t stride,
-  );
   external void _SurfaceOrientationBuilder_positions(
     Pointer<TSurfaceOrientationBuilder> builder,
     Pointer<Float32> positions,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_tangents(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> tangents,
     size_t stride,
   );
   external void _SurfaceOrientationBuilder_triangleCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
@@ -2222,18 +1858,16 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TSurfaceOrientationBuilder> builder,
     Pointer<Uint16> triangles,
   );
-  external Pointer<TSurfaceOrientation> _SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder);
-  external void _SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder);
-  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
+  external void _SurfaceOrientationBuilder_uvs(
+    Pointer<TSurfaceOrientationBuilder> builder,
+    Pointer<Float32> uvs,
+    size_t stride,
+  );
+  external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
   external void _SurfaceOrientation_getQuats_float4(
     Pointer<TSurfaceOrientation> orientation,
     Pointer<Float32> out,
-    size_t quatCount,
-    size_t stride,
-  );
-  external void _SurfaceOrientation_getQuats_short4(
-    Pointer<TSurfaceOrientation> orientation,
-    Pointer<Int16> out,
     size_t quatCount,
     size_t stride,
   );
@@ -2243,218 +1877,334 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t quatCount,
     size_t stride,
   );
-  external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
-  external Pointer<TAnimationManager> _AnimationManager_create(Pointer<TEngine> tEngine);
-  external void _AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager);
-  external void _AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, JSBigInt frameTimeInNanos);
-  external int _AnimationManager_addGltfAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _SurfaceOrientation_getQuats_short4(
+    Pointer<TSurfaceOrientation> orientation,
+    Pointer<Int16> out,
+    size_t quatCount,
+    size_t stride,
   );
-  external int _AnimationManager_removeGltfAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
+  external size_t _SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation);
+  external Pointer<Int32> _TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
+  external Pointer<Int32> _TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER;
+  external Pointer<Int32> _TSWAP_CHAIN_CONFIG_READABLE;
+  external Pointer<Int32> _TSWAP_CHAIN_CONFIG_TRANSPARENT;
+  external Pointer<TTextureSampler> _TextureSampler_create();
+  external void _TextureSampler_createRenderThread(
+    Pointer<NativeFunction<void Function(PointerClass<TTextureSampler>)>> onComplete,
   );
-  external void _AnimationManager_addMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
+  external Pointer<TTextureSampler> _TextureSampler_createWithComparison(int compareMode, int compareFunc);
+  external void _TextureSampler_createWithComparisonRenderThread(
+    int compareMode,
+    int compareFunc,
+    Pointer<NativeFunction<void Function(PointerClass<TTextureSampler>)>> onComplete,
   );
-  external void _AnimationManager_removeMorphAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
+  external Pointer<TTextureSampler> _TextureSampler_createWithFiltering(
+    int minFilter,
+    int magFilter,
+    int wrapS,
+    int wrapT,
+    int wrapR,
   );
-  external int _AnimationManager_addBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _TextureSampler_createWithFilteringRenderThread(
+    int minFilter,
+    int magFilter,
+    int wrapS,
+    int wrapT,
+    int wrapR,
+    Pointer<NativeFunction<void Function(PointerClass<TTextureSampler>)>> onComplete,
   );
-  external int _AnimationManager_removeBoneAnimationComponent(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
+  external void _TextureSampler_destroy(Pointer<TTextureSampler> sampler);
+  external void _TextureSampler_destroyRenderThread(
+    Pointer<TTextureSampler> sampler,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external int _AnimationManager_setMorphAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    Pointer<Uint32> morphIndices,
-    int numMorphTargets,
-    int numFrames,
-    double frameLengthInMs,
+  external void _TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy);
+  external void _TextureSampler_setAnisotropyRenderThread(
+    Pointer<TTextureSampler> sampler,
+    double anisotropy,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external int _AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, EntityId entityId);
-  external void _AnimationManager_resetToRestPose(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
+  external void _TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func);
+  external void _TextureSampler_setCompareModeRenderThread(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+    int func,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external int _AnimationManager_addBoneAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> frameData,
-    int numFrames,
-    double frameLengthInMs,
-    double fadeOutInSecs,
-    double fadeInInSecs,
-    double maxDelta,
-    bool loop,
+  external void _TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setMagFilterRenderThread(
+    Pointer<TTextureSampler> sampler,
+    int filter,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external void _AnimationManager_getRestLocalTransforms(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    Pointer<Float32> out,
-    int numBones,
+  external void _TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter);
+  external void _TextureSampler_setMinFilterRenderThread(
+    Pointer<TTextureSampler> sampler,
+    int filter,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external void _AnimationManager_getInverseBindMatrix(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int skinIndex,
-    int boneIndex,
-    Pointer<Float32> out,
+  external void _TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeRRenderThread(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external int _AnimationManager_playGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int index,
-    bool loop,
-    bool reverse,
-    bool replaceActive,
-    double crossfade,
-    double startOffset,
-    double speed,
+  external void _TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeSRenderThread(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external int _AnimationManager_stopGltfAnimation(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int index,
+  external void _TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode);
+  external void _TextureSampler_setWrapModeTRenderThread(
+    Pointer<TTextureSampler> sampler,
+    int mode,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external double _AnimationManager_getGltfAnimationDuration(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    int animationIndex,
+  external Pointer<TTexture> _Texture_build(
+    Pointer<TEngine> engine,
+    int width,
+    int height,
+    int depth,
+    int levels,
+    int tUsage,
+    int import1,
+    int sampler,
+    int format,
   );
-  external int _AnimationManager_getGltfAnimationCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
+  external void _Texture_buildRenderThread(
+    Pointer<TEngine> engine,
+    int width,
+    int height,
+    int depth,
+    int levels,
+    int tUsage,
+    int import1,
+    int sampler,
+    int format,
+    Pointer<NativeFunction<void Function(PointerClass<TTexture>)>> onComplete,
   );
-  external void _AnimationManager_getGltfAnimationName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_getMorphTargetNameCount(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-  );
-  external void _AnimationManager_getMorphTargetName(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-    EntityId childEntity,
-    Pointer<Char> outPtr,
-    int index,
-  );
-  external int _AnimationManager_updateBoneMatrices(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> sceneAsset,
-  );
-  external int _AnimationManager_setMorphTargetWeights(
-    Pointer<TAnimationManager> tAnimationManager,
-    EntityId entityId,
-    Pointer<Float32> morphData,
-    int numWeights,
-  );
-  external int _AnimationManager_setGltfAnimationTime(
-    Pointer<TAnimationManager> tAnimationManager,
-    Pointer<TSceneAsset> tSceneAsset,
-    int animationIndex,
-    double timeInSeconds,
-  );
-  external Pointer<TGltfAssetLoader> _GltfAssetLoader_create(
+  external void _Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine);
+  external void _Texture_generateMipMapsRenderThread(
+    Pointer<TTexture> tTexture,
     Pointer<TEngine> tEngine,
-    Pointer<TMaterialProvider> tMaterialProvider,
-    Pointer<TNameComponentManager> tNameComponentManager,
+    int requestId,
+    VoidCallback onComplete,
   );
-  external void _GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader);
-  external Pointer<TFilamentAsset> _GltfAssetLoader_load(
+  external int _Texture_getDepth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getFormat(Pointer<TTexture> tTexture);
+  external int _Texture_getHeight(Pointer<TTexture> tTexture, int level);
+  external size_t _Texture_getLevels(Pointer<TTexture> tTexture);
+  external int _Texture_getUsage(Pointer<TTexture> tTexture, int level);
+  external int _Texture_getWidth(Pointer<TTexture> tTexture, int level);
+  external int _Texture_loadImage(
     Pointer<TEngine> tEngine,
-    Pointer<TGltfAssetLoader> tAssetLoader,
+    Pointer<TTexture> tTexture,
+    Pointer<TLinearImage> tImage,
+    int bufferFormat,
+    int pixelDataType,
+    int level,
+  );
+  external void _Texture_loadImageRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<TLinearImage> tImage,
+    int bufferFormat,
+    int pixelDataType,
+    int level,
+    Pointer<NativeFunction<void Function(bool)>> onComplete,
+  );
+  external void _Texture_setExternalImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<Void> externalImage,
+  );
+  external void _Texture_setExternalImageRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    Pointer<Void> externalImage,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _Texture_setImage(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    int level,
     Pointer<Uint8> data,
-    size_t length,
-    int numInstances,
+    size_t size,
+    int x_offset,
+    int y_offset,
+    int z_offset,
+    int width,
+    int height,
+    int depth,
+    int bufferFormat,
+    int pixelDataType,
   );
-  external Pointer<TMaterialInstance> _GltfAssetLoader_getMaterialInstance(
-    Pointer<TRenderableManager> tRenderableManager,
-    Pointer<TFilamentAsset> tAsset,
-  );
-  external Pointer<TMaterialProvider> _GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader);
-  external int _FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset);
-  external Pointer<PointerClass<Char>> _FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset);
-  external Pointer<TGltfResourceLoader> _GltfResourceLoader_create(Pointer<TEngine> tEngine);
-  external void _GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external int _GltfResourceLoader_asyncBeginLoad(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
-  );
-  external void _GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external double _GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader);
-  external void _GltfResourceLoader_addResourceData(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<Char> uri,
+  external void _Texture_setImageRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TTexture> tTexture,
+    int level,
     Pointer<Uint8> data,
-    size_t length,
+    size_t size,
+    int x_offset,
+    int y_offset,
+    int z_offset,
+    int width,
+    int height,
+    int depth,
+    int bufferFormat,
+    int pixelDataType,
+    Pointer<NativeFunction<void Function(bool)>> onComplete,
   );
-  external int _GltfResourceLoader_loadResources(
-    Pointer<TGltfResourceLoader> tGltfResourceLoader,
-    Pointer<TFilamentAsset> tFilamentAsset,
+  external int _Thermion_createGLContext(Pointer<Char> canvasSelector);
+  external void _Thermion_destroyCanvas(Pointer<Char> canvasSelector);
+  external int _Thermion_getGLContext();
+  external void _Thermion_setCanvasElementSize(Pointer<Char> name, int width, int height);
+  external Pointer<TToneMapper> _ToneMapper_createACES(Pointer<TEngine> tEngine);
+  external Pointer<TToneMapper> _ToneMapper_createACESLegacy(Pointer<TEngine> tEngine);
+  external void _ToneMapper_createACESLegacyRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
   );
-  external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
-  external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_addAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
+  external void _ToneMapper_createACESRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
   );
-  external void _RenderManager_removeAnimationManager(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TAnimationManager> tAnimationManager,
+  external Pointer<TToneMapper> _ToneMapper_createAGX(Pointer<TEngine> tEngine);
+  external void _ToneMapper_createAGXRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
   );
-  external void _RenderManager_render(Pointer<TRenderManager> tRenderer, JSBigInt frameTimeInNanos);
-  external void _RenderManager_setRenderable(
-    Pointer<TRenderManager> tRenderer,
-    Pointer<TSwapChain> swapChain,
-    Pointer<PointerClass<TView>> views,
-    int numViews,
+  external Pointer<TToneMapper> _ToneMapper_createAGXWithLook(Pointer<TEngine> tEngine, int look);
+  external void _ToneMapper_createAGXWithLookRenderThread(
+    Pointer<TEngine> tEngine,
+    int look,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
   );
-  external void _RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain);
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
-  external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
-  external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
-  external int _FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset);
-  external void _FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out);
-  external EntityId _FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset);
-  external Pointer<Void> _FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset);
-  external void _Scene_addEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_removeEntity(Pointer<TScene> tScene, EntityId entityId);
-  external void _Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox);
-  external Pointer<TSkybox> _Scene_getSkybox(Pointer<TScene> tScene);
-  external void _Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight);
-  external void _Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset);
-  external void _FrameScheduler_startWithCallback(FrameTickCallback tickCallback, int targetFps);
-  external void _FrameScheduler_stop();
-  external int _FrameScheduler_initDartApi(Pointer<Void> data);
-  external void _FrameScheduler_startWithPort(JSBigInt port, int targetFps);
-  external void _FrameScheduler_setTargetFps(int fps);
-  external JSBigInt _FrameScheduler_steadyClockUs();
-  external void _MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor);
-  external void _MovementIntentExecutor_process(
-    Pointer<TMovementIntentExecutor> executor,
-    Pointer<TMovementIntent> intent,
-    JSBigInt deltaTimeInNanos,
+  external Pointer<TToneMapper> _ToneMapper_createDisplayRange(Pointer<TEngine> tEngine);
+  external void _ToneMapper_createDisplayRangeRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
   );
-  external void _Pipeline_registerMovementIntentExecutor(Pointer<TMovementIntentExecutor> executor);
-  external void _TransformPipeline_setEngine(Pointer<Void> enginePtr);
+  external Pointer<TToneMapper> _ToneMapper_createFilmic(Pointer<TEngine> tEngine);
+  external void _ToneMapper_createFilmicRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createGeneric(
+    Pointer<TEngine> tEngine,
+    double contrast,
+    double midGrayIn,
+    double midGrayOut,
+    double hdrMax,
+  );
+  external void _ToneMapper_createGenericRenderThread(
+    Pointer<TEngine> tEngine,
+    double contrast,
+    double midGrayIn,
+    double midGrayOut,
+    double hdrMax,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createLinear(Pointer<TEngine> tEngine);
+  external void _ToneMapper_createLinearRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
+  );
+  external Pointer<TToneMapper> _ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine);
+  external void _ToneMapper_createPBRNeutralRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TToneMapper>)>> onComplete,
+  );
+  external void _ToneMapper_destroy(Pointer<TToneMapper> toneMapper);
+  external void _ToneMapper_destroyRenderThread(
+    Pointer<TToneMapper> tToneMapper,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
+  external void _TransformManager_createComponent(Pointer<TTransformManager> tTransformManager, EntityId entity);
+  external void _TransformManager_createComponentRenderThread(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _TransformManager_empty(Pointer<TTransformManager> tTransformManager);
+  external EntityId _TransformManager_getAncestor(Pointer<TTransformManager> tTransformManager, EntityId childEntityId);
+  external int _TransformManager_getChildCount(Pointer<TTransformManager> tTransformManager, EntityId entityId);
+  external void _TransformManager_getChildren(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<Int32> children,
+    int count,
+  );
+  external int _TransformManager_getComponentCount(Pointer<TTransformManager> tTransformManager);
+  external void _TransformManager_getLocalTransform(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external EntityId _TransformManager_getParent(Pointer<TTransformManager> tTransformManager, EntityId child);
+  external void _TransformManager_getWorldTransform(
+    Pointer<double4x4> double4x4_out,
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+  );
+  external int _TransformManager_hasComponent(Pointer<TTransformManager> tTransformManager, EntityId entityId);
+  external void _TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager);
+  external void _TransformManager_removeComponent(Pointer<TTransformManager> tTransformManager, EntityId entity);
+  external void _TransformManager_removeComponentRenderThread(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _TransformManager_setParent(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId child,
+    EntityId parent,
+    bool preserveScaling,
+  );
+  external void _TransformManager_setParentRenderThread(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId child,
+    EntityId parent,
+    bool preserveScaling,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _TransformManager_setTransform(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<double4x4> transformPtr,
+  );
+  external void _TransformManager_setTransformRenderThread(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<double4x4> transformPtr,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external int _TransformManager_transformToUnitCube(
+    Pointer<TTransformManager> tTransformManager,
+    EntityId entityId,
+    Pointer<Aabb3> boundingBoxPtr,
+  );
+  external void _TransformPipeline_addKeyBinding(int logicalKey, int intentAction, double value);
+  external void _TransformPipeline_addMouseButtonBinding(int mouseButton, int intentAction, double value);
+  external void _TransformPipeline_cleanup();
+  external void _TransformPipeline_clearKeyBindings();
+  external void _TransformPipeline_onKeyEvent(int eventType, int logicalKey, int physicalKey, int synthesized);
   external void _TransformPipeline_onMouseEvent(
     int eventType,
     int button,
@@ -2463,142 +2213,952 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     double deltaX,
     double deltaY,
   );
-  external void _TransformPipeline_onKeyEvent(int eventType, int logicalKey, int physicalKey, int synthesized);
   external void _TransformPipeline_onScrollEvent(double localX, double localY, double delta);
-  external void _TransformPipeline_update(double deltaTime);
   external void _TransformPipeline_registerPipelineStage(Pointer<Void> pipelineStageHandle, Pointer<Char> name);
-  external void _TransformPipeline_unregisterPipelineStage(Pointer<Void> pipelineStageHandle);
-  external void _TransformPipeline_cleanup();
-  external void _TransformPipeline_addKeyBinding(int logicalKey, int intentAction, double value);
-  external void _TransformPipeline_removeKeyBindingsForKey(int logicalKey);
   external void _TransformPipeline_removeKeyBindingsForAction(int intentAction);
-  external void _TransformPipeline_clearKeyBindings();
-  external void _TransformPipeline_addMouseButtonBinding(int mouseButton, int intentAction, double value);
+  external void _TransformPipeline_removeKeyBindingsForKey(int logicalKey);
   external void _TransformPipeline_removeMouseButtonBindings(int mouseButton);
-  external void _TransformPipeline_setMouseSensitivity(double sensitivity);
+  external void _TransformPipeline_setEngine(Pointer<Void> enginePtr);
   external void _TransformPipeline_setInvertMouseY(int invert);
-}
-
-void Thermion_setCanvasElementSize(Pointer<Char> name, int width, int height) {
-  final result = GeneratedBindings.instance._Thermion_setCanvasElementSize(name, width, height);
-  return result;
-}
-
-void Thermion_destroyCanvas(Pointer<Char> canvasSelector) {
-  final result = GeneratedBindings.instance._Thermion_destroyCanvas(canvasSelector);
-  return result;
-}
-
-int Thermion_createGLContext(Pointer<Char> canvasSelector) {
-  final result = GeneratedBindings.instance._Thermion_createGLContext(canvasSelector);
-  return result;
-}
-
-int Thermion_getGLContext() {
-  final result = GeneratedBindings.instance._Thermion_getGLContext();
-  return result;
-}
-
-BigInt get TSWAP_CHAIN_CONFIG_TRANSPARENT {
-  final value = NativeLibrary.instance.getValueBigInt(
-    GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_TRANSPARENT,
-    "i64",
+  external void _TransformPipeline_setMouseSensitivity(double sensitivity);
+  external void _TransformPipeline_unregisterPipelineStage(Pointer<Void> pipelineStageHandle);
+  external void _TransformPipeline_update(double deltaTime);
+  external void _VertexBufferBuilder_attribute(
+    Pointer<TVertexBufferBuilder> builder,
+    int attribute,
+    int bufferIndex,
+    int attributeType,
+    int byteOffset,
+    int byteStride,
   );
-  return bigIntasUintN(64, value).toDart;
-}
-
-BigInt get TSWAP_CHAIN_CONFIG_READABLE {
-  final value = NativeLibrary.instance.getValueBigInt(GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_READABLE, "i64");
-  return bigIntasUintN(64, value).toDart;
-}
-
-BigInt get TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER {
-  final value = NativeLibrary.instance.getValueBigInt(
-    GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER,
-    "i64",
+  external void _VertexBufferBuilder_bufferCount(Pointer<TVertexBufferBuilder> builder, int count);
+  external Pointer<TVertexBuffer> _VertexBufferBuilder_build(
+    Pointer<TVertexBufferBuilder> builder,
+    Pointer<TEngine> engine,
   );
-  return bigIntasUintN(64, value).toDart;
-}
-
-BigInt get TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER {
-  final value = NativeLibrary.instance.getValueBigInt(
-    GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER,
-    "i64",
+  external void _VertexBufferBuilder_buildRenderThread(
+    Pointer<TVertexBufferBuilder> tBuilder,
+    Pointer<TEngine> tEngine,
+    Pointer<NativeFunction<void Function(PointerClass<TVertexBuffer>)>> onComplete,
   );
-  return bigIntasUintN(64, value).toDart;
+  external Pointer<TVertexBufferBuilder> _VertexBufferBuilder_create();
+  external void _VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder);
+  external void _VertexBufferBuilder_enableBufferObjects(Pointer<TVertexBufferBuilder> builder, bool enabled);
+  external int _VertexBufferBuilder_getStorageMode(Pointer<TVertexBufferBuilder> builder);
+  external void _VertexBufferBuilder_normalized(Pointer<TVertexBufferBuilder> builder, int attribute, bool normalize);
+  external void _VertexBufferBuilder_vertexCount(Pointer<TVertexBufferBuilder> builder, int count);
+  external void _VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer);
+  external void _VertexBuffer_destroyRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tBuffer,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external size_t _VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer);
+  external void _VertexBuffer_setBufferAt(
+    Pointer<TEngine> engine,
+    Pointer<TVertexBuffer> buffer,
+    int bufferIndex,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+  );
+  external void _VertexBuffer_setBufferAtRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tBuffer,
+    int bufferIndex,
+    Pointer<Void> data,
+    size_t sizeInBytes,
+    int byteOffset,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _VertexBuffer_setBufferObjectAt(
+    Pointer<TEngine> engine,
+    Pointer<TVertexBuffer> buffer,
+    int bufferIndex,
+    Pointer<TBufferObject> bufferObject,
+  );
+  external void _VertexBuffer_setBufferObjectAtRenderThread(
+    Pointer<TEngine> tEngine,
+    Pointer<TVertexBuffer> tBuffer,
+    int bufferIndex,
+    Pointer<TBufferObject> tBufferObject,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_getAmbientOcclusionOptions(
+    Pointer<TAmbientOcclusionOptions> TAmbientOcclusionOptions_out,
+    Pointer<TView> tView,
+  );
+  external Pointer<TCamera> _View_getCamera(Pointer<TView> tView);
+  external Pointer<TColorGrading> _View_getColorGrading(Pointer<TView> tView);
+  external void _View_getFogOptions(Pointer<TFogOptions> TFogOptions_out, Pointer<TView> tView);
+  external Pointer<Char> _View_getName(Pointer<TView> tView);
+  external void _View_getNameRenderThread(
+    Pointer<TView> tView,
+    Pointer<NativeFunction<void Function(PointerClass<Char>)>> onComplete,
+  );
+  external Pointer<TRenderTarget> _View_getRenderTarget(Pointer<TView> tView);
+  external Pointer<TScene> _View_getScene(Pointer<TView> tView);
+  external int _View_getShadowType(Pointer<TView> tView);
+  external void _View_getSoftShadowOptions(Pointer<TSoftShadowOptions> TSoftShadowOptions_out, Pointer<TView> tView);
+  external void _View_getViewport(Pointer<TViewport> TViewport_out, Pointer<TView> view);
+  external int _View_getVisibleRenderableCount(Pointer<TView> view);
+  external void _View_getVsmShadowOptions(Pointer<TVsmShadowOptions> TVsmShadowOptions_out, Pointer<TView> tView);
+  external int _View_isDitheringEnabled(Pointer<TView> tView);
+  external int _View_isStencilBufferEnabled(Pointer<TView> tView);
+  external int _View_isTransparentPickingEnabled(Pointer<TView> tView);
+  external void _View_pick(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
+  external void _View_pickRenderThread(Pointer<TView> tView, int requestId, int x, int y, PickCallback callback);
+  external void _View_setAmbientOcclusionOptions(Pointer<TView> tView, Pointer<TAmbientOcclusionOptions> optionsPtr);
+  external void _View_setAmbientOcclusionOptionsRenderThread(
+    Pointer<TView> tView,
+    Pointer<TAmbientOcclusionOptions> optionsPtr,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setAntiAliasing(Pointer<TView> tView, bool msaa, bool fxaa, bool taa);
+  external void _View_setAntiAliasingRenderThread(
+    Pointer<TView> tView,
+    bool msaa,
+    bool fxaa,
+    bool taa,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setBlendMode(Pointer<TView> view, int blendMode);
+  external void _View_setBlendModeRenderThread(
+    Pointer<TView> tView,
+    int blendMode,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setBloom(Pointer<TView> tView, bool enabled, double strength);
+  external void _View_setBloomRenderThread(
+    Pointer<TView> tView,
+    bool enabled,
+    double strength,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera);
+  external void _View_setCameraRenderThread(
+    Pointer<TView> tView,
+    Pointer<TCamera> tCamera,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setColorGrading(Pointer<TView> tView, Pointer<TColorGrading> tColorGrading);
+  external void _View_setColorGradingRenderThread(
+    Pointer<TView> tView,
+    Pointer<TColorGrading> tColorGrading,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setDitheringEnabled(Pointer<TView> tView, bool enabled);
+  external void _View_setDitheringEnabledRenderThread(
+    Pointer<TView> tView,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setFogOptions(Pointer<TView> tView, Pointer<TFogOptions> tFogOptionsPtr);
+  external void _View_setFogOptionsRenderThread(
+    Pointer<TView> tView,
+    Pointer<TFogOptions> tFogOptionsPtr,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted);
+  external void _View_setFrontFaceWindingInvertedRenderThread(
+    Pointer<TView> tView,
+    bool inverted,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled);
+  external void _View_setFrustumCullingEnabledRenderThread(
+    Pointer<TView> tView,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible);
+  external void _View_setLayerEnabledRenderThread(
+    Pointer<TView> tView,
+    int layer,
+    bool visible,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setName(Pointer<TView> tView, Pointer<Char> name);
+  external void _View_setNameRenderThread(
+    Pointer<TView> tView,
+    Pointer<Char> name,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setPostProcessing(Pointer<TView> tView, bool enabled);
+  external void _View_setPostProcessingRenderThread(
+    Pointer<TView> tView,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setRenderQuality(Pointer<TView> tView, int qualityLevel);
+  external void _View_setRenderQualityRenderThread(
+    Pointer<TView> tView,
+    int qualityLevel,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget);
+  external void _View_setRenderTargetRenderThread(
+    Pointer<TView> tView,
+    Pointer<TRenderTarget> tRenderTarget,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setScene(Pointer<TView> tView, Pointer<TScene> tScene);
+  external void _View_setSceneRenderThread(
+    Pointer<TView> tView,
+    Pointer<TScene> tScene,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setShadowType(Pointer<TView> tView, int shadowType);
+  external void _View_setShadowTypeRenderThread(
+    Pointer<TView> tView,
+    int shadowType,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setShadowsEnabled(Pointer<TView> tView, bool enabled);
+  external void _View_setShadowsEnabledRenderThread(
+    Pointer<TView> tView,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setSoftShadowOptions(Pointer<TView> tView, Pointer<TSoftShadowOptions> optionsPtr);
+  external void _View_setSoftShadowOptionsRenderThread(
+    Pointer<TView> tView,
+    Pointer<TSoftShadowOptions> optionsPtr,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled);
+  external void _View_setStencilBufferEnabledRenderThread(
+    Pointer<TView> tView,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled);
+  external void _View_setTransparentPickingEnabledRenderThread(
+    Pointer<TView> tView,
+    bool enabled,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setViewport(Pointer<TView> view, int width, int height);
+  external void _View_setViewportRenderThread(
+    Pointer<TView> tView,
+    int width,
+    int height,
+    int requestId,
+    VoidCallback onComplete,
+  );
+  external void _View_setVsmShadowOptions(Pointer<TView> tView, Pointer<TVsmShadowOptions> optionsPtr);
+  external void _View_setVsmShadowOptionsRenderThread(
+    Pointer<TView> tView,
+    Pointer<TVsmShadowOptions> optionsPtr,
+    int requestId,
+    VoidCallback onComplete,
+  );
 }
 
-TViewport View_getViewport(Pointer<TView> view) {
-  final TViewport_out = TViewport.stackAlloc();
-  final result = GeneratedBindings.instance._View_getViewport(TViewport_out.cast(), view.cast());
-  return TViewport_out.toDart();
-}
-
-Pointer<TToneMapper> ToneMapper_createLinear(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createLinear(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createACES(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createACES(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createACESLegacy(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createACESLegacy(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createFilmic(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createFilmic(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createPBRNeutral(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createAGX(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createAGX(tEngine.cast());
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createAGXWithLook(Pointer<TEngine> tEngine, int look) {
-  final result = GeneratedBindings.instance._ToneMapper_createAGXWithLook(tEngine.cast(), look);
-  return Pointer<TToneMapper>(result);
-}
-
-Pointer<TToneMapper> ToneMapper_createGeneric(
-  Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
+bool AnimationManager_addBoneAnimation(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+  int skinIndex,
+  int boneIndex,
+  Pointer<Float32> frameData,
+  int numFrames,
+  double frameLengthInMs,
+  double fadeOutInSecs,
+  double fadeInInSecs,
+  double maxDelta,
+  bool loop,
 ) {
-  final result = GeneratedBindings.instance._ToneMapper_createGeneric(
-    tEngine.cast(),
-    contrast,
-    midGrayIn,
-    midGrayOut,
-    hdrMax,
+  final result = GeneratedBindings.instance._AnimationManager_addBoneAnimation(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+    skinIndex,
+    boneIndex,
+    frameData,
+    numFrames,
+    frameLengthInMs,
+    fadeOutInSecs,
+    fadeInInSecs,
+    maxDelta,
+    loop,
   );
-  return Pointer<TToneMapper>(result);
+  return result == 1;
 }
 
-Pointer<TToneMapper> ToneMapper_createDisplayRange(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._ToneMapper_createDisplayRange(tEngine.cast());
-  return Pointer<TToneMapper>(result);
+bool AnimationManager_addBoneAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_addBoneAnimationComponent(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+  );
+  return result == 1;
 }
 
-void ToneMapper_destroy(Pointer<TToneMapper> toneMapper) {
-  final result = GeneratedBindings.instance._ToneMapper_destroy(toneMapper.cast());
+bool AnimationManager_addGltfAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_addGltfAnimationComponent(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+void AnimationManager_addMorphAnimationComponent(Pointer<TAnimationManager> tAnimationManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._AnimationManager_addMorphAnimationComponent(
+    tAnimationManager.cast(),
+    entityId,
+  );
   return result;
 }
 
-Pointer<TColorGradingBuilder> ColorGradingBuilder_create() {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_create();
-  return Pointer<TColorGradingBuilder>(result);
+bool AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._AnimationManager_clearMorphAnimation(tAnimationManager.cast(), entityId);
+  return result == 1;
+}
+
+Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._AnimationManager_create(tEngine.cast());
+  return Pointer<TAnimationManager>(result);
+}
+
+void AnimationManager_createRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TAnimationManager>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_createRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+void AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager) {
+  final result = GeneratedBindings.instance._AnimationManager_destroy(tAnimationManager.cast());
+  return result;
+}
+
+void AnimationManager_destroyRenderThread(
+  Pointer<TAnimationManager> tAnimationManager,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_destroyRenderThread(
+    tAnimationManager.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+int AnimationManager_getGltfAnimationCount(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationCount(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+  );
+  return result;
+}
+
+double AnimationManager_getGltfAnimationDuration(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  int animationIndex,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationDuration(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    animationIndex,
+  );
+  return result;
+}
+
+void AnimationManager_getGltfAnimationName(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  Pointer<Char> outPtr,
+  int index,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationName(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    outPtr,
+    index,
+  );
+  return result;
+}
+
+void AnimationManager_getInverseBindMatrix(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  int skinIndex,
+  int boneIndex,
+  Pointer<Float32> out,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getInverseBindMatrix(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    skinIndex,
+    boneIndex,
+    out,
+  );
+  return result;
+}
+
+void AnimationManager_getMorphTargetName(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  DartEntityId childEntity,
+  Pointer<Char> outPtr,
+  int index,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getMorphTargetName(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    childEntity,
+    outPtr,
+    index,
+  );
+  return result;
+}
+
+int AnimationManager_getMorphTargetNameCount(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  DartEntityId childEntity,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getMorphTargetNameCount(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    childEntity,
+  );
+  return result;
+}
+
+void AnimationManager_getRestLocalTransforms(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  int skinIndex,
+  Pointer<Float32> out,
+  int numBones,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_getRestLocalTransforms(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    skinIndex,
+    out,
+    numBones,
+  );
+  return result;
+}
+
+bool AnimationManager_playGltfAnimation(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+  int index,
+  bool loop,
+  bool reverse,
+  bool replaceActive,
+  double crossfade,
+  double startOffset,
+  double speed,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_playGltfAnimation(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+    index,
+    loop,
+    reverse,
+    replaceActive,
+    crossfade,
+    startOffset,
+    speed,
+  );
+  return result == 1;
+}
+
+bool AnimationManager_removeBoneAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_removeBoneAnimationComponent(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+bool AnimationManager_removeGltfAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_removeGltfAnimationComponent(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+void AnimationManager_removeMorphAnimationComponent(
+  Pointer<TAnimationManager> tAnimationManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_removeMorphAnimationComponent(
+    tAnimationManager.cast(),
+    entityId,
+  );
+  return result;
+}
+
+void AnimationManager_resetToRestPose(Pointer<TAnimationManager> tAnimationManager, Pointer<TSceneAsset> sceneAsset) {
+  final result = GeneratedBindings.instance._AnimationManager_resetToRestPose(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+  );
+  return result;
+}
+
+void AnimationManager_resetToRestPoseRenderThread(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_resetToRestPoseRenderThread(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+bool AnimationManager_setGltfAnimationTime(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+  int animationIndex,
+  double timeInSeconds,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_setGltfAnimationTime(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+    animationIndex,
+    timeInSeconds,
+  );
+  return result == 1;
+}
+
+void AnimationManager_setGltfAnimationTimeRenderThread(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> tSceneAsset,
+  int animationIndex,
+  double timeInSeconds,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_setGltfAnimationTimeRenderThread(
+    tAnimationManager.cast(),
+    tSceneAsset.cast(),
+    animationIndex,
+    timeInSeconds,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+bool AnimationManager_setMorphAnimation(
+  Pointer<TAnimationManager> tAnimationManager,
+  DartEntityId entityId,
+  Pointer<Float32> morphData,
+  Pointer<Uint32> morphIndices,
+  int numMorphTargets,
+  int numFrames,
+  double frameLengthInMs,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_setMorphAnimation(
+    tAnimationManager.cast(),
+    entityId,
+    morphData,
+    morphIndices,
+    numMorphTargets,
+    numFrames,
+    frameLengthInMs,
+  );
+  return result == 1;
+}
+
+bool AnimationManager_setMorphTargetWeights(
+  Pointer<TAnimationManager> tAnimationManager,
+  DartEntityId entityId,
+  Pointer<Float32> morphData,
+  int numWeights,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_setMorphTargetWeights(
+    tAnimationManager.cast(),
+    entityId,
+    morphData,
+    numWeights,
+  );
+  return result == 1;
+}
+
+void AnimationManager_setMorphTargetWeightsRenderThread(
+  Pointer<TAnimationManager> tAnimationManager,
+  DartEntityId entityId,
+  Pointer<Float32> morphData,
+  int numWeights,
+  Pointer<NativeFunction<void Function(bool)>> callback,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_setMorphTargetWeightsRenderThread(
+    tAnimationManager.cast(),
+    entityId,
+    morphData,
+    numWeights,
+    callback.cast(),
+  );
+  return result;
+}
+
+bool AnimationManager_stopGltfAnimation(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  int index,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_stopGltfAnimation(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    index,
+  );
+  return result == 1;
+}
+
+void AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._AnimationManager_update(
+    tAnimationManager.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result;
+}
+
+bool AnimationManager_updateBoneMatrices(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_updateBoneMatrices(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+  );
+  return result == 1;
+}
+
+void AnimationManager_updateBoneMatricesRenderThread(
+  Pointer<TAnimationManager> tAnimationManager,
+  Pointer<TSceneAsset> sceneAsset,
+  Pointer<NativeFunction<void Function(bool)>> callback,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_updateBoneMatricesRenderThread(
+    tAnimationManager.cast(),
+    sceneAsset.cast(),
+    callback.cast(),
+  );
+  return result;
+}
+
+void AnimationManager_updateRenderThread(
+  Pointer<TAnimationManager> tAnimationManager,
+  BigInt frameTimeInNanos,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._AnimationManager_updateRenderThread(
+    tAnimationManager.cast(),
+    frameTimeInNanos.toJSBigInt,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TBufferObject>(result);
+}
+
+void BufferObjectBuilder_buildRenderThread(
+  Pointer<TBufferObjectBuilder> tBuilder,
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TBufferObject>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_buildRenderThread(
+    tBuilder.cast(),
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
+  return Pointer<TBufferObjectBuilder>(result);
+}
+
+void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
+  return result;
+}
+
+void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
+  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
+  return result;
+}
+
+void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
+  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
+  return result;
+}
+
+void BufferObject_destroyRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TBufferObject> tBuffer,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._BufferObject_destroyRenderThread(
+    tEngine.cast(),
+    tBuffer.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void BufferObject_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TBufferObject> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._BufferObject_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void BufferObject_setBufferRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TBufferObject> tBuffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._BufferObject_setBufferRenderThread(
+    tEngine.cast(),
+    tBuffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+double Camera_getAperture(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
+  return result;
+}
+
+double Camera_getCullingFar(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
+  return result;
+}
+
+double Camera_getFocalLength(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
+  return result;
+}
+
+double Camera_getFocusDistance(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
+  return result;
+}
+
+double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
+  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
+  return result;
+}
+
+void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
+  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
+  return result;
+}
+
+double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double Camera_getNear(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+double Camera_getSensitivity(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
+  return result;
+}
+
+double Camera_getShutterSpeed(Pointer<TCamera> camera) {
+  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
+  return result;
+}
+
+double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
+  return double4x4_out.toDart();
+}
+
+void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
+  final eyePtr = eye.address;
+  final focusPtr = focus.address;
+  final upPtr = up.address;
+  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
+  return result;
+}
+
+void Camera_setCustomProjectionWithCulling(
+  Pointer<TCamera> camera,
+  double4x4 projectionMatrix,
+  double near,
+  double far,
+) {
+  final projectionMatrixPtr = projectionMatrix.address;
+  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
+    camera.cast(),
+    projectionMatrixPtr.cast(),
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
+  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
+  return result;
+}
+
+void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
+  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
+  return result;
+}
+
+void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
+  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
+  return result;
+}
+
+void Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix) {
+  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrix);
+  return result;
+}
+
+void Camera_setProjection(
+  Pointer<TCamera> tCamera,
+  int projection,
+  double left,
+  double right,
+  double bottom,
+  double top,
+  double near,
+  double far,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjection(
+    tCamera.cast(),
+    projection,
+    left,
+    right,
+    bottom,
+    top,
+    near,
+    far,
+  );
+  return result;
+}
+
+void Camera_setProjectionFromFov(
+  Pointer<TCamera> camera,
+  double fovInDegrees,
+  double aspect,
+  double near,
+  double far,
+  bool horizontal,
+) {
+  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
+    camera.cast(),
+    fovInDegrees,
+    aspect,
+    near,
+    far,
+    horizontal,
+  );
+  return result;
+}
+
+void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
+  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
+  return result;
 }
 
 Pointer<TColorGrading> ColorGradingBuilder_build(Pointer<TColorGradingBuilder> builder, Pointer<TEngine> engine) {
@@ -2606,63 +3166,16 @@ Pointer<TColorGrading> ColorGradingBuilder_build(Pointer<TColorGradingBuilder> b
   return Pointer<TColorGrading>(result);
 }
 
-void ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_destroy(builder.cast());
-  return result;
-}
-
-void ColorGrading_destroy(Pointer<TEngine> engine, Pointer<TColorGrading> colorGrading) {
-  final result = GeneratedBindings.instance._ColorGrading_destroy(engine.cast(), colorGrading.cast());
-  return result;
-}
-
-void ColorGradingBuilder_quality(Pointer<TColorGradingBuilder> builder, int level) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_quality(builder.cast(), level);
-  return result;
-}
-
-void ColorGradingBuilder_format(Pointer<TColorGradingBuilder> builder, int format) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_format(builder.cast(), format);
-  return result;
-}
-
-void ColorGradingBuilder_dimensions(Pointer<TColorGradingBuilder> builder, int dim) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_dimensions(builder.cast(), dim);
-  return result;
-}
-
-void ColorGradingBuilder_toneMapper(Pointer<TColorGradingBuilder> builder, Pointer<TToneMapper> toneMapper) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_toneMapper(builder.cast(), toneMapper.cast());
-  return result;
-}
-
-void ColorGradingBuilder_exposure(Pointer<TColorGradingBuilder> builder, double exposure) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_exposure(builder.cast(), exposure);
-  return result;
-}
-
-void ColorGradingBuilder_nightAdaptation(Pointer<TColorGradingBuilder> builder, double adaptation) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_nightAdaptation(builder.cast(), adaptation);
-  return result;
-}
-
-void ColorGradingBuilder_whiteBalance(Pointer<TColorGradingBuilder> builder, double temperature, double tint) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_whiteBalance(builder.cast(), temperature, tint);
-  return result;
-}
-
-void ColorGradingBuilder_contrast(Pointer<TColorGradingBuilder> builder, double contrast) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_contrast(builder.cast(), contrast);
-  return result;
-}
-
-void ColorGradingBuilder_vibrance(Pointer<TColorGradingBuilder> builder, double vibrance) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_vibrance(builder.cast(), vibrance);
-  return result;
-}
-
-void ColorGradingBuilder_saturation(Pointer<TColorGradingBuilder> builder, double saturation) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_saturation(builder.cast(), saturation);
+void ColorGradingBuilder_buildRenderThread(
+  Pointer<TColorGradingBuilder> tBuilder,
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TColorGrading>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_buildRenderThread(
+    tBuilder.cast(),
+    tEngine.cast(),
+    onComplete.cast(),
+  );
   return result;
 }
 
@@ -2690,6 +3203,108 @@ void ColorGradingBuilder_channelMixer(
     outBlueG,
     outBlueB,
   );
+  return result;
+}
+
+void ColorGradingBuilder_contrast(Pointer<TColorGradingBuilder> builder, double contrast) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_contrast(builder.cast(), contrast);
+  return result;
+}
+
+Pointer<TColorGradingBuilder> ColorGradingBuilder_create() {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_create();
+  return Pointer<TColorGradingBuilder>(result);
+}
+
+void ColorGradingBuilder_createRenderThread(
+  Pointer<NativeFunction<void Function(Pointer<TColorGradingBuilder>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_createRenderThread(onComplete.cast());
+  return result;
+}
+
+void ColorGradingBuilder_curves(
+  Pointer<TColorGradingBuilder> builder,
+  double shadowGammaR,
+  double shadowGammaG,
+  double shadowGammaB,
+  double midPointR,
+  double midPointG,
+  double midPointB,
+  double highlightScaleR,
+  double highlightScaleG,
+  double highlightScaleB,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_curves(
+    builder.cast(),
+    shadowGammaR,
+    shadowGammaG,
+    shadowGammaB,
+    midPointR,
+    midPointG,
+    midPointB,
+    highlightScaleR,
+    highlightScaleG,
+    highlightScaleB,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_destroy(Pointer<TColorGradingBuilder> builder) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_destroy(builder.cast());
+  return result;
+}
+
+void ColorGradingBuilder_destroyRenderThread(
+  Pointer<TColorGradingBuilder> tBuilder,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_destroyRenderThread(
+    tBuilder.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void ColorGradingBuilder_dimensions(Pointer<TColorGradingBuilder> builder, int dim) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_dimensions(builder.cast(), dim);
+  return result;
+}
+
+void ColorGradingBuilder_exposure(Pointer<TColorGradingBuilder> builder, double exposure) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_exposure(builder.cast(), exposure);
+  return result;
+}
+
+void ColorGradingBuilder_format(Pointer<TColorGradingBuilder> builder, int format) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_format(builder.cast(), format);
+  return result;
+}
+
+void ColorGradingBuilder_gamutMapping(Pointer<TColorGradingBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_gamutMapping(builder.cast(), enabled);
+  return result;
+}
+
+void ColorGradingBuilder_luminanceScaling(Pointer<TColorGradingBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_luminanceScaling(builder.cast(), enabled);
+  return result;
+}
+
+void ColorGradingBuilder_nightAdaptation(Pointer<TColorGradingBuilder> builder, double adaptation) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_nightAdaptation(builder.cast(), adaptation);
+  return result;
+}
+
+void ColorGradingBuilder_quality(Pointer<TColorGradingBuilder> builder, int level) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_quality(builder.cast(), level);
+  return result;
+}
+
+void ColorGradingBuilder_saturation(Pointer<TColorGradingBuilder> builder, double saturation) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_saturation(builder.cast(), saturation);
   return result;
 }
 
@@ -2761,252 +3376,834 @@ void ColorGradingBuilder_slopeOffsetPower(
   return result;
 }
 
-void ColorGradingBuilder_curves(
-  Pointer<TColorGradingBuilder> builder,
-  double shadowGammaR,
-  double shadowGammaG,
-  double shadowGammaB,
-  double midPointR,
-  double midPointG,
-  double midPointB,
-  double highlightScaleR,
-  double highlightScaleG,
-  double highlightScaleB,
+void ColorGradingBuilder_toneMapper(Pointer<TColorGradingBuilder> builder, Pointer<TToneMapper> toneMapper) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_toneMapper(builder.cast(), toneMapper.cast());
+  return result;
+}
+
+void ColorGradingBuilder_vibrance(Pointer<TColorGradingBuilder> builder, double vibrance) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_vibrance(builder.cast(), vibrance);
+  return result;
+}
+
+void ColorGradingBuilder_whiteBalance(Pointer<TColorGradingBuilder> builder, double temperature, double tint) {
+  final result = GeneratedBindings.instance._ColorGradingBuilder_whiteBalance(builder.cast(), temperature, tint);
+  return result;
+}
+
+void ColorGrading_destroy(Pointer<TEngine> engine, Pointer<TColorGrading> colorGrading) {
+  final result = GeneratedBindings.instance._ColorGrading_destroy(engine.cast(), colorGrading.cast());
+  return result;
+}
+
+bool DebugRegistry_getProperty_bool(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Bool> outValue,
 ) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_curves(
-    builder.cast(),
-    shadowGammaR,
-    shadowGammaG,
-    shadowGammaB,
-    midPointR,
-    midPointG,
-    midPointB,
-    highlightScaleR,
-    highlightScaleG,
-    highlightScaleB,
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_float(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Float32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_getProperty_int(
+  Pointer<TDebugRegistry> tDebugRegistry,
+  Pointer<Char> name,
+  Pointer<Int32> outValue,
+) {
+  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
+  return result == 1;
+}
+
+bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
+  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
+  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
+  return result == 1;
+}
+
+Pointer<TSkybox> Engine_buildColoredSkybox(
+  Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
+    tEngine.cast(),
+    r,
+    g,
+    b,
+    a,
+    showSun,
+    intensity,
+    priority,
+  );
+  return Pointer<TSkybox>(result);
+}
+
+void Engine_buildColoredSkyboxRenderThread(
+  Pointer<TEngine> tEngine,
+  double r,
+  double g,
+  double b,
+  double a,
+  bool showSun,
+  double intensity,
+  int priority,
+  Pointer<NativeFunction<void Function(Pointer<TSkybox>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_buildColoredSkyboxRenderThread(
+    tEngine.cast(),
+    r,
+    g,
+    b,
+    a,
+    showSun,
+    intensity,
+    priority,
+    onComplete.cast(),
   );
   return result;
 }
 
-void ColorGradingBuilder_luminanceScaling(Pointer<TColorGradingBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_luminanceScaling(builder.cast(), enabled);
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<Float32> irradianceHarmonics,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    irradianceHarmonics,
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<Float32> harmonics,
+  double intensity,
+  Pointer<NativeFunction<void Function(Pointer<TIndirectLight>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    harmonics,
+    intensity,
+    onComplete.cast(),
+  );
   return result;
 }
 
-void ColorGradingBuilder_gamutMapping(Pointer<TColorGradingBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_gamutMapping(builder.cast(), enabled);
+Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    tIrradianceTexture.cast(),
+    intensity,
+  );
+  return Pointer<TIndirectLight>(result);
+}
+
+void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tReflectionsTexture,
+  Pointer<TTexture> tIrradianceTexture,
+  double intensity,
+  Pointer<NativeFunction<void Function(Pointer<TIndirectLight>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTextureRenderThread(
+    tEngine.cast(),
+    tReflectionsTexture.cast(),
+    tIrradianceTexture.cast(),
+    intensity,
+    onComplete.cast(),
+  );
   return result;
 }
 
-void View_setColorGrading(Pointer<TView> tView, Pointer<TColorGrading> tColorGrading) {
-  final result = GeneratedBindings.instance._View_setColorGrading(tView.cast(), tColorGrading.cast());
+Pointer<TMaterial> Engine_buildMaterial(Pointer<TEngine> tEngine, Pointer<Uint8> materialData, Dartsize_t length) {
+  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
+  return Pointer<TMaterial>(result);
+}
+
+void Engine_buildMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<Uint8> materialData,
+  Dartsize_t length,
+  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
+    tEngine.cast(),
+    materialData,
+    length,
+    onComplete.cast(),
+  );
   return result;
 }
 
-Pointer<TColorGrading> View_getColorGrading(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getColorGrading(tView.cast());
-  return Pointer<TColorGrading>(result);
+Pointer<TSkybox> Engine_buildSkybox(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._Engine_buildSkybox(
+    tEngine.cast(),
+    tTexture.cast(),
+    showSun,
+    intensity,
+    priority,
+  );
+  return Pointer<TSkybox>(result);
 }
 
-void View_setBlendMode(Pointer<TView> view, int blendMode) {
-  final result = GeneratedBindings.instance._View_setBlendMode(view.cast(), blendMode);
+void Engine_buildSkyboxRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  bool showSun,
+  double intensity,
+  int priority,
+  Pointer<NativeFunction<void Function(Pointer<TSkybox>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_buildSkyboxRenderThread(
+    tEngine.cast(),
+    tTexture.cast(),
+    showSun,
+    intensity,
+    priority,
+    onComplete.cast(),
+  );
   return result;
 }
 
-void View_setViewport(Pointer<TView> view, int width, int height) {
-  final result = GeneratedBindings.instance._View_setViewport(view.cast(), width, height);
-  return result;
+Pointer<TEngine> Engine_create(
+  int backend,
+  Pointer<Void> platform,
+  Pointer<Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+) {
+  final result = GeneratedBindings.instance._Engine_create(
+    backend,
+    platform,
+    sharedContext,
+    stereoscopicEyeCount,
+    disableHandleUseAfterFreeCheck,
+  );
+  return Pointer<TEngine>(result);
 }
 
-void View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget) {
-  final result = GeneratedBindings.instance._View_setRenderTarget(view.cast(), renderTarget.cast());
-  return result;
-}
-
-void View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled) {
-  final result = GeneratedBindings.instance._View_setFrustumCullingEnabled(view.cast(), enabled);
-  return result;
-}
-
-int View_getVisibleRenderableCount(Pointer<TView> view) {
-  final result = GeneratedBindings.instance._View_getVisibleRenderableCount(view.cast());
-  return result;
-}
-
-Pointer<TRenderTarget> View_getRenderTarget(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getRenderTarget(tView.cast());
-  return Pointer<TRenderTarget>(result);
-}
-
-void View_setPostProcessing(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setPostProcessing(tView.cast(), enabled);
-  return result;
-}
-
-void View_setShadowsEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setShadowsEnabled(tView.cast(), enabled);
-  return result;
-}
-
-void View_setShadowType(Pointer<TView> tView, int shadowType) {
-  final result = GeneratedBindings.instance._View_setShadowType(tView.cast(), shadowType);
-  return result;
-}
-
-int View_getShadowType(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getShadowType(tView.cast());
-  return result;
-}
-
-void View_setSoftShadowOptions(Pointer<TView> tView, TSoftShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setSoftShadowOptions(tView.cast(), optionsPtr.cast());
-  return result;
-}
-
-TSoftShadowOptions View_getSoftShadowOptions(Pointer<TView> tView) {
-  final TSoftShadowOptions_out = TSoftShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getSoftShadowOptions(TSoftShadowOptions_out.cast(), tView.cast());
-  return TSoftShadowOptions_out.toDart();
-}
-
-void View_setVsmShadowOptions(Pointer<TView> tView, TVsmShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setVsmShadowOptions(tView.cast(), optionsPtr.cast());
-  return result;
-}
-
-TVsmShadowOptions View_getVsmShadowOptions(Pointer<TView> tView) {
-  final TVsmShadowOptions_out = TVsmShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getVsmShadowOptions(TVsmShadowOptions_out.cast(), tView.cast());
-  return TVsmShadowOptions_out.toDart();
-}
-
-void View_setBloom(Pointer<TView> tView, bool enabled, double strength) {
-  final result = GeneratedBindings.instance._View_setBloom(tView.cast(), enabled, strength);
-  return result;
-}
-
-void View_setRenderQuality(Pointer<TView> tView, int qualityLevel) {
-  final result = GeneratedBindings.instance._View_setRenderQuality(tView.cast(), qualityLevel);
-  return result;
-}
-
-void View_setAntiAliasing(Pointer<TView> tView, bool msaa, bool fxaa, bool taa) {
-  final result = GeneratedBindings.instance._View_setAntiAliasing(tView.cast(), msaa, fxaa, taa);
-  return result;
-}
-
-void View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible) {
-  final result = GeneratedBindings.instance._View_setLayerEnabled(tView.cast(), layer, visible);
-  return result;
-}
-
-void View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera) {
-  final result = GeneratedBindings.instance._View_setCamera(tView.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TScene> View_getScene(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getScene(tView.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TCamera> View_getCamera(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getCamera(tView.cast());
+Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
   return Pointer<TCamera>(result);
 }
 
-void View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setStencilBufferEnabled(tView.cast(), enabled);
-  return result;
-}
-
-bool View_isStencilBufferEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isStencilBufferEnabled(tView.cast());
-  return result == 1;
-}
-
-void View_setDitheringEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setDitheringEnabled(tView.cast(), enabled);
-  return result;
-}
-
-bool View_isDitheringEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isDitheringEnabled(tView.cast());
-  return result == 1;
-}
-
-void View_setScene(Pointer<TView> tView, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._View_setScene(tView.cast(), tScene.cast());
-  return result;
-}
-
-void View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted) {
-  final result = GeneratedBindings.instance._View_setFrontFaceWindingInverted(tView.cast(), inverted);
-  return result;
-}
-
-void View_setAmbientOcclusionOptions(Pointer<TView> tView, TAmbientOcclusionOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setAmbientOcclusionOptions(tView.cast(), optionsPtr.cast());
-  return result;
-}
-
-TAmbientOcclusionOptions View_getAmbientOcclusionOptions(Pointer<TView> tView) {
-  final TAmbientOcclusionOptions_out = TAmbientOcclusionOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getAmbientOcclusionOptions(
-    TAmbientOcclusionOptions_out.cast(),
-    tView.cast(),
+void Engine_createCameraRenderThread(
+  Pointer<TEngine> tEngine,
+  DartEntityId entityId,
+  Pointer<NativeFunction<void Function(Pointer<TCamera>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_createCameraRenderThread(
+    tEngine.cast(),
+    entityId,
+    onComplete.cast(),
   );
-  return TAmbientOcclusionOptions_out.toDart();
-}
-
-void View_setFogOptions(Pointer<TView> tView, TFogOptions tFogOptions) {
-  final tFogOptionsPtr = tFogOptions.address;
-  final result = GeneratedBindings.instance._View_setFogOptions(tView.cast(), tFogOptionsPtr.cast());
   return result;
 }
 
-TFogOptions View_getFogOptions(Pointer<TView> tView) {
-  final TFogOptions_out = TFogOptions.stackAlloc();
-  final result = GeneratedBindings.instance._View_getFogOptions(TFogOptions_out.cast(), tView.cast());
-  return TFogOptions_out.toDart();
+Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
+  return Pointer<TFence>(result);
 }
 
-void View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled) {
-  final result = GeneratedBindings.instance._View_setTransparentPickingEnabled(tView.cast(), enabled);
+void Engine_createFenceRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TFence>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_createFenceRenderThread(tEngine.cast(), onComplete.cast());
   return result;
 }
 
-bool View_isTransparentPickingEnabled(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_isTransparentPickingEnabled(tView.cast());
-  return result == 1;
+Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
+    tEngine.cast(),
+    width,
+    height,
+    flags.toJSBigInt,
+  );
+  return Pointer<TSwapChain>(result);
 }
 
-void View_pick(Pointer<TView> tView, int requestId, int x, int y, DartPickCallback callback) {
-  final result = GeneratedBindings.instance._View_pick(
+void Engine_createHeadlessSwapChainRenderThread(
+  Pointer<TEngine> tEngine,
+  int width,
+  int height,
+  BigInt flags,
+  Pointer<NativeFunction<void Function(Pointer<TSwapChain>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChainRenderThread(
+    tEngine.cast(),
+    width,
+    height,
+    flags.toJSBigInt,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+void Engine_createRenderThread(
+  int backend,
+  Pointer<Void> platform,
+  Pointer<Void> sharedContext,
+  int stereoscopicEyeCount,
+  bool disableHandleUseAfterFreeCheck,
+  Pointer<NativeFunction<void Function(Pointer<TEngine>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_createRenderThread(
+    backend,
+    platform,
+    sharedContext,
+    stereoscopicEyeCount,
+    disableHandleUseAfterFreeCheck,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
+  return Pointer<TRenderer>(result);
+}
+
+void Engine_createRendererRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TRenderer>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_createRendererRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
+  return Pointer<TScene>(result);
+}
+
+Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
+  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
+  return Pointer<TSwapChain>(result);
+}
+
+void Engine_createSwapChainRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<Void> window,
+  BigInt flags,
+  Pointer<NativeFunction<void Function(Pointer<TSwapChain>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_createSwapChainRenderThread(
+    tEngine.cast(),
+    window,
+    flags.toJSBigInt,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
+  return Pointer<TView>(result);
+}
+
+void Engine_createViewRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TView>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_createViewRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+void Engine_destroy(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
+  return result;
+}
+
+void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
+  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
+  return result;
+}
+
+void Engine_destroyCameraRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TCamera> tCamera,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyCameraRenderThread(
+    tEngine.cast(),
+    tCamera.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
+  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
+  return result;
+}
+
+void Engine_destroyColorGradingRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TColorGrading> tColorGrading,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyColorGradingRenderThread(
+    tEngine.cast(),
+    tColorGrading.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
+  return result;
+}
+
+void Engine_destroyFenceRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TFence> tFence,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyFenceRenderThread(
+    tEngine.cast(),
+    tFence.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Engine_destroyIndirectLightRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TIndirectLight> tIndirectLight,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyIndirectLightRenderThread(
+    tEngine.cast(),
+    tIndirectLight.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
+  return result;
+}
+
+void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
+  return result;
+}
+
+void Engine_destroyMaterialInstanceRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialInstance> tMaterialInstance,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialInstanceRenderThread(
+    tEngine.cast(),
+    tMaterialInstance.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterial> tMaterial,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyMaterialRenderThread(
+    tEngine.cast(),
+    tMaterial.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyRenderThread(Pointer<TEngine> tEngine, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._Engine_destroyRenderThread(
+    tEngine.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
+  return result;
+}
+
+void Engine_destroyRendererRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TRenderer> tRenderer,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyRendererRenderThread(
+    tEngine.cast(),
+    tRenderer.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
+  return result;
+}
+
+void Engine_destroySceneRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TScene> tScene,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroySceneRenderThread(
+    tEngine.cast(),
+    tScene.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
+  return result;
+}
+
+void Engine_destroySkyboxRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TSkybox> tSkybox,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroySkyboxRenderThread(
+    tEngine.cast(),
+    tSkybox.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
+  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
+  return result;
+}
+
+void Engine_destroySwapChainRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TSwapChain> tSwapChain,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroySwapChainRenderThread(
+    tEngine.cast(),
+    tSwapChain.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
+  return result;
+}
+
+void Engine_destroyTextureRenderThread(
+  Pointer<TEngine> engine,
+  Pointer<TTexture> tTexture,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyTextureRenderThread(
+    engine.cast(),
+    tTexture.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
+  return result;
+}
+
+void Engine_destroyViewRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TView> tView,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Engine_destroyViewRenderThread(
+    tEngine.cast(),
     tView.cast(),
     requestId,
-    x,
-    y,
-    callback as Pointer<NativeFunction<PickCallbackFunction>>,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
   return result;
 }
 
-void View_setName(Pointer<TView> tView, Pointer<Char> name) {
-  final result = GeneratedBindings.instance._View_setName(tView.cast(), name);
+void Engine_execute(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
   return result;
 }
 
-Pointer<Char> View_getName(Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._View_getName(tView.cast());
-  return Pointer<Char>(result);
+void Engine_executeRenderThread(Pointer<TEngine> tEngine, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._Engine_executeRenderThread(
+    tEngine.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
 }
 
-void Gizmo_dummy(int t) {
-  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+void Engine_flushAndWait(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
+  return result;
+}
+
+void Engine_flushAndWaitRenderThread(Pointer<TEngine> tEngine, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._Engine_flushAndWaitRenderThread(
+    tEngine.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
+  return Pointer<TCamera>(result);
+}
+
+Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
+  return Pointer<TDebugRegistry>(result);
+}
+
+Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
+  return Pointer<TEntityManager>(result);
+}
+
+Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
+  return Pointer<TLightManager>(result);
+}
+
+Dartsize_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
+  return result;
+}
+
+Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
+  return Pointer<TRenderableManager>(result);
+}
+
+int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
+  return result;
+}
+
+Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
+  return Pointer<TTransformManager>(result);
+}
+
+void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
+  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
+  return result;
+}
+
+DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
+  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
+  return result;
+}
+
+void EntityManager_createEntityRenderThread(
+  Pointer<TEntityManager> tEntityManager,
+  Pointer<NativeFunction<void Function(EntityId)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._EntityManager_createEntityRenderThread(
+    tEntityManager.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
+  return result;
+}
+
+void EntityManager_destroyEntityRenderThread(
+  Pointer<TEntityManager> tEntityManager,
+  DartEntityId entityId,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._EntityManager_destroyEntityRenderThread(
+    tEntityManager.cast(),
+    entityId,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Fence_waitAndDestroy(Pointer<TFence> tFence) {
+  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
+  return result;
+}
+
+void Fence_waitAndDestroyRenderThread(Pointer<TFence> tFence, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._Fence_waitAndDestroyRenderThread(
+    tFence.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
+  return result;
+}
+
+int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
+  return result;
+}
+
+int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
+  return result;
+}
+
+Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
+  return Pointer<PointerClass<Char>>(result);
+}
+
+Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
+  return Pointer<Void>(result);
+}
+
+DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
+  return result;
+}
+
+void FilamentAsset_getWireframeRenderThread(
+  Pointer<TFilamentAsset> tFilamentAsset,
+  Pointer<NativeFunction<void Function(EntityId)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._FilamentAsset_getWireframeRenderThread(
+    tFilamentAsset.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+int FrameScheduler_initDartApi(Pointer<Void> data) {
+  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
+  return result;
+}
+
+void FrameScheduler_setTargetFps(int fps) {
+  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
+  return result;
+}
+
+void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
+    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
+    targetFps,
+  );
+  return result;
+}
+
+void FrameScheduler_startWithPort(BigInt port, int targetFps) {
+  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
+  return result;
+}
+
+BigInt FrameScheduler_steadyClockUs() {
+  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
+  return result.toDart;
+}
+
+void FrameScheduler_stop() {
+  final result = GeneratedBindings.instance._FrameScheduler_stop();
   return result;
 }
 
@@ -3031,6 +4228,39 @@ Pointer<TGizmo> Gizmo_create(
   return Pointer<TGizmo>(result);
 }
 
+void Gizmo_createRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TView> tView,
+  Pointer<TMaterial> tMaterial,
+  int tGizmoType,
+  Pointer<NativeFunction<void Function(Pointer<TGizmo>)>> callback,
+) {
+  final result = GeneratedBindings.instance._Gizmo_createRenderThread(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    tGltfResourceLoader.cast(),
+    tNameComponentManager.cast(),
+    tView.cast(),
+    tMaterial.cast(),
+    tGizmoType,
+    callback.cast(),
+  );
+  return result;
+}
+
+void Gizmo_dummy(int t) {
+  final result = GeneratedBindings.instance._Gizmo_dummy(t);
+  return result;
+}
+
+void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
+  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
+  return result;
+}
+
 void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback callback) {
   final result = GeneratedBindings.instance._Gizmo_pick(
     tGizmo.cast(),
@@ -3041,69 +4271,829 @@ void Gizmo_pick(Pointer<TGizmo> tGizmo, int x, int y, DartGizmoPickCallback call
   return result;
 }
 
-void Gizmo_highlight(Pointer<TGizmo> tGizmo, int axis) {
-  final result = GeneratedBindings.instance._Gizmo_highlight(tGizmo.cast(), axis);
-  return result;
-}
-
 void Gizmo_unhighlight(Pointer<TGizmo> tGizmo) {
   final result = GeneratedBindings.instance._Gizmo_unhighlight(tGizmo.cast());
   return result;
 }
 
-Pointer<TMaterialInstance> Material_createInstance(Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Material_createInstance(tMaterial.cast());
-  return Pointer<TMaterialInstance>(result);
+Pointer<TGltfAssetLoader> GltfAssetLoader_create(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_create(
+    tEngine.cast(),
+    tMaterialProvider.cast(),
+    tNameComponentManager.cast(),
+  );
+  return Pointer<TGltfAssetLoader>(result);
 }
 
-int Material_getFeatureLevel(Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Material_getFeatureLevel(tMaterial.cast());
+void GltfAssetLoader_createRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TMaterialProvider> tMaterialProvider,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<NativeFunction<void Function(Pointer<TGltfAssetLoader>)>> callback,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_createRenderThread(
+    tEngine.cast(),
+    tMaterialProvider.cast(),
+    tNameComponentManager.cast(),
+    callback.cast(),
+  );
   return result;
 }
 
-Pointer<TMaterial> Material_createImageMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createImageMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
+void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
+  return result;
 }
 
-Pointer<TMaterial> Material_createGridMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createGridMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
+void GltfAssetLoader_destroyRenderThread(
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_destroyRenderThread(
+    tAssetLoader.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
 }
 
-Pointer<TMaterial> Material_createGizmoMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createGizmoMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
+Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
+  Pointer<TRenderableManager> tRenderableManager,
+  Pointer<TFilamentAsset> tAsset,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
+    tRenderableManager.cast(),
+    tAsset.cast(),
+  );
+  return Pointer<TMaterialInstance>(result);
 }
 
-Pointer<TMaterial> Material_createSilhouetteMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createSilhouetteMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
+Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
+  return Pointer<TMaterialProvider>(result);
 }
 
-Pointer<TMaterial> Material_createEdgeOutlineMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createEdgeOutlineMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
+Pointer<TFilamentAsset> GltfAssetLoader_load(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  int numInstances,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_load(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    data,
+    length,
+    numInstances,
+  );
+  return Pointer<TFilamentAsset>(result);
 }
 
-Pointer<TMaterial> Material_createWireframeMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createWireframeMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
+void GltfAssetLoader_loadRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  int numInstances,
+  Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
+) {
+  final result = GeneratedBindings.instance._GltfAssetLoader_loadRenderThread(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    data,
+    length,
+    numInstances,
+    callback.cast(),
+  );
+  return result;
 }
 
-Pointer<TMaterial> Material_createTranslationAxisMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createTranslationAxisMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
+int GltfParser_parseBuffer(
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  Pointer<Char> meshName,
+  Pointer<TMeshData> outMeshData,
+) {
+  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
+  return result;
 }
 
-Pointer<TMaterial> Material_createBoneOverlayMaterial(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Material_createBoneOverlayMaterial(tEngine.cast());
-  return Pointer<TMaterial>(result);
+void GltfResourceLoader_addResourceData(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+  );
+  return result;
 }
 
-bool Material_hasParameter(Pointer<TMaterial> tMaterial, Pointer<Char> propertyName) {
-  final result = GeneratedBindings.instance._Material_hasParameter(tMaterial.cast(), propertyName);
+void GltfResourceLoader_addResourceDataRenderThread(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<Char> uri,
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceDataRenderThread(
+    tGltfResourceLoader.cast(),
+    uri,
+    data,
+    length,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_asyncBeginLoad(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
   return result == 1;
+}
+
+void GltfResourceLoader_asyncBeginLoadRenderThread(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  Pointer<NativeFunction<void Function(bool)>> callback,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoadRenderThread(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+    callback.cast(),
+  );
+  return result;
+}
+
+double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_asyncGetLoadProgressRenderThread(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<NativeFunction<void Function(double)>> callback,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgressRenderThread(
+    tGltfResourceLoader.cast(),
+    callback.cast(),
+  );
+  return result;
+}
+
+void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_asyncUpdateLoadRenderThread(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoadRenderThread(tGltfResourceLoader.cast());
+  return result;
+}
+
+Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
+  return Pointer<TGltfResourceLoader>(result);
+}
+
+void GltfResourceLoader_createRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TGltfResourceLoader>)>> callback,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_createRenderThread(tEngine.cast(), callback.cast());
+  return result;
+}
+
+void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
+  return result;
+}
+
+void GltfResourceLoader_destroyRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfResourceLoader> tResourceLoader,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_destroyRenderThread(
+    tEngine.cast(),
+    tResourceLoader.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+bool GltfResourceLoader_loadResources(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+  );
+  return result == 1;
+}
+
+void GltfResourceLoader_loadResourcesRenderThread(
+  Pointer<TGltfResourceLoader> tGltfResourceLoader,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  Pointer<NativeFunction<void Function(bool)>> callback,
+) {
+  final result = GeneratedBindings.instance._GltfResourceLoader_loadResourcesRenderThread(
+    tGltfResourceLoader.cast(),
+    tFilamentAsset.cast(),
+    callback.cast(),
+  );
+  return result;
+}
+
+Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
+  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
+  return Pointer<TLinearImage>(result);
+}
+
+void Image_createEmptyRenderThread(
+  int width,
+  int height,
+  int channel,
+  Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Image_createEmptyRenderThread(width, height, channel, onComplete.cast());
+  return result;
+}
+
+Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dartsize_t length, Pointer<Char> name, bool alpha) {
+  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
+  return Pointer<TLinearImage>(result);
+}
+
+void Image_decodeRenderThread(
+  Pointer<Uint8> data,
+  Dartsize_t length,
+  Pointer<Char> name,
+  bool alpha,
+  Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Image_decodeRenderThread(data, length, name, alpha, onComplete.cast());
+  return result;
+}
+
+void Image_destroy(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
+  return result;
+}
+
+void Image_destroyRenderThread(Pointer<TLinearImage> tLinearImage, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._Image_destroyRenderThread(
+    tLinearImage.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
+  return Pointer<Float32>(result);
+}
+
+void Image_getBytesRenderThread(
+  Pointer<TLinearImage> tLinearImage,
+  Pointer<NativeFunction<void Function(Pointer<Float32>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Image_getBytesRenderThread(tLinearImage.cast(), onComplete.cast());
+  return result;
+}
+
+int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
+  return result;
+}
+
+void Image_getChannelsRenderThread(
+  Pointer<TLinearImage> tLinearImage,
+  Pointer<NativeFunction<void Function(int)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Image_getChannelsRenderThread(tLinearImage.cast(), onComplete.cast());
+  return result;
+}
+
+int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
+  return result;
+}
+
+void Image_getHeightRenderThread(
+  Pointer<TLinearImage> tLinearImage,
+  Pointer<NativeFunction<void Function(int)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Image_getHeightRenderThread(tLinearImage.cast(), onComplete.cast());
+  return result;
+}
+
+int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
+  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
+  return result;
+}
+
+void Image_getWidthRenderThread(
+  Pointer<TLinearImage> tLinearImage,
+  Pointer<NativeFunction<void Function(int)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Image_getWidthRenderThread(tLinearImage.cast(), onComplete.cast());
+  return result;
+}
+
+void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
+  return result;
+}
+
+Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TIndexBuffer>(result);
+}
+
+void IndexBufferBuilder_buildRenderThread(
+  Pointer<TIndexBufferBuilder> tBuilder,
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TIndexBuffer>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_buildRenderThread(
+    tBuilder.cast(),
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
+  return Pointer<TIndexBufferBuilder>(result);
+}
+
+void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
+  return result;
+}
+
+void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
+  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
+  return result;
+}
+
+void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
+  return result;
+}
+
+void IndexBuffer_destroyRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TIndexBuffer> tBuffer,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_destroyRenderThread(
+    tEngine.cast(),
+    tBuffer.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
+  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
+  return result;
+}
+
+void IndexBuffer_setBuffer(
+  Pointer<TEngine> engine,
+  Pointer<TIndexBuffer> buffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
+    engine.cast(),
+    buffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void IndexBuffer_setBufferRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TIndexBuffer> tBuffer,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._IndexBuffer_setBufferRenderThread(
+    tEngine.cast(),
+    tBuffer.cast(),
+    data,
+    sizeInBytes,
+    byteOffset,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
+  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+  return result;
+}
+
+Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dartsize_t length) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
+  return Pointer<TKtx1Bundle>(result);
+}
+
+void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
+  return result;
+}
+
+void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
+  return result;
+}
+
+bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
+  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
+  return result == 1;
+}
+
+Pointer<TTexture> Ktx1Reader_createTexture(
+  Pointer<TEngine> tEngine,
+  Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  DartVoidCallback onTextureUploadComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
+    tEngine.cast(),
+    tBundle.cast(),
+    requestId,
+    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return Pointer<TTexture>(result);
+}
+
+void Ktx1Reader_createTextureRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TKtx1Bundle> tBundle,
+  int requestId,
+  DartVoidCallback onTextureUploadComplete,
+  Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx1Reader_createTextureRenderThread(
+    tEngine.cast(),
+    tBundle.cast(),
+    requestId,
+    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dartsize_t size) {
+  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
+  return Pointer<TTexture>(result);
+}
+
+void Ktx2Reader_createTextureRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<Uint8> data,
+  Dartsize_t size,
+  Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Ktx2Reader_createTextureRenderThread(
+    tEngine.cast(),
+    data,
+    size,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
+  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
+  return result;
+}
+
+void LightManager_computePracticalSplits(
+  Pointer<Float32> splitPositions,
+  int cascades,
+  double near,
+  double far,
+  double lambda,
+) {
+  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
+    splitPositions,
+    cascades,
+    near,
+    far,
+    lambda,
+  );
+  return result;
+}
+
+void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
+  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
+  return result;
+}
+
+int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
+  final result = GeneratedBindings.instance._LightManager_createLight(
+    tEngine.cast(),
+    tLightManager.cast(),
+    tLightTtype,
+  );
+  return result;
+}
+
+void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
+  return result;
+}
+
+double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
+  return double3_out.toDart();
+}
+
+double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
+  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
+  return result == 1;
+}
+
+double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
+  final double3_out = double3.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
+  return double3_out.toDart();
+}
+
+TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final TShadowOptions_out = TShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
+    TShadowOptions_out.cast(),
+    tLightManager.cast(),
+    entity,
+  );
+  return TShadowOptions_out.toDart();
+}
+
+double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
+  return result;
+}
+
+double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
+  return result;
+}
+
+int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
+  return result;
+}
+
+bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
+  return result == 1;
+}
+
+double LightManager_rgbToColorTemperature(double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
+  return result;
+}
+
+void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
+  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
+  return result;
+}
+
+void LightManager_setColorTemperature(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double colorTemperature,
+) {
+  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
+    tLightManager.cast(),
+    entity,
+    colorTemperature,
+  );
+  return result;
+}
+
+void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
+  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
+  return result;
+}
+
+void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
+  return result;
+}
+
+void LightManager_setIntensityWatts(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double watts,
+  double efficiency,
+) {
+  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
+    tLightManager.cast(),
+    entity,
+    watts,
+    efficiency,
+  );
+  return result;
+}
+
+void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
+  final result = GeneratedBindings.instance._LightManager_setLightChannel(
+    tLightManager.cast(),
+    entity,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
+  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
+  return result;
+}
+
+void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
+  return result;
+}
+
+void LightManager_setShadowCasterRenderThread(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entityId,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._LightManager_setShadowCasterRenderThread(
+    tLightManager.cast(),
+    entityId,
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
+    tLightManager.cast(),
+    entity,
+    optionsPtr.cast(),
+  );
+  return result;
+}
+
+void LightManager_setShadowOptionsRenderThread(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entityId,
+  TShadowOptions options,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._LightManager_setShadowOptionsRenderThread(
+    tLightManager.cast(),
+    entityId,
+    optionsPtr.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void LightManager_setSpotLightCone(
+  Pointer<TLightManager> tLightManager,
+  DartEntityId entity,
+  double inner,
+  double outer,
+) {
+  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
+  return result;
+}
+
+void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
+  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
+    tLightManager.cast(),
+    entity,
+    angularRadius,
+  );
+  return result;
+}
+
+void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
+  return result;
+}
+
+void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
+  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
+  return result;
+}
+
+int MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance) {
+  final result = GeneratedBindings.instance._MaterialInstance_getTransparencyMode(materialInstance.cast());
+  return result;
 }
 
 bool MaterialInstance_isStencilWriteEnabled(Pointer<TMaterialInstance> materialInstance) {
@@ -3111,18 +5101,18 @@ bool MaterialInstance_isStencilWriteEnabled(Pointer<TMaterialInstance> materialI
   return result == 1;
 }
 
-void MaterialInstance_setStencilWrite(Pointer<TMaterialInstance> materialInstance, bool enabled) {
-  final result = GeneratedBindings.instance._MaterialInstance_setStencilWrite(materialInstance.cast(), enabled);
-  return result;
-}
-
 void MaterialInstance_setCullingMode(Pointer<TMaterialInstance> materialInstance, int culling) {
   final result = GeneratedBindings.instance._MaterialInstance_setCullingMode(materialInstance.cast(), culling);
   return result;
 }
 
-void MaterialInstance_setDoubleSided(Pointer<TMaterialInstance> materialInstance, bool doubleSided) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDoubleSided(materialInstance.cast(), doubleSided);
+void MaterialInstance_setDepthCulling(Pointer<TMaterialInstance> materialInstance, bool enabled) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDepthCulling(materialInstance.cast(), enabled);
+  return result;
+}
+
+void MaterialInstance_setDepthFunc(Pointer<TMaterialInstance> materialInstance, int depthFunc) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDepthFunc(materialInstance.cast(), depthFunc);
   return result;
 }
 
@@ -3131,8 +5121,21 @@ void MaterialInstance_setDepthWrite(Pointer<TMaterialInstance> materialInstance,
   return result;
 }
 
-void MaterialInstance_setDepthCulling(Pointer<TMaterialInstance> materialInstance, bool enabled) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDepthCulling(materialInstance.cast(), enabled);
+void MaterialInstance_setDoubleSided(Pointer<TMaterialInstance> materialInstance, bool doubleSided) {
+  final result = GeneratedBindings.instance._MaterialInstance_setDoubleSided(materialInstance.cast(), doubleSided);
+  return result;
+}
+
+void MaterialInstance_setParameterBool(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  bool value,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterBool(
+    materialInstance.cast(),
+    propertyName,
+    value,
+  );
   return result;
 }
 
@@ -3215,6 +5218,19 @@ void MaterialInstance_setParameterFloat4(
   return result;
 }
 
+void MaterialInstance_setParameterInt(
+  Pointer<TMaterialInstance> materialInstance,
+  Pointer<Char> propertyName,
+  int value,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterInt(
+    materialInstance.cast(),
+    propertyName,
+    value,
+  );
+  return result;
+}
+
 void MaterialInstance_setParameterMat3(
   Pointer<TMaterialInstance> materialInstance,
   Pointer<Char> propertyName,
@@ -3241,32 +5257,6 @@ void MaterialInstance_setParameterMat4(
   return result;
 }
 
-void MaterialInstance_setParameterInt(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  int value,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterInt(
-    materialInstance.cast(),
-    propertyName,
-    value,
-  );
-  return result;
-}
-
-void MaterialInstance_setParameterBool(
-  Pointer<TMaterialInstance> materialInstance,
-  Pointer<Char> propertyName,
-  bool value,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterBool(
-    materialInstance.cast(),
-    propertyName,
-    value,
-  );
-  return result;
-}
-
 void MaterialInstance_setParameterTexture(
   Pointer<TMaterialInstance> materialInstance,
   Pointer<Char> propertyName,
@@ -3282,15 +5272,29 @@ void MaterialInstance_setParameterTexture(
   return result;
 }
 
-void MaterialInstance_setDepthFunc(Pointer<TMaterialInstance> materialInstance, int depthFunc) {
-  final result = GeneratedBindings.instance._MaterialInstance_setDepthFunc(materialInstance.cast(), depthFunc);
+void MaterialInstance_setParameterTextureRenderThread(
+  Pointer<TMaterialInstance> tMaterialInstance,
+  Pointer<Char> propertyName,
+  Pointer<TTexture> tTexture,
+  Pointer<TTextureSampler> tSampler,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._MaterialInstance_setParameterTextureRenderThread(
+    tMaterialInstance.cast(),
+    propertyName,
+    tTexture.cast(),
+    tSampler.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
   return result;
 }
 
-void MaterialInstance_setStencilOpStencilFail(Pointer<TMaterialInstance> materialInstance, int op, int face) {
-  final result = GeneratedBindings.instance._MaterialInstance_setStencilOpStencilFail(
+void MaterialInstance_setStencilCompareFunction(Pointer<TMaterialInstance> materialInstance, int func, int face) {
+  final result = GeneratedBindings.instance._MaterialInstance_setStencilCompareFunction(
     materialInstance.cast(),
-    op,
+    func,
     face,
   );
   return result;
@@ -3310,12 +5314,17 @@ void MaterialInstance_setStencilOpDepthStencilPass(Pointer<TMaterialInstance> ma
   return result;
 }
 
-void MaterialInstance_setStencilCompareFunction(Pointer<TMaterialInstance> materialInstance, int func, int face) {
-  final result = GeneratedBindings.instance._MaterialInstance_setStencilCompareFunction(
+void MaterialInstance_setStencilOpStencilFail(Pointer<TMaterialInstance> materialInstance, int op, int face) {
+  final result = GeneratedBindings.instance._MaterialInstance_setStencilOpStencilFail(
     materialInstance.cast(),
-    func,
+    op,
     face,
   );
+  return result;
+}
+
+void MaterialInstance_setStencilReadMask(Pointer<TMaterialInstance> materialInstance, int mask) {
+  final result = GeneratedBindings.instance._MaterialInstance_setStencilReadMask(materialInstance.cast(), mask);
   return result;
 }
 
@@ -3328,8 +5337,8 @@ void MaterialInstance_setStencilReferenceValue(Pointer<TMaterialInstance> materi
   return result;
 }
 
-void MaterialInstance_setStencilReadMask(Pointer<TMaterialInstance> materialInstance, int mask) {
-  final result = GeneratedBindings.instance._MaterialInstance_setStencilReadMask(materialInstance.cast(), mask);
+void MaterialInstance_setStencilWrite(Pointer<TMaterialInstance> materialInstance, bool enabled) {
+  final result = GeneratedBindings.instance._MaterialInstance_setStencilWrite(materialInstance.cast(), enabled);
   return result;
 }
 
@@ -3344,979 +5353,6 @@ void MaterialInstance_setTransparencyMode(Pointer<TMaterialInstance> materialIns
     transparencyMode,
   );
   return result;
-}
-
-int MaterialInstance_getTransparencyMode(Pointer<TMaterialInstance> materialInstance) {
-  final result = GeneratedBindings.instance._MaterialInstance_getTransparencyMode(materialInstance.cast());
-  return result;
-}
-
-int Material_getBlendingMode(Pointer<TMaterial> material) {
-  final result = GeneratedBindings.instance._Material_getBlendingMode(material.cast());
-  return result;
-}
-
-Pointer<TNameComponentManager> NameComponentManager_create() {
-  final result = GeneratedBindings.instance._NameComponentManager_create();
-  return Pointer<TNameComponentManager>(result);
-}
-
-void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
-  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
-  return result;
-}
-
-Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
-  return Pointer<Char>(result);
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromBuffers(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tVertexBuffer,
-  Pointer<TIndexBuffer> tIndexBuffer,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  int vertexBufferStorageMode,
-  Aabb3 boundingBox,
-) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
-    tEngine.cast(),
-    tVertexBuffer.cast(),
-    tIndexBuffer.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-    tPrimitiveType,
-    vertexBufferStorageMode,
-    boundingBoxPtr.cast(),
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  int requiredGeometryCapabilities,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    tNameComponentManager.cast(),
-    tFilamentAsset.cast(),
-    requiredGeometryCapabilities,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(tSceneAsset.cast());
-  return Pointer<TFilamentAsset>(result);
-}
-
-int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getType(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_destroy(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._SceneAsset_addToScene(tSceneAsset.cast(), tScene.cast());
-  return result;
-}
-
-void SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(tSceneAsset.cast(), tScene.cast());
-  return result;
-}
-
-DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getEntity(tSceneAsset.cast());
-  return result;
-}
-
-int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(tSceneAsset.cast(), out);
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(tSceneAsset.cast());
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(tSceneAsset.cast());
-  return Pointer<Int32>(result);
-}
-
-Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstance(tSceneAsset.cast(), index);
-  return Pointer<TSceneAsset>(result);
-}
-
-Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(tSceneAsset.cast());
-  return result;
-}
-
-Pointer<TSceneAsset> SceneAsset_createInstance(
-  Pointer<TSceneAsset> asset,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createInstance(
-    asset.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-  );
-  return Pointer<TSceneAsset>(result);
-}
-
-Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(Aabb3_out.cast(), asset.cast());
-  return Aabb3_out.toDart();
-}
-
-int SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset) {
-  final result = GeneratedBindings.instance._SceneAsset_getGeometryCapabilities(asset.cast());
-  return result;
-}
-
-bool SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset) {
-  final result = GeneratedBindings.instance._SceneAsset_supportsFlatShading(asset.cast());
-  return result == 1;
-}
-
-Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(tSceneAsset.cast(), primitiveIndex);
-  return Pointer<TVertexBuffer>(result);
-}
-
-int SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getVertexBufferStorageMode(tSceneAsset.cast(), primitiveIndex);
-  return result;
-}
-
-Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(tSceneAsset.cast(), primitiveIndex);
-  return Pointer<TIndexBuffer>(result);
-}
-
-int SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, DartEntityId entity) {
-  final result = GeneratedBindings.instance._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
-  return result;
-}
-
-void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
-  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(tSceneAsset.cast());
-  return result;
-}
-
-void SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading) {
-  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(tSceneAsset.cast(), flatShading);
-  return result;
-}
-
-void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
-  return result;
-}
-
-Dartsize_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
-  return result;
-}
-
-Pointer<Char> SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Dartsize_t boneIndex) {
-  final result = GeneratedBindings.instance._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
-  return Pointer<Char>(result);
-}
-
-void Camera_setExposure(Pointer<TCamera> camera, double aperture, double shutterSpeed, double sensitivity) {
-  final result = GeneratedBindings.instance._Camera_setExposure(camera.cast(), aperture, shutterSpeed, sensitivity);
-  return result;
-}
-
-double Camera_getAperture(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getAperture(camera.cast());
-  return result;
-}
-
-double Camera_getShutterSpeed(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getShutterSpeed(camera.cast());
-  return result;
-}
-
-double Camera_getSensitivity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getSensitivity(camera.cast());
-  return result;
-}
-
-double4x4 Camera_getModelMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getModelMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getViewMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getViewMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-double4x4 Camera_getCullingProjectionMatrix(Pointer<TCamera> camera) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._Camera_getCullingProjectionMatrix(double4x4_out.cast(), camera.cast());
-  return double4x4_out.toDart();
-}
-
-void Camera_getFrustum(Pointer<TCamera> camera, Pointer<Float64> out) {
-  final result = GeneratedBindings.instance._Camera_getFrustum(camera.cast(), out);
-  return result;
-}
-
-void Camera_setProjectionMatrix(Pointer<TCamera> camera, Pointer<Float64> matrix, double near, double far) {
-  final result = GeneratedBindings.instance._Camera_setProjectionMatrix(camera.cast(), matrix, near, far);
-  return result;
-}
-
-void Camera_setProjectionFromFov(
-  Pointer<TCamera> camera,
-  double fovInDegrees,
-  double aspect,
-  double near,
-  double far,
-  bool horizontal,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjectionFromFov(
-    camera.cast(),
-    fovInDegrees,
-    aspect,
-    near,
-    far,
-    horizontal,
-  );
-  return result;
-}
-
-double Camera_getFocalLength(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocalLength(camera.cast());
-  return result;
-}
-
-void Camera_lookAt(Pointer<TCamera> camera, double3 eye, double3 focus, double3 up) {
-  final eyePtr = eye.address;
-  final focusPtr = focus.address;
-  final upPtr = up.address;
-  final result = GeneratedBindings.instance._Camera_lookAt(camera.cast(), eyePtr.cast(), focusPtr.cast(), upPtr.cast());
-  return result;
-}
-
-double Camera_getNear(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getNear(camera.cast());
-  return result;
-}
-
-double Camera_getCullingFar(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getCullingFar(camera.cast());
-  return result;
-}
-
-double Camera_getFov(Pointer<TCamera> camera, bool horizontal) {
-  final result = GeneratedBindings.instance._Camera_getFov(camera.cast(), horizontal);
-  return result;
-}
-
-double Camera_getFocusDistance(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getFocusDistance(camera.cast());
-  return result;
-}
-
-void Camera_setFocusDistance(Pointer<TCamera> camera, double focusDistance) {
-  final result = GeneratedBindings.instance._Camera_setFocusDistance(camera.cast(), focusDistance);
-  return result;
-}
-
-void Camera_setCustomProjectionWithCulling(
-  Pointer<TCamera> camera,
-  double4x4 projectionMatrix,
-  double near,
-  double far,
-) {
-  final projectionMatrixPtr = projectionMatrix.address;
-  final result = GeneratedBindings.instance._Camera_setCustomProjectionWithCulling(
-    camera.cast(),
-    projectionMatrixPtr.cast(),
-    near,
-    far,
-  );
-  return result;
-}
-
-void Camera_setModelMatrix(Pointer<TCamera> camera, Pointer<Float64> tModelMatrix) {
-  final result = GeneratedBindings.instance._Camera_setModelMatrix(camera.cast(), tModelMatrix);
-  return result;
-}
-
-void Camera_setLensProjection(Pointer<TCamera> camera, double near, double far, double aspect, double focalLength) {
-  final result = GeneratedBindings.instance._Camera_setLensProjection(camera.cast(), near, far, aspect, focalLength);
-  return result;
-}
-
-DartEntityId Camera_getEntity(Pointer<TCamera> camera) {
-  final result = GeneratedBindings.instance._Camera_getEntity(camera.cast());
-  return result;
-}
-
-void Camera_setProjection(
-  Pointer<TCamera> tCamera,
-  int projection,
-  double left,
-  double right,
-  double bottom,
-  double top,
-  double near,
-  double far,
-) {
-  final result = GeneratedBindings.instance._Camera_setProjection(
-    tCamera.cast(),
-    projection,
-    left,
-    right,
-    bottom,
-    top,
-    near,
-    far,
-  );
-  return result;
-}
-
-void MeshData_dispose(Pointer<TMeshData> meshData) {
-  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
-  return result;
-}
-
-int GltfParser_parseBuffer(
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  Pointer<Char> meshName,
-  Pointer<TMeshData> outMeshData,
-) {
-  final result = GeneratedBindings.instance._GltfParser_parseBuffer(data, length, meshName, outMeshData.cast());
-  return result;
-}
-
-Pointer<TTexture> Texture_build(
-  Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import1,
-  int sampler,
-  int format,
-) {
-  final result = GeneratedBindings.instance._Texture_build(
-    engine.cast(),
-    width,
-    height,
-    depth,
-    levels,
-    tUsage,
-    import1,
-    sampler,
-    format,
-  );
-  return Pointer<TTexture>(result);
-}
-
-void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
-  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
-  return result;
-}
-
-Dartsize_t Texture_getLevels(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
-  return result;
-}
-
-bool Texture_loadImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-) {
-  final result = GeneratedBindings.instance._Texture_loadImage(
-    tEngine.cast(),
-    tTexture.cast(),
-    tImage.cast(),
-    bufferFormat,
-    pixelDataType,
-    level,
-  );
-  return result == 1;
-}
-
-bool Texture_setImage(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  int level,
-  Pointer<Uint8> data,
-  Dartsize_t size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-) {
-  final result = GeneratedBindings.instance._Texture_setImage(
-    tEngine.cast(),
-    tTexture.cast(),
-    level,
-    data,
-    size,
-    x_offset,
-    y_offset,
-    z_offset,
-    width,
-    height,
-    depth,
-    bufferFormat,
-    pixelDataType,
-  );
-  return result == 1;
-}
-
-int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
-  return result;
-}
-
-int Texture_getFormat(Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
-  return result;
-}
-
-int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
-  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
-  return result;
-}
-
-void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
-  return result;
-}
-
-Pointer<TKtx1Bundle> Ktx1Bundle_create(Pointer<Uint8> ktxData, Dartsize_t length) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_create(ktxData, length);
-  return Pointer<TKtx1Bundle>(result);
-}
-
-void Ktx1Bundle_getSphericalHarmonics(Pointer<TKtx1Bundle> tBundle, Pointer<Float32> harmonics) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_getSphericalHarmonics(tBundle.cast(), harmonics);
-  return result;
-}
-
-bool Ktx1Bundle_isCubemap(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_isCubemap(tBundle.cast());
-  return result == 1;
-}
-
-void Ktx1Bundle_destroy(Pointer<TKtx1Bundle> tBundle) {
-  final result = GeneratedBindings.instance._Ktx1Bundle_destroy(tBundle.cast());
-  return result;
-}
-
-Pointer<TTexture> Ktx1Reader_createTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  DartVoidCallback onTextureUploadComplete,
-) {
-  final result = GeneratedBindings.instance._Ktx1Reader_createTexture(
-    tEngine.cast(),
-    tBundle.cast(),
-    requestId,
-    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> Ktx2Reader_createTexture(Pointer<TEngine> tEngine, Pointer<Uint8> data, Dartsize_t size) {
-  final result = GeneratedBindings.instance._Ktx2Reader_createTexture(tEngine.cast(), data, size);
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TLinearImage> Image_createEmpty(int width, int height, int channel) {
-  final result = GeneratedBindings.instance._Image_createEmpty(width, height, channel);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<TLinearImage> Image_decode(Pointer<Uint8> data, Dartsize_t length, Pointer<Char> name, bool alpha) {
-  final result = GeneratedBindings.instance._Image_decode(data, length, name, alpha);
-  return Pointer<TLinearImage>(result);
-}
-
-Pointer<Float32> Image_getBytes(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getBytes(tLinearImage.cast());
-  return Pointer<Float32>(result);
-}
-
-void Image_destroy(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_destroy(tLinearImage.cast());
-  return result;
-}
-
-int Image_getWidth(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getWidth(tLinearImage.cast());
-  return result;
-}
-
-int Image_getHeight(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getHeight(tLinearImage.cast());
-  return result;
-}
-
-int Image_getChannels(Pointer<TLinearImage> tLinearImage) {
-  final result = GeneratedBindings.instance._Image_getChannels(tLinearImage.cast());
-  return result;
-}
-
-Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
-  return Pointer<TTexture>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_create() {
-  final result = GeneratedBindings.instance._TextureSampler_create();
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithFiltering(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
-    minFilter,
-    magFilter,
-    wrapS,
-    wrapT,
-    wrapR,
-  );
-  return Pointer<TTextureSampler>(result);
-}
-
-Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
-  return Pointer<TTextureSampler>(result);
-}
-
-void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
-  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
-  return result;
-}
-
-void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
-  return result;
-}
-
-void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
-  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
-  return result;
-}
-
-void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
-  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
-  return result;
-}
-
-void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
-  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
-  return result;
-}
-
-Pointer<TEngine> Engine_create(
-  int backend,
-  Pointer<Void> platform,
-  Pointer<Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-) {
-  final result = GeneratedBindings.instance._Engine_create(
-    backend,
-    platform,
-    sharedContext,
-    stereoscopicEyeCount,
-    disableHandleUseAfterFreeCheck,
-  );
-  return Pointer<TEngine>(result);
-}
-
-int Engine_getSupportedFeatureLevel(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getSupportedFeatureLevel(tEngine.cast());
-  return result;
-}
-
-void Engine_destroy(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_destroy(tEngine.cast());
-  return result;
-}
-
-Pointer<TRenderer> Engine_createRenderer(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createRenderer(tEngine.cast());
-  return Pointer<TRenderer>(result);
-}
-
-void Engine_destroyRenderer(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Engine_destroyRenderer(tEngine.cast(), tRenderer.cast());
-  return result;
-}
-
-Pointer<TSwapChain> Engine_createSwapChain(Pointer<TEngine> tEngine, Pointer<Void> window, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createSwapChain(tEngine.cast(), window, flags.toJSBigInt);
-  return Pointer<TSwapChain>(result);
-}
-
-Pointer<TSwapChain> Engine_createHeadlessSwapChain(Pointer<TEngine> tEngine, int width, int height, BigInt flags) {
-  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChain(
-    tEngine.cast(),
-    width,
-    height,
-    flags.toJSBigInt,
-  );
-  return Pointer<TSwapChain>(result);
-}
-
-void Engine_destroySwapChain(Pointer<TEngine> tEngine, Pointer<TSwapChain> tSwapChain) {
-  final result = GeneratedBindings.instance._Engine_destroySwapChain(tEngine.cast(), tSwapChain.cast());
-  return result;
-}
-
-void Engine_destroyView(Pointer<TEngine> tEngine, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Engine_destroyView(tEngine.cast(), tView.cast());
-  return result;
-}
-
-void Engine_destroyScene(Pointer<TEngine> tEngine, Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Engine_destroyScene(tEngine.cast(), tScene.cast());
-  return result;
-}
-
-void Engine_destroyColorGrading(Pointer<TEngine> tEngine, Pointer<TColorGrading> tColorGrading) {
-  final result = GeneratedBindings.instance._Engine_destroyColorGrading(tEngine.cast(), tColorGrading.cast());
-  return result;
-}
-
-Pointer<TCamera> Engine_createCamera(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_createCamera(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-void Engine_destroyCamera(Pointer<TEngine> tEngine, Pointer<TCamera> tCamera) {
-  final result = GeneratedBindings.instance._Engine_destroyCamera(tEngine.cast(), tCamera.cast());
-  return result;
-}
-
-Pointer<TView> Engine_createView(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createView(tEngine.cast());
-  return Pointer<TView>(result);
-}
-
-Pointer<TCamera> Engine_getCameraComponent(Pointer<TEngine> tEngine, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Engine_getCameraComponent(tEngine.cast(), entityId);
-  return Pointer<TCamera>(result);
-}
-
-Pointer<TTransformManager> Engine_getTransformManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getTransformManager(engine.cast());
-  return Pointer<TTransformManager>(result);
-}
-
-Pointer<TRenderableManager> Engine_getRenderableManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getRenderableManager(engine.cast());
-  return Pointer<TRenderableManager>(result);
-}
-
-Pointer<TLightManager> Engine_getLightManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getLightManager(engine.cast());
-  return Pointer<TLightManager>(result);
-}
-
-Pointer<TEntityManager> Engine_getEntityManager(Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._Engine_getEntityManager(engine.cast());
-  return Pointer<TEntityManager>(result);
-}
-
-void Engine_setAutomaticInstancingEnabled(Pointer<TEngine> tEngine, bool enabled) {
-  final result = GeneratedBindings.instance._Engine_setAutomaticInstancingEnabled(tEngine.cast(), enabled);
-  return result;
-}
-
-Dartsize_t Engine_getMaxAutomaticInstances(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getMaxAutomaticInstances(tEngine.cast());
-  return result;
-}
-
-void Engine_destroyTexture(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture) {
-  final result = GeneratedBindings.instance._Engine_destroyTexture(tEngine.cast(), tTexture.cast());
-  return result;
-}
-
-Pointer<TFence> Engine_createFence(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createFence(tEngine.cast());
-  return Pointer<TFence>(result);
-}
-
-void Engine_destroyFence(Pointer<TEngine> tEngine, Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Engine_destroyFence(tEngine.cast(), tFence.cast());
-  return result;
-}
-
-void Engine_flushAndWait(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_flushAndWait(tEngine.cast());
-  return result;
-}
-
-void Engine_execute(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_execute(tEngine.cast());
-  return result;
-}
-
-Pointer<TMaterial> Engine_buildMaterial(Pointer<TEngine> tEngine, Pointer<Uint8> materialData, Dartsize_t length) {
-  final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
-  return Pointer<TMaterial>(result);
-}
-
-void Engine_destroyMaterial(Pointer<TEngine> tEngine, Pointer<TMaterial> tMaterial) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterial(tEngine.cast(), tMaterial.cast());
-  return result;
-}
-
-void Engine_destroyMaterialInstance(Pointer<TEngine> tEngine, Pointer<TMaterialInstance> tMaterialInstance) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialInstance(tEngine.cast(), tMaterialInstance.cast());
-  return result;
-}
-
-Pointer<TScene> Engine_createScene(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_createScene(tEngine.cast());
-  return Pointer<TScene>(result);
-}
-
-Pointer<TSkybox> Engine_buildSkybox(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildSkybox(
-    tEngine.cast(),
-    tTexture.cast(),
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TSkybox> Engine_buildColoredSkybox(
-  Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._Engine_buildColoredSkybox(
-    tEngine.cast(),
-    r,
-    g,
-    b,
-    a,
-    showSun,
-    intensity,
-    priority,
-  );
-  return Pointer<TSkybox>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceTexture(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTexture(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    tIrradianceTexture.cast(),
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-Pointer<TIndirectLight> Engine_buildIndirectLightFromIrradianceHarmonics(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<Float32> irradianceHarmonics,
-  double intensity,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonics(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    irradianceHarmonics,
-    intensity,
-  );
-  return Pointer<TIndirectLight>(result);
-}
-
-void Engine_destroySkybox(Pointer<TEngine> tEngine, Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Engine_destroySkybox(tEngine.cast(), tSkybox.cast());
-  return result;
-}
-
-void Engine_destroyIndirectLight(Pointer<TEngine> tEngine, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Engine_destroyIndirectLight(tEngine.cast(), tIndirectLight.cast());
-  return result;
-}
-
-DartEntityId EntityManager_createEntity(Pointer<TEntityManager> tEntityManager) {
-  final result = GeneratedBindings.instance._EntityManager_createEntity(tEntityManager.cast());
-  return result;
-}
-
-void EntityManager_destroyEntity(Pointer<TEntityManager> tEntityManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._EntityManager_destroyEntity(tEntityManager.cast(), entityId);
-  return result;
-}
-
-void Fence_waitAndDestroy(Pointer<TFence> tFence) {
-  final result = GeneratedBindings.instance._Fence_waitAndDestroy(tFence.cast());
-  return result;
-}
-
-Pointer<TDebugRegistry> Engine_getDebugRegistry(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._Engine_getDebugRegistry(tEngine.cast());
-  return Pointer<TDebugRegistry>(result);
-}
-
-bool DebugRegistry_hasProperty(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name) {
-  final result = GeneratedBindings.instance._DebugRegistry_hasProperty(tDebugRegistry.cast(), name);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_bool(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, bool value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_bool(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_int(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, int value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_int(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_setProperty_float(Pointer<TDebugRegistry> tDebugRegistry, Pointer<Char> name, double value) {
-  final result = GeneratedBindings.instance._DebugRegistry_setProperty_float(tDebugRegistry.cast(), name, value);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_bool(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Bool> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_bool(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_int(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Int32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_int(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
-}
-
-bool DebugRegistry_getProperty_float(
-  Pointer<TDebugRegistry> tDebugRegistry,
-  Pointer<Char> name,
-  Pointer<Float32> outValue,
-) {
-  final result = GeneratedBindings.instance._DebugRegistry_getProperty_float(tDebugRegistry.cast(), name, outValue);
-  return result == 1;
 }
 
 Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
@@ -4402,2001 +5438,6 @@ Pointer<TMaterialInstance> MaterialProvider_createMaterialInstance(
     hasVolume,
   );
   return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_create();
-  return Pointer<TVertexBufferBuilder>(result);
-}
-
-void VertexBufferBuilder_bufferCount(Pointer<TVertexBufferBuilder> builder, int count) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_bufferCount(builder.cast(), count);
-  return result;
-}
-
-void VertexBufferBuilder_vertexCount(Pointer<TVertexBufferBuilder> builder, int count) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_vertexCount(builder.cast(), count);
-  return result;
-}
-
-void VertexBufferBuilder_enableBufferObjects(Pointer<TVertexBufferBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_enableBufferObjects(builder.cast(), enabled);
-  return result;
-}
-
-int VertexBufferBuilder_getStorageMode(Pointer<TVertexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_getStorageMode(builder.cast());
-  return result;
-}
-
-void VertexBufferBuilder_attribute(
-  Pointer<TVertexBufferBuilder> builder,
-  int attribute,
-  int bufferIndex,
-  int attributeType,
-  int byteOffset,
-  int byteStride,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_attribute(
-    builder.cast(),
-    attribute,
-    bufferIndex,
-    attributeType,
-    byteOffset,
-    byteStride,
-  );
-  return result;
-}
-
-void VertexBufferBuilder_normalized(Pointer<TVertexBufferBuilder> builder, int attribute, bool normalize) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_normalized(builder.cast(), attribute, normalize);
-  return result;
-}
-
-Pointer<TVertexBuffer> VertexBufferBuilder_build(Pointer<TVertexBufferBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TVertexBuffer>(result);
-}
-
-void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dartsize_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
-  final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(buffer.cast());
-  return result;
-}
-
-void VertexBuffer_setBufferAt(
-  Pointer<TEngine> engine,
-  Pointer<TVertexBuffer> buffer,
-  int bufferIndex,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
-    engine.cast(),
-    buffer.cast(),
-    bufferIndex,
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void VertexBuffer_setBufferObjectAt(
-  Pointer<TEngine> engine,
-  Pointer<TVertexBuffer> buffer,
-  int bufferIndex,
-  Pointer<TBufferObject> bufferObject,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_setBufferObjectAt(
-    engine.cast(),
-    buffer.cast(),
-    bufferIndex,
-    bufferObject.cast(),
-  );
-  return result;
-}
-
-void VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer) {
-  final result = GeneratedBindings.instance._VertexBuffer_destroy(engine.cast(), buffer.cast());
-  return result;
-}
-
-Pointer<TIndexBufferBuilder> IndexBufferBuilder_create() {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_create();
-  return Pointer<TIndexBufferBuilder>(result);
-}
-
-void IndexBufferBuilder_indexCount(Pointer<TIndexBufferBuilder> builder, int count) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_indexCount(builder.cast(), count);
-  return result;
-}
-
-void IndexBufferBuilder_bufferType(Pointer<TIndexBufferBuilder> builder, int indexType) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_bufferType(builder.cast(), indexType);
-  return result;
-}
-
-Pointer<TIndexBuffer> IndexBufferBuilder_build(Pointer<TIndexBufferBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TIndexBuffer>(result);
-}
-
-void IndexBufferBuilder_destroy(Pointer<TIndexBufferBuilder> builder) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_destroy(builder.cast());
-  return result;
-}
-
-Dartsize_t IndexBuffer_getIndexCount(Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_getIndexCount(buffer.cast());
-  return result;
-}
-
-void IndexBuffer_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TIndexBuffer> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void IndexBuffer_destroy(Pointer<TEngine> engine, Pointer<TIndexBuffer> buffer) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroy(engine.cast(), buffer.cast());
-  return result;
-}
-
-Pointer<TBufferObjectBuilder> BufferObjectBuilder_create() {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_create();
-  return Pointer<TBufferObjectBuilder>(result);
-}
-
-void BufferObjectBuilder_size(Pointer<TBufferObjectBuilder> builder, int sizeInBytes) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_size(builder.cast(), sizeInBytes);
-  return result;
-}
-
-Pointer<TBufferObject> BufferObjectBuilder_build(Pointer<TBufferObjectBuilder> builder, Pointer<TEngine> engine) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_build(builder.cast(), engine.cast());
-  return Pointer<TBufferObject>(result);
-}
-
-void BufferObjectBuilder_destroy(Pointer<TBufferObjectBuilder> builder) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_destroy(builder.cast());
-  return result;
-}
-
-void BufferObject_setBuffer(
-  Pointer<TEngine> engine,
-  Pointer<TBufferObject> buffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
-) {
-  final result = GeneratedBindings.instance._BufferObject_setBuffer(
-    engine.cast(),
-    buffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
-  );
-  return result;
-}
-
-void BufferObject_destroy(Pointer<TEngine> engine, Pointer<TBufferObject> buffer) {
-  final result = GeneratedBindings.instance._BufferObject_destroy(engine.cast(), buffer.cast());
-  return result;
-}
-
-double4x4 TransformManager_getLocalTransform(Pointer<TTransformManager> tTransformManager, DartEntityId entityId) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._TransformManager_getLocalTransform(
-    double4x4_out.cast(),
-    tTransformManager.cast(),
-    entityId,
-  );
-  return double4x4_out.toDart();
-}
-
-double4x4 TransformManager_getWorldTransform(Pointer<TTransformManager> tTransformManager, DartEntityId entityId) {
-  final double4x4_out = double4x4.stackAlloc();
-  final result = GeneratedBindings.instance._TransformManager_getWorldTransform(
-    double4x4_out.cast(),
-    tTransformManager.cast(),
-    entityId,
-  );
-  return double4x4_out.toDart();
-}
-
-void TransformManager_setTransform(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  double4x4 transform,
-) {
-  final transformPtr = transform.address;
-  final result = GeneratedBindings.instance._TransformManager_setTransform(
-    tTransformManager.cast(),
-    entityId,
-    transformPtr.cast(),
-  );
-  return result;
-}
-
-bool TransformManager_transformToUnitCube(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  Aabb3 boundingBox,
-) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._TransformManager_transformToUnitCube(
-    tTransformManager.cast(),
-    entityId,
-    boundingBoxPtr.cast(),
-  );
-  return result == 1;
-}
-
-void TransformManager_setParent(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId child,
-  DartEntityId parent,
-  bool preserveScaling,
-) {
-  final result = GeneratedBindings.instance._TransformManager_setParent(
-    tTransformManager.cast(),
-    child,
-    parent,
-    preserveScaling,
-  );
-  return result;
-}
-
-DartEntityId TransformManager_getParent(Pointer<TTransformManager> tTransformManager, DartEntityId child) {
-  final result = GeneratedBindings.instance._TransformManager_getParent(tTransformManager.cast(), child);
-  return result;
-}
-
-DartEntityId TransformManager_getAncestor(Pointer<TTransformManager> tTransformManager, DartEntityId childEntityId) {
-  final result = GeneratedBindings.instance._TransformManager_getAncestor(tTransformManager.cast(), childEntityId);
-  return result;
-}
-
-void TransformManager_createComponent(Pointer<TTransformManager> tTransformManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._TransformManager_createComponent(tTransformManager.cast(), entity);
-  return result;
-}
-
-void TransformManager_removeComponent(Pointer<TTransformManager> tTransformManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._TransformManager_removeComponent(tTransformManager.cast(), entity);
-  return result;
-}
-
-bool TransformManager_hasComponent(Pointer<TTransformManager> tTransformManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._TransformManager_hasComponent(tTransformManager.cast(), entityId);
-  return result == 1;
-}
-
-bool TransformManager_empty(Pointer<TTransformManager> tTransformManager) {
-  final result = GeneratedBindings.instance._TransformManager_empty(tTransformManager.cast());
-  return result == 1;
-}
-
-int TransformManager_getComponentCount(Pointer<TTransformManager> tTransformManager) {
-  final result = GeneratedBindings.instance._TransformManager_getComponentCount(tTransformManager.cast());
-  return result;
-}
-
-int TransformManager_getChildCount(Pointer<TTransformManager> tTransformManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._TransformManager_getChildCount(tTransformManager.cast(), entityId);
-  return result;
-}
-
-void TransformManager_getChildren(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  Pointer<Int32> children,
-  int count,
-) {
-  final result = GeneratedBindings.instance._TransformManager_getChildren(
-    tTransformManager.cast(),
-    entityId,
-    children,
-    count,
-  );
-  return result;
-}
-
-void TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager) {
-  final result = GeneratedBindings.instance._TransformManager_openLocalTransformTransaction(tTransformManager.cast());
-  return result;
-}
-
-void TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager) {
-  final result = GeneratedBindings.instance._TransformManager_commitLocalTransformTransaction(tTransformManager.cast());
-  return result;
-}
-
-int LightManager_createLight(Pointer<TEngine> tEngine, Pointer<TLightManager> tLightManager, int tLightTtype) {
-  final result = GeneratedBindings.instance._LightManager_createLight(
-    tEngine.cast(),
-    tLightManager.cast(),
-    tLightTtype,
-  );
-  return result;
-}
-
-void LightManager_destroyLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_destroyLight(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_hasComponent(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_hasComponent(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-int LightManager_getType(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getType(tLightManager.cast(), entity);
-  return result;
-}
-
-bool LightManager_isDirectional(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isDirectional(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isPointLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isPointLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-bool LightManager_isSpotLight(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isSpotLight(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setPosition(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setPosition(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getPosition(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getPosition(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setDirection(Pointer<TLightManager> tLightManager, DartEntityId light, double x, double y, double z) {
-  final result = GeneratedBindings.instance._LightManager_setDirection(tLightManager.cast(), light, x, y, z);
-  return result;
-}
-
-double3 LightManager_getDirection(Pointer<TLightManager> tLightManager, DartEntityId light) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getDirection(double3_out.cast(), tLightManager.cast(), light);
-  return double3_out.toDart();
-}
-
-void LightManager_setColor(Pointer<TLightManager> tLightManager, DartEntityId entity, double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_setColor(tLightManager.cast(), entity, r, g, b);
-  return result;
-}
-
-void LightManager_setColorTemperature(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double colorTemperature,
-) {
-  final result = GeneratedBindings.instance._LightManager_setColorTemperature(
-    tLightManager.cast(),
-    entity,
-    colorTemperature,
-  );
-  return result;
-}
-
-double3 LightManager_getColor(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final double3_out = double3.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getColor(double3_out.cast(), tLightManager.cast(), entity);
-  return double3_out.toDart();
-}
-
-void LightManager_setIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensity(tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityCandela(Pointer<TLightManager> tLightManager, DartEntityId entity, double intensity) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityCandela(tLightManager.cast(), entity, intensity);
-  return result;
-}
-
-void LightManager_setIntensityWatts(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double watts,
-  double efficiency,
-) {
-  final result = GeneratedBindings.instance._LightManager_setIntensityWatts(
-    tLightManager.cast(),
-    entity,
-    watts,
-    efficiency,
-  );
-  return result;
-}
-
-double LightManager_getIntensity(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getIntensity(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double falloff) {
-  final result = GeneratedBindings.instance._LightManager_setFalloff(tLightManager.cast(), entity, falloff);
-  return result;
-}
-
-double LightManager_getFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSpotLightCone(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entity,
-  double inner,
-  double outer,
-) {
-  final result = GeneratedBindings.instance._LightManager_setSpotLightCone(tLightManager.cast(), entity, inner, outer);
-  return result;
-}
-
-double LightManager_getSpotLightOuterCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightOuterCone(tLightManager.cast(), entity);
-  return result;
-}
-
-double LightManager_getSpotLightInnerCone(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSpotLightInnerCone(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity, double angularRadius) {
-  final result = GeneratedBindings.instance._LightManager_setSunAngularRadius(
-    tLightManager.cast(),
-    entity,
-    angularRadius,
-  );
-  return result;
-}
-
-double LightManager_getSunAngularRadius(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunAngularRadius(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloSize) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloSize(tLightManager.cast(), entity, haloSize);
-  return result;
-}
-
-double LightManager_getSunHaloSize(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloSize(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity, double haloFalloff) {
-  final result = GeneratedBindings.instance._LightManager_setSunHaloFalloff(tLightManager.cast(), entity, haloFalloff);
-  return result;
-}
-
-double LightManager_getSunHaloFalloff(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_getSunHaloFalloff(tLightManager.cast(), entity);
-  return result;
-}
-
-void LightManager_setShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity, bool enabled) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCaster(tLightManager.cast(), entity, enabled);
-  return result;
-}
-
-bool LightManager_isShadowCaster(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final result = GeneratedBindings.instance._LightManager_isShadowCaster(tLightManager.cast(), entity);
-  return result == 1;
-}
-
-void LightManager_setShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity, TShadowOptions options) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptions(
-    tLightManager.cast(),
-    entity,
-    optionsPtr.cast(),
-  );
-  return result;
-}
-
-TShadowOptions LightManager_getShadowOptions(Pointer<TLightManager> tLightManager, DartEntityId entity) {
-  final TShadowOptions_out = TShadowOptions.stackAlloc();
-  final result = GeneratedBindings.instance._LightManager_getShadowOptions(
-    TShadowOptions_out.cast(),
-    tLightManager.cast(),
-    entity,
-  );
-  return TShadowOptions_out.toDart();
-}
-
-void LightManager_setLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel, bool enable) {
-  final result = GeneratedBindings.instance._LightManager_setLightChannel(
-    tLightManager.cast(),
-    entity,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool LightManager_getLightChannel(Pointer<TLightManager> tLightManager, DartEntityId entity, int channel) {
-  final result = GeneratedBindings.instance._LightManager_getLightChannel(tLightManager.cast(), entity, channel);
-  return result == 1;
-}
-
-void LightManager_computeUniformSplits(Pointer<Float32> splitPositions, int cascades) {
-  final result = GeneratedBindings.instance._LightManager_computeUniformSplits(splitPositions, cascades);
-  return result;
-}
-
-void LightManager_computeLogSplits(Pointer<Float32> splitPositions, int cascades, double near, double far) {
-  final result = GeneratedBindings.instance._LightManager_computeLogSplits(splitPositions, cascades, near, far);
-  return result;
-}
-
-void LightManager_computePracticalSplits(
-  Pointer<Float32> splitPositions,
-  int cascades,
-  double near,
-  double far,
-  double lambda,
-) {
-  final result = GeneratedBindings.instance._LightManager_computePracticalSplits(
-    splitPositions,
-    cascades,
-    near,
-    far,
-    lambda,
-  );
-  return result;
-}
-
-double LightManager_rgbToColorTemperature(double r, double g, double b) {
-  final result = GeneratedBindings.instance._LightManager_rgbToColorTemperature(r, g, b);
-  return result;
-}
-
-Pointer<Void> RenderThread_create() {
-  final result = GeneratedBindings.instance._RenderThread_create();
-  return Pointer<Void>(result);
-}
-
-Pointer<Void> RenderThread_createForCanvas(Pointer<Char> canvasSelector) {
-  final result = GeneratedBindings.instance._RenderThread_createForCanvas(canvasSelector);
-  return Pointer<Void>(result);
-}
-
-void RenderThread_destroy(Pointer<Void> renderThread) {
-  final result = GeneratedBindings.instance._RenderThread_destroy(renderThread);
-  return result;
-}
-
-void RenderThread_addTask(Pointer<NativeFunction<void Function()>> task) {
-  final result = GeneratedBindings.instance._RenderThread_addTask(task.cast());
-  return result;
-}
-
-void RenderManager_setRenderableRenderThread(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> tSwapChain,
-  Pointer<PointerClass<TView>> tViews,
-  int numViews,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderableRenderThread(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    tViews.cast(),
-    numViews,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderManager_renderRenderThread(
-  Pointer<TRenderManager> tRenderManager,
-  BigInt frameTimeInNanos,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderManager_renderRenderThread(
-    tRenderManager.cast(),
-    frameTimeInNanos.toJSBigInt,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderManager_addAnimationManagerRenderThread(
-  Pointer<TRenderManager> tRenderManager,
-  Pointer<TAnimationManager> tAnimationManager,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManagerRenderThread(
-    tRenderManager.cast(),
-    tAnimationManager.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderManager_removeAnimationManagerRenderThread(
-  Pointer<TRenderManager> tRenderManager,
-  Pointer<TAnimationManager> tAnimationManager,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeAnimationManagerRenderThread(
-    tRenderManager.cast(),
-    tAnimationManager.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChainRenderThread(
-  Pointer<TRenderManager> tRenderManager,
-  Pointer<TSwapChain> tSwapChain,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChainRenderThread(
-    tRenderManager.cast(),
-    tSwapChain.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void AnimationManager_createRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TAnimationManager>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_createRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void AnimationManager_destroyRenderThread(
-  Pointer<TAnimationManager> tAnimationManager,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_destroyRenderThread(
-    tAnimationManager.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_createRenderThread(
-  int backend,
-  Pointer<Void> platform,
-  Pointer<Void> sharedContext,
-  int stereoscopicEyeCount,
-  bool disableHandleUseAfterFreeCheck,
-  Pointer<NativeFunction<void Function(Pointer<TEngine>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_createRenderThread(
-    backend,
-    platform,
-    sharedContext,
-    stereoscopicEyeCount,
-    disableHandleUseAfterFreeCheck,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_createRendererRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TRenderer>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_createRendererRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void Engine_destroyRendererRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TRenderer> tRenderer,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyRendererRenderThread(
-    tEngine.cast(),
-    tRenderer.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_createSwapChainRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<Void> window,
-  BigInt flags,
-  Pointer<NativeFunction<void Function(Pointer<TSwapChain>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_createSwapChainRenderThread(
-    tEngine.cast(),
-    window,
-    flags.toJSBigInt,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_createHeadlessSwapChainRenderThread(
-  Pointer<TEngine> tEngine,
-  int width,
-  int height,
-  BigInt flags,
-  Pointer<NativeFunction<void Function(Pointer<TSwapChain>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_createHeadlessSwapChainRenderThread(
-    tEngine.cast(),
-    width,
-    height,
-    flags.toJSBigInt,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_createCameraRenderThread(
-  Pointer<TEngine> tEngine,
-  DartEntityId entityId,
-  Pointer<NativeFunction<void Function(Pointer<TCamera>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_createCameraRenderThread(
-    tEngine.cast(),
-    entityId,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_destroyCameraRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TCamera> tCamera,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyCameraRenderThread(
-    tEngine.cast(),
-    tCamera.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_createViewRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TView>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_createViewRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void Engine_buildMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<Uint8> materialData,
-  Dartsize_t length,
-  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_buildMaterialRenderThread(
-    tEngine.cast(),
-    materialData,
-    length,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_destroyRenderThread(Pointer<TEngine> tEngine, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._Engine_destroyRenderThread(
-    tEngine.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroySwapChainRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TSwapChain> tSwapChain,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroySwapChainRenderThread(
-    tEngine.cast(),
-    tSwapChain.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroyViewRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TView> tView,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyViewRenderThread(
-    tEngine.cast(),
-    tView.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroySceneRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TScene> tScene,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroySceneRenderThread(
-    tEngine.cast(),
-    tScene.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroyColorGradingRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TColorGrading> tColorGrading,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyColorGradingRenderThread(
-    tEngine.cast(),
-    tColorGrading.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroyMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterial> tMaterial,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialRenderThread(
-    tEngine.cast(),
-    tMaterial.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroyMaterialInstanceRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialInstance> tMaterialInstance,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyMaterialInstanceRenderThread(
-    tEngine.cast(),
-    tMaterialInstance.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroySkyboxRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TSkybox> tSkybox,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroySkyboxRenderThread(
-    tEngine.cast(),
-    tSkybox.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroyIndirectLightRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TIndirectLight> tIndirectLight,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyIndirectLightRenderThread(
-    tEngine.cast(),
-    tIndirectLight.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Texture_buildRenderThread(
-  Pointer<TEngine> engine,
-  int width,
-  int height,
-  int depth,
-  int levels,
-  int tUsage,
-  int import1,
-  int sampler,
-  int format,
-  Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Texture_buildRenderThread(
-    engine.cast(),
-    width,
-    height,
-    depth,
-    levels,
-    tUsage,
-    import1,
-    sampler,
-    format,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Texture_setExternalImageRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<Void> externalImage,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Texture_setExternalImageRenderThread(
-    tEngine.cast(),
-    tTexture.cast(),
-    externalImage,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Texture_generateMipMapsRenderThread(
-  Pointer<TTexture> tTexture,
-  Pointer<TEngine> tEngine,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Texture_generateMipMapsRenderThread(
-    tTexture.cast(),
-    tEngine.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Ktx1Reader_createTextureRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TKtx1Bundle> tBundle,
-  int requestId,
-  DartVoidCallback onTextureUploadComplete,
-  Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Ktx1Reader_createTextureRenderThread(
-    tEngine.cast(),
-    tBundle.cast(),
-    requestId,
-    onTextureUploadComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Ktx2Reader_createTextureRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<Uint8> data,
-  Dartsize_t size,
-  Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Ktx2Reader_createTextureRenderThread(
-    tEngine.cast(),
-    data,
-    size,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_destroyTextureRenderThread(
-  Pointer<TEngine> engine,
-  Pointer<TTexture> tTexture,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyTextureRenderThread(
-    engine.cast(),
-    tTexture.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_createFenceRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TFence>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_createFenceRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void Fence_waitAndDestroyRenderThread(Pointer<TFence> tFence, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._Fence_waitAndDestroyRenderThread(
-    tFence.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_destroyFenceRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TFence> tFence,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_destroyFenceRenderThread(
-    tEngine.cast(),
-    tFence.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_flushAndWaitRenderThread(Pointer<TEngine> tEngine, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._Engine_flushAndWaitRenderThread(
-    tEngine.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_executeRenderThread(Pointer<TEngine> tEngine, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._Engine_executeRenderThread(
-    tEngine.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Engine_buildSkyboxRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  bool showSun,
-  double intensity,
-  int priority,
-  Pointer<NativeFunction<void Function(Pointer<TSkybox>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_buildSkyboxRenderThread(
-    tEngine.cast(),
-    tTexture.cast(),
-    showSun,
-    intensity,
-    priority,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_buildColoredSkyboxRenderThread(
-  Pointer<TEngine> tEngine,
-  double r,
-  double g,
-  double b,
-  double a,
-  bool showSun,
-  double intensity,
-  int priority,
-  Pointer<NativeFunction<void Function(Pointer<TSkybox>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_buildColoredSkyboxRenderThread(
-    tEngine.cast(),
-    r,
-    g,
-    b,
-    a,
-    showSun,
-    intensity,
-    priority,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<TTexture> tIrradianceTexture,
-  double intensity,
-  Pointer<NativeFunction<void Function(Pointer<TIndirectLight>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceTextureRenderThread(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    tIrradianceTexture.cast(),
-    intensity,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tReflectionsTexture,
-  Pointer<Float32> harmonics,
-  double intensity,
-  Pointer<NativeFunction<void Function(Pointer<TIndirectLight>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
-    tEngine.cast(),
-    tReflectionsTexture.cast(),
-    harmonics,
-    intensity,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Renderer_setClearOptionsRenderThread(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptionsRenderThread(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Renderer_beginFrameRenderThread(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TSwapChain> tSwapChain,
-  BigInt frameTimeInNanos,
-  Pointer<NativeFunction<void Function(bool)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Renderer_beginFrameRenderThread(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Renderer_endFrameRenderThread(Pointer<TRenderer> tRenderer, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._Renderer_endFrameRenderThread(
-    tRenderer.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Renderer_renderRenderThread(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TView> tView,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Renderer_renderRenderThread(
-    tRenderer.cast(),
-    tView.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Renderer_renderStandaloneViewRenderThread(
-  Pointer<TRenderer> tRenderer,
-  Pointer<TView> tView,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneViewRenderThread(
-    tRenderer.cast(),
-    tView.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Renderer_readPixelsRenderThread(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dartsize_t outLength,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixelsRenderThread(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Material_createInstanceRenderThread(
-  Pointer<TMaterial> tMaterial,
-  Pointer<NativeFunction<void Function(Pointer<TMaterialInstance>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Material_createInstanceRenderThread(tMaterial.cast(), onComplete.cast());
-  return result;
-}
-
-void MaterialInstance_setParameterTextureRenderThread(
-  Pointer<TMaterialInstance> tMaterialInstance,
-  Pointer<Char> propertyName,
-  Pointer<TTexture> tTexture,
-  Pointer<TTextureSampler> tSampler,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._MaterialInstance_setParameterTextureRenderThread(
-    tMaterialInstance.cast(),
-    propertyName,
-    tTexture.cast(),
-    tSampler.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Material_createImageMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Material_createImageMaterialRenderThread(
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Material_createGizmoMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Material_createGizmoMaterialRenderThread(
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Material_createBoneOverlayMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Material_createBoneOverlayMaterialRenderThread(
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Material_createSilhouetteMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Material_createSilhouetteMaterialRenderThread(
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Material_createEdgeOutlineMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Material_createEdgeOutlineMaterialRenderThread(
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Material_createWireframeMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Material_createWireframeMaterialRenderThread(
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Material_createTranslationAxisMaterialRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Material_createTranslationAxisMaterialRenderThread(
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void ColorGradingBuilder_createRenderThread(
-  Pointer<NativeFunction<void Function(Pointer<TColorGradingBuilder>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_createRenderThread(onComplete.cast());
-  return result;
-}
-
-void ColorGradingBuilder_buildRenderThread(
-  Pointer<TColorGradingBuilder> tBuilder,
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TColorGrading>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_buildRenderThread(
-    tBuilder.cast(),
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void ColorGradingBuilder_destroyRenderThread(
-  Pointer<TColorGradingBuilder> tBuilder,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._ColorGradingBuilder_destroyRenderThread(
-    tBuilder.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void ToneMapper_createLinearRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createLinearRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void ToneMapper_createACESRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createACESRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void ToneMapper_createACESLegacyRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createACESLegacyRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void ToneMapper_createFilmicRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createFilmicRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void ToneMapper_createPBRNeutralRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createPBRNeutralRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void ToneMapper_createAGXRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createAGXRenderThread(tEngine.cast(), onComplete.cast());
-  return result;
-}
-
-void ToneMapper_createAGXWithLookRenderThread(
-  Pointer<TEngine> tEngine,
-  int look,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createAGXWithLookRenderThread(
-    tEngine.cast(),
-    look,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void ToneMapper_createGenericRenderThread(
-  Pointer<TEngine> tEngine,
-  double contrast,
-  double midGrayIn,
-  double midGrayOut,
-  double hdrMax,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createGenericRenderThread(
-    tEngine.cast(),
-    contrast,
-    midGrayIn,
-    midGrayOut,
-    hdrMax,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void ToneMapper_createDisplayRangeRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._ToneMapper_createDisplayRangeRenderThread(
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void ToneMapper_destroyRenderThread(Pointer<TToneMapper> tToneMapper, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._ToneMapper_destroyRenderThread(
-    tToneMapper.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_pickRenderThread(Pointer<TView> tView, int requestId, int x, int y, DartPickCallback callback) {
-  final result = GeneratedBindings.instance._View_pickRenderThread(
-    tView.cast(),
-    requestId,
-    x,
-    y,
-    callback as Pointer<NativeFunction<PickCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setColorGradingRenderThread(
-  Pointer<TView> tView,
-  Pointer<TColorGrading> tColorGrading,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setColorGradingRenderThread(
-    tView.cast(),
-    tColorGrading.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setBloomRenderThread(
-  Pointer<TView> tView,
-  bool enabled,
-  double strength,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setBloomRenderThread(
-    tView.cast(),
-    enabled,
-    strength,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setCameraRenderThread(
-  Pointer<TView> tView,
-  Pointer<TCamera> tCamera,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setCameraRenderThread(
-    tView.cast(),
-    tCamera.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_getNameRenderThread(Pointer<TView> tView, Pointer<NativeFunction<void Function(Pointer<Char>)>> onComplete) {
-  final result = GeneratedBindings.instance._View_getNameRenderThread(tView.cast(), onComplete.cast());
-  return result;
-}
-
-void View_setNameRenderThread(Pointer<TView> tView, Pointer<Char> name, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._View_setNameRenderThread(
-    tView.cast(),
-    name,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setViewportRenderThread(
-  Pointer<TView> tView,
-  int width,
-  int height,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setViewportRenderThread(
-    tView.cast(),
-    width,
-    height,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setRenderTargetRenderThread(
-  Pointer<TView> tView,
-  Pointer<TRenderTarget> tRenderTarget,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setRenderTargetRenderThread(
-    tView.cast(),
-    tRenderTarget.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setAntiAliasingRenderThread(
-  Pointer<TView> tView,
-  bool msaa,
-  bool fxaa,
-  bool taa,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setAntiAliasingRenderThread(
-    tView.cast(),
-    msaa,
-    fxaa,
-    taa,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setPostProcessingRenderThread(
-  Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setPostProcessingRenderThread(
-    tView.cast(),
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setFrustumCullingEnabledRenderThread(
-  Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setFrustumCullingEnabledRenderThread(
-    tView.cast(),
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setStencilBufferEnabledRenderThread(
-  Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setStencilBufferEnabledRenderThread(
-    tView.cast(),
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setDitheringEnabledRenderThread(
-  Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setDitheringEnabledRenderThread(
-    tView.cast(),
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setRenderQualityRenderThread(
-  Pointer<TView> tView,
-  int qualityLevel,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setRenderQualityRenderThread(
-    tView.cast(),
-    qualityLevel,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setSceneRenderThread(
-  Pointer<TView> tView,
-  Pointer<TScene> tScene,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setSceneRenderThread(
-    tView.cast(),
-    tScene.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setLayerEnabledRenderThread(
-  Pointer<TView> tView,
-  int layer,
-  bool visible,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setLayerEnabledRenderThread(
-    tView.cast(),
-    layer,
-    visible,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setBlendModeRenderThread(Pointer<TView> tView, int blendMode, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._View_setBlendModeRenderThread(
-    tView.cast(),
-    blendMode,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setFogOptionsRenderThread(
-  Pointer<TView> tView,
-  TFogOptions tFogOptions,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final tFogOptionsPtr = tFogOptions.address;
-  final result = GeneratedBindings.instance._View_setFogOptionsRenderThread(
-    tView.cast(),
-    tFogOptionsPtr.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setAmbientOcclusionOptionsRenderThread(
-  Pointer<TView> tView,
-  TAmbientOcclusionOptions options,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setAmbientOcclusionOptionsRenderThread(
-    tView.cast(),
-    optionsPtr.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setFrontFaceWindingInvertedRenderThread(
-  Pointer<TView> tView,
-  bool inverted,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setFrontFaceWindingInvertedRenderThread(
-    tView.cast(),
-    inverted,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setShadowsEnabledRenderThread(
-  Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setShadowsEnabledRenderThread(
-    tView.cast(),
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setShadowTypeRenderThread(Pointer<TView> tView, int shadowType, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._View_setShadowTypeRenderThread(
-    tView.cast(),
-    shadowType,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setSoftShadowOptionsRenderThread(
-  Pointer<TView> tView,
-  TSoftShadowOptions options,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setSoftShadowOptionsRenderThread(
-    tView.cast(),
-    optionsPtr.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setVsmShadowOptionsRenderThread(
-  Pointer<TView> tView,
-  TVsmShadowOptions options,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._View_setVsmShadowOptionsRenderThread(
-    tView.cast(),
-    optionsPtr.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void View_setTransparentPickingEnabledRenderThread(
-  Pointer<TView> tView,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._View_setTransparentPickingEnabledRenderThread(
-    tView.cast(),
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void SceneAsset_destroyRenderThread(Pointer<TSceneAsset> tSceneAsset, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._SceneAsset_destroyRenderThread(
-    tSceneAsset.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void SceneAsset_createFromFilamentAssetRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  int requiredGeometryCapabilities,
-  Pointer<NativeFunction<void Function(Pointer<TSceneAsset>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAssetRenderThread(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    tNameComponentManager.cast(),
-    tFilamentAsset.cast(),
-    requiredGeometryCapabilities,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_createFromBuffersRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tVertexBuffer,
-  Pointer<TIndexBuffer> tIndexBuffer,
-  Pointer<PointerClass<TMaterialInstance>> materialInstances,
-  int materialInstanceCount,
-  int tPrimitiveType,
-  int vertexBufferStorageMode,
-  Aabb3 boundingBox,
-  Pointer<NativeFunction<void Function(Pointer<TSceneAsset>)>> callback,
-) {
-  final boundingBoxPtr = boundingBox.address;
-  final result = GeneratedBindings.instance._SceneAsset_createFromBuffersRenderThread(
-    tEngine.cast(),
-    tVertexBuffer.cast(),
-    tIndexBuffer.cast(),
-    materialInstances.cast(),
-    materialInstanceCount,
-    tPrimitiveType,
-    vertexBufferStorageMode,
-    boundingBoxPtr.cast(),
-    callback.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_createInstanceRenderThread(
-  Pointer<TSceneAsset> asset,
-  Pointer<PointerClass<TMaterialInstance>> tMaterialInstances,
-  int materialInstanceCount,
-  Pointer<NativeFunction<void Function(Pointer<TSceneAsset>)>> callback,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_createInstanceRenderThread(
-    asset.cast(),
-    tMaterialInstances.cast(),
-    materialInstanceCount,
-    callback.cast(),
-  );
-  return result;
-}
-
-void SceneAsset_releaseSourceDataRenderThread(
-  Pointer<TSceneAsset> tSceneAsset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_releaseSourceDataRenderThread(
-    tSceneAsset.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void SceneAsset_setFlatShadingRenderThread(
-  Pointer<TSceneAsset> tSceneAsset,
-  bool flatShading,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_setFlatShadingRenderThread(
-    tSceneAsset.cast(),
-    flatShading,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
 }
 
 void MaterialProvider_createMaterialInstanceRenderThread(
@@ -6486,14 +5527,299 @@ void MaterialProvider_createMaterialInstanceRenderThread(
   return result;
 }
 
-void AnimationManager_updateRenderThread(
+Pointer<TMaterial> Material_createBoneOverlayMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createBoneOverlayMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+void Material_createBoneOverlayMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Material_createBoneOverlayMaterialRenderThread(
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TMaterial> Material_createEdgeOutlineMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createEdgeOutlineMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+void Material_createEdgeOutlineMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Material_createEdgeOutlineMaterialRenderThread(
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TMaterial> Material_createGizmoMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createGizmoMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+void Material_createGizmoMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Material_createGizmoMaterialRenderThread(
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TMaterial> Material_createGridMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createGridMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+Pointer<TMaterial> Material_createImageMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createImageMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+void Material_createImageMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Material_createImageMaterialRenderThread(
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TMaterialInstance> Material_createInstance(Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Material_createInstance(tMaterial.cast());
+  return Pointer<TMaterialInstance>(result);
+}
+
+void Material_createInstanceRenderThread(
+  Pointer<TMaterial> tMaterial,
+  Pointer<NativeFunction<void Function(Pointer<TMaterialInstance>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Material_createInstanceRenderThread(tMaterial.cast(), onComplete.cast());
+  return result;
+}
+
+Pointer<TMaterial> Material_createSilhouetteMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createSilhouetteMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+void Material_createSilhouetteMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Material_createSilhouetteMaterialRenderThread(
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TMaterial> Material_createTranslationAxisMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createTranslationAxisMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+void Material_createTranslationAxisMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Material_createTranslationAxisMaterialRenderThread(
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TMaterial> Material_createWireframeMaterial(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Material_createWireframeMaterial(tEngine.cast());
+  return Pointer<TMaterial>(result);
+}
+
+void Material_createWireframeMaterialRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TMaterial>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Material_createWireframeMaterialRenderThread(
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+int Material_getBlendingMode(Pointer<TMaterial> material) {
+  final result = GeneratedBindings.instance._Material_getBlendingMode(material.cast());
+  return result;
+}
+
+int Material_getFeatureLevel(Pointer<TMaterial> tMaterial) {
+  final result = GeneratedBindings.instance._Material_getFeatureLevel(tMaterial.cast());
+  return result;
+}
+
+bool Material_hasParameter(Pointer<TMaterial> tMaterial, Pointer<Char> propertyName) {
+  final result = GeneratedBindings.instance._Material_hasParameter(tMaterial.cast(), propertyName);
+  return result == 1;
+}
+
+void MeshData_dispose(Pointer<TMeshData> meshData) {
+  final result = GeneratedBindings.instance._MeshData_dispose(meshData.cast());
+  return result;
+}
+
+void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
+  final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(executor.cast());
+  return result;
+}
+
+void MovementIntentExecutor_process(
+  Pointer<TMovementIntentExecutor> executor,
+  Pointer<TMovementIntent> intent,
+  BigInt deltaTimeInNanos,
+) {
+  final result = GeneratedBindings.instance._MovementIntentExecutor_process(
+    executor.cast(),
+    intent.cast(),
+    deltaTimeInNanos.toJSBigInt,
+  );
+  return result;
+}
+
+Pointer<TNameComponentManager> NameComponentManager_create() {
+  final result = GeneratedBindings.instance._NameComponentManager_create();
+  return Pointer<TNameComponentManager>(result);
+}
+
+void NameComponentManager_destroy(Pointer<TNameComponentManager> tNameComponentManager) {
+  final result = GeneratedBindings.instance._NameComponentManager_destroy(tNameComponentManager.cast());
+  return result;
+}
+
+Pointer<Char> NameComponentManager_getName(Pointer<TNameComponentManager> tNameComponentManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._NameComponentManager_getName(tNameComponentManager.cast(), entity);
+  return Pointer<Char>(result);
+}
+
+void Pipeline_registerMovementIntentExecutor(Pointer<TMovementIntentExecutor> executor) {
+  final result = GeneratedBindings.instance._Pipeline_registerMovementIntentExecutor(executor.cast());
+  return result;
+}
+
+void RenderManager_addAnimationManager(
+  Pointer<TRenderManager> tRenderer,
   Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_addAnimationManagerRenderThread(
+  Pointer<TRenderManager> tRenderManager,
+  Pointer<TAnimationManager> tAnimationManager,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderManager_addAnimationManagerRenderThread(
+    tRenderManager.cast(),
+    tAnimationManager.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
+  return result;
+}
+
+Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
+  return Pointer<TRenderManager>(result);
+}
+
+void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
+  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
+  return result;
+}
+
+void RenderManager_removeAnimationManager(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TAnimationManager> tAnimationManager,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
+    tRenderer.cast(),
+    tAnimationManager.cast(),
+  );
+  return result;
+}
+
+void RenderManager_removeAnimationManagerRenderThread(
+  Pointer<TRenderManager> tRenderManager,
+  Pointer<TAnimationManager> tAnimationManager,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeAnimationManagerRenderThread(
+    tRenderManager.cast(),
+    tAnimationManager.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
+  return result;
+}
+
+void RenderManager_removeSwapChainRenderThread(
+  Pointer<TRenderManager> tRenderManager,
+  Pointer<TSwapChain> tSwapChain,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderManager_removeSwapChainRenderThread(
+    tRenderManager.cast(),
+    tSwapChain.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
+  return result;
+}
+
+void RenderManager_renderRenderThread(
+  Pointer<TRenderManager> tRenderManager,
   BigInt frameTimeInNanos,
   int requestId,
   DartVoidCallback onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_updateRenderThread(
-    tAnimationManager.cast(),
+  final result = GeneratedBindings.instance._RenderManager_renderRenderThread(
+    tRenderManager.cast(),
     frameTimeInNanos.toJSBigInt,
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
@@ -6501,182 +5827,53 @@ void AnimationManager_updateRenderThread(
   return result;
 }
 
-void AnimationManager_setGltfAnimationTimeRenderThread(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-  int animationIndex,
-  double timeInSeconds,
+void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
+  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
+  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
+  return result;
+}
+
+void RenderManager_setRenderable(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> swapChain,
+  Pointer<PointerClass<TView>> views,
+  int numViews,
+) {
+  final result = GeneratedBindings.instance._RenderManager_setRenderable(
+    tRenderer.cast(),
+    swapChain.cast(),
+    views.cast(),
+    numViews,
+  );
+  return result;
+}
+
+void RenderManager_setRenderableRenderThread(
+  Pointer<TRenderManager> tRenderer,
+  Pointer<TSwapChain> tSwapChain,
+  Pointer<PointerClass<TView>> tViews,
+  int numViews,
   int requestId,
   DartVoidCallback onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_setGltfAnimationTimeRenderThread(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-    animationIndex,
-    timeInSeconds,
+  final result = GeneratedBindings.instance._RenderManager_setRenderableRenderThread(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    tViews.cast(),
+    numViews,
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
   return result;
 }
 
-void AnimationManager_updateBoneMatricesRenderThread(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  Pointer<NativeFunction<void Function(bool)>> callback,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_updateBoneMatricesRenderThread(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    callback.cast(),
-  );
-  return result;
-}
-
-void AnimationManager_setMorphTargetWeightsRenderThread(
-  Pointer<TAnimationManager> tAnimationManager,
-  DartEntityId entityId,
-  Pointer<Float32> morphData,
-  int numWeights,
-  Pointer<NativeFunction<void Function(bool)>> callback,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_setMorphTargetWeightsRenderThread(
-    tAnimationManager.cast(),
-    entityId,
-    morphData,
-    numWeights,
-    callback.cast(),
-  );
-  return result;
-}
-
-void Image_createEmptyRenderThread(
-  int width,
-  int height,
-  int channel,
-  Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Image_createEmptyRenderThread(width, height, channel, onComplete.cast());
-  return result;
-}
-
-void Image_decodeRenderThread(
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  Pointer<Char> name,
-  bool alpha,
-  Pointer<NativeFunction<void Function(Pointer<TLinearImage>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Image_decodeRenderThread(data, length, name, alpha, onComplete.cast());
-  return result;
-}
-
-void Image_getBytesRenderThread(
-  Pointer<TLinearImage> tLinearImage,
-  Pointer<NativeFunction<void Function(Pointer<Float32>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Image_getBytesRenderThread(tLinearImage.cast(), onComplete.cast());
-  return result;
-}
-
-void Image_destroyRenderThread(Pointer<TLinearImage> tLinearImage, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._Image_destroyRenderThread(
-    tLinearImage.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Image_getWidthRenderThread(
-  Pointer<TLinearImage> tLinearImage,
-  Pointer<NativeFunction<void Function(int)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Image_getWidthRenderThread(tLinearImage.cast(), onComplete.cast());
-  return result;
-}
-
-void Image_getHeightRenderThread(
-  Pointer<TLinearImage> tLinearImage,
-  Pointer<NativeFunction<void Function(int)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Image_getHeightRenderThread(tLinearImage.cast(), onComplete.cast());
-  return result;
-}
-
-void Image_getChannelsRenderThread(
-  Pointer<TLinearImage> tLinearImage,
-  Pointer<NativeFunction<void Function(int)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Image_getChannelsRenderThread(tLinearImage.cast(), onComplete.cast());
-  return result;
-}
-
-void Texture_loadImageRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  Pointer<TLinearImage> tImage,
-  int bufferFormat,
-  int pixelDataType,
-  int level,
-  Pointer<NativeFunction<void Function(bool)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Texture_loadImageRenderThread(
-    tEngine.cast(),
-    tTexture.cast(),
-    tImage.cast(),
-    bufferFormat,
-    pixelDataType,
-    level,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Texture_setImageRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TTexture> tTexture,
-  int level,
-  Pointer<Uint8> data,
-  Dartsize_t size,
-  int x_offset,
-  int y_offset,
-  int z_offset,
-  int width,
-  int height,
-  int depth,
-  int bufferFormat,
-  int pixelDataType,
-  Pointer<NativeFunction<void Function(bool)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._Texture_setImageRenderThread(
-    tEngine.cast(),
-    tTexture.cast(),
-    level,
-    data,
-    size,
-    x_offset,
-    y_offset,
-    z_offset,
-    width,
-    height,
-    depth,
-    bufferFormat,
-    pixelDataType,
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void RenderTarget_getColorTextureRenderThread(
-  Pointer<TRenderTarget> tRenderTarget,
-  Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderTarget_getColorTextureRenderThread(
-    tRenderTarget.cast(),
-    onComplete.cast(),
-  );
-  return result;
+Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
+  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
+  return Pointer<TRenderTarget>(result);
 }
 
 void RenderTarget_createRenderThread(
@@ -6691,6 +5888,11 @@ void RenderTarget_createRenderThread(
     depth.cast(),
     onComplete.cast(),
   );
+  return result;
+}
+
+void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
   return result;
 }
 
@@ -6709,609 +5911,77 @@ void RenderTarget_destroyRenderThread(
   return result;
 }
 
-void TextureSampler_createRenderThread(Pointer<NativeFunction<void Function(Pointer<TTextureSampler>)>> onComplete) {
-  final result = GeneratedBindings.instance._TextureSampler_createRenderThread(onComplete.cast());
-  return result;
+Pointer<TTexture> RenderTarget_getColorTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getColorTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
 }
 
-void TextureSampler_createWithFilteringRenderThread(
-  int minFilter,
-  int magFilter,
-  int wrapS,
-  int wrapT,
-  int wrapR,
-  Pointer<NativeFunction<void Function(Pointer<TTextureSampler>)>> onComplete,
+void RenderTarget_getColorTextureRenderThread(
+  Pointer<TRenderTarget> tRenderTarget,
+  Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
 ) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithFilteringRenderThread(
-    minFilter,
-    magFilter,
-    wrapS,
-    wrapT,
-    wrapR,
+  final result = GeneratedBindings.instance._RenderTarget_getColorTextureRenderThread(
+    tRenderTarget.cast(),
     onComplete.cast(),
   );
   return result;
 }
 
-void TextureSampler_createWithComparisonRenderThread(
-  int compareMode,
-  int compareFunc,
-  Pointer<NativeFunction<void Function(Pointer<TTextureSampler>)>> onComplete,
+Pointer<TTexture> RenderTarget_getDepthTexture(Pointer<TRenderTarget> tRenderTarget) {
+  final result = GeneratedBindings.instance._RenderTarget_getDepthTexture(tRenderTarget.cast());
+  return Pointer<TTexture>(result);
+}
+
+void RenderThread_addTask(Pointer<NativeFunction<void Function()>> task) {
+  final result = GeneratedBindings.instance._RenderThread_addTask(task.cast());
+  return result;
+}
+
+Pointer<Void> RenderThread_create() {
+  final result = GeneratedBindings.instance._RenderThread_create();
+  return Pointer<Void>(result);
+}
+
+Pointer<Void> RenderThread_createForCanvas(Pointer<Char> canvasSelector) {
+  final result = GeneratedBindings.instance._RenderThread_createForCanvas(canvasSelector);
+  return Pointer<Void>(result);
+}
+
+void RenderThread_destroy(Pointer<Void> renderThread) {
+  final result = GeneratedBindings.instance._RenderThread_destroy(renderThread);
+  return result;
+}
+
+void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dartsize_t primitiveIndex, int order) {
+  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
+  return result;
+}
+
+void RenderableBuilder_boneIndicesAndWeights(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t primitiveIndex,
+  Pointer<Float32> indicesAndWeights,
+  Dartsize_t count,
+  Dartsize_t bonesPerVertex,
 ) {
-  final result = GeneratedBindings.instance._TextureSampler_createWithComparisonRenderThread(
-    compareMode,
-    compareFunc,
-    onComplete.cast(),
+  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
+    builder.cast(),
+    primitiveIndex,
+    indicesAndWeights,
+    count,
+    bonesPerVertex,
   );
   return result;
 }
 
-void TextureSampler_setMinFilterRenderThread(
-  Pointer<TTextureSampler> sampler,
-  int filter,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_setMinFilterRenderThread(
-    sampler.cast(),
-    filter,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
+void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
   return result;
 }
 
-void TextureSampler_setMagFilterRenderThread(
-  Pointer<TTextureSampler> sampler,
-  int filter,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_setMagFilterRenderThread(
-    sampler.cast(),
-    filter,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TextureSampler_setWrapModeSRenderThread(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeSRenderThread(
-    sampler.cast(),
-    mode,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TextureSampler_setWrapModeTRenderThread(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeTRenderThread(
-    sampler.cast(),
-    mode,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TextureSampler_setWrapModeRRenderThread(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_setWrapModeRRenderThread(
-    sampler.cast(),
-    mode,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TextureSampler_setAnisotropyRenderThread(
-  Pointer<TTextureSampler> sampler,
-  double anisotropy,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_setAnisotropyRenderThread(
-    sampler.cast(),
-    anisotropy,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TextureSampler_setCompareModeRenderThread(
-  Pointer<TTextureSampler> sampler,
-  int mode,
-  int func,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TextureSampler_setCompareModeRenderThread(
-    sampler.cast(),
-    mode,
-    func,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TextureSampler_destroyRenderThread(Pointer<TTextureSampler> sampler, int requestId, DartVoidCallback onComplete) {
-  final result = GeneratedBindings.instance._TextureSampler_destroyRenderThread(
-    sampler.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void AnimationManager_resetToRestPoseRenderThread(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_resetToRestPoseRenderThread(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void GltfAssetLoader_createRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<NativeFunction<void Function(Pointer<TGltfAssetLoader>)>> callback,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_createRenderThread(
-    tEngine.cast(),
-    tMaterialProvider.cast(),
-    tNameComponentManager.cast(),
-    callback.cast(),
-  );
-  return result;
-}
-
-void GltfAssetLoader_destroyRenderThread(
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_destroyRenderThread(
-    tAssetLoader.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void GltfResourceLoader_createRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TGltfResourceLoader>)>> callback,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_createRenderThread(tEngine.cast(), callback.cast());
-  return result;
-}
-
-void GltfResourceLoader_destroyRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfResourceLoader> tResourceLoader,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroyRenderThread(
-    tEngine.cast(),
-    tResourceLoader.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void GltfResourceLoader_loadResourcesRenderThread(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  Pointer<NativeFunction<void Function(bool)>> callback,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResourcesRenderThread(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-    callback.cast(),
-  );
-  return result;
-}
-
-void GltfResourceLoader_addResourceDataRenderThread(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceDataRenderThread(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void GltfResourceLoader_asyncBeginLoadRenderThread(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-  Pointer<NativeFunction<void Function(bool)>> callback,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoadRenderThread(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-    callback.cast(),
-  );
-  return result;
-}
-
-void GltfResourceLoader_asyncUpdateLoadRenderThread(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoadRenderThread(tGltfResourceLoader.cast());
-  return result;
-}
-
-void GltfResourceLoader_asyncGetLoadProgressRenderThread(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<NativeFunction<void Function(double)>> callback,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgressRenderThread(
-    tGltfResourceLoader.cast(),
-    callback.cast(),
-  );
-  return result;
-}
-
-void GltfAssetLoader_loadRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  int numInstances,
-  Pointer<NativeFunction<void Function(Pointer<TFilamentAsset>)>> callback,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_loadRenderThread(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    data,
-    length,
-    numInstances,
-    callback.cast(),
-  );
-  return result;
-}
-
-void Scene_addFilamentAssetRenderThread(
-  Pointer<TScene> tScene,
-  Pointer<TFilamentAsset> tAsset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAssetRenderThread(
-    tScene.cast(),
-    tAsset.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void FilamentAsset_getWireframeRenderThread(
-  Pointer<TFilamentAsset> tFilamentAsset,
-  Pointer<NativeFunction<void Function(EntityId)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframeRenderThread(
-    tFilamentAsset.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void Scene_addEntityRenderThread(
-  Pointer<TScene> tScene,
-  DartEntityId entityId,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Scene_addEntityRenderThread(
-    tScene.cast(),
-    entityId,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Scene_removeEntityRenderThread(
-  Pointer<TScene> tScene,
-  DartEntityId entityId,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Scene_removeEntityRenderThread(
-    tScene.cast(),
-    entityId,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void SceneAsset_addToSceneRenderThread(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_addToSceneRenderThread(
-    tSceneAsset.cast(),
-    tScene.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void SceneAsset_removeFromSceneRenderThread(
-  Pointer<TSceneAsset> tSceneAsset,
-  Pointer<TScene> tScene,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._SceneAsset_removeFromSceneRenderThread(
-    tSceneAsset.cast(),
-    tScene.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Scene_setSkyboxRenderThread(
-  Pointer<TScene> tScene,
-  Pointer<TSkybox> tSkybox,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Scene_setSkyboxRenderThread(
-    tScene.cast(),
-    tSkybox.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Scene_setIndirectLightRenderThread(
-  Pointer<TScene> tScene,
-  Pointer<TIndirectLight> tIndirectLight,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLightRenderThread(
-    tScene.cast(),
-    tIndirectLight.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Gizmo_createRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TNameComponentManager> tNameComponentManager,
-  Pointer<TView> tView,
-  Pointer<TMaterial> tMaterial,
-  int tGizmoType,
-  Pointer<NativeFunction<void Function(Pointer<TGizmo>)>> callback,
-) {
-  final result = GeneratedBindings.instance._Gizmo_createRenderThread(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    tGltfResourceLoader.cast(),
-    tNameComponentManager.cast(),
-    tView.cast(),
-    tMaterial.cast(),
-    tGizmoType,
-    callback.cast(),
-  );
-  return result;
-}
-
-void VertexBufferBuilder_buildRenderThread(
-  Pointer<TVertexBufferBuilder> tBuilder,
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TVertexBuffer>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._VertexBufferBuilder_buildRenderThread(
-    tBuilder.cast(),
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void VertexBuffer_destroyRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tBuffer,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_destroyRenderThread(
-    tEngine.cast(),
-    tBuffer.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void VertexBuffer_setBufferAtRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tBuffer,
-  int bufferIndex,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_setBufferAtRenderThread(
-    tEngine.cast(),
-    tBuffer.cast(),
-    bufferIndex,
-    data,
-    sizeInBytes,
-    byteOffset,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void VertexBuffer_setBufferObjectAtRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TVertexBuffer> tBuffer,
-  int bufferIndex,
-  Pointer<TBufferObject> tBufferObject,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._VertexBuffer_setBufferObjectAtRenderThread(
-    tEngine.cast(),
-    tBuffer.cast(),
-    bufferIndex,
-    tBufferObject.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void BufferObjectBuilder_buildRenderThread(
-  Pointer<TBufferObjectBuilder> tBuilder,
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TBufferObject>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._BufferObjectBuilder_buildRenderThread(
-    tBuilder.cast(),
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void BufferObject_setBufferRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TBufferObject> tBuffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._BufferObject_setBufferRenderThread(
-    tEngine.cast(),
-    tBuffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void BufferObject_destroyRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TBufferObject> tBuffer,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._BufferObject_destroyRenderThread(
-    tEngine.cast(),
-    tBuffer.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void IndexBufferBuilder_buildRenderThread(
-  Pointer<TIndexBufferBuilder> tBuilder,
-  Pointer<TEngine> tEngine,
-  Pointer<NativeFunction<void Function(Pointer<TIndexBuffer>)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._IndexBufferBuilder_buildRenderThread(
-    tBuilder.cast(),
-    tEngine.cast(),
-    onComplete.cast(),
-  );
-  return result;
-}
-
-void IndexBuffer_destroyRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TIndexBuffer> tBuffer,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_destroyRenderThread(
-    tEngine.cast(),
-    tBuffer.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void IndexBuffer_setBufferRenderThread(
-  Pointer<TEngine> tEngine,
-  Pointer<TIndexBuffer> tBuffer,
-  Pointer<Void> data,
-  Dartsize_t sizeInBytes,
-  int byteOffset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._IndexBuffer_setBufferRenderThread(
-    tEngine.cast(),
-    tBuffer.cast(),
-    data,
-    sizeInBytes,
-    byteOffset,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
+int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
+  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
   return result;
 }
 
@@ -7330,785 +6000,13 @@ void RenderableBuilder_buildRenderThread(
   return result;
 }
 
-void EntityManager_createEntityRenderThread(
-  Pointer<TEntityManager> tEntityManager,
-  Pointer<NativeFunction<void Function(EntityId)>> onComplete,
-) {
-  final result = GeneratedBindings.instance._EntityManager_createEntityRenderThread(
-    tEntityManager.cast(),
-    onComplete.cast(),
-  );
+void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
   return result;
 }
 
-void EntityManager_destroyEntityRenderThread(
-  Pointer<TEntityManager> tEntityManager,
-  DartEntityId entityId,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._EntityManager_destroyEntityRenderThread(
-    tEntityManager.cast(),
-    entityId,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TransformManager_setTransformRenderThread(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  double4x4 transform,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final transformPtr = transform.address;
-  final result = GeneratedBindings.instance._TransformManager_setTransformRenderThread(
-    tTransformManager.cast(),
-    entityId,
-    transformPtr.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TransformManager_setParentRenderThread(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId child,
-  DartEntityId parent,
-  bool preserveScaling,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TransformManager_setParentRenderThread(
-    tTransformManager.cast(),
-    child,
-    parent,
-    preserveScaling,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TransformManager_createComponentRenderThread(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TransformManager_createComponentRenderThread(
-    tTransformManager.cast(),
-    entityId,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void TransformManager_removeComponentRenderThread(
-  Pointer<TTransformManager> tTransformManager,
-  DartEntityId entityId,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._TransformManager_removeComponentRenderThread(
-    tTransformManager.cast(),
-    entityId,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderableManager_destroyEntityRenderThread(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_destroyEntityRenderThread(
-    tRenderableManager.cast(),
-    entityId,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderableManager_setMorphWeightsRenderThread(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> weights,
-  Dartsize_t count,
-  Dartsize_t offset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMorphWeightsRenderThread(
-    tRenderableManager.cast(),
-    entityId,
-    weights,
-    count,
-    offset,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderableManager_setBonesFromMat4RenderThread(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4RenderThread(
-    tRenderableManager.cast(),
-    entityId,
-    transforms,
-    boneCount,
-    offset,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderableManager_setBonesFromBoneRenderThread(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBoneRenderThread(
-    tRenderableManager.cast(),
-    entityId,
-    bones,
-    boneCount,
-    offset,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderableManager_setGeometryAtNonIndexedRenderThread(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> tVertices,
-  Dartsize_t offset,
-  Dartsize_t count,
-  Pointer<NativeFunction<void Function(bool)>> callback,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexedRenderThread(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    type,
-    tVertices.cast(),
-    offset,
-    count,
-    callback.cast(),
-  );
-  return result;
-}
-
-void RenderableManager_setCastShadowsRenderThread(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setCastShadowsRenderThread(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void RenderableManager_setReceiveShadowsRenderThread(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadowsRenderThread(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void LightManager_setShadowCasterRenderThread(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entityId,
-  bool enabled,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final result = GeneratedBindings.instance._LightManager_setShadowCasterRenderThread(
-    tLightManager.cast(),
-    entityId,
-    enabled,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void LightManager_setShadowOptionsRenderThread(
-  Pointer<TLightManager> tLightManager,
-  DartEntityId entityId,
-  TShadowOptions options,
-  int requestId,
-  DartVoidCallback onComplete,
-) {
-  final optionsPtr = options.address;
-  final result = GeneratedBindings.instance._LightManager_setShadowOptionsRenderThread(
-    tLightManager.cast(),
-    entityId,
-    optionsPtr.cast(),
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
-  );
-  return result;
-}
-
-void Renderer_setClearOptions(
-  Pointer<TRenderer> tRenderer,
-  double clearR,
-  double clearG,
-  double clearB,
-  double clearA,
-  int clearStencil,
-  bool clear,
-  bool discard,
-) {
-  final result = GeneratedBindings.instance._Renderer_setClearOptions(
-    tRenderer.cast(),
-    clearR,
-    clearG,
-    clearB,
-    clearA,
-    clearStencil,
-    clear,
-    discard,
-  );
-  return result;
-}
-
-bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._Renderer_beginFrame(
-    tRenderer.cast(),
-    tSwapChain.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result == 1;
-}
-
-void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
-  return result;
-}
-
-void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
-  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
-  return result;
-}
-
-void Renderer_readPixels(
-  Pointer<TRenderer> tRenderer,
-  int width,
-  int height,
-  int xOffset,
-  int yOffset,
-  Pointer<TRenderTarget> tRenderTarget,
-  int tPixelBufferFormat,
-  int tPixelDataType,
-  Pointer<Uint8> out,
-  Dartsize_t outLength,
-) {
-  final result = GeneratedBindings.instance._Renderer_readPixels(
-    tRenderer.cast(),
-    width,
-    height,
-    xOffset,
-    yOffset,
-    tRenderTarget.cast(),
-    tPixelBufferFormat,
-    tPixelDataType,
-    out,
-    outLength,
-  );
-  return result;
-}
-
-void Renderer_setFrameInterval(
-  Pointer<TRenderer> tRenderer,
-  double headRoomRatio,
-  double scaleRate,
-  int history,
-  int interval,
-) {
-  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
-    tRenderer.cast(),
-    headRoomRatio,
-    scaleRate,
-    history,
-    interval,
-  );
-  return result;
-}
-
-Pointer<TRenderTarget> RenderTarget_create(Pointer<TEngine> tEngine, Pointer<TTexture> color, Pointer<TTexture> depth) {
-  final result = GeneratedBindings.instance._RenderTarget_create(tEngine.cast(), color.cast(), depth.cast());
-  return Pointer<TRenderTarget>(result);
-}
-
-void RenderTarget_destroy(Pointer<TEngine> tEngine, Pointer<TRenderTarget> tRenderTarget) {
-  final result = GeneratedBindings.instance._RenderTarget_destroy(tEngine.cast(), tRenderTarget.cast());
-  return result;
-}
-
-void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
-  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
-  return result;
-}
-
-/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
-void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
-  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
-  return result;
-}
-
-/// Returns the visibility mask bits.
-int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
-  return result;
-}
-
-/// Returns the skybox intensity in lux.
-double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
-  return result;
-}
-
-/// Returns the environment texture, or nullptr for a color-only skybox.
-Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
-  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
-  return Pointer<TTexture>(result);
-}
-
-void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
-  return result == 1;
-}
-
-bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-Dartsize_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
-  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
-  return result;
-}
-
-bool RenderableManager_setMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  Pointer<TMaterialInstance> tMaterialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    tMaterialInstance.cast(),
-  );
-  return result == 1;
-}
-
-Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-void RenderableManager_clearMaterialInstanceAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-  );
-  return result;
-}
-
-bool RenderableManager_setGeometryAtNonIndexed(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int primitiveIndex,
-  int type,
-  Pointer<TVertexBuffer> vertices,
-  Dartsize_t offset,
-  Dartsize_t count,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    type,
-    vertices.cast(),
-    offset,
-    count,
-  );
-  return result == 1;
-}
-
-Dartsize_t RenderableManager_getPrimitiveCount(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-Aabb3 RenderableManager_getAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setAxisAlignedBoundingBox(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Aabb3 aabb,
-) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
-    tRenderableManager.cast(),
-    entityId,
-    aabbPtr.cast(),
-  );
-  return result;
-}
-
-Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getAabb(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final Aabb3_out = Aabb3.stackAlloc();
-  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
-    Aabb3_out.cast(),
-    tRenderableManager.cast(),
-    entityId,
-  );
-  return Aabb3_out.toDart();
-}
-
-void RenderableManager_setLayerMask(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int select,
-  int values,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
-    tRenderableManager.cast(),
-    entityId,
-    select,
-    values,
-  );
-  return result;
-}
-
-int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setVisibilityLayer(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int layer,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
-    tRenderableManager.cast(),
-    entityId,
-    layer,
-  );
-  return result;
-}
-
-void RenderableManager_setPriority(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int priority,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setPriority(
-    tRenderableManager.cast(),
-    entityId,
-    priority,
-  );
-  return result;
-}
-
-int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
-  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
-  return result;
-}
-
-void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
-  return result;
-}
-
-bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setFogEnabled(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-  bool enable,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-    enable,
-  );
-  return result;
-}
-
-bool RenderableManager_getLightChannel(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  int channel,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
-    tRenderableManager.cast(),
-    entityId,
-    channel,
-  );
-  return result == 1;
-}
-
-void RenderableManager_setCastShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool castShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
-    tRenderableManager.cast(),
-    entityId,
-    castShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setReceiveShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool receiveShadows,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
-    tRenderableManager.cast(),
-    entityId,
-    receiveShadows,
-  );
-  return result;
-}
-
-bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
-  return result == 1;
-}
-
-void RenderableManager_setScreenSpaceContactShadows(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
-    tRenderableManager.cast(),
-    entityId,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setBlendOrderAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dartsize_t primitiveIndex,
-  int order,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    order,
-  );
-  return result;
-}
-
-void RenderableManager_setGlobalBlendOrderEnabledAt(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Dartsize_t primitiveIndex,
-  bool enabled,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
-    tRenderableManager.cast(),
-    entityId,
-    primitiveIndex,
-    enabled,
-  );
-  return result;
-}
-
-void RenderableManager_setMorphWeights(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> weights,
-  Dartsize_t count,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
-    tRenderableManager.cast(),
-    entityId,
-    weights,
-    count,
-    offset,
-  );
-  return result;
-}
-
-Dartsize_t RenderableManager_getMorphTargetCount(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
-  return result;
-}
-
-void RenderableManager_setBonesFromMat4(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> transforms,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
-    tRenderableManager.cast(),
-    entityId,
-    transforms,
-    boneCount,
-    offset,
-  );
-  return result;
-}
-
-void RenderableManager_setBonesFromBone(
-  Pointer<TRenderableManager> tRenderableManager,
-  DartEntityId entityId,
-  Pointer<Float32> bones,
-  Dartsize_t boneCount,
-  Dartsize_t offset,
-) {
-  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
-    tRenderableManager.cast(),
-    entityId,
-    bones,
-    boneCount,
-    offset,
-  );
+void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
+  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
   return result;
 }
 
@@ -8117,27 +6015,23 @@ Pointer<TRenderableBuilder> RenderableBuilder_create(Dartsize_t primitiveCount) 
   return Pointer<TRenderableBuilder>(result);
 }
 
+void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
+  return result;
+}
+
 void RenderableBuilder_destroy(Pointer<TRenderableBuilder> builder) {
   final result = GeneratedBindings.instance._RenderableBuilder_destroy(builder.cast());
   return result;
 }
 
-void RenderableBuilder_boundingBox(Pointer<TRenderableBuilder> builder, Aabb3 aabb) {
-  final aabbPtr = aabb.address;
-  final result = GeneratedBindings.instance._RenderableBuilder_boundingBox(builder.cast(), aabbPtr.cast());
+void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
   return result;
 }
 
-void RenderableBuilder_material(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  Pointer<TMaterialInstance> materialInstance,
-) {
-  final result = GeneratedBindings.instance._RenderableBuilder_material(
-    builder.cast(),
-    primitiveIndex,
-    materialInstance.cast(),
-  );
+void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
   return result;
 }
 
@@ -8181,56 +6075,6 @@ void RenderableBuilder_geometryNonIndexed(
   return result;
 }
 
-void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
-  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
-  return result;
-}
-
-void RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel) {
-  final result = GeneratedBindings.instance._RenderableBuilder_channel(builder.cast(), channel);
-  return result;
-}
-
-void RenderableBuilder_culling(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_culling(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_castShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_fog(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_fog(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
-  return result;
-}
-
-void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
-  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
-  return result;
-}
-
-void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
-  return result;
-}
-
-void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dartsize_t primitiveIndex, int order) {
-  final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
-  return result;
-}
-
 void RenderableBuilder_globalBlendOrderEnabled(
   Pointer<TRenderableBuilder> builder,
   Dartsize_t primitiveIndex,
@@ -8249,12 +6093,41 @@ void RenderableBuilder_instances(Pointer<TRenderableBuilder> builder, Dartsize_t
   return result;
 }
 
-void RenderableBuilder_skinningFromMat4(
+void RenderableBuilder_layerMask(Pointer<TRenderableBuilder> builder, int select, int values) {
+  final result = GeneratedBindings.instance._RenderableBuilder_layerMask(builder.cast(), select, values);
+  return result;
+}
+
+void RenderableBuilder_lightChannel(Pointer<TRenderableBuilder> builder, int channel, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_lightChannel(builder.cast(), channel, enabled);
+  return result;
+}
+
+void RenderableBuilder_material(
   Pointer<TRenderableBuilder> builder,
-  Dartsize_t boneCount,
-  Pointer<Float32> transforms,
+  Dartsize_t primitiveIndex,
+  Pointer<TMaterialInstance> materialInstance,
 ) {
-  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
+  final result = GeneratedBindings.instance._RenderableBuilder_material(
+    builder.cast(),
+    primitiveIndex,
+    materialInstance.cast(),
+  );
+  return result;
+}
+
+void RenderableBuilder_priority(Pointer<TRenderableBuilder> builder, int priority) {
+  final result = GeneratedBindings.instance._RenderableBuilder_priority(builder.cast(), priority);
+  return result;
+}
+
+void RenderableBuilder_receiveShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_receiveShadows(builder.cast(), enabled);
+  return result;
+}
+
+void RenderableBuilder_screenSpaceContactShadows(Pointer<TRenderableBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableBuilder_screenSpaceContactShadows(builder.cast(), enabled);
   return result;
 }
 
@@ -8267,36 +6140,1191 @@ void RenderableBuilder_skinningFromBone(
   return result;
 }
 
-void RenderableBuilder_enableSkinningBuffers(Pointer<TRenderableBuilder> builder, bool enabled) {
-  final result = GeneratedBindings.instance._RenderableBuilder_enableSkinningBuffers(builder.cast(), enabled);
+void RenderableBuilder_skinningFromMat4(
+  Pointer<TRenderableBuilder> builder,
+  Dartsize_t boneCount,
+  Pointer<Float32> transforms,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_skinningFromMat4(builder.cast(), boneCount, transforms);
   return result;
 }
 
-void RenderableBuilder_boneIndicesAndWeights(
-  Pointer<TRenderableBuilder> builder,
-  Dartsize_t primitiveIndex,
-  Pointer<Float32> indicesAndWeights,
-  Dartsize_t count,
-  Dartsize_t bonesPerVertex,
+void RenderableManager_clearMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
 ) {
-  final result = GeneratedBindings.instance._RenderableBuilder_boneIndicesAndWeights(
-    builder.cast(),
+  final result = GeneratedBindings.instance._RenderableManager_clearMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
     primitiveIndex,
-    indicesAndWeights,
-    count,
-    bonesPerVertex,
   );
   return result;
 }
 
-int RenderableBuilder_build(Pointer<TRenderableBuilder> builder, Pointer<TEngine> engine, DartEntityId entity) {
-  final result = GeneratedBindings.instance._RenderableBuilder_build(builder.cast(), engine.cast(), entity);
+void RenderableManager_destroyEntity(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_destroyEntity(tRenderableManager.cast(), entityId);
   return result;
 }
 
-void IndirectLight_setRotation(Pointer<TIndirectLight> tIndirectLight, Pointer<Float64> rotation) {
-  final result = GeneratedBindings.instance._IndirectLight_setRotation(tIndirectLight.cast(), rotation);
+void RenderableManager_destroyEntityRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_destroyEntityRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
   return result;
+}
+
+bool RenderableManager_empty(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_empty(tRenderableManager.cast());
+  return result == 1;
+}
+
+Aabb3 RenderableManager_getAabb(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAabb(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+Aabb3 RenderableManager_getAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getAxisAlignedBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+Aabb3 RenderableManager_getBoundingBox(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._RenderableManager_getBoundingBox(
+    Aabb3_out.cast(),
+    tRenderableManager.cast(),
+    entityId,
+  );
+  return Aabb3_out.toDart();
+}
+
+Dartsize_t RenderableManager_getComponentCount(Pointer<TRenderableManager> tRenderableManager) {
+  final result = GeneratedBindings.instance._RenderableManager_getComponentCount(tRenderableManager.cast());
+  return result;
+}
+
+bool RenderableManager_getCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getCulling(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+bool RenderableManager_getFogEnabled(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getFogEnabled(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+int RenderableManager_getLayerMask(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getLayerMask(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+bool RenderableManager_getLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+  );
+  return result == 1;
+}
+
+Pointer<TMaterialInstance> RenderableManager_getMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+  );
+  return Pointer<TMaterialInstance>(result);
+}
+
+Dartsize_t RenderableManager_getMorphTargetCount(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_getMorphTargetCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+Dartsize_t RenderableManager_getPrimitiveCount(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getPrimitiveCount(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+int RenderableManager_getPriority(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_getPriority(tRenderableManager.cast(), entityId);
+  return result;
+}
+
+bool RenderableManager_hasComponent(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_hasComponent(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+bool RenderableManager_isRenderable(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isRenderable(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+bool RenderableManager_isShadowCaster(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowCaster(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+bool RenderableManager_isShadowReceiver(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._RenderableManager_isShadowReceiver(tRenderableManager.cast(), entityId);
+  return result == 1;
+}
+
+void RenderableManager_setAxisAlignedBoundingBox(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Aabb3 aabb,
+) {
+  final aabbPtr = aabb.address;
+  final result = GeneratedBindings.instance._RenderableManager_setAxisAlignedBoundingBox(
+    tRenderableManager.cast(),
+    entityId,
+    aabbPtr.cast(),
+  );
+  return result;
+}
+
+void RenderableManager_setBlendOrderAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dartsize_t primitiveIndex,
+  int order,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBlendOrderAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    order,
+  );
+  return result;
+}
+
+void RenderableManager_setBonesFromBone(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> bones,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBone(
+    tRenderableManager.cast(),
+    entityId,
+    bones,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+void RenderableManager_setBonesFromBoneRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> bones,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromBoneRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    bones,
+    boneCount,
+    offset,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderableManager_setBonesFromMat4(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> transforms,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4(
+    tRenderableManager.cast(),
+    entityId,
+    transforms,
+    boneCount,
+    offset,
+  );
+  return result;
+}
+
+void RenderableManager_setBonesFromMat4RenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> transforms,
+  Dartsize_t boneCount,
+  Dartsize_t offset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setBonesFromMat4RenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    transforms,
+    boneCount,
+    offset,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderableManager_setCastShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool castShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setCastShadows(
+    tRenderableManager.cast(),
+    entityId,
+    castShadows,
+  );
+  return result;
+}
+
+void RenderableManager_setCastShadowsRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setCastShadowsRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderableManager_setChannel(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, int channel) {
+  final result = GeneratedBindings.instance._RenderableManager_setChannel(tRenderableManager.cast(), entityId, channel);
+  return result;
+}
+
+void RenderableManager_setCulling(Pointer<TRenderableManager> tRenderableManager, DartEntityId entityId, bool enabled) {
+  final result = GeneratedBindings.instance._RenderableManager_setCulling(tRenderableManager.cast(), entityId, enabled);
+  return result;
+}
+
+void RenderableManager_setFogEnabled(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setFogEnabled(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+bool RenderableManager_setGeometryAtNonIndexed(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> vertices,
+  Dartsize_t offset,
+  Dartsize_t count,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexed(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    type,
+    vertices.cast(),
+    offset,
+    count,
+  );
+  return result == 1;
+}
+
+void RenderableManager_setGeometryAtNonIndexedRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  int type,
+  Pointer<TVertexBuffer> tVertices,
+  Dartsize_t offset,
+  Dartsize_t count,
+  Pointer<NativeFunction<void Function(bool)>> callback,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGeometryAtNonIndexedRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    type,
+    tVertices.cast(),
+    offset,
+    count,
+    callback.cast(),
+  );
+  return result;
+}
+
+void RenderableManager_setGlobalBlendOrderEnabledAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Dartsize_t primitiveIndex,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setGlobalBlendOrderEnabledAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setLayerMask(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int select,
+  int values,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLayerMask(
+    tRenderableManager.cast(),
+    entityId,
+    select,
+    values,
+  );
+  return result;
+}
+
+void RenderableManager_setLightChannel(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int channel,
+  bool enable,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setLightChannel(
+    tRenderableManager.cast(),
+    entityId,
+    channel,
+    enable,
+  );
+  return result;
+}
+
+bool RenderableManager_setMaterialInstanceAt(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int primitiveIndex,
+  Pointer<TMaterialInstance> tMaterialInstance,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMaterialInstanceAt(
+    tRenderableManager.cast(),
+    entityId,
+    primitiveIndex,
+    tMaterialInstance.cast(),
+  );
+  return result == 1;
+}
+
+void RenderableManager_setMorphWeights(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> weights,
+  Dartsize_t count,
+  Dartsize_t offset,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMorphWeights(
+    tRenderableManager.cast(),
+    entityId,
+    weights,
+    count,
+    offset,
+  );
+  return result;
+}
+
+void RenderableManager_setMorphWeightsRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  Pointer<Float32> weights,
+  Dartsize_t count,
+  Dartsize_t offset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setMorphWeightsRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    weights,
+    count,
+    offset,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderableManager_setPriority(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int priority,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setPriority(
+    tRenderableManager.cast(),
+    entityId,
+    priority,
+  );
+  return result;
+}
+
+void RenderableManager_setReceiveShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool receiveShadows,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadows(
+    tRenderableManager.cast(),
+    entityId,
+    receiveShadows,
+  );
+  return result;
+}
+
+void RenderableManager_setReceiveShadowsRenderThread(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setReceiveShadowsRenderThread(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void RenderableManager_setScreenSpaceContactShadows(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  bool enabled,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setScreenSpaceContactShadows(
+    tRenderableManager.cast(),
+    entityId,
+    enabled,
+  );
+  return result;
+}
+
+void RenderableManager_setVisibilityLayer(
+  Pointer<TRenderableManager> tRenderableManager,
+  DartEntityId entityId,
+  int layer,
+) {
+  final result = GeneratedBindings.instance._RenderableManager_setVisibilityLayer(
+    tRenderableManager.cast(),
+    entityId,
+    layer,
+  );
+  return result;
+}
+
+bool Renderer_beginFrame(Pointer<TRenderer> tRenderer, Pointer<TSwapChain> tSwapChain, BigInt frameTimeInNanos) {
+  final result = GeneratedBindings.instance._Renderer_beginFrame(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+  );
+  return result == 1;
+}
+
+void Renderer_beginFrameRenderThread(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TSwapChain> tSwapChain,
+  BigInt frameTimeInNanos,
+  Pointer<NativeFunction<void Function(bool)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Renderer_beginFrameRenderThread(
+    tRenderer.cast(),
+    tSwapChain.cast(),
+    frameTimeInNanos.toJSBigInt,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
+  final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
+  return result;
+}
+
+void Renderer_endFrameRenderThread(Pointer<TRenderer> tRenderer, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._Renderer_endFrameRenderThread(
+    tRenderer.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Renderer_readPixels(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dartsize_t outLength,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixels(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+  );
+  return result;
+}
+
+void Renderer_readPixelsRenderThread(
+  Pointer<TRenderer> tRenderer,
+  int width,
+  int height,
+  int xOffset,
+  int yOffset,
+  Pointer<TRenderTarget> tRenderTarget,
+  int tPixelBufferFormat,
+  int tPixelDataType,
+  Pointer<Uint8> out,
+  Dartsize_t outLength,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Renderer_readPixelsRenderThread(
+    tRenderer.cast(),
+    width,
+    height,
+    xOffset,
+    yOffset,
+    tRenderTarget.cast(),
+    tPixelBufferFormat,
+    tPixelDataType,
+    out,
+    outLength,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_render(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderRenderThread(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TView> tView,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Renderer_renderRenderThread(
+    tRenderer.cast(),
+    tView.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Renderer_renderStandaloneView(Pointer<TRenderer> tRenderer, Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneView(tRenderer.cast(), tView.cast());
+  return result;
+}
+
+void Renderer_renderStandaloneViewRenderThread(
+  Pointer<TRenderer> tRenderer,
+  Pointer<TView> tView,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Renderer_renderStandaloneViewRenderThread(
+    tRenderer.cast(),
+    tView.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Renderer_setClearOptions(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptions(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+  );
+  return result;
+}
+
+void Renderer_setClearOptionsRenderThread(
+  Pointer<TRenderer> tRenderer,
+  double clearR,
+  double clearG,
+  double clearB,
+  double clearA,
+  int clearStencil,
+  bool clear,
+  bool discard,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Renderer_setClearOptionsRenderThread(
+    tRenderer.cast(),
+    clearR,
+    clearG,
+    clearB,
+    clearA,
+    clearStencil,
+    clear,
+    discard,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Renderer_setFrameInterval(
+  Pointer<TRenderer> tRenderer,
+  double headRoomRatio,
+  double scaleRate,
+  int history,
+  int interval,
+) {
+  final result = GeneratedBindings.instance._Renderer_setFrameInterval(
+    tRenderer.cast(),
+    headRoomRatio,
+    scaleRate,
+    history,
+    interval,
+  );
+  return result;
+}
+
+void SceneAsset_addToScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._SceneAsset_addToScene(tSceneAsset.cast(), tScene.cast());
+  return result;
+}
+
+void SceneAsset_addToSceneRenderThread(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_addToSceneRenderThread(
+    tSceneAsset.cast(),
+    tScene.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromBuffers(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tVertexBuffer,
+  Pointer<TIndexBuffer> tIndexBuffer,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  int vertexBufferStorageMode,
+  Aabb3 boundingBox,
+) {
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._SceneAsset_createFromBuffers(
+    tEngine.cast(),
+    tVertexBuffer.cast(),
+    tIndexBuffer.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+    tPrimitiveType,
+    vertexBufferStorageMode,
+    boundingBoxPtr.cast(),
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+void SceneAsset_createFromBuffersRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tVertexBuffer,
+  Pointer<TIndexBuffer> tIndexBuffer,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+  int tPrimitiveType,
+  int vertexBufferStorageMode,
+  Aabb3 boundingBox,
+  Pointer<NativeFunction<void Function(Pointer<TSceneAsset>)>> callback,
+) {
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._SceneAsset_createFromBuffersRenderThread(
+    tEngine.cast(),
+    tVertexBuffer.cast(),
+    tIndexBuffer.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+    tPrimitiveType,
+    vertexBufferStorageMode,
+    boundingBoxPtr.cast(),
+    callback.cast(),
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createFromFilamentAsset(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  int requiredGeometryCapabilities,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAsset(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    tNameComponentManager.cast(),
+    tFilamentAsset.cast(),
+    requiredGeometryCapabilities,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+void SceneAsset_createFromFilamentAssetRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TGltfAssetLoader> tAssetLoader,
+  Pointer<TNameComponentManager> tNameComponentManager,
+  Pointer<TFilamentAsset> tFilamentAsset,
+  int requiredGeometryCapabilities,
+  Pointer<NativeFunction<void Function(Pointer<TSceneAsset>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createFromFilamentAssetRenderThread(
+    tEngine.cast(),
+    tAssetLoader.cast(),
+    tNameComponentManager.cast(),
+    tFilamentAsset.cast(),
+    requiredGeometryCapabilities,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TSceneAsset> SceneAsset_createInstance(
+  Pointer<TSceneAsset> asset,
+  Pointer<PointerClass<TMaterialInstance>> materialInstances,
+  int materialInstanceCount,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createInstance(
+    asset.cast(),
+    materialInstances.cast(),
+    materialInstanceCount,
+  );
+  return Pointer<TSceneAsset>(result);
+}
+
+void SceneAsset_createInstanceRenderThread(
+  Pointer<TSceneAsset> asset,
+  Pointer<PointerClass<TMaterialInstance>> tMaterialInstances,
+  int materialInstanceCount,
+  Pointer<NativeFunction<void Function(Pointer<TSceneAsset>)>> callback,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_createInstanceRenderThread(
+    asset.cast(),
+    tMaterialInstances.cast(),
+    materialInstanceCount,
+    callback.cast(),
+  );
+  return result;
+}
+
+void SceneAsset_destroy(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_destroy(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_destroyRenderThread(Pointer<TSceneAsset> tSceneAsset, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._SceneAsset_destroyRenderThread(
+    tSceneAsset.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Dartsize_t SceneAsset_getBoneCount(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getBoneCount(tSceneAsset.cast(), skinIndex);
+  return result;
+}
+
+Pointer<Char> SceneAsset_getBoneName(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Dartsize_t boneIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getBoneName(tSceneAsset.cast(), skinIndex, boneIndex);
+  return Pointer<Char>(result);
+}
+
+void SceneAsset_getBones(Pointer<TSceneAsset> tSceneAsset, Dartsize_t skinIndex, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._SceneAsset_getBones(tSceneAsset.cast(), skinIndex, out);
+  return result;
+}
+
+Aabb3 SceneAsset_getBoundingBox(Pointer<TSceneAsset> asset) {
+  final Aabb3_out = Aabb3.stackAlloc();
+  final result = GeneratedBindings.instance._SceneAsset_getBoundingBox(Aabb3_out.cast(), asset.cast());
+  return Aabb3_out.toDart();
+}
+
+Pointer<Int32> SceneAsset_getCameraEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntities(tSceneAsset.cast());
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getCameraEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getCameraEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_getChildEntities(Pointer<TSceneAsset> tSceneAsset, Pointer<Int32> out) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntities(tSceneAsset.cast(), out);
+  return result;
+}
+
+int SceneAsset_getChildEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getChildEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+DartEntityId SceneAsset_getEntity(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getEntity(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<TFilamentAsset> SceneAsset_getFilamentAsset(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getFilamentAsset(tSceneAsset.cast());
+  return Pointer<TFilamentAsset>(result);
+}
+
+int SceneAsset_getGeometryCapabilities(Pointer<TSceneAsset> asset) {
+  final result = GeneratedBindings.instance._SceneAsset_getGeometryCapabilities(asset.cast());
+  return result;
+}
+
+Pointer<TIndexBuffer> SceneAsset_getIndexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getIndexBuffer(tSceneAsset.cast(), primitiveIndex);
+  return Pointer<TIndexBuffer>(result);
+}
+
+Pointer<TSceneAsset> SceneAsset_getInstance(Pointer<TSceneAsset> tSceneAsset, int index) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstance(tSceneAsset.cast(), index);
+  return Pointer<TSceneAsset>(result);
+}
+
+Dartsize_t SceneAsset_getInstanceCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getInstanceCount(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<Int32> SceneAsset_getLightEntities(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntities(tSceneAsset.cast());
+  return Pointer<Int32>(result);
+}
+
+Dartsize_t SceneAsset_getLightEntityCount(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getLightEntityCount(tSceneAsset.cast());
+  return result;
+}
+
+int SceneAsset_getPrimitiveOffsetForEntity(Pointer<TSceneAsset> tSceneAsset, DartEntityId entity) {
+  final result = GeneratedBindings.instance._SceneAsset_getPrimitiveOffsetForEntity(tSceneAsset.cast(), entity);
+  return result;
+}
+
+int SceneAsset_getType(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_getType(tSceneAsset.cast());
+  return result;
+}
+
+Pointer<TVertexBuffer> SceneAsset_getVertexBuffer(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getVertexBuffer(tSceneAsset.cast(), primitiveIndex);
+  return Pointer<TVertexBuffer>(result);
+}
+
+int SceneAsset_getVertexBufferStorageMode(Pointer<TSceneAsset> tSceneAsset, int primitiveIndex) {
+  final result = GeneratedBindings.instance._SceneAsset_getVertexBufferStorageMode(tSceneAsset.cast(), primitiveIndex);
+  return result;
+}
+
+void SceneAsset_releaseSourceData(Pointer<TSceneAsset> tSceneAsset) {
+  final result = GeneratedBindings.instance._SceneAsset_releaseSourceData(tSceneAsset.cast());
+  return result;
+}
+
+void SceneAsset_releaseSourceDataRenderThread(
+  Pointer<TSceneAsset> tSceneAsset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_releaseSourceDataRenderThread(
+    tSceneAsset.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void SceneAsset_removeFromScene(Pointer<TSceneAsset> tSceneAsset, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._SceneAsset_removeFromScene(tSceneAsset.cast(), tScene.cast());
+  return result;
+}
+
+void SceneAsset_removeFromSceneRenderThread(
+  Pointer<TSceneAsset> tSceneAsset,
+  Pointer<TScene> tScene,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_removeFromSceneRenderThread(
+    tSceneAsset.cast(),
+    tScene.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void SceneAsset_setFlatShading(Pointer<TSceneAsset> tSceneAsset, bool flatShading) {
+  final result = GeneratedBindings.instance._SceneAsset_setFlatShading(tSceneAsset.cast(), flatShading);
+  return result;
+}
+
+void SceneAsset_setFlatShadingRenderThread(
+  Pointer<TSceneAsset> tSceneAsset,
+  bool flatShading,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._SceneAsset_setFlatShadingRenderThread(
+    tSceneAsset.cast(),
+    flatShading,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+bool SceneAsset_supportsFlatShading(Pointer<TSceneAsset> asset) {
+  final result = GeneratedBindings.instance._SceneAsset_supportsFlatShading(asset.cast());
+  return result == 1;
+}
+
+void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
+  return result;
+}
+
+void Scene_addEntityRenderThread(
+  Pointer<TScene> tScene,
+  DartEntityId entityId,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Scene_addEntityRenderThread(
+    tScene.cast(),
+    entityId,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
+  return result;
+}
+
+void Scene_addFilamentAssetRenderThread(
+  Pointer<TScene> tScene,
+  Pointer<TFilamentAsset> tAsset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Scene_addFilamentAssetRenderThread(
+    tScene.cast(),
+    tAsset.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
+  return Pointer<TSkybox>(result);
+}
+
+void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
+  return result;
+}
+
+void Scene_removeEntityRenderThread(
+  Pointer<TScene> tScene,
+  DartEntityId entityId,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Scene_removeEntityRenderThread(
+    tScene.cast(),
+    entityId,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
+  return result;
+}
+
+void Scene_setIndirectLightRenderThread(
+  Pointer<TScene> tScene,
+  Pointer<TIndirectLight> tIndirectLight,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Scene_setIndirectLightRenderThread(
+    tScene.cast(),
+    tIndirectLight.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
+  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
+  return result;
+}
+
+void Scene_setSkyboxRenderThread(
+  Pointer<TScene> tScene,
+  Pointer<TSkybox> tSkybox,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Scene_setSkyboxRenderThread(
+    tScene.cast(),
+    tSkybox.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+/// Returns the skybox intensity in lux.
+double Skybox_getIntensity(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getIntensity(tSkybox.cast());
+  return result;
+}
+
+/// Returns the visibility mask bits.
+int Skybox_getLayerMask(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getLayerMask(tSkybox.cast());
+  return result;
+}
+
+/// Returns the environment texture, or nullptr for a color-only skybox.
+Pointer<TTexture> Skybox_getTexture(Pointer<TSkybox> tSkybox) {
+  final result = GeneratedBindings.instance._Skybox_getTexture(tSkybox.cast());
+  return Pointer<TTexture>(result);
+}
+
+void Skybox_setColor(Pointer<TSkybox> tSkybox, double r, double g, double b, double a) {
+  final result = GeneratedBindings.instance._Skybox_setColor(tSkybox.cast(), r, g, b, a);
+  return result;
+}
+
+/// Sets bits in a visibility mask (see filament::Skybox::setLayerMask).
+void Skybox_setLayerMask(Pointer<TSkybox> tSkybox, int select, int values) {
+  final result = GeneratedBindings.instance._Skybox_setLayerMask(tSkybox.cast(), select, values);
+  return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
+  return Pointer<TSurfaceOrientation>(result);
 }
 
 Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
@@ -8304,8 +7332,8 @@ Pointer<TSurfaceOrientationBuilder> SurfaceOrientationBuilder_create() {
   return Pointer<TSurfaceOrientationBuilder>(result);
 }
 
-void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
   return result;
 }
 
@@ -8318,30 +7346,21 @@ void SurfaceOrientationBuilder_normals(
   return result;
 }
 
-void SurfaceOrientationBuilder_tangents(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> tangents,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
-  return result;
-}
-
-void SurfaceOrientationBuilder_uvs(
-  Pointer<TSurfaceOrientationBuilder> builder,
-  Pointer<Float32> uvs,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
-  return result;
-}
-
 void SurfaceOrientationBuilder_positions(
   Pointer<TSurfaceOrientationBuilder> builder,
   Pointer<Float32> positions,
   Dartsize_t stride,
 ) {
   final result = GeneratedBindings.instance._SurfaceOrientationBuilder_positions(builder.cast(), positions, stride);
+  return result;
+}
+
+void SurfaceOrientationBuilder_tangents(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> tangents,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_tangents(builder.cast(), tangents, stride);
   return result;
 }
 
@@ -8363,18 +7382,22 @@ void SurfaceOrientationBuilder_triangles_ushort(
   return result;
 }
 
-Pointer<TSurfaceOrientation> SurfaceOrientationBuilder_build(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_build(builder.cast());
-  return Pointer<TSurfaceOrientation>(result);
-}
-
-void SurfaceOrientationBuilder_destroy(Pointer<TSurfaceOrientationBuilder> builder) {
-  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_destroy(builder.cast());
+void SurfaceOrientationBuilder_uvs(
+  Pointer<TSurfaceOrientationBuilder> builder,
+  Pointer<Float32> uvs,
+  Dartsize_t stride,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_uvs(builder.cast(), uvs, stride);
   return result;
 }
 
-Dartsize_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
+void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
+  final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
   return result;
 }
 
@@ -8385,21 +7408,6 @@ void SurfaceOrientation_getQuats_float4(
   Dartsize_t stride,
 ) {
   final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_float4(
-    orientation.cast(),
-    out,
-    quatCount,
-    stride,
-  );
-  return result;
-}
-
-void SurfaceOrientation_getQuats_short4(
-  Pointer<TSurfaceOrientation> orientation,
-  Pointer<Int16> out,
-  Dartsize_t quatCount,
-  Dartsize_t stride,
-) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
     orientation.cast(),
     out,
     quatCount,
@@ -8423,640 +7431,911 @@ void SurfaceOrientation_getQuats_half4(
   return result;
 }
 
-void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {
-  final result = GeneratedBindings.instance._SurfaceOrientation_destroy(orientation.cast());
-  return result;
-}
-
-Pointer<TAnimationManager> AnimationManager_create(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._AnimationManager_create(tEngine.cast());
-  return Pointer<TAnimationManager>(result);
-}
-
-void AnimationManager_destroy(Pointer<TAnimationManager> tAnimationManager) {
-  final result = GeneratedBindings.instance._AnimationManager_destroy(tAnimationManager.cast());
-  return result;
-}
-
-void AnimationManager_update(Pointer<TAnimationManager> tAnimationManager, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._AnimationManager_update(
-    tAnimationManager.cast(),
-    frameTimeInNanos.toJSBigInt,
-  );
-  return result;
-}
-
-bool AnimationManager_addGltfAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
+void SurfaceOrientation_getQuats_short4(
+  Pointer<TSurfaceOrientation> orientation,
+  Pointer<Int16> out,
+  Dartsize_t quatCount,
+  Dartsize_t stride,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_addGltfAnimationComponent(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-bool AnimationManager_removeGltfAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_removeGltfAnimationComponent(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-void AnimationManager_addMorphAnimationComponent(Pointer<TAnimationManager> tAnimationManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._AnimationManager_addMorphAnimationComponent(
-    tAnimationManager.cast(),
-    entityId,
-  );
-  return result;
-}
-
-void AnimationManager_removeMorphAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  DartEntityId entityId,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_removeMorphAnimationComponent(
-    tAnimationManager.cast(),
-    entityId,
-  );
-  return result;
-}
-
-bool AnimationManager_addBoneAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_addBoneAnimationComponent(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-bool AnimationManager_removeBoneAnimationComponent(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_removeBoneAnimationComponent(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-  );
-  return result == 1;
-}
-
-bool AnimationManager_setMorphAnimation(
-  Pointer<TAnimationManager> tAnimationManager,
-  DartEntityId entityId,
-  Pointer<Float32> morphData,
-  Pointer<Uint32> morphIndices,
-  int numMorphTargets,
-  int numFrames,
-  double frameLengthInMs,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_setMorphAnimation(
-    tAnimationManager.cast(),
-    entityId,
-    morphData,
-    morphIndices,
-    numMorphTargets,
-    numFrames,
-    frameLengthInMs,
-  );
-  return result == 1;
-}
-
-bool AnimationManager_clearMorphAnimation(Pointer<TAnimationManager> tAnimationManager, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._AnimationManager_clearMorphAnimation(tAnimationManager.cast(), entityId);
-  return result == 1;
-}
-
-void AnimationManager_resetToRestPose(Pointer<TAnimationManager> tAnimationManager, Pointer<TSceneAsset> sceneAsset) {
-  final result = GeneratedBindings.instance._AnimationManager_resetToRestPose(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-  );
-  return result;
-}
-
-bool AnimationManager_addBoneAnimation(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-  int skinIndex,
-  int boneIndex,
-  Pointer<Float32> frameData,
-  int numFrames,
-  double frameLengthInMs,
-  double fadeOutInSecs,
-  double fadeInInSecs,
-  double maxDelta,
-  bool loop,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_addBoneAnimation(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-    skinIndex,
-    boneIndex,
-    frameData,
-    numFrames,
-    frameLengthInMs,
-    fadeOutInSecs,
-    fadeInInSecs,
-    maxDelta,
-    loop,
-  );
-  return result == 1;
-}
-
-void AnimationManager_getRestLocalTransforms(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  int skinIndex,
-  Pointer<Float32> out,
-  int numBones,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_getRestLocalTransforms(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    skinIndex,
+  final result = GeneratedBindings.instance._SurfaceOrientation_getQuats_short4(
+    orientation.cast(),
     out,
-    numBones,
+    quatCount,
+    stride,
   );
   return result;
 }
 
-void AnimationManager_getInverseBindMatrix(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  int skinIndex,
-  int boneIndex,
-  Pointer<Float32> out,
+Dartsize_t SurfaceOrientation_getVertexCount(Pointer<TSurfaceOrientation> orientation) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_getVertexCount(orientation.cast());
+  return result;
+}
+
+BigInt get TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER {
+  final value = NativeLibrary.instance.getValueBigInt(
+    GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER,
+    "i64",
+  );
+  return bigIntasUintN(64, value).toDart;
+}
+
+BigInt get TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER {
+  final value = NativeLibrary.instance.getValueBigInt(
+    GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_HAS_STENCIL_BUFFER,
+    "i64",
+  );
+  return bigIntasUintN(64, value).toDart;
+}
+
+BigInt get TSWAP_CHAIN_CONFIG_READABLE {
+  final value = NativeLibrary.instance.getValueBigInt(GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_READABLE, "i64");
+  return bigIntasUintN(64, value).toDart;
+}
+
+BigInt get TSWAP_CHAIN_CONFIG_TRANSPARENT {
+  final value = NativeLibrary.instance.getValueBigInt(
+    GeneratedBindings.instance._TSWAP_CHAIN_CONFIG_TRANSPARENT,
+    "i64",
+  );
+  return bigIntasUintN(64, value).toDart;
+}
+
+Pointer<TTextureSampler> TextureSampler_create() {
+  final result = GeneratedBindings.instance._TextureSampler_create();
+  return Pointer<TTextureSampler>(result);
+}
+
+void TextureSampler_createRenderThread(Pointer<NativeFunction<void Function(Pointer<TTextureSampler>)>> onComplete) {
+  final result = GeneratedBindings.instance._TextureSampler_createRenderThread(onComplete.cast());
+  return result;
+}
+
+Pointer<TTextureSampler> TextureSampler_createWithComparison(int compareMode, int compareFunc) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithComparison(compareMode, compareFunc);
+  return Pointer<TTextureSampler>(result);
+}
+
+void TextureSampler_createWithComparisonRenderThread(
+  int compareMode,
+  int compareFunc,
+  Pointer<NativeFunction<void Function(Pointer<TTextureSampler>)>> onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_getInverseBindMatrix(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    skinIndex,
-    boneIndex,
-    out,
+  final result = GeneratedBindings.instance._TextureSampler_createWithComparisonRenderThread(
+    compareMode,
+    compareFunc,
+    onComplete.cast(),
   );
   return result;
 }
 
-bool AnimationManager_playGltfAnimation(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-  int index,
-  bool loop,
-  bool reverse,
-  bool replaceActive,
-  double crossfade,
-  double startOffset,
-  double speed,
+Pointer<TTextureSampler> TextureSampler_createWithFiltering(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_playGltfAnimation(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-    index,
-    loop,
-    reverse,
-    replaceActive,
-    crossfade,
-    startOffset,
-    speed,
+  final result = GeneratedBindings.instance._TextureSampler_createWithFiltering(
+    minFilter,
+    magFilter,
+    wrapS,
+    wrapT,
+    wrapR,
+  );
+  return Pointer<TTextureSampler>(result);
+}
+
+void TextureSampler_createWithFilteringRenderThread(
+  int minFilter,
+  int magFilter,
+  int wrapS,
+  int wrapT,
+  int wrapR,
+  Pointer<NativeFunction<void Function(Pointer<TTextureSampler>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_createWithFilteringRenderThread(
+    minFilter,
+    magFilter,
+    wrapS,
+    wrapT,
+    wrapR,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+void TextureSampler_destroy(Pointer<TTextureSampler> sampler) {
+  final result = GeneratedBindings.instance._TextureSampler_destroy(sampler.cast());
+  return result;
+}
+
+void TextureSampler_destroyRenderThread(Pointer<TTextureSampler> sampler, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._TextureSampler_destroyRenderThread(
+    sampler.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TextureSampler_setAnisotropy(Pointer<TTextureSampler> sampler, double anisotropy) {
+  final result = GeneratedBindings.instance._TextureSampler_setAnisotropy(sampler.cast(), anisotropy);
+  return result;
+}
+
+void TextureSampler_setAnisotropyRenderThread(
+  Pointer<TTextureSampler> sampler,
+  double anisotropy,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_setAnisotropyRenderThread(
+    sampler.cast(),
+    anisotropy,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TextureSampler_setCompareMode(Pointer<TTextureSampler> sampler, int mode, int func) {
+  final result = GeneratedBindings.instance._TextureSampler_setCompareMode(sampler.cast(), mode, func);
+  return result;
+}
+
+void TextureSampler_setCompareModeRenderThread(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+  int func,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_setCompareModeRenderThread(
+    sampler.cast(),
+    mode,
+    func,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TextureSampler_setMagFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMagFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setMagFilterRenderThread(
+  Pointer<TTextureSampler> sampler,
+  int filter,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_setMagFilterRenderThread(
+    sampler.cast(),
+    filter,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TextureSampler_setMinFilter(Pointer<TTextureSampler> sampler, int filter) {
+  final result = GeneratedBindings.instance._TextureSampler_setMinFilter(sampler.cast(), filter);
+  return result;
+}
+
+void TextureSampler_setMinFilterRenderThread(
+  Pointer<TTextureSampler> sampler,
+  int filter,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_setMinFilterRenderThread(
+    sampler.cast(),
+    filter,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TextureSampler_setWrapModeR(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeR(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeRRenderThread(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeRRenderThread(
+    sampler.cast(),
+    mode,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TextureSampler_setWrapModeS(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeS(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeSRenderThread(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeSRenderThread(
+    sampler.cast(),
+    mode,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TextureSampler_setWrapModeT(Pointer<TTextureSampler> sampler, int mode) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeT(sampler.cast(), mode);
+  return result;
+}
+
+void TextureSampler_setWrapModeTRenderThread(
+  Pointer<TTextureSampler> sampler,
+  int mode,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TextureSampler_setWrapModeTRenderThread(
+    sampler.cast(),
+    mode,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Pointer<TTexture> Texture_build(
+  Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import1,
+  int sampler,
+  int format,
+) {
+  final result = GeneratedBindings.instance._Texture_build(
+    engine.cast(),
+    width,
+    height,
+    depth,
+    levels,
+    tUsage,
+    import1,
+    sampler,
+    format,
+  );
+  return Pointer<TTexture>(result);
+}
+
+void Texture_buildRenderThread(
+  Pointer<TEngine> engine,
+  int width,
+  int height,
+  int depth,
+  int levels,
+  int tUsage,
+  int import1,
+  int sampler,
+  int format,
+  Pointer<NativeFunction<void Function(Pointer<TTexture>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._Texture_buildRenderThread(
+    engine.cast(),
+    width,
+    height,
+    depth,
+    levels,
+    tUsage,
+    import1,
+    sampler,
+    format,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+void Texture_generateMipMaps(Pointer<TTexture> tTexture, Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._Texture_generateMipMaps(tTexture.cast(), tEngine.cast());
+  return result;
+}
+
+void Texture_generateMipMapsRenderThread(
+  Pointer<TTexture> tTexture,
+  Pointer<TEngine> tEngine,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Texture_generateMipMapsRenderThread(
+    tTexture.cast(),
+    tEngine.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+int Texture_getDepth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getDepth(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getFormat(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getFormat(tTexture.cast());
+  return result;
+}
+
+int Texture_getHeight(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getHeight(tTexture.cast(), level);
+  return result;
+}
+
+Dartsize_t Texture_getLevels(Pointer<TTexture> tTexture) {
+  final result = GeneratedBindings.instance._Texture_getLevels(tTexture.cast());
+  return result;
+}
+
+int Texture_getUsage(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getUsage(tTexture.cast(), level);
+  return result;
+}
+
+int Texture_getWidth(Pointer<TTexture> tTexture, int level) {
+  final result = GeneratedBindings.instance._Texture_getWidth(tTexture.cast(), level);
+  return result;
+}
+
+bool Texture_loadImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+) {
+  final result = GeneratedBindings.instance._Texture_loadImage(
+    tEngine.cast(),
+    tTexture.cast(),
+    tImage.cast(),
+    bufferFormat,
+    pixelDataType,
+    level,
   );
   return result == 1;
 }
 
-bool AnimationManager_stopGltfAnimation(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  int index,
+void Texture_loadImageRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  Pointer<TLinearImage> tImage,
+  int bufferFormat,
+  int pixelDataType,
+  int level,
+  Pointer<NativeFunction<void Function(bool)>> onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_stopGltfAnimation(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    index,
+  final result = GeneratedBindings.instance._Texture_loadImageRenderThread(
+    tEngine.cast(),
+    tTexture.cast(),
+    tImage.cast(),
+    bufferFormat,
+    pixelDataType,
+    level,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+void Texture_setExternalImage(Pointer<TEngine> tEngine, Pointer<TTexture> tTexture, Pointer<Void> externalImage) {
+  final result = GeneratedBindings.instance._Texture_setExternalImage(tEngine.cast(), tTexture.cast(), externalImage);
+  return result;
+}
+
+void Texture_setExternalImageRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  Pointer<Void> externalImage,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._Texture_setExternalImageRenderThread(
+    tEngine.cast(),
+    tTexture.cast(),
+    externalImage,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+bool Texture_setImage(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  int level,
+  Pointer<Uint8> data,
+  Dartsize_t size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+) {
+  final result = GeneratedBindings.instance._Texture_setImage(
+    tEngine.cast(),
+    tTexture.cast(),
+    level,
+    data,
+    size,
+    x_offset,
+    y_offset,
+    z_offset,
+    width,
+    height,
+    depth,
+    bufferFormat,
+    pixelDataType,
   );
   return result == 1;
 }
 
-double AnimationManager_getGltfAnimationDuration(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  int animationIndex,
+void Texture_setImageRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TTexture> tTexture,
+  int level,
+  Pointer<Uint8> data,
+  Dartsize_t size,
+  int x_offset,
+  int y_offset,
+  int z_offset,
+  int width,
+  int height,
+  int depth,
+  int bufferFormat,
+  int pixelDataType,
+  Pointer<NativeFunction<void Function(bool)>> onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationDuration(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    animationIndex,
+  final result = GeneratedBindings.instance._Texture_setImageRenderThread(
+    tEngine.cast(),
+    tTexture.cast(),
+    level,
+    data,
+    size,
+    x_offset,
+    y_offset,
+    z_offset,
+    width,
+    height,
+    depth,
+    bufferFormat,
+    pixelDataType,
+    onComplete.cast(),
   );
   return result;
 }
 
-int AnimationManager_getGltfAnimationCount(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
+int Thermion_createGLContext(Pointer<Char> canvasSelector) {
+  final result = GeneratedBindings.instance._Thermion_createGLContext(canvasSelector);
+  return result;
+}
+
+void Thermion_destroyCanvas(Pointer<Char> canvasSelector) {
+  final result = GeneratedBindings.instance._Thermion_destroyCanvas(canvasSelector);
+  return result;
+}
+
+int Thermion_getGLContext() {
+  final result = GeneratedBindings.instance._Thermion_getGLContext();
+  return result;
+}
+
+void Thermion_setCanvasElementSize(Pointer<Char> name, int width, int height) {
+  final result = GeneratedBindings.instance._Thermion_setCanvasElementSize(name, width, height);
+  return result;
+}
+
+Pointer<TToneMapper> ToneMapper_createACES(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createACES(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+Pointer<TToneMapper> ToneMapper_createACESLegacy(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createACESLegacy(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_createACESLegacyRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationCount(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
+  final result = GeneratedBindings.instance._ToneMapper_createACESLegacyRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+void ToneMapper_createACESRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createACESRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+Pointer<TToneMapper> ToneMapper_createAGX(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createAGX(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_createAGXRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createAGXRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+Pointer<TToneMapper> ToneMapper_createAGXWithLook(Pointer<TEngine> tEngine, int look) {
+  final result = GeneratedBindings.instance._ToneMapper_createAGXWithLook(tEngine.cast(), look);
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_createAGXWithLookRenderThread(
+  Pointer<TEngine> tEngine,
+  int look,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createAGXWithLookRenderThread(
+    tEngine.cast(),
+    look,
+    onComplete.cast(),
   );
   return result;
 }
 
-void AnimationManager_getGltfAnimationName(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  Pointer<Char> outPtr,
-  int index,
+Pointer<TToneMapper> ToneMapper_createDisplayRange(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createDisplayRange(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_createDisplayRangeRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_getGltfAnimationName(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    outPtr,
-    index,
+  final result = GeneratedBindings.instance._ToneMapper_createDisplayRangeRenderThread(
+    tEngine.cast(),
+    onComplete.cast(),
   );
   return result;
 }
 
-int AnimationManager_getMorphTargetNameCount(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  DartEntityId childEntity,
+Pointer<TToneMapper> ToneMapper_createFilmic(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createFilmic(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_createFilmicRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_getMorphTargetNameCount(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    childEntity,
+  final result = GeneratedBindings.instance._ToneMapper_createFilmicRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+Pointer<TToneMapper> ToneMapper_createGeneric(
+  Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createGeneric(
+    tEngine.cast(),
+    contrast,
+    midGrayIn,
+    midGrayOut,
+    hdrMax,
+  );
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_createGenericRenderThread(
+  Pointer<TEngine> tEngine,
+  double contrast,
+  double midGrayIn,
+  double midGrayOut,
+  double hdrMax,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createGenericRenderThread(
+    tEngine.cast(),
+    contrast,
+    midGrayIn,
+    midGrayOut,
+    hdrMax,
+    onComplete.cast(),
   );
   return result;
 }
 
-void AnimationManager_getMorphTargetName(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-  DartEntityId childEntity,
-  Pointer<Char> outPtr,
-  int index,
+Pointer<TToneMapper> ToneMapper_createLinear(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createLinear(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_createLinearRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_getMorphTargetName(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-    childEntity,
-    outPtr,
-    index,
+  final result = GeneratedBindings.instance._ToneMapper_createLinearRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+Pointer<TToneMapper> ToneMapper_createPBRNeutral(Pointer<TEngine> tEngine) {
+  final result = GeneratedBindings.instance._ToneMapper_createPBRNeutral(tEngine.cast());
+  return Pointer<TToneMapper>(result);
+}
+
+void ToneMapper_createPBRNeutralRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TToneMapper>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._ToneMapper_createPBRNeutralRenderThread(tEngine.cast(), onComplete.cast());
+  return result;
+}
+
+void ToneMapper_destroy(Pointer<TToneMapper> toneMapper) {
+  final result = GeneratedBindings.instance._ToneMapper_destroy(toneMapper.cast());
+  return result;
+}
+
+void ToneMapper_destroyRenderThread(Pointer<TToneMapper> tToneMapper, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._ToneMapper_destroyRenderThread(
+    tToneMapper.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
   return result;
 }
 
-bool AnimationManager_updateBoneMatrices(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> sceneAsset,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_updateBoneMatrices(
-    tAnimationManager.cast(),
-    sceneAsset.cast(),
-  );
-  return result == 1;
+void TransformManager_commitLocalTransformTransaction(Pointer<TTransformManager> tTransformManager) {
+  final result = GeneratedBindings.instance._TransformManager_commitLocalTransformTransaction(tTransformManager.cast());
+  return result;
 }
 
-bool AnimationManager_setMorphTargetWeights(
-  Pointer<TAnimationManager> tAnimationManager,
+void TransformManager_createComponent(Pointer<TTransformManager> tTransformManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._TransformManager_createComponent(tTransformManager.cast(), entity);
+  return result;
+}
+
+void TransformManager_createComponentRenderThread(
+  Pointer<TTransformManager> tTransformManager,
   DartEntityId entityId,
-  Pointer<Float32> morphData,
-  int numWeights,
+  int requestId,
+  DartVoidCallback onComplete,
 ) {
-  final result = GeneratedBindings.instance._AnimationManager_setMorphTargetWeights(
-    tAnimationManager.cast(),
+  final result = GeneratedBindings.instance._TransformManager_createComponentRenderThread(
+    tTransformManager.cast(),
     entityId,
-    morphData,
-    numWeights,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+bool TransformManager_empty(Pointer<TTransformManager> tTransformManager) {
+  final result = GeneratedBindings.instance._TransformManager_empty(tTransformManager.cast());
+  return result == 1;
+}
+
+DartEntityId TransformManager_getAncestor(Pointer<TTransformManager> tTransformManager, DartEntityId childEntityId) {
+  final result = GeneratedBindings.instance._TransformManager_getAncestor(tTransformManager.cast(), childEntityId);
+  return result;
+}
+
+int TransformManager_getChildCount(Pointer<TTransformManager> tTransformManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._TransformManager_getChildCount(tTransformManager.cast(), entityId);
+  return result;
+}
+
+void TransformManager_getChildren(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  Pointer<Int32> children,
+  int count,
+) {
+  final result = GeneratedBindings.instance._TransformManager_getChildren(
+    tTransformManager.cast(),
+    entityId,
+    children,
+    count,
+  );
+  return result;
+}
+
+int TransformManager_getComponentCount(Pointer<TTransformManager> tTransformManager) {
+  final result = GeneratedBindings.instance._TransformManager_getComponentCount(tTransformManager.cast());
+  return result;
+}
+
+double4x4 TransformManager_getLocalTransform(Pointer<TTransformManager> tTransformManager, DartEntityId entityId) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._TransformManager_getLocalTransform(
+    double4x4_out.cast(),
+    tTransformManager.cast(),
+    entityId,
+  );
+  return double4x4_out.toDart();
+}
+
+DartEntityId TransformManager_getParent(Pointer<TTransformManager> tTransformManager, DartEntityId child) {
+  final result = GeneratedBindings.instance._TransformManager_getParent(tTransformManager.cast(), child);
+  return result;
+}
+
+double4x4 TransformManager_getWorldTransform(Pointer<TTransformManager> tTransformManager, DartEntityId entityId) {
+  final double4x4_out = double4x4.stackAlloc();
+  final result = GeneratedBindings.instance._TransformManager_getWorldTransform(
+    double4x4_out.cast(),
+    tTransformManager.cast(),
+    entityId,
+  );
+  return double4x4_out.toDart();
+}
+
+bool TransformManager_hasComponent(Pointer<TTransformManager> tTransformManager, DartEntityId entityId) {
+  final result = GeneratedBindings.instance._TransformManager_hasComponent(tTransformManager.cast(), entityId);
+  return result == 1;
+}
+
+void TransformManager_openLocalTransformTransaction(Pointer<TTransformManager> tTransformManager) {
+  final result = GeneratedBindings.instance._TransformManager_openLocalTransformTransaction(tTransformManager.cast());
+  return result;
+}
+
+void TransformManager_removeComponent(Pointer<TTransformManager> tTransformManager, DartEntityId entity) {
+  final result = GeneratedBindings.instance._TransformManager_removeComponent(tTransformManager.cast(), entity);
+  return result;
+}
+
+void TransformManager_removeComponentRenderThread(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TransformManager_removeComponentRenderThread(
+    tTransformManager.cast(),
+    entityId,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TransformManager_setParent(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId child,
+  DartEntityId parent,
+  bool preserveScaling,
+) {
+  final result = GeneratedBindings.instance._TransformManager_setParent(
+    tTransformManager.cast(),
+    child,
+    parent,
+    preserveScaling,
+  );
+  return result;
+}
+
+void TransformManager_setParentRenderThread(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId child,
+  DartEntityId parent,
+  bool preserveScaling,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._TransformManager_setParentRenderThread(
+    tTransformManager.cast(),
+    child,
+    parent,
+    preserveScaling,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void TransformManager_setTransform(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  double4x4 transform,
+) {
+  final transformPtr = transform.address;
+  final result = GeneratedBindings.instance._TransformManager_setTransform(
+    tTransformManager.cast(),
+    entityId,
+    transformPtr.cast(),
+  );
+  return result;
+}
+
+void TransformManager_setTransformRenderThread(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  double4x4 transform,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final transformPtr = transform.address;
+  final result = GeneratedBindings.instance._TransformManager_setTransformRenderThread(
+    tTransformManager.cast(),
+    entityId,
+    transformPtr.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+bool TransformManager_transformToUnitCube(
+  Pointer<TTransformManager> tTransformManager,
+  DartEntityId entityId,
+  Aabb3 boundingBox,
+) {
+  final boundingBoxPtr = boundingBox.address;
+  final result = GeneratedBindings.instance._TransformManager_transformToUnitCube(
+    tTransformManager.cast(),
+    entityId,
+    boundingBoxPtr.cast(),
   );
   return result == 1;
 }
 
-bool AnimationManager_setGltfAnimationTime(
-  Pointer<TAnimationManager> tAnimationManager,
-  Pointer<TSceneAsset> tSceneAsset,
-  int animationIndex,
-  double timeInSeconds,
-) {
-  final result = GeneratedBindings.instance._AnimationManager_setGltfAnimationTime(
-    tAnimationManager.cast(),
-    tSceneAsset.cast(),
-    animationIndex,
-    timeInSeconds,
+void TransformPipeline_addKeyBinding(int logicalKey, int intentAction, double value) {
+  final result = GeneratedBindings.instance._TransformPipeline_addKeyBinding(logicalKey, intentAction, value);
+  return result;
+}
+
+void TransformPipeline_addMouseButtonBinding(int mouseButton, int intentAction, double value) {
+  final result = GeneratedBindings.instance._TransformPipeline_addMouseButtonBinding(mouseButton, intentAction, value);
+  return result;
+}
+
+void TransformPipeline_cleanup() {
+  final result = GeneratedBindings.instance._TransformPipeline_cleanup();
+  return result;
+}
+
+void TransformPipeline_clearKeyBindings() {
+  final result = GeneratedBindings.instance._TransformPipeline_clearKeyBindings();
+  return result;
+}
+
+void TransformPipeline_onKeyEvent(int eventType, int logicalKey, int physicalKey, int synthesized) {
+  final result = GeneratedBindings.instance._TransformPipeline_onKeyEvent(
+    eventType,
+    logicalKey,
+    physicalKey,
+    synthesized,
   );
-  return result == 1;
-}
-
-Pointer<TGltfAssetLoader> GltfAssetLoader_create(
-  Pointer<TEngine> tEngine,
-  Pointer<TMaterialProvider> tMaterialProvider,
-  Pointer<TNameComponentManager> tNameComponentManager,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_create(
-    tEngine.cast(),
-    tMaterialProvider.cast(),
-    tNameComponentManager.cast(),
-  );
-  return Pointer<TGltfAssetLoader>(result);
-}
-
-void GltfAssetLoader_destroy(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_destroy(tAssetLoader.cast());
-  return result;
-}
-
-Pointer<TFilamentAsset> GltfAssetLoader_load(
-  Pointer<TEngine> tEngine,
-  Pointer<TGltfAssetLoader> tAssetLoader,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-  int numInstances,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_load(
-    tEngine.cast(),
-    tAssetLoader.cast(),
-    data,
-    length,
-    numInstances,
-  );
-  return Pointer<TFilamentAsset>(result);
-}
-
-Pointer<TMaterialInstance> GltfAssetLoader_getMaterialInstance(
-  Pointer<TRenderableManager> tRenderableManager,
-  Pointer<TFilamentAsset> tAsset,
-) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialInstance(
-    tRenderableManager.cast(),
-    tAsset.cast(),
-  );
-  return Pointer<TMaterialInstance>(result);
-}
-
-Pointer<TMaterialProvider> GltfAssetLoader_getMaterialProvider(Pointer<TGltfAssetLoader> tAssetLoader) {
-  final result = GeneratedBindings.instance._GltfAssetLoader_getMaterialProvider(tAssetLoader.cast());
-  return Pointer<TMaterialProvider>(result);
-}
-
-int FilamentAsset_getResourceUriCount(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUriCount(tFilamentAsset.cast());
-  return result;
-}
-
-Pointer<PointerClass<Char>> FilamentAsset_getResourceUris(Pointer<TFilamentAsset> tFilamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getResourceUris(tFilamentAsset.cast());
-  return Pointer<PointerClass<Char>>(result);
-}
-
-Pointer<TGltfResourceLoader> GltfResourceLoader_create(Pointer<TEngine> tEngine) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_create(tEngine.cast());
-  return Pointer<TGltfResourceLoader>(result);
-}
-
-void GltfResourceLoader_destroy(Pointer<TEngine> tEngine, Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_destroy(tEngine.cast(), tGltfResourceLoader.cast());
-  return result;
-}
-
-bool GltfResourceLoader_asyncBeginLoad(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncBeginLoad(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-void GltfResourceLoader_asyncUpdateLoad(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader.cast());
-  return result;
-}
-
-double GltfResourceLoader_asyncGetLoadProgress(Pointer<TGltfResourceLoader> tGltfResourceLoader) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader.cast());
-  return result;
-}
-
-void GltfResourceLoader_addResourceData(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<Char> uri,
-  Pointer<Uint8> data,
-  Dartsize_t length,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
-    tGltfResourceLoader.cast(),
-    uri,
-    data,
-    length,
-  );
-  return result;
-}
-
-bool GltfResourceLoader_loadResources(
-  Pointer<TGltfResourceLoader> tGltfResourceLoader,
-  Pointer<TFilamentAsset> tFilamentAsset,
-) {
-  final result = GeneratedBindings.instance._GltfResourceLoader_loadResources(
-    tGltfResourceLoader.cast(),
-    tFilamentAsset.cast(),
-  );
-  return result == 1;
-}
-
-Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_create(tEngine.cast(), tRenderer.cast());
-  return Pointer<TRenderManager>(result);
-}
-
-void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_addAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_addAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_removeAnimationManager(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TAnimationManager> tAnimationManager,
-) {
-  final result = GeneratedBindings.instance._RenderManager_removeAnimationManager(
-    tRenderer.cast(),
-    tAnimationManager.cast(),
-  );
-  return result;
-}
-
-void RenderManager_render(Pointer<TRenderManager> tRenderer, BigInt frameTimeInNanos) {
-  final result = GeneratedBindings.instance._RenderManager_render(tRenderer.cast(), frameTimeInNanos.toJSBigInt);
-  return result;
-}
-
-void RenderManager_setRenderable(
-  Pointer<TRenderManager> tRenderer,
-  Pointer<TSwapChain> swapChain,
-  Pointer<PointerClass<TView>> views,
-  int numViews,
-) {
-  final result = GeneratedBindings.instance._RenderManager_setRenderable(
-    tRenderer.cast(),
-    swapChain.cast(),
-    views.cast(),
-    numViews,
-  );
-  return result;
-}
-
-void RenderManager_removeSwapChain(Pointer<TRenderManager> tRenderer, Pointer<TSwapChain> swapChain) {
-  final result = GeneratedBindings.instance._RenderManager_removeSwapChain(tRenderer.cast(), swapChain.cast());
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_attachToRenderThread(tRenderer.cast());
-  return result;
-}
-
-void RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager) {
-  final result = GeneratedBindings.instance._RenderManager_detachFromRenderThread(tRenderManager.cast());
-  return result;
-}
-
-void RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused) {
-  final result = GeneratedBindings.instance._RenderManager_setPaused(tRenderer.cast(), paused);
-  return result;
-}
-
-int FilamentAsset_getEntityCount(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntityCount(filamentAsset.cast());
-  return result;
-}
-
-void FilamentAsset_getEntities(Pointer<TFilamentAsset> filamentAsset, Pointer<Int32> out) {
-  final result = GeneratedBindings.instance._FilamentAsset_getEntities(filamentAsset.cast(), out);
-  return result;
-}
-
-DartEntityId FilamentAsset_getWireframe(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getWireframe(filamentAsset.cast());
-  return result;
-}
-
-Pointer<Void> FilamentAsset_getSourceAsset(Pointer<TFilamentAsset> filamentAsset) {
-  final result = GeneratedBindings.instance._FilamentAsset_getSourceAsset(filamentAsset.cast());
-  return Pointer<Void>(result);
-}
-
-void Scene_addEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_addEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_removeEntity(Pointer<TScene> tScene, DartEntityId entityId) {
-  final result = GeneratedBindings.instance._Scene_removeEntity(tScene.cast(), entityId);
-  return result;
-}
-
-void Scene_setSkybox(Pointer<TScene> tScene, Pointer<TSkybox> skybox) {
-  final result = GeneratedBindings.instance._Scene_setSkybox(tScene.cast(), skybox.cast());
-  return result;
-}
-
-Pointer<TSkybox> Scene_getSkybox(Pointer<TScene> tScene) {
-  final result = GeneratedBindings.instance._Scene_getSkybox(tScene.cast());
-  return Pointer<TSkybox>(result);
-}
-
-void Scene_setIndirectLight(Pointer<TScene> tScene, Pointer<TIndirectLight> tIndirectLight) {
-  final result = GeneratedBindings.instance._Scene_setIndirectLight(tScene.cast(), tIndirectLight.cast());
-  return result;
-}
-
-void Scene_addFilamentAsset(Pointer<TScene> tScene, Pointer<TFilamentAsset> asset) {
-  final result = GeneratedBindings.instance._Scene_addFilamentAsset(tScene.cast(), asset.cast());
-  return result;
-}
-
-void FrameScheduler_startWithCallback(DartFrameTickCallback tickCallback, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithCallback(
-    tickCallback as Pointer<NativeFunction<FrameTickCallbackFunction>>,
-    targetFps,
-  );
-  return result;
-}
-
-void FrameScheduler_stop() {
-  final result = GeneratedBindings.instance._FrameScheduler_stop();
-  return result;
-}
-
-int FrameScheduler_initDartApi(Pointer<Void> data) {
-  final result = GeneratedBindings.instance._FrameScheduler_initDartApi(data);
-  return result;
-}
-
-void FrameScheduler_startWithPort(BigInt port, int targetFps) {
-  final result = GeneratedBindings.instance._FrameScheduler_startWithPort(port.toJSBigInt, targetFps);
-  return result;
-}
-
-void FrameScheduler_setTargetFps(int fps) {
-  final result = GeneratedBindings.instance._FrameScheduler_setTargetFps(fps);
-  return result;
-}
-
-BigInt FrameScheduler_steadyClockUs() {
-  final result = GeneratedBindings.instance._FrameScheduler_steadyClockUs();
-  return result.toDart;
-}
-
-void MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor) {
-  final result = GeneratedBindings.instance._MovementIntentExecutor_destroy(executor.cast());
-  return result;
-}
-
-void MovementIntentExecutor_process(
-  Pointer<TMovementIntentExecutor> executor,
-  Pointer<TMovementIntent> intent,
-  BigInt deltaTimeInNanos,
-) {
-  final result = GeneratedBindings.instance._MovementIntentExecutor_process(
-    executor.cast(),
-    intent.cast(),
-    deltaTimeInNanos.toJSBigInt,
-  );
-  return result;
-}
-
-void Pipeline_registerMovementIntentExecutor(Pointer<TMovementIntentExecutor> executor) {
-  final result = GeneratedBindings.instance._Pipeline_registerMovementIntentExecutor(executor.cast());
-  return result;
-}
-
-void TransformPipeline_setEngine(Pointer<Void> enginePtr) {
-  final result = GeneratedBindings.instance._TransformPipeline_setEngine(enginePtr);
   return result;
 }
 
@@ -9079,23 +8358,8 @@ void TransformPipeline_onMouseEvent(
   return result;
 }
 
-void TransformPipeline_onKeyEvent(int eventType, int logicalKey, int physicalKey, int synthesized) {
-  final result = GeneratedBindings.instance._TransformPipeline_onKeyEvent(
-    eventType,
-    logicalKey,
-    physicalKey,
-    synthesized,
-  );
-  return result;
-}
-
 void TransformPipeline_onScrollEvent(double localX, double localY, double delta) {
   final result = GeneratedBindings.instance._TransformPipeline_onScrollEvent(localX, localY, delta);
-  return result;
-}
-
-void TransformPipeline_update(double deltaTime) {
-  final result = GeneratedBindings.instance._TransformPipeline_update(deltaTime);
   return result;
 }
 
@@ -9104,18 +8368,8 @@ void TransformPipeline_registerPipelineStage(Pointer<Void> pipelineStageHandle, 
   return result;
 }
 
-void TransformPipeline_unregisterPipelineStage(Pointer<Void> pipelineStageHandle) {
-  final result = GeneratedBindings.instance._TransformPipeline_unregisterPipelineStage(pipelineStageHandle);
-  return result;
-}
-
-void TransformPipeline_cleanup() {
-  final result = GeneratedBindings.instance._TransformPipeline_cleanup();
-  return result;
-}
-
-void TransformPipeline_addKeyBinding(int logicalKey, int intentAction, double value) {
-  final result = GeneratedBindings.instance._TransformPipeline_addKeyBinding(logicalKey, intentAction, value);
+void TransformPipeline_removeKeyBindingsForAction(int intentAction) {
+  final result = GeneratedBindings.instance._TransformPipeline_removeKeyBindingsForAction(intentAction);
   return result;
 }
 
@@ -9124,28 +8378,13 @@ void TransformPipeline_removeKeyBindingsForKey(int logicalKey) {
   return result;
 }
 
-void TransformPipeline_removeKeyBindingsForAction(int intentAction) {
-  final result = GeneratedBindings.instance._TransformPipeline_removeKeyBindingsForAction(intentAction);
-  return result;
-}
-
-void TransformPipeline_clearKeyBindings() {
-  final result = GeneratedBindings.instance._TransformPipeline_clearKeyBindings();
-  return result;
-}
-
-void TransformPipeline_addMouseButtonBinding(int mouseButton, int intentAction, double value) {
-  final result = GeneratedBindings.instance._TransformPipeline_addMouseButtonBinding(mouseButton, intentAction, value);
-  return result;
-}
-
 void TransformPipeline_removeMouseButtonBindings(int mouseButton) {
   final result = GeneratedBindings.instance._TransformPipeline_removeMouseButtonBindings(mouseButton);
   return result;
 }
 
-void TransformPipeline_setMouseSensitivity(double sensitivity) {
-  final result = GeneratedBindings.instance._TransformPipeline_setMouseSensitivity(sensitivity);
+void TransformPipeline_setEngine(Pointer<Void> enginePtr) {
+  final result = GeneratedBindings.instance._TransformPipeline_setEngine(enginePtr);
   return result;
 }
 
@@ -9154,331 +8393,869 @@ void TransformPipeline_setInvertMouseY(int invert) {
   return result;
 }
 
-extension TViewportExt on Pointer<TViewport> {
-  TViewport toDart() {
-    return TViewport(this);
+void TransformPipeline_setMouseSensitivity(double sensitivity) {
+  final result = GeneratedBindings.instance._TransformPipeline_setMouseSensitivity(sensitivity);
+  return result;
+}
+
+void TransformPipeline_unregisterPipelineStage(Pointer<Void> pipelineStageHandle) {
+  final result = GeneratedBindings.instance._TransformPipeline_unregisterPipelineStage(pipelineStageHandle);
+  return result;
+}
+
+void TransformPipeline_update(double deltaTime) {
+  final result = GeneratedBindings.instance._TransformPipeline_update(deltaTime);
+  return result;
+}
+
+void VertexBufferBuilder_attribute(
+  Pointer<TVertexBufferBuilder> builder,
+  int attribute,
+  int bufferIndex,
+  int attributeType,
+  int byteOffset,
+  int byteStride,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_attribute(
+    builder.cast(),
+    attribute,
+    bufferIndex,
+    attributeType,
+    byteOffset,
+    byteStride,
+  );
+  return result;
+}
+
+void VertexBufferBuilder_bufferCount(Pointer<TVertexBufferBuilder> builder, int count) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_bufferCount(builder.cast(), count);
+  return result;
+}
+
+Pointer<TVertexBuffer> VertexBufferBuilder_build(Pointer<TVertexBufferBuilder> builder, Pointer<TEngine> engine) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_build(builder.cast(), engine.cast());
+  return Pointer<TVertexBuffer>(result);
+}
+
+void VertexBufferBuilder_buildRenderThread(
+  Pointer<TVertexBufferBuilder> tBuilder,
+  Pointer<TEngine> tEngine,
+  Pointer<NativeFunction<void Function(Pointer<TVertexBuffer>)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_buildRenderThread(
+    tBuilder.cast(),
+    tEngine.cast(),
+    onComplete.cast(),
+  );
+  return result;
+}
+
+Pointer<TVertexBufferBuilder> VertexBufferBuilder_create() {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_create();
+  return Pointer<TVertexBufferBuilder>(result);
+}
+
+void VertexBufferBuilder_destroy(Pointer<TVertexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_destroy(builder.cast());
+  return result;
+}
+
+void VertexBufferBuilder_enableBufferObjects(Pointer<TVertexBufferBuilder> builder, bool enabled) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_enableBufferObjects(builder.cast(), enabled);
+  return result;
+}
+
+int VertexBufferBuilder_getStorageMode(Pointer<TVertexBufferBuilder> builder) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_getStorageMode(builder.cast());
+  return result;
+}
+
+void VertexBufferBuilder_normalized(Pointer<TVertexBufferBuilder> builder, int attribute, bool normalize) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_normalized(builder.cast(), attribute, normalize);
+  return result;
+}
+
+void VertexBufferBuilder_vertexCount(Pointer<TVertexBufferBuilder> builder, int count) {
+  final result = GeneratedBindings.instance._VertexBufferBuilder_vertexCount(builder.cast(), count);
+  return result;
+}
+
+void VertexBuffer_destroy(Pointer<TEngine> engine, Pointer<TVertexBuffer> buffer) {
+  final result = GeneratedBindings.instance._VertexBuffer_destroy(engine.cast(), buffer.cast());
+  return result;
+}
+
+void VertexBuffer_destroyRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tBuffer,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_destroyRenderThread(
+    tEngine.cast(),
+    tBuffer.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+Dartsize_t VertexBuffer_getVertexCount(Pointer<TVertexBuffer> buffer) {
+  final result = GeneratedBindings.instance._VertexBuffer_getVertexCount(buffer.cast());
+  return result;
+}
+
+void VertexBuffer_setBufferAt(
+  Pointer<TEngine> engine,
+  Pointer<TVertexBuffer> buffer,
+  int bufferIndex,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_setBufferAt(
+    engine.cast(),
+    buffer.cast(),
+    bufferIndex,
+    data,
+    sizeInBytes,
+    byteOffset,
+  );
+  return result;
+}
+
+void VertexBuffer_setBufferAtRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tBuffer,
+  int bufferIndex,
+  Pointer<Void> data,
+  Dartsize_t sizeInBytes,
+  int byteOffset,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_setBufferAtRenderThread(
+    tEngine.cast(),
+    tBuffer.cast(),
+    bufferIndex,
+    data,
+    sizeInBytes,
+    byteOffset,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void VertexBuffer_setBufferObjectAt(
+  Pointer<TEngine> engine,
+  Pointer<TVertexBuffer> buffer,
+  int bufferIndex,
+  Pointer<TBufferObject> bufferObject,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_setBufferObjectAt(
+    engine.cast(),
+    buffer.cast(),
+    bufferIndex,
+    bufferObject.cast(),
+  );
+  return result;
+}
+
+void VertexBuffer_setBufferObjectAtRenderThread(
+  Pointer<TEngine> tEngine,
+  Pointer<TVertexBuffer> tBuffer,
+  int bufferIndex,
+  Pointer<TBufferObject> tBufferObject,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._VertexBuffer_setBufferObjectAtRenderThread(
+    tEngine.cast(),
+    tBuffer.cast(),
+    bufferIndex,
+    tBufferObject.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+TAmbientOcclusionOptions View_getAmbientOcclusionOptions(Pointer<TView> tView) {
+  final TAmbientOcclusionOptions_out = TAmbientOcclusionOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getAmbientOcclusionOptions(
+    TAmbientOcclusionOptions_out.cast(),
+    tView.cast(),
+  );
+  return TAmbientOcclusionOptions_out.toDart();
+}
+
+Pointer<TCamera> View_getCamera(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getCamera(tView.cast());
+  return Pointer<TCamera>(result);
+}
+
+Pointer<TColorGrading> View_getColorGrading(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getColorGrading(tView.cast());
+  return Pointer<TColorGrading>(result);
+}
+
+TFogOptions View_getFogOptions(Pointer<TView> tView) {
+  final TFogOptions_out = TFogOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getFogOptions(TFogOptions_out.cast(), tView.cast());
+  return TFogOptions_out.toDart();
+}
+
+Pointer<Char> View_getName(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getName(tView.cast());
+  return Pointer<Char>(result);
+}
+
+void View_getNameRenderThread(Pointer<TView> tView, Pointer<NativeFunction<void Function(Pointer<Char>)>> onComplete) {
+  final result = GeneratedBindings.instance._View_getNameRenderThread(tView.cast(), onComplete.cast());
+  return result;
+}
+
+Pointer<TRenderTarget> View_getRenderTarget(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getRenderTarget(tView.cast());
+  return Pointer<TRenderTarget>(result);
+}
+
+Pointer<TScene> View_getScene(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getScene(tView.cast());
+  return Pointer<TScene>(result);
+}
+
+int View_getShadowType(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_getShadowType(tView.cast());
+  return result;
+}
+
+TSoftShadowOptions View_getSoftShadowOptions(Pointer<TView> tView) {
+  final TSoftShadowOptions_out = TSoftShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getSoftShadowOptions(TSoftShadowOptions_out.cast(), tView.cast());
+  return TSoftShadowOptions_out.toDart();
+}
+
+TViewport View_getViewport(Pointer<TView> view) {
+  final TViewport_out = TViewport.stackAlloc();
+  final result = GeneratedBindings.instance._View_getViewport(TViewport_out.cast(), view.cast());
+  return TViewport_out.toDart();
+}
+
+int View_getVisibleRenderableCount(Pointer<TView> view) {
+  final result = GeneratedBindings.instance._View_getVisibleRenderableCount(view.cast());
+  return result;
+}
+
+TVsmShadowOptions View_getVsmShadowOptions(Pointer<TView> tView) {
+  final TVsmShadowOptions_out = TVsmShadowOptions.stackAlloc();
+  final result = GeneratedBindings.instance._View_getVsmShadowOptions(TVsmShadowOptions_out.cast(), tView.cast());
+  return TVsmShadowOptions_out.toDart();
+}
+
+bool View_isDitheringEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isDitheringEnabled(tView.cast());
+  return result == 1;
+}
+
+bool View_isStencilBufferEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isStencilBufferEnabled(tView.cast());
+  return result == 1;
+}
+
+bool View_isTransparentPickingEnabled(Pointer<TView> tView) {
+  final result = GeneratedBindings.instance._View_isTransparentPickingEnabled(tView.cast());
+  return result == 1;
+}
+
+void View_pick(Pointer<TView> tView, int requestId, int x, int y, DartPickCallback callback) {
+  final result = GeneratedBindings.instance._View_pick(
+    tView.cast(),
+    requestId,
+    x,
+    y,
+    callback as Pointer<NativeFunction<PickCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_pickRenderThread(Pointer<TView> tView, int requestId, int x, int y, DartPickCallback callback) {
+  final result = GeneratedBindings.instance._View_pickRenderThread(
+    tView.cast(),
+    requestId,
+    x,
+    y,
+    callback as Pointer<NativeFunction<PickCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setAmbientOcclusionOptions(Pointer<TView> tView, TAmbientOcclusionOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setAmbientOcclusionOptions(tView.cast(), optionsPtr.cast());
+  return result;
+}
+
+void View_setAmbientOcclusionOptionsRenderThread(
+  Pointer<TView> tView,
+  TAmbientOcclusionOptions options,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setAmbientOcclusionOptionsRenderThread(
+    tView.cast(),
+    optionsPtr.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setAntiAliasing(Pointer<TView> tView, bool msaa, bool fxaa, bool taa) {
+  final result = GeneratedBindings.instance._View_setAntiAliasing(tView.cast(), msaa, fxaa, taa);
+  return result;
+}
+
+void View_setAntiAliasingRenderThread(
+  Pointer<TView> tView,
+  bool msaa,
+  bool fxaa,
+  bool taa,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setAntiAliasingRenderThread(
+    tView.cast(),
+    msaa,
+    fxaa,
+    taa,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setBlendMode(Pointer<TView> view, int blendMode) {
+  final result = GeneratedBindings.instance._View_setBlendMode(view.cast(), blendMode);
+  return result;
+}
+
+void View_setBlendModeRenderThread(Pointer<TView> tView, int blendMode, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._View_setBlendModeRenderThread(
+    tView.cast(),
+    blendMode,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setBloom(Pointer<TView> tView, bool enabled, double strength) {
+  final result = GeneratedBindings.instance._View_setBloom(tView.cast(), enabled, strength);
+  return result;
+}
+
+void View_setBloomRenderThread(
+  Pointer<TView> tView,
+  bool enabled,
+  double strength,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setBloomRenderThread(
+    tView.cast(),
+    enabled,
+    strength,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setCamera(Pointer<TView> tView, Pointer<TCamera> tCamera) {
+  final result = GeneratedBindings.instance._View_setCamera(tView.cast(), tCamera.cast());
+  return result;
+}
+
+void View_setCameraRenderThread(
+  Pointer<TView> tView,
+  Pointer<TCamera> tCamera,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setCameraRenderThread(
+    tView.cast(),
+    tCamera.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setColorGrading(Pointer<TView> tView, Pointer<TColorGrading> tColorGrading) {
+  final result = GeneratedBindings.instance._View_setColorGrading(tView.cast(), tColorGrading.cast());
+  return result;
+}
+
+void View_setColorGradingRenderThread(
+  Pointer<TView> tView,
+  Pointer<TColorGrading> tColorGrading,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setColorGradingRenderThread(
+    tView.cast(),
+    tColorGrading.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setDitheringEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setDitheringEnabled(tView.cast(), enabled);
+  return result;
+}
+
+void View_setDitheringEnabledRenderThread(
+  Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setDitheringEnabledRenderThread(
+    tView.cast(),
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setFogOptions(Pointer<TView> tView, TFogOptions tFogOptions) {
+  final tFogOptionsPtr = tFogOptions.address;
+  final result = GeneratedBindings.instance._View_setFogOptions(tView.cast(), tFogOptionsPtr.cast());
+  return result;
+}
+
+void View_setFogOptionsRenderThread(
+  Pointer<TView> tView,
+  TFogOptions tFogOptions,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final tFogOptionsPtr = tFogOptions.address;
+  final result = GeneratedBindings.instance._View_setFogOptionsRenderThread(
+    tView.cast(),
+    tFogOptionsPtr.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setFrontFaceWindingInverted(Pointer<TView> tView, bool inverted) {
+  final result = GeneratedBindings.instance._View_setFrontFaceWindingInverted(tView.cast(), inverted);
+  return result;
+}
+
+void View_setFrontFaceWindingInvertedRenderThread(
+  Pointer<TView> tView,
+  bool inverted,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setFrontFaceWindingInvertedRenderThread(
+    tView.cast(),
+    inverted,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setFrustumCullingEnabled(Pointer<TView> view, bool enabled) {
+  final result = GeneratedBindings.instance._View_setFrustumCullingEnabled(view.cast(), enabled);
+  return result;
+}
+
+void View_setFrustumCullingEnabledRenderThread(
+  Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setFrustumCullingEnabledRenderThread(
+    tView.cast(),
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setLayerEnabled(Pointer<TView> tView, int layer, bool visible) {
+  final result = GeneratedBindings.instance._View_setLayerEnabled(tView.cast(), layer, visible);
+  return result;
+}
+
+void View_setLayerEnabledRenderThread(
+  Pointer<TView> tView,
+  int layer,
+  bool visible,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setLayerEnabledRenderThread(
+    tView.cast(),
+    layer,
+    visible,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setName(Pointer<TView> tView, Pointer<Char> name) {
+  final result = GeneratedBindings.instance._View_setName(tView.cast(), name);
+  return result;
+}
+
+void View_setNameRenderThread(Pointer<TView> tView, Pointer<Char> name, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._View_setNameRenderThread(
+    tView.cast(),
+    name,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setPostProcessing(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setPostProcessing(tView.cast(), enabled);
+  return result;
+}
+
+void View_setPostProcessingRenderThread(
+  Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setPostProcessingRenderThread(
+    tView.cast(),
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setRenderQuality(Pointer<TView> tView, int qualityLevel) {
+  final result = GeneratedBindings.instance._View_setRenderQuality(tView.cast(), qualityLevel);
+  return result;
+}
+
+void View_setRenderQualityRenderThread(
+  Pointer<TView> tView,
+  int qualityLevel,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setRenderQualityRenderThread(
+    tView.cast(),
+    qualityLevel,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setRenderTarget(Pointer<TView> view, Pointer<TRenderTarget> renderTarget) {
+  final result = GeneratedBindings.instance._View_setRenderTarget(view.cast(), renderTarget.cast());
+  return result;
+}
+
+void View_setRenderTargetRenderThread(
+  Pointer<TView> tView,
+  Pointer<TRenderTarget> tRenderTarget,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setRenderTargetRenderThread(
+    tView.cast(),
+    tRenderTarget.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setScene(Pointer<TView> tView, Pointer<TScene> tScene) {
+  final result = GeneratedBindings.instance._View_setScene(tView.cast(), tScene.cast());
+  return result;
+}
+
+void View_setSceneRenderThread(
+  Pointer<TView> tView,
+  Pointer<TScene> tScene,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setSceneRenderThread(
+    tView.cast(),
+    tScene.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setShadowType(Pointer<TView> tView, int shadowType) {
+  final result = GeneratedBindings.instance._View_setShadowType(tView.cast(), shadowType);
+  return result;
+}
+
+void View_setShadowTypeRenderThread(Pointer<TView> tView, int shadowType, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._View_setShadowTypeRenderThread(
+    tView.cast(),
+    shadowType,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setShadowsEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setShadowsEnabled(tView.cast(), enabled);
+  return result;
+}
+
+void View_setShadowsEnabledRenderThread(
+  Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setShadowsEnabledRenderThread(
+    tView.cast(),
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setSoftShadowOptions(Pointer<TView> tView, TSoftShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setSoftShadowOptions(tView.cast(), optionsPtr.cast());
+  return result;
+}
+
+void View_setSoftShadowOptionsRenderThread(
+  Pointer<TView> tView,
+  TSoftShadowOptions options,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setSoftShadowOptionsRenderThread(
+    tView.cast(),
+    optionsPtr.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setStencilBufferEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setStencilBufferEnabled(tView.cast(), enabled);
+  return result;
+}
+
+void View_setStencilBufferEnabledRenderThread(
+  Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setStencilBufferEnabledRenderThread(
+    tView.cast(),
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setTransparentPickingEnabled(Pointer<TView> tView, bool enabled) {
+  final result = GeneratedBindings.instance._View_setTransparentPickingEnabled(tView.cast(), enabled);
+  return result;
+}
+
+void View_setTransparentPickingEnabledRenderThread(
+  Pointer<TView> tView,
+  bool enabled,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setTransparentPickingEnabledRenderThread(
+    tView.cast(),
+    enabled,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setViewport(Pointer<TView> view, int width, int height) {
+  final result = GeneratedBindings.instance._View_setViewport(view.cast(), width, height);
+  return result;
+}
+
+void View_setViewportRenderThread(
+  Pointer<TView> tView,
+  int width,
+  int height,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final result = GeneratedBindings.instance._View_setViewportRenderThread(
+    tView.cast(),
+    width,
+    height,
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+void View_setVsmShadowOptions(Pointer<TView> tView, TVsmShadowOptions options) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setVsmShadowOptions(tView.cast(), optionsPtr.cast());
+  return result;
+}
+
+void View_setVsmShadowOptionsRenderThread(
+  Pointer<TView> tView,
+  TVsmShadowOptions options,
+  int requestId,
+  DartVoidCallback onComplete,
+) {
+  final optionsPtr = options.address;
+  final result = GeneratedBindings.instance._View_setVsmShadowOptionsRenderThread(
+    tView.cast(),
+    optionsPtr.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
+  return result;
+}
+
+extension Aabb3Ext on Pointer<Aabb3> {
+  Aabb3 toDart() {
+    return Aabb3(this);
   }
 }
 
-final class TViewport extends Struct {
-  Pointer<TViewport> get address => super.address.cast();
-  int get left {
-    final addr = Pointer<TViewport>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set left(int val) {
-    NativeLibrary.instance.setValue(Pointer<TViewport>(this.address.addr + 0), val.toJS, 'i32');
-  }
-
-  int get bottom {
-    final addr = Pointer<TViewport>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set bottom(int val) {
-    NativeLibrary.instance.setValue(Pointer<TViewport>(this.address.addr + 4), val.toJS, 'i32');
-  }
-
-  int get width {
-    final addr = Pointer<TViewport>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set width(int val) {
-    NativeLibrary.instance.setValue(Pointer<TViewport>(this.address.addr + 8), val.toJS, 'i32');
-  }
-
-  int get height {
-    final addr = Pointer<TViewport>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
-    return value;
-  }
-
-  set height(int val) {
-    NativeLibrary.instance.setValue(Pointer<TViewport>(this.address.addr + 12), val.toJS, 'i32');
-  }
-
-  TViewport(super.address);
-
-  static Pointer<TViewport> stackAlloc() {
-    return Pointer<TViewport>(NativeLibrary.instance.stackAlloc<TViewport>(16));
-  }
-}
-
-extension TViewExt on Pointer<TView> {
-  TView toDart() {
-    return TView(this);
-  }
-}
-
-final class TView extends Struct {
-  Pointer<TView> get address => super.address.cast();
-  TView(super.address);
-
-  static Pointer<TView> stackAlloc() {
-    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
-  }
-}
-
-extension TToneMapperExt on Pointer<TToneMapper> {
-  TToneMapper toDart() {
-    return TToneMapper(this);
-  }
-}
-
-final class TToneMapper extends Struct {
-  Pointer<TToneMapper> get address => super.address.cast();
-  TToneMapper(super.address);
-
-  static Pointer<TToneMapper> stackAlloc() {
-    return Pointer<TToneMapper>(NativeLibrary.instance.stackAlloc<TToneMapper>(0));
-  }
-}
-
-extension TEngineExt on Pointer<TEngine> {
-  TEngine toDart() {
-    return TEngine(this);
-  }
-}
-
-final class TEngine extends Struct {
-  Pointer<TEngine> get address => super.address.cast();
-  TEngine(super.address);
-
-  static Pointer<TEngine> stackAlloc() {
-    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
-  }
-}
-
-extension TColorGradingBuilderExt on Pointer<TColorGradingBuilder> {
-  TColorGradingBuilder toDart() {
-    return TColorGradingBuilder(this);
-  }
-}
-
-final class TColorGradingBuilder extends Struct {
-  Pointer<TColorGradingBuilder> get address => super.address.cast();
-  TColorGradingBuilder(super.address);
-
-  static Pointer<TColorGradingBuilder> stackAlloc() {
-    return Pointer<TColorGradingBuilder>(NativeLibrary.instance.stackAlloc<TColorGradingBuilder>(0));
-  }
-}
-
-extension TColorGradingExt on Pointer<TColorGrading> {
-  TColorGrading toDart() {
-    return TColorGrading(this);
-  }
-}
-
-final class TColorGrading extends Struct {
-  Pointer<TColorGrading> get address => super.address.cast();
-  TColorGrading(super.address);
-
-  static Pointer<TColorGrading> stackAlloc() {
-    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
-  }
-}
-
-sealed class TQualityLevel {
-  static const LOW = 0;
-  static const MEDIUM = 1;
-  static const HIGH = 2;
-  static const ULTRA = 3;
-}
-
-sealed class TLutFormat {
-  static const INTEGER = 0;
-  static const FLOAT = 1;
-}
-
-sealed class TBlendMode {
-  static const OPAQUE = 0;
-  static const TRANSLUCENT = 1;
-}
-
-extension TRenderTargetExt on Pointer<TRenderTarget> {
-  TRenderTarget toDart() {
-    return TRenderTarget(this);
-  }
-}
-
-final class TRenderTarget extends Struct {
-  Pointer<TRenderTarget> get address => super.address.cast();
-  TRenderTarget(super.address);
-
-  static Pointer<TRenderTarget> stackAlloc() {
-    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
-  }
-}
-
-/// Options for DPCF and PCSS Shadowing.
-
-extension TSoftShadowOptionsExt on Pointer<TSoftShadowOptions> {
-  TSoftShadowOptions toDart() {
-    return TSoftShadowOptions(this);
-  }
-}
-
-final class TSoftShadowOptions extends Struct {
-  Pointer<TSoftShadowOptions> get address => super.address.cast();
-  double get penumbraScale {
-    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 0);
+final class Aabb3 extends Struct {
+  Pointer<Aabb3> get address => super.address.cast();
+  double get centerX {
+    final addr = Pointer<Aabb3>(this.address.addr + 0);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set penumbraScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 0), val.toJS, 'float');
+  set centerX(double val) {
+    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 0), val.toJS, 'float');
   }
 
-  double get penumbraRatioScale {
-    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 4);
+  double get centerY {
+    final addr = Pointer<Aabb3>(this.address.addr + 4);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set penumbraRatioScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 4), val.toJS, 'float');
+  set centerY(double val) {
+    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 4), val.toJS, 'float');
   }
 
-  double get maxPenumbraRatio {
-    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 8);
+  double get centerZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 8);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set maxPenumbraRatio(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 8), val.toJS, 'float');
+  set centerZ(double val) {
+    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 8), val.toJS, 'float');
   }
 
-  double get maxSearchRadius {
-    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 12);
+  double get halfExtentX {
+    final addr = Pointer<Aabb3>(this.address.addr + 12);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set maxSearchRadius(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 12), val.toJS, 'float');
+  set halfExtentX(double val) {
+    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 12), val.toJS, 'float');
   }
 
-  TSoftShadowOptions(super.address);
-
-  static Pointer<TSoftShadowOptions> stackAlloc() {
-    return Pointer<TSoftShadowOptions>(NativeLibrary.instance.stackAlloc<TSoftShadowOptions>(16));
-  }
-}
-
-/// Options for VSM Shadowing.
-
-extension TVsmShadowOptionsExt on Pointer<TVsmShadowOptions> {
-  TVsmShadowOptions toDart() {
-    return TVsmShadowOptions(this);
-  }
-}
-
-final class TVsmShadowOptions extends Struct {
-  Pointer<TVsmShadowOptions> get address => super.address.cast();
-  int get anisotropy {
-    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set anisotropy(int val) {
-    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 0), val.toJS, 'i8');
-  }
-
-  bool get mipmapping {
-    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 1);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set mipmapping(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 1), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  int get msaaSamples {
-    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 2);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set msaaSamples(int val) {
-    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 2), val.toJS, 'i8');
-  }
-
-  bool get highPrecision {
-    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 3);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set highPrecision(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 3), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  double get minVarianceScale {
-    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 4);
+  double get halfExtentY {
+    final addr = Pointer<Aabb3>(this.address.addr + 16);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set minVarianceScale(double val) {
-    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 4), val.toJS, 'float');
+  set halfExtentY(double val) {
+    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 16), val.toJS, 'float');
   }
 
-  double get lightBleedReduction {
-    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 8);
+  double get halfExtentZ {
+    final addr = Pointer<Aabb3>(this.address.addr + 20);
     final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
     return value;
   }
 
-  set lightBleedReduction(double val) {
-    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 8), val.toJS, 'float');
+  set halfExtentZ(double val) {
+    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 20), val.toJS, 'float');
   }
 
-  TVsmShadowOptions(super.address);
+  Aabb3(super.address);
 
-  static Pointer<TVsmShadowOptions> stackAlloc() {
-    return Pointer<TVsmShadowOptions>(NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
-  }
-}
-
-extension TCameraExt on Pointer<TCamera> {
-  TCamera toDart() {
-    return TCamera(this);
+  static Pointer<Aabb3> stackAlloc() {
+    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
   }
 }
 
-final class TCamera extends Struct {
-  Pointer<TCamera> get address => super.address.cast();
-  TCamera(super.address);
+typedef EntityId = int;
+typedef DartEntityId = int;
+typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
+typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
+typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
+typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
+typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
+typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
 
-  static Pointer<TCamera> stackAlloc() {
-    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
-  }
-}
+const int JUMP_INTENT_MASK = 4;
 
-extension TSceneExt on Pointer<TScene> {
-  TScene toDart() {
-    return TScene(this);
-  }
-}
+const int MAX_CUSTOM_INTENTS = 16;
 
-final class TScene extends Struct {
-  Pointer<TScene> get address => super.address.cast();
-  TScene(super.address);
+const int MOVEMENT_INTENT_MASK = 1;
 
-  static Pointer<TScene> stackAlloc() {
-    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
-  }
-}
+typedef PickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
+typedef DartPickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
+typedef PickCallbackFunction =
+    void Function(int requestId, EntityId entityId, double depth, double fragX, double fragY, double fragZ);
+typedef DartPickCallbackFunction =
+    void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
+
+const int ROTATION_INTENT_MASK = 2;
+
+const int SPRINT_INTENT_MASK = 8;
 
 /// Options for ambient occlusion, Screen Space Cone Tracing (SSCT), and GTAO
 
@@ -9669,244 +9446,221 @@ final class TAmbientOcclusionOptions extends Struct {
   }
 }
 
-/// Screen Space Cone Tracing (SSCT) options
-/// Ambient shadows from dominant light
-
-extension TSsctExt on Pointer<TSsct> {
-  TSsct toDart() {
-    return TSsct(this);
-  }
-}
-
-final class TSsct extends Struct {
-  Pointer<TSsct> get address => super.address.cast();
-
-  /// !< full cone angle in radian, between 0 and pi/2
-  double get lightConeRad {
-    final addr = Pointer<TSsct>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set lightConeRad(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 0), val.toJS, 'float');
-  }
-
-  /// !< how far shadows can be cast
-  double get shadowDistance {
-    final addr = Pointer<TSsct>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set shadowDistance(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 4), val.toJS, 'float');
-  }
-
-  /// !< max distance for contact
-  double get contactDistanceMax {
-    final addr = Pointer<TSsct>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set contactDistanceMax(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 8), val.toJS, 'float');
-  }
-
-  /// !< intensity
-  double get intensity {
-    final addr = Pointer<TSsct>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set intensity(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 12), val.toJS, 'float');
-  }
-
-  /// !< light direction X
-  double get lightDirectionX {
-    final addr = Pointer<TSsct>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set lightDirectionX(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 16), val.toJS, 'float');
-  }
-
-  /// !< light direction Y
-  double get lightDirectionY {
-    final addr = Pointer<TSsct>(this.address.addr + 20);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set lightDirectionY(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 20), val.toJS, 'float');
-  }
-
-  /// !< light direction Z
-  double get lightDirectionZ {
-    final addr = Pointer<TSsct>(this.address.addr + 24);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set lightDirectionZ(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 24), val.toJS, 'float');
-  }
-
-  /// !< depth bias in world units (mitigate self shadowing)
-  double get depthBias {
-    final addr = Pointer<TSsct>(this.address.addr + 28);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set depthBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 28), val.toJS, 'float');
-  }
-
-  /// !< depth slope bias (mitigate self shadowing)
-  double get depthSlopeBias {
-    final addr = Pointer<TSsct>(this.address.addr + 32);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set depthSlopeBias(double val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 32), val.toJS, 'float');
-  }
-
-  /// !< tracing sample count, between 1 and 255
-  int get sampleCount {
-    final addr = Pointer<TSsct>(this.address.addr + 36);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set sampleCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 36), val.toJS, 'i8');
-  }
-
-  /// !< # of rays to trace, between 1 and 255
-  int get rayCount {
-    final addr = Pointer<TSsct>(this.address.addr + 37);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set rayCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 37), val.toJS, 'i8');
-  }
-
-  /// !< enables or disables SSCT
-  bool get enabled {
-    final addr = Pointer<TSsct>(this.address.addr + 38);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set enabled(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  TSsct(super.address);
-
-  static Pointer<TSsct> stackAlloc() {
-    return Pointer<TSsct>(NativeLibrary.instance.stackAlloc<TSsct>(39));
-  }
-}
-
-/// Ground Truth-based Ambient Occlusion (GTAO) options
-
-extension TGtaoExt on Pointer<TGtao> {
-  TGtao toDart() {
-    return TGtao(this);
-  }
-}
-
-final class TGtao extends Struct {
-  Pointer<TGtao> get address => super.address.cast();
-
-  /// !< number of slices; higher values reduce noise
-  int get sampleSliceCount {
-    final addr = Pointer<TGtao>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set sampleSliceCount(int val) {
-    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 0), val.toJS, 'i8');
-  }
-
-  /// !< integration steps per slice; higher values reduce bias
-  int get sampleStepsPerSlice {
-    final addr = Pointer<TGtao>(this.address.addr + 1);
-    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
-    return value;
-  }
-
-  set sampleStepsPerSlice(int val) {
-    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 1), val.toJS, 'i8');
-  }
-
-  /// !< ignored when visibility bitmasks are enabled
-  double get thicknessHeuristic {
-    final addr = Pointer<TGtao>(this.address.addr + 2);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set thicknessHeuristic(double val) {
-    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 2), val.toJS, 'float');
-  }
-
-  /// !< enables visibility bitmasks mode
-  bool get useVisibilityBitmasks {
-    final addr = Pointer<TGtao>(this.address.addr + 6);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set useVisibilityBitmasks(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 6), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  /// !< world-space thickness used by visibility bitmasks
-  double get constThickness {
-    final addr = Pointer<TGtao>(this.address.addr + 7);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set constThickness(double val) {
-    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 7), val.toJS, 'float');
-  }
-
-  /// !< increases thickness with distance
-  bool get linearThickness {
-    final addr = Pointer<TGtao>(this.address.addr + 11);
-    final value = NativeLibrary.instance.getValue(addr, 'i8');
-    return value.toDartInt == 1;
-  }
-
-  set linearThickness(bool val) {
-    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 11), (val ? 1 : 0).toJS, 'i8');
-  }
-
-  TGtao(super.address);
-
-  static Pointer<TGtao> stackAlloc() {
-    return Pointer<TGtao>(NativeLibrary.instance.stackAlloc<TGtao>(12));
-  }
-}
-
 sealed class TAmbientOcclusionType {
   static const SAO = 0;
   static const GTAO = 1;
+}
+
+extension TAnimationManagerExt on Pointer<TAnimationManager> {
+  TAnimationManager toDart() {
+    return TAnimationManager(this);
+  }
+}
+
+final class TAnimationManager extends Struct {
+  Pointer<TAnimationManager> get address => super.address.cast();
+  TAnimationManager(super.address);
+
+  static Pointer<TAnimationManager> stackAlloc() {
+    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+  }
+}
+
+sealed class TBackend {
+  /// !< Automatically selects an appropriate driver for the platform.
+  static const BACKEND_DEFAULT = 0;
+
+  /// !< Selects the OpenGL/ES driver (default on Android)
+  static const BACKEND_OPENGL = 1;
+
+  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+  static const BACKEND_VULKAN = 2;
+
+  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
+  static const BACKEND_METAL = 3;
+
+  /// !< Selects the no-op driver for testing purposes.
+  static const BACKEND_NOOP = 4;
+}
+
+sealed class TBlendMode {
+  static const OPAQUE = 0;
+  static const TRANSLUCENT = 1;
+}
+
+sealed class TBlendingMode {
+  static const BLENDING_MODE_OPAQUE = 0;
+  static const BLENDING_MODE_TRANSPARENT = 1;
+  static const BLENDING_MODE_ADD = 2;
+  static const BLENDING_MODE_MASKED = 3;
+  static const BLENDING_MODE_FADE = 4;
+  static const BLENDING_MODE_MULTIPLY = 5;
+  static const BLENDING_MODE_SCREEN = 6;
+  static const BLENDING_MODE_CUSTOM = 7;
+}
+
+extension TBufferObjectExt on Pointer<TBufferObject> {
+  TBufferObject toDart() {
+    return TBufferObject(this);
+  }
+}
+
+final class TBufferObject extends Struct {
+  Pointer<TBufferObject> get address => super.address.cast();
+  TBufferObject(super.address);
+
+  static Pointer<TBufferObject> stackAlloc() {
+    return Pointer<TBufferObject>(NativeLibrary.instance.stackAlloc<TBufferObject>(0));
+  }
+}
+
+extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
+  TBufferObjectBuilder toDart() {
+    return TBufferObjectBuilder(this);
+  }
+}
+
+final class TBufferObjectBuilder extends Struct {
+  Pointer<TBufferObjectBuilder> get address => super.address.cast();
+  TBufferObjectBuilder(super.address);
+
+  static Pointer<TBufferObjectBuilder> stackAlloc() {
+    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
+  }
+}
+
+extension TCameraExt on Pointer<TCamera> {
+  TCamera toDart() {
+    return TCamera(this);
+  }
+}
+
+final class TCamera extends Struct {
+  Pointer<TCamera> get address => super.address.cast();
+  TCamera(super.address);
+
+  static Pointer<TCamera> stackAlloc() {
+    return Pointer<TCamera>(NativeLibrary.instance.stackAlloc<TCamera>(0));
+  }
+}
+
+extension TColorGradingExt on Pointer<TColorGrading> {
+  TColorGrading toDart() {
+    return TColorGrading(this);
+  }
+}
+
+final class TColorGrading extends Struct {
+  Pointer<TColorGrading> get address => super.address.cast();
+  TColorGrading(super.address);
+
+  static Pointer<TColorGrading> stackAlloc() {
+    return Pointer<TColorGrading>(NativeLibrary.instance.stackAlloc<TColorGrading>(0));
+  }
+}
+
+extension TColorGradingBuilderExt on Pointer<TColorGradingBuilder> {
+  TColorGradingBuilder toDart() {
+    return TColorGradingBuilder(this);
+  }
+}
+
+final class TColorGradingBuilder extends Struct {
+  Pointer<TColorGradingBuilder> get address => super.address.cast();
+  TColorGradingBuilder(super.address);
+
+  static Pointer<TColorGradingBuilder> stackAlloc() {
+    return Pointer<TColorGradingBuilder>(NativeLibrary.instance.stackAlloc<TColorGradingBuilder>(0));
+  }
+}
+
+sealed class TCullingMode {
+  static const CULLING_MODE_NONE = 0;
+  static const CULLING_MODE_FRONT = 1;
+  static const CULLING_MODE_BACK = 2;
+  static const CULLING_MODE_FRONT_AND_BACK = 3;
+}
+
+extension TDebugRegistryExt on Pointer<TDebugRegistry> {
+  TDebugRegistry toDart() {
+    return TDebugRegistry(this);
+  }
+}
+
+final class TDebugRegistry extends Struct {
+  Pointer<TDebugRegistry> get address => super.address.cast();
+  TDebugRegistry(super.address);
+
+  static Pointer<TDebugRegistry> stackAlloc() {
+    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
+  }
+}
+
+extension TEngineExt on Pointer<TEngine> {
+  TEngine toDart() {
+    return TEngine(this);
+  }
+}
+
+final class TEngine extends Struct {
+  Pointer<TEngine> get address => super.address.cast();
+  TEngine(super.address);
+
+  static Pointer<TEngine> stackAlloc() {
+    return Pointer<TEngine>(NativeLibrary.instance.stackAlloc<TEngine>(0));
+  }
+}
+
+extension TEntityManagerExt on Pointer<TEntityManager> {
+  TEntityManager toDart() {
+    return TEntityManager(this);
+  }
+}
+
+final class TEntityManager extends Struct {
+  Pointer<TEntityManager> get address => super.address.cast();
+  TEntityManager(super.address);
+
+  static Pointer<TEntityManager> stackAlloc() {
+    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  }
+}
+
+sealed class TFeatureLevel {
+  static const FEATURE_LEVEL_0 = 0;
+  static const FEATURE_LEVEL_1 = 1;
+  static const FEATURE_LEVEL_2 = 2;
+  static const FEATURE_LEVEL_3 = 3;
+}
+
+extension TFenceExt on Pointer<TFence> {
+  TFence toDart() {
+    return TFence(this);
+  }
+}
+
+final class TFence extends Struct {
+  Pointer<TFence> get address => super.address.cast();
+  TFence(super.address);
+
+  static Pointer<TFence> stackAlloc() {
+    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  }
+}
+
+extension TFilamentAssetExt on Pointer<TFilamentAsset> {
+  TFilamentAsset toDart() {
+    return TFilamentAsset(this);
+  }
+}
+
+final class TFilamentAsset extends Struct {
+  Pointer<TFilamentAsset> get address => super.address.cast();
+  TFilamentAsset(super.address);
+
+  static Pointer<TFilamentAsset> stackAlloc() {
+    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
+  }
 }
 
 /// Copied from FogOptions in View.h
@@ -10066,38 +9820,6 @@ final class TFogOptions extends Struct {
   }
 }
 
-extension TTextureExt on Pointer<TTexture> {
-  TTexture toDart() {
-    return TTexture(this);
-  }
-}
-
-final class TTexture extends Struct {
-  Pointer<TTexture> get address => super.address.cast();
-  TTexture(super.address);
-
-  static Pointer<TTexture> stackAlloc() {
-    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
-  }
-}
-
-typedef PickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
-typedef DartPickCallback = Pointer<NativeFunction<PickCallbackFunction>>;
-typedef PickCallbackFunction =
-    void Function(int requestId, EntityId entityId, double depth, double fragX, double fragY, double fragZ);
-typedef DartPickCallbackFunction =
-    void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
-typedef EntityId = int;
-typedef DartEntityId = int;
-
-sealed class TGizmoPickResultType {
-  static const AxisX = 0;
-  static const AxisY = 1;
-  static const AxisZ = 2;
-  static const Parent = 3;
-  static const None = 4;
-}
-
 extension TGizmoExt on Pointer<TGizmo> {
   TGizmo toDart() {
     return TGizmo(this);
@@ -10111,6 +9833,25 @@ final class TGizmo extends Struct {
   static Pointer<TGizmo> stackAlloc() {
     return Pointer<TGizmo>(NativeLibrary.instance.stackAlloc<TGizmo>(0));
   }
+}
+
+sealed class TGizmoAxis {
+  static const X = 0;
+  static const Y = 1;
+  static const Z = 2;
+}
+
+sealed class TGizmoPickResultType {
+  static const AxisX = 0;
+  static const AxisY = 1;
+  static const AxisZ = 2;
+  static const Parent = 3;
+  static const None = 4;
+}
+
+sealed class TGizmoType {
+  static const GIZMO_TYPE_TRANSLATION = 0;
+  static const GIZMO_TYPE_ROTATION = 1;
 }
 
 extension TGltfAssetLoaderExt on Pointer<TGltfAssetLoader> {
@@ -10143,191 +9884,87 @@ final class TGltfResourceLoader extends Struct {
   }
 }
 
-extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
-  TNameComponentManager toDart() {
-    return TNameComponentManager(this);
+/// Ground Truth-based Ambient Occlusion (GTAO) options
+
+extension TGtaoExt on Pointer<TGtao> {
+  TGtao toDart() {
+    return TGtao(this);
   }
 }
 
-final class TNameComponentManager extends Struct {
-  Pointer<TNameComponentManager> get address => super.address.cast();
-  TNameComponentManager(super.address);
+final class TGtao extends Struct {
+  Pointer<TGtao> get address => super.address.cast();
 
-  static Pointer<TNameComponentManager> stackAlloc() {
-    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
+  /// !< number of slices; higher values reduce noise
+  int get sampleSliceCount {
+    final addr = Pointer<TGtao>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
   }
-}
 
-extension TMaterialExt on Pointer<TMaterial> {
-  TMaterial toDart() {
-    return TMaterial(this);
+  set sampleSliceCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 0), val.toJS, 'i8');
   }
-}
 
-final class TMaterial extends Struct {
-  Pointer<TMaterial> get address => super.address.cast();
-  TMaterial(super.address);
-
-  static Pointer<TMaterial> stackAlloc() {
-    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  /// !< integration steps per slice; higher values reduce bias
+  int get sampleStepsPerSlice {
+    final addr = Pointer<TGtao>(this.address.addr + 1);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
   }
-}
 
-sealed class TGizmoType {
-  static const GIZMO_TYPE_TRANSLATION = 0;
-  static const GIZMO_TYPE_ROTATION = 1;
-}
-
-typedef GizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef DartGizmoPickCallback = Pointer<NativeFunction<GizmoPickCallbackFunction>>;
-typedef GizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-typedef DartGizmoPickCallbackFunction = void Function(int resultType, double x, double y, double z);
-
-sealed class TGizmoAxis {
-  static const X = 0;
-  static const Y = 1;
-  static const Z = 2;
-}
-
-extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
-  TMaterialInstance toDart() {
-    return TMaterialInstance(this);
+  set sampleStepsPerSlice(int val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 1), val.toJS, 'i8');
   }
-}
 
-final class TMaterialInstance extends Struct {
-  Pointer<TMaterialInstance> get address => super.address.cast();
-  TMaterialInstance(super.address);
-
-  static Pointer<TMaterialInstance> stackAlloc() {
-    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
+  /// !< ignored when visibility bitmasks are enabled
+  double get thicknessHeuristic {
+    final addr = Pointer<TGtao>(this.address.addr + 2);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
   }
-}
 
-sealed class TFeatureLevel {
-  static const FEATURE_LEVEL_0 = 0;
-  static const FEATURE_LEVEL_1 = 1;
-  static const FEATURE_LEVEL_2 = 2;
-  static const FEATURE_LEVEL_3 = 3;
-}
-
-sealed class TCullingMode {
-  static const CULLING_MODE_NONE = 0;
-  static const CULLING_MODE_FRONT = 1;
-  static const CULLING_MODE_BACK = 2;
-  static const CULLING_MODE_FRONT_AND_BACK = 3;
-}
-
-extension TTextureSamplerExt on Pointer<TTextureSampler> {
-  TTextureSampler toDart() {
-    return TTextureSampler(this);
+  set thicknessHeuristic(double val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 2), val.toJS, 'float');
   }
-}
 
-final class TTextureSampler extends Struct {
-  Pointer<TTextureSampler> get address => super.address.cast();
-  TTextureSampler(super.address);
-
-  static Pointer<TTextureSampler> stackAlloc() {
-    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
+  /// !< enables visibility bitmasks mode
+  bool get useVisibilityBitmasks {
+    final addr = Pointer<TGtao>(this.address.addr + 6);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
   }
-}
 
-sealed class TSamplerCompareFunc {
-  /// !< Less or equal
-  static const LE = 0;
-
-  /// !< Greater or equal
-  static const GE = 1;
-
-  /// !< Strictly less than
-  static const L = 2;
-
-  /// !< Strictly greater than
-  static const G = 3;
-
-  /// !< Equal
-  static const E = 4;
-
-  /// !< Not equal
-  static const NE = 5;
-
-  /// !< Always. Depth / stencil testing is deactivated.
-  static const A = 6;
-
-  /// !< Never. The depth / stencil test always fails.
-  static const N = 7;
-}
-
-sealed class TStencilOperation {
-  static const KEEP = 0;
-  static const ZERO = 1;
-  static const REPLACE = 2;
-  static const INCR = 3;
-  static const INCR_WRAP = 4;
-  static const DECR = 5;
-  static const DECR_WRAP = 6;
-  static const INVERT = 7;
-}
-
-sealed class TStencilFace {
-  static const STENCIL_FACE_FRONT = 1;
-  static const STENCIL_FACE_BACK = 2;
-  static const STENCIL_FACE_FRONT_AND_BACK = 3;
-}
-
-sealed class TTransparencyMode {
-  /// ! the transparent object is drawn honoring the raster state
-  static const DEFAULT = 0;
-
-  /// the transparent object is first drawn in the depth buffer,
-  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
-  static const TWO_PASSES_ONE_SIDE = 1;
-
-  /// the transparent object is drawn twice in the color buffer,
-  /// first with back faces only, then with front faces; the culling
-  /// mode is ignored. Can be combined with two-sided lighting
-  static const TWO_PASSES_TWO_SIDES = 2;
-}
-
-sealed class TBlendingMode {
-  static const BLENDING_MODE_OPAQUE = 0;
-  static const BLENDING_MODE_TRANSPARENT = 1;
-  static const BLENDING_MODE_ADD = 2;
-  static const BLENDING_MODE_MASKED = 3;
-  static const BLENDING_MODE_FADE = 4;
-  static const BLENDING_MODE_MULTIPLY = 5;
-  static const BLENDING_MODE_SCREEN = 6;
-  static const BLENDING_MODE_CUSTOM = 7;
-}
-
-extension TSceneAssetExt on Pointer<TSceneAsset> {
-  TSceneAsset toDart() {
-    return TSceneAsset(this);
+  set useVisibilityBitmasks(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 6), (val ? 1 : 0).toJS, 'i8');
   }
-}
 
-final class TSceneAsset extends Struct {
-  Pointer<TSceneAsset> get address => super.address.cast();
-  TSceneAsset(super.address);
-
-  static Pointer<TSceneAsset> stackAlloc() {
-    return Pointer<TSceneAsset>(NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
+  /// !< world-space thickness used by visibility bitmasks
+  double get constThickness {
+    final addr = Pointer<TGtao>(this.address.addr + 7);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
   }
-}
 
-extension TVertexBufferExt on Pointer<TVertexBuffer> {
-  TVertexBuffer toDart() {
-    return TVertexBuffer(this);
+  set constThickness(double val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 7), val.toJS, 'float');
   }
-}
 
-final class TVertexBuffer extends Struct {
-  Pointer<TVertexBuffer> get address => super.address.cast();
-  TVertexBuffer(super.address);
+  /// !< increases thickness with distance
+  bool get linearThickness {
+    final addr = Pointer<TGtao>(this.address.addr + 11);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
 
-  static Pointer<TVertexBuffer> stackAlloc() {
-    return Pointer<TVertexBuffer>(NativeLibrary.instance.stackAlloc<TVertexBuffer>(0));
+  set linearThickness(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TGtao>(this.address.addr + 11), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  TGtao(super.address);
+
+  static Pointer<TGtao> stackAlloc() {
+    return Pointer<TGtao>(NativeLibrary.instance.stackAlloc<TGtao>(12));
   }
 }
 
@@ -10346,235 +9983,166 @@ final class TIndexBuffer extends Struct {
   }
 }
 
-sealed class TPrimitiveType {
-  /// !< points
-  static const PRIMITIVETYPE_POINTS = 0;
-
-  /// !< lines
-  static const PRIMITIVETYPE_LINES = 1;
-
-  /// !< line strip
-  static const PRIMITIVETYPE_LINE_STRIP = 3;
-
-  /// !< triangles
-  static const PRIMITIVETYPE_TRIANGLES = 4;
-
-  /// !< triangle strip
-  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
-}
-
-sealed class TVertexBufferStorageMode {
-  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
-  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
-  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
-}
-
-extension Aabb3Ext on Pointer<Aabb3> {
-  Aabb3 toDart() {
-    return Aabb3(this);
+extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
+  TIndexBufferBuilder toDart() {
+    return TIndexBufferBuilder(this);
   }
 }
 
-final class Aabb3 extends Struct {
-  Pointer<Aabb3> get address => super.address.cast();
-  double get centerX {
-    final addr = Pointer<Aabb3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
+final class TIndexBufferBuilder extends Struct {
+  Pointer<TIndexBufferBuilder> get address => super.address.cast();
+  TIndexBufferBuilder(super.address);
 
-  set centerX(double val) {
-    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 0), val.toJS, 'float');
-  }
-
-  double get centerY {
-    final addr = Pointer<Aabb3>(this.address.addr + 4);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerY(double val) {
-    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 4), val.toJS, 'float');
-  }
-
-  double get centerZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set centerZ(double val) {
-    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 8), val.toJS, 'float');
-  }
-
-  double get halfExtentX {
-    final addr = Pointer<Aabb3>(this.address.addr + 12);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentX(double val) {
-    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 12), val.toJS, 'float');
-  }
-
-  double get halfExtentY {
-    final addr = Pointer<Aabb3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentY(double val) {
-    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 16), val.toJS, 'float');
-  }
-
-  double get halfExtentZ {
-    final addr = Pointer<Aabb3>(this.address.addr + 20);
-    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
-    return value;
-  }
-
-  set halfExtentZ(double val) {
-    NativeLibrary.instance.setValue(Pointer<Aabb3>(this.address.addr + 20), val.toJS, 'float');
-  }
-
-  Aabb3(super.address);
-
-  static Pointer<Aabb3> stackAlloc() {
-    return Pointer<Aabb3>(NativeLibrary.instance.stackAlloc<Aabb3>(24));
+  static Pointer<TIndexBufferBuilder> stackAlloc() {
+    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
   }
 }
 
-extension TFilamentAssetExt on Pointer<TFilamentAsset> {
-  TFilamentAsset toDart() {
-    return TFilamentAsset(this);
+sealed class TIndexType {
+  static const TINDEX_TYPE_USHORT = 0;
+  static const TINDEX_TYPE_UINT = 1;
+}
+
+extension TIndirectLightExt on Pointer<TIndirectLight> {
+  TIndirectLight toDart() {
+    return TIndirectLight(this);
   }
 }
 
-final class TFilamentAsset extends Struct {
-  Pointer<TFilamentAsset> get address => super.address.cast();
-  TFilamentAsset(super.address);
+final class TIndirectLight extends Struct {
+  Pointer<TIndirectLight> get address => super.address.cast();
+  TIndirectLight(super.address);
 
-  static Pointer<TFilamentAsset> stackAlloc() {
-    return Pointer<TFilamentAsset>(NativeLibrary.instance.stackAlloc<TFilamentAsset>(0));
+  static Pointer<TIndirectLight> stackAlloc() {
+    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
   }
 }
 
-sealed class TSceneAssetType {
-  static const SCENE_ASSET_TYPE_GLTF = 0;
-  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
-  static const SCENE_ASSET_TYPE_LIGHT = 2;
-  static const SCENE_ASSET_TYPE_SKYBOX = 3;
-  static const SCENE_ASSET_TYPE_IBL = 4;
-  static const SCENE_ASSET_TYPE_IMAGE = 5;
-  static const SCENE_ASSET_TYPE_GIZMO = 6;
+sealed class TIntentAction {
+  static const INTENT_ACTION_MOVE_FORWARD = 0;
+  static const INTENT_ACTION_MOVE_BACKWARD = 1;
+  static const INTENT_ACTION_MOVE_LEFT = 2;
+  static const INTENT_ACTION_MOVE_RIGHT = 3;
+  static const INTENT_ACTION_JUMP = 4;
+  static const INTENT_ACTION_SPRINT = 5;
+  static const INTENT_ACTION_CUSTOM1 = 6;
+  static const INTENT_ACTION_CUSTOM2 = 7;
+  static const INTENT_ACTION_CUSTOM3 = 8;
+  static const INTENT_ACTION_CUSTOM4 = 9;
+  static const INTENT_ACTION_CUSTOM5 = 10;
+  static const INTENT_ACTION_CUSTOM6 = 11;
+  static const INTENT_ACTION_CUSTOM7 = 12;
+  static const INTENT_ACTION_CUSTOM8 = 13;
+  static const INTENT_ACTION_CUSTOM9 = 14;
+  static const INTENT_ACTION_CUSTOM10 = 15;
+  static const INTENT_ACTION_CROUCH = 16;
+  static const INTENT_ACTION_INTERACT = 17;
+  static const INTENT_ACTION_USE_ITEM = 18;
+  static const INTENT_ACTION_RELOAD = 19;
+  static const INTENT_ACTION_ALT_FIRE = 20;
 }
 
-typedef size_t = int;
-typedef Dartsize_t = int;
-
-extension double4x4Ext on Pointer<double4x4> {
-  double4x4 toDart() {
-    return double4x4(this);
-  }
-}
-
-final class double4x4 extends Struct {
-  Pointer<double4x4> get address => super.address.cast();
-  Array<Float64> get col1 {
-    final addr = Pointer<double4x4>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 0)));
-  }
-
-  set col1(Array<Float64> val) {
-    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 0), val.internal.addr.addr.toJS, '*');
-  }
-
-  Array<Float64> get col2 {
-    final addr = Pointer<double4x4>(this.address.addr + 32);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 32)));
-  }
-
-  set col2(Array<Float64> val) {
-    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 32), val.internal.addr.addr.toJS, '*');
-  }
-
-  Array<Float64> get col3 {
-    final addr = Pointer<double4x4>(this.address.addr + 64);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 64)));
-  }
-
-  set col3(Array<Float64> val) {
-    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 64), val.internal.addr.addr.toJS, '*');
-  }
-
-  Array<Float64> get col4 {
-    final addr = Pointer<double4x4>(this.address.addr + 96);
-    final value = NativeLibrary.instance.getValue(addr, '*');
-    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 96)));
-  }
-
-  set col4(Array<Float64> val) {
-    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 96), val.internal.addr.addr.toJS, '*');
-  }
-
-  double4x4(super.address);
-
-  static Pointer<double4x4> stackAlloc() {
-    return Pointer<double4x4>(NativeLibrary.instance.stackAlloc<double4x4>(128));
+extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
+  TKtx1Bundle toDart() {
+    return TKtx1Bundle(this);
   }
 }
 
-extension double3Ext on Pointer<double3> {
-  double3 toDart() {
-    return double3(this);
+final class TKtx1Bundle extends Struct {
+  Pointer<TKtx1Bundle> get address => super.address.cast();
+  TKtx1Bundle(super.address);
+
+  static Pointer<TKtx1Bundle> stackAlloc() {
+    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
   }
 }
 
-final class double3 extends Struct {
-  Pointer<double3> get address => super.address.cast();
-  double get x {
-    final addr = Pointer<double3>(this.address.addr + 0);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set x(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
-  }
-
-  double get y {
-    final addr = Pointer<double3>(this.address.addr + 8);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set y(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
-  }
-
-  double get z {
-    final addr = Pointer<double3>(this.address.addr + 16);
-    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
-    return value;
-  }
-
-  set z(double val) {
-    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
-  }
-
-  double3(super.address);
-
-  static Pointer<double3> stackAlloc() {
-    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+extension TLightManagerExt on Pointer<TLightManager> {
+  TLightManager toDart() {
+    return TLightManager(this);
   }
 }
 
-sealed class TProjection {
-  static const Perspective = 0;
-  static const Orthographic = 1;
+final class TLightManager extends Struct {
+  Pointer<TLightManager> get address => super.address.cast();
+  TLightManager(super.address);
+
+  static Pointer<TLightManager> stackAlloc() {
+    return Pointer<TLightManager>(NativeLibrary.instance.stackAlloc<TLightManager>(0));
+  }
+}
+
+sealed class TLightType {
+  static const LIGHT_TYPE_SUN = 0;
+  static const LIGHT_TYPE_DIRECTIONAL = 1;
+  static const LIGHT_TYPE_POINT = 2;
+  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
+  static const LIGHT_TYPE_SPOT = 4;
+}
+
+extension TLinearImageExt on Pointer<TLinearImage> {
+  TLinearImage toDart() {
+    return TLinearImage(this);
+  }
+}
+
+final class TLinearImage extends Struct {
+  Pointer<TLinearImage> get address => super.address.cast();
+  TLinearImage(super.address);
+
+  static Pointer<TLinearImage> stackAlloc() {
+    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  }
+}
+
+sealed class TLutFormat {
+  static const INTEGER = 0;
+  static const FLOAT = 1;
+}
+
+extension TMaterialExt on Pointer<TMaterial> {
+  TMaterial toDart() {
+    return TMaterial(this);
+  }
+}
+
+final class TMaterial extends Struct {
+  Pointer<TMaterial> get address => super.address.cast();
+  TMaterial(super.address);
+
+  static Pointer<TMaterial> stackAlloc() {
+    return Pointer<TMaterial>(NativeLibrary.instance.stackAlloc<TMaterial>(0));
+  }
+}
+
+extension TMaterialInstanceExt on Pointer<TMaterialInstance> {
+  TMaterialInstance toDart() {
+    return TMaterialInstance(this);
+  }
+}
+
+final class TMaterialInstance extends Struct {
+  Pointer<TMaterialInstance> get address => super.address.cast();
+  TMaterialInstance(super.address);
+
+  static Pointer<TMaterialInstance> stackAlloc() {
+    return Pointer<TMaterialInstance>(NativeLibrary.instance.stackAlloc<TMaterialInstance>(0));
+  }
+}
+
+extension TMaterialProviderExt on Pointer<TMaterialProvider> {
+  TMaterialProvider toDart() {
+    return TMaterialProvider(this);
+  }
+}
+
+final class TMaterialProvider extends Struct {
+  Pointer<TMaterialProvider> get address => super.address.cast();
+  TMaterialProvider(super.address);
+
+  static Pointer<TMaterialProvider> stackAlloc() {
+    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
+  }
 }
 
 extension TMeshDataExt on Pointer<TMeshData> {
@@ -10592,139 +10160,53 @@ final class TMeshData extends Struct {
   }
 }
 
-sealed class TTextureSamplerType {
-  static const SAMPLER_2D = 0;
-  static const SAMPLER_2D_ARRAY = 1;
-  static const SAMPLER_CUBEMAP = 2;
-  static const SAMPLER_EXTERNAL = 3;
-  static const SAMPLER_3D = 4;
-  static const SAMPLER_CUBEMAP_ARRAY = 5;
-}
-
-sealed class TTextureFormat {
-  static const TEXTUREFORMAT_R8 = 0;
-  static const TEXTUREFORMAT_R8_SNORM = 1;
-  static const TEXTUREFORMAT_R8UI = 2;
-  static const TEXTUREFORMAT_R8I = 3;
-  static const TEXTUREFORMAT_STENCIL8 = 4;
-  static const TEXTUREFORMAT_R16F = 5;
-  static const TEXTUREFORMAT_R16UI = 6;
-  static const TEXTUREFORMAT_R16I = 7;
-  static const TEXTUREFORMAT_RG8 = 8;
-  static const TEXTUREFORMAT_RG8_SNORM = 9;
-  static const TEXTUREFORMAT_RG8UI = 10;
-  static const TEXTUREFORMAT_RG8I = 11;
-  static const TEXTUREFORMAT_RGB565 = 12;
-  static const TEXTUREFORMAT_RGB9_E5 = 13;
-  static const TEXTUREFORMAT_RGB5_A1 = 14;
-  static const TEXTUREFORMAT_RGBA4 = 15;
-  static const TEXTUREFORMAT_DEPTH16 = 16;
-  static const TEXTUREFORMAT_RGB8 = 17;
-  static const TEXTUREFORMAT_SRGB8 = 18;
-  static const TEXTUREFORMAT_RGB8_SNORM = 19;
-  static const TEXTUREFORMAT_RGB8UI = 20;
-  static const TEXTUREFORMAT_RGB8I = 21;
-  static const TEXTUREFORMAT_DEPTH24 = 22;
-  static const TEXTUREFORMAT_R32F = 23;
-  static const TEXTUREFORMAT_R32UI = 24;
-  static const TEXTUREFORMAT_R32I = 25;
-  static const TEXTUREFORMAT_RG16F = 26;
-  static const TEXTUREFORMAT_RG16UI = 27;
-  static const TEXTUREFORMAT_RG16I = 28;
-  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
-  static const TEXTUREFORMAT_RGBA8 = 30;
-  static const TEXTUREFORMAT_SRGB8_A8 = 31;
-  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
-  static const TEXTUREFORMAT_UNUSED = 33;
-  static const TEXTUREFORMAT_RGB10_A2 = 34;
-  static const TEXTUREFORMAT_RGBA8UI = 35;
-  static const TEXTUREFORMAT_RGBA8I = 36;
-  static const TEXTUREFORMAT_DEPTH32F = 37;
-  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
-  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
-  static const TEXTUREFORMAT_RGB16F = 40;
-  static const TEXTUREFORMAT_RGB16UI = 41;
-  static const TEXTUREFORMAT_RGB16I = 42;
-  static const TEXTUREFORMAT_RG32F = 43;
-  static const TEXTUREFORMAT_RG32UI = 44;
-  static const TEXTUREFORMAT_RG32I = 45;
-  static const TEXTUREFORMAT_RGBA16F = 46;
-  static const TEXTUREFORMAT_RGBA16UI = 47;
-  static const TEXTUREFORMAT_RGBA16I = 48;
-  static const TEXTUREFORMAT_RGB32F = 49;
-  static const TEXTUREFORMAT_RGB32UI = 50;
-  static const TEXTUREFORMAT_RGB32I = 51;
-  static const TEXTUREFORMAT_RGBA32F = 52;
-  static const TEXTUREFORMAT_RGBA32UI = 53;
-  static const TEXTUREFORMAT_RGBA32I = 54;
-  static const TEXTUREFORMAT_EAC_R11 = 55;
-  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
-  static const TEXTUREFORMAT_EAC_RG11 = 57;
-  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
-  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
-  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
-  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
-  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
-  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
-  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
-  static const TEXTUREFORMAT_DXT1_RGB = 65;
-  static const TEXTUREFORMAT_DXT1_RGBA = 66;
-  static const TEXTUREFORMAT_DXT3_RGBA = 67;
-  static const TEXTUREFORMAT_DXT5_RGBA = 68;
-  static const TEXTUREFORMAT_DXT1_SRGB = 69;
-  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
-  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
-  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
-  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
-  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
-  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
-  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
-  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
-  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
-  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
-  static const TEXTUREFORMAT_RED_RGTC1 = 101;
-  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
-  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
-  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
-  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
-  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
-  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
-  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
-}
-
-extension TLinearImageExt on Pointer<TLinearImage> {
-  TLinearImage toDart() {
-    return TLinearImage(this);
+extension TMovementIntentExt on Pointer<TMovementIntent> {
+  TMovementIntent toDart() {
+    return TMovementIntent(this);
   }
 }
 
-final class TLinearImage extends Struct {
-  Pointer<TLinearImage> get address => super.address.cast();
-  TLinearImage(super.address);
+final class TMovementIntent extends Struct {
+  Pointer<TMovementIntent> get address => super.address.cast();
+  TMovementIntent(super.address);
 
-  static Pointer<TLinearImage> stackAlloc() {
-    return Pointer<TLinearImage>(NativeLibrary.instance.stackAlloc<TLinearImage>(0));
+  static Pointer<TMovementIntent> stackAlloc() {
+    return Pointer<TMovementIntent>(NativeLibrary.instance.stackAlloc<TMovementIntent>(0));
+  }
+}
+
+extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
+  TMovementIntentExecutor toDart() {
+    return TMovementIntentExecutor(this);
+  }
+}
+
+final class TMovementIntentExecutor extends Struct {
+  Pointer<TMovementIntentExecutor> get address => super.address.cast();
+  TMovementIntentExecutor(super.address);
+
+  static Pointer<TMovementIntentExecutor> stackAlloc() {
+    return Pointer<TMovementIntentExecutor>(NativeLibrary.instance.stackAlloc<TMovementIntentExecutor>(0));
+  }
+}
+
+sealed class TMovementSpace {
+  static const MOVEMENT_SPACE_WORLD = 0;
+  static const MOVEMENT_SPACE_OBJECT = 1;
+}
+
+extension TNameComponentManagerExt on Pointer<TNameComponentManager> {
+  TNameComponentManager toDart() {
+    return TNameComponentManager(this);
+  }
+}
+
+final class TNameComponentManager extends Struct {
+  Pointer<TNameComponentManager> get address => super.address.cast();
+  TNameComponentManager(super.address);
+
+  static Pointer<TNameComponentManager> stackAlloc() {
+    return Pointer<TNameComponentManager>(NativeLibrary.instance.stackAlloc<TNameComponentManager>(0));
   }
 }
 
@@ -10801,147 +10283,77 @@ sealed class TPixelDataType {
   static const PIXELDATATYPE_UINT_2_10_10_10_REV = 11;
 }
 
-sealed class TTextureUsage {
-  static const TEXTURE_USAGE_NONE = 0;
+sealed class TPrimitiveType {
+  /// !< points
+  static const PRIMITIVETYPE_POINTS = 0;
 
-  /// !< Texture can be used as a color attachment
-  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+  /// !< lines
+  static const PRIMITIVETYPE_LINES = 1;
 
-  /// !< Texture can be used as a depth attachment
-  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+  /// !< line strip
+  static const PRIMITIVETYPE_LINE_STRIP = 3;
 
-  /// !< Texture can be used as a stencil attachment
-  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+  /// !< triangles
+  static const PRIMITIVETYPE_TRIANGLES = 4;
 
-  /// !< Data can be uploaded into this texture (default)
-  static const TEXTURE_USAGE_UPLOADABLE = 8;
-
-  /// !< Texture can be sampled (default)
-  static const TEXTURE_USAGE_SAMPLEABLE = 16;
-
-  /// !< Texture can be used as a subpass input
-  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
-
-  /// !< Texture can be used the source of a blit()
-  static const TEXTURE_USAGE_BLIT_SRC = 64;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_BLIT_DST = 128;
-
-  /// !< Texture can be used the destination of a blit()
-  static const TEXTURE_USAGE_PROTECTED = 256;
-
-  /// !< Texture can be used with generateMipmaps()
-  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
-
-  /// !< Default texture usage
-  static const TEXTURE_USAGE_DEFAULT = 24;
+  /// !< triangle strip
+  static const PRIMITIVETYPE_TRIANGLE_STRIP = 5;
 }
 
-extension TKtx1BundleExt on Pointer<TKtx1Bundle> {
-  TKtx1Bundle toDart() {
-    return TKtx1Bundle(this);
+sealed class TProjection {
+  static const Perspective = 0;
+  static const Orthographic = 1;
+}
+
+sealed class TQualityLevel {
+  static const LOW = 0;
+  static const MEDIUM = 1;
+  static const HIGH = 2;
+  static const ULTRA = 3;
+}
+
+extension TRenderManagerExt on Pointer<TRenderManager> {
+  TRenderManager toDart() {
+    return TRenderManager(this);
   }
 }
 
-final class TKtx1Bundle extends Struct {
-  Pointer<TKtx1Bundle> get address => super.address.cast();
-  TKtx1Bundle(super.address);
+final class TRenderManager extends Struct {
+  Pointer<TRenderManager> get address => super.address.cast();
+  TRenderManager(super.address);
 
-  static Pointer<TKtx1Bundle> stackAlloc() {
-    return Pointer<TKtx1Bundle>(NativeLibrary.instance.stackAlloc<TKtx1Bundle>(0));
+  static Pointer<TRenderManager> stackAlloc() {
+    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
   }
 }
 
-typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
-typedef VoidCallbackFunction = void Function(int requestId);
-typedef DartVoidCallbackFunction = void Function(int requestId);
-
-sealed class TSamplerMinFilter {
-  static const FILTER_NEAREST = 0;
-  static const FILTER_LINEAR = 1;
-  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
-  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
-  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
-  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
-}
-
-sealed class TSamplerMagFilter {
-  static const MAG_FILTER_NEAREST = 0;
-  static const MAG_FILTER_LINEAR = 1;
-}
-
-sealed class TSamplerWrapMode {
-  static const WRAP_CLAMP_TO_EDGE = 0;
-  static const WRAP_REPEAT = 1;
-  static const WRAP_MIRRORED_REPEAT = 2;
-}
-
-sealed class TSamplerCompareMode {
-  static const COMPARE_MODE_NONE = 0;
-  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
-}
-
-sealed class TBackend {
-  /// !< Automatically selects an appropriate driver for the platform.
-  static const BACKEND_DEFAULT = 0;
-
-  /// !< Selects the OpenGL/ES driver (default on Android)
-  static const BACKEND_OPENGL = 1;
-
-  /// !< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
-  static const BACKEND_VULKAN = 2;
-
-  /// !< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
-  static const BACKEND_METAL = 3;
-
-  /// !< Selects the no-op driver for testing purposes.
-  static const BACKEND_NOOP = 4;
-}
-
-extension TRendererExt on Pointer<TRenderer> {
-  TRenderer toDart() {
-    return TRenderer(this);
+extension TRenderTargetExt on Pointer<TRenderTarget> {
+  TRenderTarget toDart() {
+    return TRenderTarget(this);
   }
 }
 
-final class TRenderer extends Struct {
-  Pointer<TRenderer> get address => super.address.cast();
-  TRenderer(super.address);
+final class TRenderTarget extends Struct {
+  Pointer<TRenderTarget> get address => super.address.cast();
+  TRenderTarget(super.address);
 
-  static Pointer<TRenderer> stackAlloc() {
-    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
+  static Pointer<TRenderTarget> stackAlloc() {
+    return Pointer<TRenderTarget>(NativeLibrary.instance.stackAlloc<TRenderTarget>(0));
   }
 }
 
-extension TSwapChainExt on Pointer<TSwapChain> {
-  TSwapChain toDart() {
-    return TSwapChain(this);
+extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
+  TRenderableBuilder toDart() {
+    return TRenderableBuilder(this);
   }
 }
 
-final class TSwapChain extends Struct {
-  Pointer<TSwapChain> get address => super.address.cast();
-  TSwapChain(super.address);
+final class TRenderableBuilder extends Struct {
+  Pointer<TRenderableBuilder> get address => super.address.cast();
+  TRenderableBuilder(super.address);
 
-  static Pointer<TSwapChain> stackAlloc() {
-    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
-  }
-}
-
-extension TTransformManagerExt on Pointer<TTransformManager> {
-  TTransformManager toDart() {
-    return TTransformManager(this);
-  }
-}
-
-final class TTransformManager extends Struct {
-  Pointer<TTransformManager> get address => super.address.cast();
-  TTransformManager(super.address);
-
-  static Pointer<TTransformManager> stackAlloc() {
-    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
+  static Pointer<TRenderableBuilder> stackAlloc() {
+    return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
   }
 }
 
@@ -10960,229 +10372,119 @@ final class TRenderableManager extends Struct {
   }
 }
 
-extension TLightManagerExt on Pointer<TLightManager> {
-  TLightManager toDart() {
-    return TLightManager(this);
+extension TRendererExt on Pointer<TRenderer> {
+  TRenderer toDart() {
+    return TRenderer(this);
   }
 }
 
-final class TLightManager extends Struct {
-  Pointer<TLightManager> get address => super.address.cast();
-  TLightManager(super.address);
+final class TRenderer extends Struct {
+  Pointer<TRenderer> get address => super.address.cast();
+  TRenderer(super.address);
 
-  static Pointer<TLightManager> stackAlloc() {
-    return Pointer<TLightManager>(NativeLibrary.instance.stackAlloc<TLightManager>(0));
+  static Pointer<TRenderer> stackAlloc() {
+    return Pointer<TRenderer>(NativeLibrary.instance.stackAlloc<TRenderer>(0));
   }
 }
 
-extension TEntityManagerExt on Pointer<TEntityManager> {
-  TEntityManager toDart() {
-    return TEntityManager(this);
+sealed class TSamplerCompareFunc {
+  /// !< Less or equal
+  static const LE = 0;
+
+  /// !< Greater or equal
+  static const GE = 1;
+
+  /// !< Strictly less than
+  static const L = 2;
+
+  /// !< Strictly greater than
+  static const G = 3;
+
+  /// !< Equal
+  static const E = 4;
+
+  /// !< Not equal
+  static const NE = 5;
+
+  /// !< Always. Depth / stencil testing is deactivated.
+  static const A = 6;
+
+  /// !< Never. The depth / stencil test always fails.
+  static const N = 7;
+}
+
+sealed class TSamplerCompareMode {
+  static const COMPARE_MODE_NONE = 0;
+  static const COMPARE_MODE_COMPARE_TO_TEXTURE = 1;
+}
+
+sealed class TSamplerMagFilter {
+  static const MAG_FILTER_NEAREST = 0;
+  static const MAG_FILTER_LINEAR = 1;
+}
+
+sealed class TSamplerMinFilter {
+  static const FILTER_NEAREST = 0;
+  static const FILTER_LINEAR = 1;
+  static const FILTER_NEAREST_MIPMAP_NEAREST = 2;
+  static const FILTER_LINEAR_MIPMAP_NEAREST = 3;
+  static const FILTER_NEAREST_MIPMAP_LINEAR = 4;
+  static const FILTER_LINEAR_MIPMAP_LINEAR = 5;
+}
+
+sealed class TSamplerWrapMode {
+  static const WRAP_CLAMP_TO_EDGE = 0;
+  static const WRAP_REPEAT = 1;
+  static const WRAP_MIRRORED_REPEAT = 2;
+}
+
+extension TSceneExt on Pointer<TScene> {
+  TScene toDart() {
+    return TScene(this);
   }
 }
 
-final class TEntityManager extends Struct {
-  Pointer<TEntityManager> get address => super.address.cast();
-  TEntityManager(super.address);
+final class TScene extends Struct {
+  Pointer<TScene> get address => super.address.cast();
+  TScene(super.address);
 
-  static Pointer<TEntityManager> stackAlloc() {
-    return Pointer<TEntityManager>(NativeLibrary.instance.stackAlloc<TEntityManager>(0));
+  static Pointer<TScene> stackAlloc() {
+    return Pointer<TScene>(NativeLibrary.instance.stackAlloc<TScene>(0));
   }
 }
 
-extension TFenceExt on Pointer<TFence> {
-  TFence toDart() {
-    return TFence(this);
+extension TSceneAssetExt on Pointer<TSceneAsset> {
+  TSceneAsset toDart() {
+    return TSceneAsset(this);
   }
 }
 
-final class TFence extends Struct {
-  Pointer<TFence> get address => super.address.cast();
-  TFence(super.address);
+final class TSceneAsset extends Struct {
+  Pointer<TSceneAsset> get address => super.address.cast();
+  TSceneAsset(super.address);
 
-  static Pointer<TFence> stackAlloc() {
-    return Pointer<TFence>(NativeLibrary.instance.stackAlloc<TFence>(0));
+  static Pointer<TSceneAsset> stackAlloc() {
+    return Pointer<TSceneAsset>(NativeLibrary.instance.stackAlloc<TSceneAsset>(0));
   }
 }
 
-extension TSkyboxExt on Pointer<TSkybox> {
-  TSkybox toDart() {
-    return TSkybox(this);
-  }
+sealed class TSceneAssetGeometryCapability {
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_NONE = 0;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_BARYCENTRICS = 1;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_WRITABLE_VERTICES = 2;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_ACCESSIBLE_GEOMETRY_BUFFERS = 4;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_PRESERVED_TOPOLOGY = 8;
+  static const SCENE_ASSET_GEOMETRY_CAPABILITY_UNIQUE_TRIANGLE_CORNERS = 16;
 }
 
-final class TSkybox extends Struct {
-  Pointer<TSkybox> get address => super.address.cast();
-  TSkybox(super.address);
-
-  static Pointer<TSkybox> stackAlloc() {
-    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
-  }
-}
-
-extension TIndirectLightExt on Pointer<TIndirectLight> {
-  TIndirectLight toDart() {
-    return TIndirectLight(this);
-  }
-}
-
-final class TIndirectLight extends Struct {
-  Pointer<TIndirectLight> get address => super.address.cast();
-  TIndirectLight(super.address);
-
-  static Pointer<TIndirectLight> stackAlloc() {
-    return Pointer<TIndirectLight>(NativeLibrary.instance.stackAlloc<TIndirectLight>(0));
-  }
-}
-
-extension TDebugRegistryExt on Pointer<TDebugRegistry> {
-  TDebugRegistry toDart() {
-    return TDebugRegistry(this);
-  }
-}
-
-final class TDebugRegistry extends Struct {
-  Pointer<TDebugRegistry> get address => super.address.cast();
-  TDebugRegistry(super.address);
-
-  static Pointer<TDebugRegistry> stackAlloc() {
-    return Pointer<TDebugRegistry>(NativeLibrary.instance.stackAlloc<TDebugRegistry>(0));
-  }
-}
-
-extension TMaterialProviderExt on Pointer<TMaterialProvider> {
-  TMaterialProvider toDart() {
-    return TMaterialProvider(this);
-  }
-}
-
-final class TMaterialProvider extends Struct {
-  Pointer<TMaterialProvider> get address => super.address.cast();
-  TMaterialProvider(super.address);
-
-  static Pointer<TMaterialProvider> stackAlloc() {
-    return Pointer<TMaterialProvider>(NativeLibrary.instance.stackAlloc<TMaterialProvider>(0));
-  }
-}
-
-extension TVertexBufferBuilderExt on Pointer<TVertexBufferBuilder> {
-  TVertexBufferBuilder toDart() {
-    return TVertexBufferBuilder(this);
-  }
-}
-
-final class TVertexBufferBuilder extends Struct {
-  Pointer<TVertexBufferBuilder> get address => super.address.cast();
-  TVertexBufferBuilder(super.address);
-
-  static Pointer<TVertexBufferBuilder> stackAlloc() {
-    return Pointer<TVertexBufferBuilder>(NativeLibrary.instance.stackAlloc<TVertexBufferBuilder>(0));
-  }
-}
-
-sealed class TVertexAttribute {
-  static const TVERTEX_ATTRIBUTE_POSITION = 0;
-  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
-  static const TVERTEX_ATTRIBUTE_COLOR = 2;
-  static const TVERTEX_ATTRIBUTE_UV0 = 3;
-  static const TVERTEX_ATTRIBUTE_UV1 = 4;
-  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
-  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
-  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
-  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
-  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
-  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
-  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
-  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
-  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
-  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
-}
-
-sealed class TVertexAttributeType {
-  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
-  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
-  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
-  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
-  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
-  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
-  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
-  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
-  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
-  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
-  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
-  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
-}
-
-extension TBufferObjectExt on Pointer<TBufferObject> {
-  TBufferObject toDart() {
-    return TBufferObject(this);
-  }
-}
-
-final class TBufferObject extends Struct {
-  Pointer<TBufferObject> get address => super.address.cast();
-  TBufferObject(super.address);
-
-  static Pointer<TBufferObject> stackAlloc() {
-    return Pointer<TBufferObject>(NativeLibrary.instance.stackAlloc<TBufferObject>(0));
-  }
-}
-
-extension TIndexBufferBuilderExt on Pointer<TIndexBufferBuilder> {
-  TIndexBufferBuilder toDart() {
-    return TIndexBufferBuilder(this);
-  }
-}
-
-final class TIndexBufferBuilder extends Struct {
-  Pointer<TIndexBufferBuilder> get address => super.address.cast();
-  TIndexBufferBuilder(super.address);
-
-  static Pointer<TIndexBufferBuilder> stackAlloc() {
-    return Pointer<TIndexBufferBuilder>(NativeLibrary.instance.stackAlloc<TIndexBufferBuilder>(0));
-  }
-}
-
-sealed class TIndexType {
-  static const TINDEX_TYPE_USHORT = 0;
-  static const TINDEX_TYPE_UINT = 1;
-}
-
-extension TBufferObjectBuilderExt on Pointer<TBufferObjectBuilder> {
-  TBufferObjectBuilder toDart() {
-    return TBufferObjectBuilder(this);
-  }
-}
-
-final class TBufferObjectBuilder extends Struct {
-  Pointer<TBufferObjectBuilder> get address => super.address.cast();
-  TBufferObjectBuilder(super.address);
-
-  static Pointer<TBufferObjectBuilder> stackAlloc() {
-    return Pointer<TBufferObjectBuilder>(NativeLibrary.instance.stackAlloc<TBufferObjectBuilder>(0));
-  }
-}
-
-sealed class TLightType {
-  static const LIGHT_TYPE_SUN = 0;
-  static const LIGHT_TYPE_DIRECTIONAL = 1;
-  static const LIGHT_TYPE_POINT = 2;
-  static const LIGHT_TYPE_FOCUSED_SPOT = 3;
-  static const LIGHT_TYPE_SPOT = 4;
+sealed class TSceneAssetType {
+  static const SCENE_ASSET_TYPE_GLTF = 0;
+  static const SCENE_ASSET_TYPE_GEOMETRY = 1;
+  static const SCENE_ASSET_TYPE_LIGHT = 2;
+  static const SCENE_ASSET_TYPE_SKYBOX = 3;
+  static const SCENE_ASSET_TYPE_IBL = 4;
+  static const SCENE_ASSET_TYPE_IMAGE = 5;
+  static const SCENE_ASSET_TYPE_GIZMO = 6;
 }
 
 extension TShadowOptionsExt on Pointer<TShadowOptions> {
@@ -11460,48 +10762,258 @@ final class TShadowOptions extends Struct {
   }
 }
 
-extension TRenderManagerExt on Pointer<TRenderManager> {
-  TRenderManager toDart() {
-    return TRenderManager(this);
+extension TSkyboxExt on Pointer<TSkybox> {
+  TSkybox toDart() {
+    return TSkybox(this);
   }
 }
 
-final class TRenderManager extends Struct {
-  Pointer<TRenderManager> get address => super.address.cast();
-  TRenderManager(super.address);
+final class TSkybox extends Struct {
+  Pointer<TSkybox> get address => super.address.cast();
+  TSkybox(super.address);
 
-  static Pointer<TRenderManager> stackAlloc() {
-    return Pointer<TRenderManager>(NativeLibrary.instance.stackAlloc<TRenderManager>(0));
+  static Pointer<TSkybox> stackAlloc() {
+    return Pointer<TSkybox>(NativeLibrary.instance.stackAlloc<TSkybox>(0));
   }
 }
 
-extension TAnimationManagerExt on Pointer<TAnimationManager> {
-  TAnimationManager toDart() {
-    return TAnimationManager(this);
+/// Options for DPCF and PCSS Shadowing.
+
+extension TSoftShadowOptionsExt on Pointer<TSoftShadowOptions> {
+  TSoftShadowOptions toDart() {
+    return TSoftShadowOptions(this);
   }
 }
 
-final class TAnimationManager extends Struct {
-  Pointer<TAnimationManager> get address => super.address.cast();
-  TAnimationManager(super.address);
+final class TSoftShadowOptions extends Struct {
+  Pointer<TSoftShadowOptions> get address => super.address.cast();
+  double get penumbraScale {
+    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
 
-  static Pointer<TAnimationManager> stackAlloc() {
-    return Pointer<TAnimationManager>(NativeLibrary.instance.stackAlloc<TAnimationManager>(0));
+  set penumbraScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 0), val.toJS, 'float');
+  }
+
+  double get penumbraRatioScale {
+    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set penumbraRatioScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 4), val.toJS, 'float');
+  }
+
+  double get maxPenumbraRatio {
+    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxPenumbraRatio(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 8), val.toJS, 'float');
+  }
+
+  double get maxSearchRadius {
+    final addr = Pointer<TSoftShadowOptions>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set maxSearchRadius(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSoftShadowOptions>(this.address.addr + 12), val.toJS, 'float');
+  }
+
+  TSoftShadowOptions(super.address);
+
+  static Pointer<TSoftShadowOptions> stackAlloc() {
+    return Pointer<TSoftShadowOptions>(NativeLibrary.instance.stackAlloc<TSoftShadowOptions>(16));
   }
 }
 
-extension TRenderableBuilderExt on Pointer<TRenderableBuilder> {
-  TRenderableBuilder toDart() {
-    return TRenderableBuilder(this);
+/// Screen Space Cone Tracing (SSCT) options
+/// Ambient shadows from dominant light
+
+extension TSsctExt on Pointer<TSsct> {
+  TSsct toDart() {
+    return TSsct(this);
   }
 }
 
-final class TRenderableBuilder extends Struct {
-  Pointer<TRenderableBuilder> get address => super.address.cast();
-  TRenderableBuilder(super.address);
+final class TSsct extends Struct {
+  Pointer<TSsct> get address => super.address.cast();
 
-  static Pointer<TRenderableBuilder> stackAlloc() {
-    return Pointer<TRenderableBuilder>(NativeLibrary.instance.stackAlloc<TRenderableBuilder>(0));
+  /// !< full cone angle in radian, between 0 and pi/2
+  double get lightConeRad {
+    final addr = Pointer<TSsct>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set lightConeRad(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 0), val.toJS, 'float');
+  }
+
+  /// !< how far shadows can be cast
+  double get shadowDistance {
+    final addr = Pointer<TSsct>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set shadowDistance(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 4), val.toJS, 'float');
+  }
+
+  /// !< max distance for contact
+  double get contactDistanceMax {
+    final addr = Pointer<TSsct>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set contactDistanceMax(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 8), val.toJS, 'float');
+  }
+
+  /// !< intensity
+  double get intensity {
+    final addr = Pointer<TSsct>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set intensity(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 12), val.toJS, 'float');
+  }
+
+  /// !< light direction X
+  double get lightDirectionX {
+    final addr = Pointer<TSsct>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set lightDirectionX(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 16), val.toJS, 'float');
+  }
+
+  /// !< light direction Y
+  double get lightDirectionY {
+    final addr = Pointer<TSsct>(this.address.addr + 20);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set lightDirectionY(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 20), val.toJS, 'float');
+  }
+
+  /// !< light direction Z
+  double get lightDirectionZ {
+    final addr = Pointer<TSsct>(this.address.addr + 24);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set lightDirectionZ(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 24), val.toJS, 'float');
+  }
+
+  /// !< depth bias in world units (mitigate self shadowing)
+  double get depthBias {
+    final addr = Pointer<TSsct>(this.address.addr + 28);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set depthBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 28), val.toJS, 'float');
+  }
+
+  /// !< depth slope bias (mitigate self shadowing)
+  double get depthSlopeBias {
+    final addr = Pointer<TSsct>(this.address.addr + 32);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set depthSlopeBias(double val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 32), val.toJS, 'float');
+  }
+
+  /// !< tracing sample count, between 1 and 255
+  int get sampleCount {
+    final addr = Pointer<TSsct>(this.address.addr + 36);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set sampleCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 36), val.toJS, 'i8');
+  }
+
+  /// !< # of rays to trace, between 1 and 255
+  int get rayCount {
+    final addr = Pointer<TSsct>(this.address.addr + 37);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set rayCount(int val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 37), val.toJS, 'i8');
+  }
+
+  /// !< enables or disables SSCT
+  bool get enabled {
+    final addr = Pointer<TSsct>(this.address.addr + 38);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set enabled(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TSsct>(this.address.addr + 38), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  TSsct(super.address);
+
+  static Pointer<TSsct> stackAlloc() {
+    return Pointer<TSsct>(NativeLibrary.instance.stackAlloc<TSsct>(39));
+  }
+}
+
+sealed class TStencilFace {
+  static const STENCIL_FACE_FRONT = 1;
+  static const STENCIL_FACE_BACK = 2;
+  static const STENCIL_FACE_FRONT_AND_BACK = 3;
+}
+
+sealed class TStencilOperation {
+  static const KEEP = 0;
+  static const ZERO = 1;
+  static const REPLACE = 2;
+  static const INCR = 3;
+  static const INCR_WRAP = 4;
+  static const DECR = 5;
+  static const DECR_WRAP = 6;
+  static const INVERT = 7;
+}
+
+extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
+  TSurfaceOrientation toDart() {
+    return TSurfaceOrientation(this);
+  }
+}
+
+final class TSurfaceOrientation extends Struct {
+  Pointer<TSurfaceOrientation> get address => super.address.cast();
+  TSurfaceOrientation(super.address);
+
+  static Pointer<TSurfaceOrientation> stackAlloc() {
+    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
   }
 }
 
@@ -11520,118 +11032,637 @@ final class TSurfaceOrientationBuilder extends Struct {
   }
 }
 
-extension TSurfaceOrientationExt on Pointer<TSurfaceOrientation> {
-  TSurfaceOrientation toDart() {
-    return TSurfaceOrientation(this);
+extension TSwapChainExt on Pointer<TSwapChain> {
+  TSwapChain toDart() {
+    return TSwapChain(this);
   }
 }
 
-final class TSurfaceOrientation extends Struct {
-  Pointer<TSurfaceOrientation> get address => super.address.cast();
-  TSurfaceOrientation(super.address);
+final class TSwapChain extends Struct {
+  Pointer<TSwapChain> get address => super.address.cast();
+  TSwapChain(super.address);
 
-  static Pointer<TSurfaceOrientation> stackAlloc() {
-    return Pointer<TSurfaceOrientation>(NativeLibrary.instance.stackAlloc<TSurfaceOrientation>(0));
+  static Pointer<TSwapChain> stackAlloc() {
+    return Pointer<TSwapChain>(NativeLibrary.instance.stackAlloc<TSwapChain>(0));
   }
 }
 
-typedef FrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef DartFrameTickCallback = Pointer<NativeFunction<FrameTickCallbackFunction>>;
-typedef FrameTickCallbackFunction = void Function(JSBigInt frameTimeNanos);
-typedef DartFrameTickCallbackFunction = void Function(BigInt frameTimeNanos);
-
-extension TMovementIntentExecutorExt on Pointer<TMovementIntentExecutor> {
-  TMovementIntentExecutor toDart() {
-    return TMovementIntentExecutor(this);
+extension TTextureExt on Pointer<TTexture> {
+  TTexture toDart() {
+    return TTexture(this);
   }
 }
 
-final class TMovementIntentExecutor extends Struct {
-  Pointer<TMovementIntentExecutor> get address => super.address.cast();
-  TMovementIntentExecutor(super.address);
+final class TTexture extends Struct {
+  Pointer<TTexture> get address => super.address.cast();
+  TTexture(super.address);
 
-  static Pointer<TMovementIntentExecutor> stackAlloc() {
-    return Pointer<TMovementIntentExecutor>(NativeLibrary.instance.stackAlloc<TMovementIntentExecutor>(0));
+  static Pointer<TTexture> stackAlloc() {
+    return Pointer<TTexture>(NativeLibrary.instance.stackAlloc<TTexture>(0));
   }
 }
 
-extension TMovementIntentExt on Pointer<TMovementIntent> {
-  TMovementIntent toDart() {
-    return TMovementIntent(this);
+sealed class TTextureFormat {
+  static const TEXTUREFORMAT_R8 = 0;
+  static const TEXTUREFORMAT_R8_SNORM = 1;
+  static const TEXTUREFORMAT_R8UI = 2;
+  static const TEXTUREFORMAT_R8I = 3;
+  static const TEXTUREFORMAT_STENCIL8 = 4;
+  static const TEXTUREFORMAT_R16F = 5;
+  static const TEXTUREFORMAT_R16UI = 6;
+  static const TEXTUREFORMAT_R16I = 7;
+  static const TEXTUREFORMAT_RG8 = 8;
+  static const TEXTUREFORMAT_RG8_SNORM = 9;
+  static const TEXTUREFORMAT_RG8UI = 10;
+  static const TEXTUREFORMAT_RG8I = 11;
+  static const TEXTUREFORMAT_RGB565 = 12;
+  static const TEXTUREFORMAT_RGB9_E5 = 13;
+  static const TEXTUREFORMAT_RGB5_A1 = 14;
+  static const TEXTUREFORMAT_RGBA4 = 15;
+  static const TEXTUREFORMAT_DEPTH16 = 16;
+  static const TEXTUREFORMAT_RGB8 = 17;
+  static const TEXTUREFORMAT_SRGB8 = 18;
+  static const TEXTUREFORMAT_RGB8_SNORM = 19;
+  static const TEXTUREFORMAT_RGB8UI = 20;
+  static const TEXTUREFORMAT_RGB8I = 21;
+  static const TEXTUREFORMAT_DEPTH24 = 22;
+  static const TEXTUREFORMAT_R32F = 23;
+  static const TEXTUREFORMAT_R32UI = 24;
+  static const TEXTUREFORMAT_R32I = 25;
+  static const TEXTUREFORMAT_RG16F = 26;
+  static const TEXTUREFORMAT_RG16UI = 27;
+  static const TEXTUREFORMAT_RG16I = 28;
+  static const TEXTUREFORMAT_R11F_G11F_B10F = 29;
+  static const TEXTUREFORMAT_RGBA8 = 30;
+  static const TEXTUREFORMAT_SRGB8_A8 = 31;
+  static const TEXTUREFORMAT_RGBA8_SNORM = 32;
+  static const TEXTUREFORMAT_UNUSED = 33;
+  static const TEXTUREFORMAT_RGB10_A2 = 34;
+  static const TEXTUREFORMAT_RGBA8UI = 35;
+  static const TEXTUREFORMAT_RGBA8I = 36;
+  static const TEXTUREFORMAT_DEPTH32F = 37;
+  static const TEXTUREFORMAT_DEPTH24_STENCIL8 = 38;
+  static const TEXTUREFORMAT_DEPTH32F_STENCIL8 = 39;
+  static const TEXTUREFORMAT_RGB16F = 40;
+  static const TEXTUREFORMAT_RGB16UI = 41;
+  static const TEXTUREFORMAT_RGB16I = 42;
+  static const TEXTUREFORMAT_RG32F = 43;
+  static const TEXTUREFORMAT_RG32UI = 44;
+  static const TEXTUREFORMAT_RG32I = 45;
+  static const TEXTUREFORMAT_RGBA16F = 46;
+  static const TEXTUREFORMAT_RGBA16UI = 47;
+  static const TEXTUREFORMAT_RGBA16I = 48;
+  static const TEXTUREFORMAT_RGB32F = 49;
+  static const TEXTUREFORMAT_RGB32UI = 50;
+  static const TEXTUREFORMAT_RGB32I = 51;
+  static const TEXTUREFORMAT_RGBA32F = 52;
+  static const TEXTUREFORMAT_RGBA32UI = 53;
+  static const TEXTUREFORMAT_RGBA32I = 54;
+  static const TEXTUREFORMAT_EAC_R11 = 55;
+  static const TEXTUREFORMAT_EAC_R11_SIGNED = 56;
+  static const TEXTUREFORMAT_EAC_RG11 = 57;
+  static const TEXTUREFORMAT_EAC_RG11_SIGNED = 58;
+  static const TEXTUREFORMAT_ETC2_RGB8 = 59;
+  static const TEXTUREFORMAT_ETC2_SRGB8 = 60;
+  static const TEXTUREFORMAT_ETC2_RGB8_A1 = 61;
+  static const TEXTUREFORMAT_ETC2_SRGB8_A1 = 62;
+  static const TEXTUREFORMAT_ETC2_EAC_RGBA8 = 63;
+  static const TEXTUREFORMAT_ETC2_EAC_SRGBA8 = 64;
+  static const TEXTUREFORMAT_DXT1_RGB = 65;
+  static const TEXTUREFORMAT_DXT1_RGBA = 66;
+  static const TEXTUREFORMAT_DXT3_RGBA = 67;
+  static const TEXTUREFORMAT_DXT5_RGBA = 68;
+  static const TEXTUREFORMAT_DXT1_SRGB = 69;
+  static const TEXTUREFORMAT_DXT1_SRGBA = 70;
+  static const TEXTUREFORMAT_DXT3_SRGBA = 71;
+  static const TEXTUREFORMAT_DXT5_SRGBA = 72;
+  static const TEXTUREFORMAT_RGBA_ASTC_4x4 = 73;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x4 = 74;
+  static const TEXTUREFORMAT_RGBA_ASTC_5x5 = 75;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x5 = 76;
+  static const TEXTUREFORMAT_RGBA_ASTC_6x6 = 77;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x5 = 78;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x6 = 79;
+  static const TEXTUREFORMAT_RGBA_ASTC_8x8 = 80;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x5 = 81;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x6 = 82;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x8 = 83;
+  static const TEXTUREFORMAT_RGBA_ASTC_10x10 = 84;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x10 = 85;
+  static const TEXTUREFORMAT_RGBA_ASTC_12x12 = 86;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_4x4 = 87;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x4 = 88;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_5x5 = 89;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x5 = 90;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_6x6 = 91;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x5 = 92;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x6 = 93;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_8x8 = 94;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x5 = 95;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x6 = 96;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x8 = 97;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_10x10 = 98;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x10 = 99;
+  static const TEXTUREFORMAT_SRGB8_ALPHA8_ASTC_12x12 = 100;
+  static const TEXTUREFORMAT_RED_RGTC1 = 101;
+  static const TEXTUREFORMAT_SIGNED_RED_RGTC1 = 102;
+  static const TEXTUREFORMAT_RED_GREEN_RGTC2 = 103;
+  static const TEXTUREFORMAT_SIGNED_RED_GREEN_RGTC2 = 104;
+  static const TEXTUREFORMAT_RGB_BPTC_SIGNED_FLOAT = 105;
+  static const TEXTUREFORMAT_RGB_BPTC_UNSIGNED_FLOAT = 106;
+  static const TEXTUREFORMAT_RGBA_BPTC_UNORM = 107;
+  static const TEXTUREFORMAT_SRGB_ALPHA_BPTC_UNORM = 108;
+}
+
+extension TTextureSamplerExt on Pointer<TTextureSampler> {
+  TTextureSampler toDart() {
+    return TTextureSampler(this);
   }
 }
 
-final class TMovementIntent extends Struct {
-  Pointer<TMovementIntent> get address => super.address.cast();
-  TMovementIntent(super.address);
+final class TTextureSampler extends Struct {
+  Pointer<TTextureSampler> get address => super.address.cast();
+  TTextureSampler(super.address);
 
-  static Pointer<TMovementIntent> stackAlloc() {
-    return Pointer<TMovementIntent>(NativeLibrary.instance.stackAlloc<TMovementIntent>(0));
+  static Pointer<TTextureSampler> stackAlloc() {
+    return Pointer<TTextureSampler>(NativeLibrary.instance.stackAlloc<TTextureSampler>(0));
   }
 }
+
+sealed class TTextureSamplerType {
+  static const SAMPLER_2D = 0;
+  static const SAMPLER_2D_ARRAY = 1;
+  static const SAMPLER_CUBEMAP = 2;
+  static const SAMPLER_EXTERNAL = 3;
+  static const SAMPLER_3D = 4;
+  static const SAMPLER_CUBEMAP_ARRAY = 5;
+}
+
+sealed class TTextureUsage {
+  static const TEXTURE_USAGE_NONE = 0;
+
+  /// !< Texture can be used as a color attachment
+  static const TEXTURE_USAGE_COLOR_ATTACHMENT = 1;
+
+  /// !< Texture can be used as a depth attachment
+  static const TEXTURE_USAGE_DEPTH_ATTACHMENT = 2;
+
+  /// !< Texture can be used as a stencil attachment
+  static const TEXTURE_USAGE_STENCIL_ATTACHMENT = 4;
+
+  /// !< Data can be uploaded into this texture (default)
+  static const TEXTURE_USAGE_UPLOADABLE = 8;
+
+  /// !< Texture can be sampled (default)
+  static const TEXTURE_USAGE_SAMPLEABLE = 16;
+
+  /// !< Texture can be used as a subpass input
+  static const TEXTURE_USAGE_SUBPASS_INPUT = 32;
+
+  /// !< Texture can be used the source of a blit()
+  static const TEXTURE_USAGE_BLIT_SRC = 64;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_BLIT_DST = 128;
+
+  /// !< Texture can be used the destination of a blit()
+  static const TEXTURE_USAGE_PROTECTED = 256;
+
+  /// !< Texture can be used with generateMipmaps()
+  static const TEXTURE_USAGE_GEN_MIPMAPPABLE = 512;
+
+  /// !< Default texture usage
+  static const TEXTURE_USAGE_DEFAULT = 24;
+}
+
+extension TToneMapperExt on Pointer<TToneMapper> {
+  TToneMapper toDart() {
+    return TToneMapper(this);
+  }
+}
+
+final class TToneMapper extends Struct {
+  Pointer<TToneMapper> get address => super.address.cast();
+  TToneMapper(super.address);
+
+  static Pointer<TToneMapper> stackAlloc() {
+    return Pointer<TToneMapper>(NativeLibrary.instance.stackAlloc<TToneMapper>(0));
+  }
+}
+
+extension TTransformManagerExt on Pointer<TTransformManager> {
+  TTransformManager toDart() {
+    return TTransformManager(this);
+  }
+}
+
+final class TTransformManager extends Struct {
+  Pointer<TTransformManager> get address => super.address.cast();
+  TTransformManager(super.address);
+
+  static Pointer<TTransformManager> stackAlloc() {
+    return Pointer<TTransformManager>(NativeLibrary.instance.stackAlloc<TTransformManager>(0));
+  }
+}
+
+sealed class TTransparencyMode {
+  /// ! the transparent object is drawn honoring the raster state
+  static const DEFAULT = 0;
+
+  /// the transparent object is first drawn in the depth buffer,
+  /// then in the color buffer, honoring the culling mode, but ignoring the depth test function
+  static const TWO_PASSES_ONE_SIDE = 1;
+
+  /// the transparent object is drawn twice in the color buffer,
+  /// first with back faces only, then with front faces; the culling
+  /// mode is ignored. Can be combined with two-sided lighting
+  static const TWO_PASSES_TWO_SIDES = 2;
+}
+
+sealed class TVertexAttribute {
+  static const TVERTEX_ATTRIBUTE_POSITION = 0;
+  static const TVERTEX_ATTRIBUTE_TANGENTS = 1;
+  static const TVERTEX_ATTRIBUTE_COLOR = 2;
+  static const TVERTEX_ATTRIBUTE_UV0 = 3;
+  static const TVERTEX_ATTRIBUTE_UV1 = 4;
+  static const TVERTEX_ATTRIBUTE_BONE_INDICES = 5;
+  static const TVERTEX_ATTRIBUTE_BONE_WEIGHTS = 6;
+  static const TVERTEX_ATTRIBUTE_CUSTOM0 = 8;
+  static const TVERTEX_ATTRIBUTE_CUSTOM1 = 9;
+  static const TVERTEX_ATTRIBUTE_CUSTOM2 = 10;
+  static const TVERTEX_ATTRIBUTE_CUSTOM3 = 11;
+  static const TVERTEX_ATTRIBUTE_CUSTOM4 = 12;
+  static const TVERTEX_ATTRIBUTE_CUSTOM5 = 13;
+  static const TVERTEX_ATTRIBUTE_CUSTOM6 = 14;
+  static const TVERTEX_ATTRIBUTE_CUSTOM7 = 15;
+}
+
+sealed class TVertexAttributeType {
+  static const TVERTEXATTRIBUTE_TYPE_BYTE = 0;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE2 = 1;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE3 = 2;
+  static const TVERTEXATTRIBUTE_TYPE_BYTE4 = 3;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE = 4;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE2 = 5;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE3 = 6;
+  static const TVERTEXATTRIBUTE_TYPE_UBYTE4 = 7;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT = 8;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT2 = 9;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT3 = 10;
+  static const TVERTEXATTRIBUTE_TYPE_SHORT4 = 11;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT = 12;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT2 = 13;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT3 = 14;
+  static const TVERTEXATTRIBUTE_TYPE_USHORT4 = 15;
+  static const TVERTEXATTRIBUTE_TYPE_INT = 16;
+  static const TVERTEXATTRIBUTE_TYPE_UINT = 17;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT = 18;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT2 = 19;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT3 = 20;
+  static const TVERTEXATTRIBUTE_TYPE_FLOAT4 = 21;
+  static const TVERTEXATTRIBUTE_TYPE_HALF = 22;
+  static const TVERTEXATTRIBUTE_TYPE_HALF2 = 23;
+  static const TVERTEXATTRIBUTE_TYPE_HALF3 = 24;
+  static const TVERTEXATTRIBUTE_TYPE_HALF4 = 25;
+}
+
+extension TVertexBufferExt on Pointer<TVertexBuffer> {
+  TVertexBuffer toDart() {
+    return TVertexBuffer(this);
+  }
+}
+
+final class TVertexBuffer extends Struct {
+  Pointer<TVertexBuffer> get address => super.address.cast();
+  TVertexBuffer(super.address);
+
+  static Pointer<TVertexBuffer> stackAlloc() {
+    return Pointer<TVertexBuffer>(NativeLibrary.instance.stackAlloc<TVertexBuffer>(0));
+  }
+}
+
+extension TVertexBufferBuilderExt on Pointer<TVertexBufferBuilder> {
+  TVertexBufferBuilder toDart() {
+    return TVertexBufferBuilder(this);
+  }
+}
+
+final class TVertexBufferBuilder extends Struct {
+  Pointer<TVertexBufferBuilder> get address => super.address.cast();
+  TVertexBufferBuilder(super.address);
+
+  static Pointer<TVertexBufferBuilder> stackAlloc() {
+    return Pointer<TVertexBufferBuilder>(NativeLibrary.instance.stackAlloc<TVertexBufferBuilder>(0));
+  }
+}
+
+sealed class TVertexBufferStorageMode {
+  static const VERTEX_BUFFER_STORAGE_MODE_UNKNOWN = 0;
+  static const VERTEX_BUFFER_STORAGE_MODE_DIRECT = 1;
+  static const VERTEX_BUFFER_STORAGE_MODE_BUFFER_OBJECTS = 2;
+}
+
+extension TViewExt on Pointer<TView> {
+  TView toDart() {
+    return TView(this);
+  }
+}
+
+final class TView extends Struct {
+  Pointer<TView> get address => super.address.cast();
+  TView(super.address);
+
+  static Pointer<TView> stackAlloc() {
+    return Pointer<TView>(NativeLibrary.instance.stackAlloc<TView>(0));
+  }
+}
+
+extension TViewportExt on Pointer<TViewport> {
+  TViewport toDart() {
+    return TViewport(this);
+  }
+}
+
+final class TViewport extends Struct {
+  Pointer<TViewport> get address => super.address.cast();
+  int get left {
+    final addr = Pointer<TViewport>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set left(int val) {
+    NativeLibrary.instance.setValue(Pointer<TViewport>(this.address.addr + 0), val.toJS, 'i32');
+  }
+
+  int get bottom {
+    final addr = Pointer<TViewport>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set bottom(int val) {
+    NativeLibrary.instance.setValue(Pointer<TViewport>(this.address.addr + 4), val.toJS, 'i32');
+  }
+
+  int get width {
+    final addr = Pointer<TViewport>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set width(int val) {
+    NativeLibrary.instance.setValue(Pointer<TViewport>(this.address.addr + 8), val.toJS, 'i32');
+  }
+
+  int get height {
+    final addr = Pointer<TViewport>(this.address.addr + 12);
+    final value = NativeLibrary.instance.getValue(addr, 'i32').toDartInt;
+    return value;
+  }
+
+  set height(int val) {
+    NativeLibrary.instance.setValue(Pointer<TViewport>(this.address.addr + 12), val.toJS, 'i32');
+  }
+
+  TViewport(super.address);
+
+  static Pointer<TViewport> stackAlloc() {
+    return Pointer<TViewport>(NativeLibrary.instance.stackAlloc<TViewport>(16));
+  }
+}
+
+/// Options for VSM Shadowing.
+
+extension TVsmShadowOptionsExt on Pointer<TVsmShadowOptions> {
+  TVsmShadowOptions toDart() {
+    return TVsmShadowOptions(this);
+  }
+}
+
+final class TVsmShadowOptions extends Struct {
+  Pointer<TVsmShadowOptions> get address => super.address.cast();
+  int get anisotropy {
+    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set anisotropy(int val) {
+    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 0), val.toJS, 'i8');
+  }
+
+  bool get mipmapping {
+    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 1);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set mipmapping(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 1), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  int get msaaSamples {
+    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 2);
+    final value = NativeLibrary.instance.getValue(addr, 'i8').toDartInt;
+    return value;
+  }
+
+  set msaaSamples(int val) {
+    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 2), val.toJS, 'i8');
+  }
+
+  bool get highPrecision {
+    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 3);
+    final value = NativeLibrary.instance.getValue(addr, 'i8');
+    return value.toDartInt == 1;
+  }
+
+  set highPrecision(bool val) {
+    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 3), (val ? 1 : 0).toJS, 'i8');
+  }
+
+  double get minVarianceScale {
+    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 4);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set minVarianceScale(double val) {
+    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 4), val.toJS, 'float');
+  }
+
+  double get lightBleedReduction {
+    final addr = Pointer<TVsmShadowOptions>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'float').toDartDouble;
+    return value;
+  }
+
+  set lightBleedReduction(double val) {
+    NativeLibrary.instance.setValue(Pointer<TVsmShadowOptions>(this.address.addr + 8), val.toJS, 'float');
+  }
+
+  TVsmShadowOptions(super.address);
+
+  static Pointer<TVsmShadowOptions> stackAlloc() {
+    return Pointer<TVsmShadowOptions>(NativeLibrary.instance.stackAlloc<TVsmShadowOptions>(12));
+  }
+}
+
+typedef VoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef DartVoidCallback = Pointer<NativeFunction<VoidCallbackFunction>>;
+typedef VoidCallbackFunction = void Function(int requestId);
+typedef DartVoidCallbackFunction = void Function(int requestId);
 
 const int __bool_true_false_are_defined = 1;
 
-const int MAX_CUSTOM_INTENTS = 16;
+extension double3Ext on Pointer<double3> {
+  double3 toDart() {
+    return double3(this);
+  }
+}
 
-const int MOVEMENT_INTENT_MASK = 1;
+final class double3 extends Struct {
+  Pointer<double3> get address => super.address.cast();
+  double get x {
+    final addr = Pointer<double3>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
 
-const int ROTATION_INTENT_MASK = 2;
+  set x(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 0), val.toJS, 'double');
+  }
 
-const int JUMP_INTENT_MASK = 4;
+  double get y {
+    final addr = Pointer<double3>(this.address.addr + 8);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
 
-const int SPRINT_INTENT_MASK = 8;
+  set y(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 8), val.toJS, 'double');
+  }
+
+  double get z {
+    final addr = Pointer<double3>(this.address.addr + 16);
+    final value = NativeLibrary.instance.getValue(addr, 'double').toDartDouble;
+    return value;
+  }
+
+  set z(double val) {
+    NativeLibrary.instance.setValue(Pointer<double3>(this.address.addr + 16), val.toJS, 'double');
+  }
+
+  double3(super.address);
+
+  static Pointer<double3> stackAlloc() {
+    return Pointer<double3>(NativeLibrary.instance.stackAlloc<double3>(24));
+  }
+}
+
+extension double4x4Ext on Pointer<double4x4> {
+  double4x4 toDart() {
+    return double4x4(this);
+  }
+}
+
+final class double4x4 extends Struct {
+  Pointer<double4x4> get address => super.address.cast();
+  Array<Float64> get col1 {
+    final addr = Pointer<double4x4>(this.address.addr + 0);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 0)));
+  }
+
+  set col1(Array<Float64> val) {
+    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 0), val.internal.addr.addr.toJS, '*');
+  }
+
+  Array<Float64> get col2 {
+    final addr = Pointer<double4x4>(this.address.addr + 32);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 32)));
+  }
+
+  set col2(Array<Float64> val) {
+    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 32), val.internal.addr.addr.toJS, '*');
+  }
+
+  Array<Float64> get col3 {
+    final addr = Pointer<double4x4>(this.address.addr + 64);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 64)));
+  }
+
+  set col3(Array<Float64> val) {
+    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 64), val.internal.addr.addr.toJS, '*');
+  }
+
+  Array<Float64> get col4 {
+    final addr = Pointer<double4x4>(this.address.addr + 96);
+    final value = NativeLibrary.instance.getValue(addr, '*');
+    return Array<Float64>((numElements: 4, addr: Pointer<Float64>(this.address.addr + 96)));
+  }
+
+  set col4(Array<Float64> val) {
+    NativeLibrary.instance.setValue(Pointer<double4x4>(this.address.addr + 96), val.internal.addr.addr.toJS, '*');
+  }
+
+  double4x4(super.address);
+
+  static Pointer<double4x4> stackAlloc() {
+    return Pointer<double4x4>(NativeLibrary.instance.stackAlloc<double4x4>(128));
+  }
+}
+
+typedef size_t = int;
+typedef Dartsize_t = int;
 
 extension StructAllocator on Struct {
   static T create<T>() {
     switch (T) {
-      case TViewport:
-        final ptr = TViewport.stackAlloc();
-        return ptr.toDart() as T;
-      case TView:
-        final ptr = TView.stackAlloc();
-        return ptr.toDart() as T;
-      case TToneMapper:
-        final ptr = TToneMapper.stackAlloc();
-        return ptr.toDart() as T;
-      case TEngine:
-        final ptr = TEngine.stackAlloc();
-        return ptr.toDart() as T;
-      case TColorGradingBuilder:
-        final ptr = TColorGradingBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TColorGrading:
-        final ptr = TColorGrading.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderTarget:
-        final ptr = TRenderTarget.stackAlloc();
-        return ptr.toDart() as T;
-      case TSoftShadowOptions:
-        final ptr = TSoftShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TVsmShadowOptions:
-        final ptr = TVsmShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TCamera:
-        final ptr = TCamera.stackAlloc();
-        return ptr.toDart() as T;
-      case TScene:
-        final ptr = TScene.stackAlloc();
+      case Aabb3:
+        final ptr = Aabb3.stackAlloc();
         return ptr.toDart() as T;
       case TAmbientOcclusionOptions:
         final ptr = TAmbientOcclusionOptions.stackAlloc();
         return ptr.toDart() as T;
-      case TSsct:
-        final ptr = TSsct.stackAlloc();
+      case TAnimationManager:
+        final ptr = TAnimationManager.stackAlloc();
         return ptr.toDart() as T;
-      case TGtao:
-        final ptr = TGtao.stackAlloc();
+      case TBufferObject:
+        final ptr = TBufferObject.stackAlloc();
+        return ptr.toDart() as T;
+      case TBufferObjectBuilder:
+        final ptr = TBufferObjectBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TCamera:
+        final ptr = TCamera.stackAlloc();
+        return ptr.toDart() as T;
+      case TColorGrading:
+        final ptr = TColorGrading.stackAlloc();
+        return ptr.toDart() as T;
+      case TColorGradingBuilder:
+        final ptr = TColorGradingBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TDebugRegistry:
+        final ptr = TDebugRegistry.stackAlloc();
+        return ptr.toDart() as T;
+      case TEngine:
+        final ptr = TEngine.stackAlloc();
+        return ptr.toDart() as T;
+      case TEntityManager:
+        final ptr = TEntityManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TFence:
+        final ptr = TFence.stackAlloc();
+        return ptr.toDart() as T;
+      case TFilamentAsset:
+        final ptr = TFilamentAsset.stackAlloc();
         return ptr.toDart() as T;
       case TFogOptions:
         final ptr = TFogOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TTexture:
-        final ptr = TTexture.stackAlloc();
         return ptr.toDart() as T;
       case TGizmo:
         final ptr = TGizmo.stackAlloc();
@@ -11642,8 +11673,26 @@ extension StructAllocator on Struct {
       case TGltfResourceLoader:
         final ptr = TGltfResourceLoader.stackAlloc();
         return ptr.toDart() as T;
-      case TNameComponentManager:
-        final ptr = TNameComponentManager.stackAlloc();
+      case TGtao:
+        final ptr = TGtao.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBuffer:
+        final ptr = TIndexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndexBufferBuilder:
+        final ptr = TIndexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TIndirectLight:
+        final ptr = TIndirectLight.stackAlloc();
+        return ptr.toDart() as T;
+      case TKtx1Bundle:
+        final ptr = TKtx1Bundle.stackAlloc();
+        return ptr.toDart() as T;
+      case TLightManager:
+        final ptr = TLightManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TLinearImage:
+        final ptr = TLinearImage.stackAlloc();
         return ptr.toDart() as T;
       case TMaterial:
         final ptr = TMaterial.stackAlloc();
@@ -11651,122 +11700,102 @@ extension StructAllocator on Struct {
       case TMaterialInstance:
         final ptr = TMaterialInstance.stackAlloc();
         return ptr.toDart() as T;
-      case TTextureSampler:
-        final ptr = TTextureSampler.stackAlloc();
-        return ptr.toDart() as T;
-      case TSceneAsset:
-        final ptr = TSceneAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBuffer:
-        final ptr = TVertexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBuffer:
-        final ptr = TIndexBuffer.stackAlloc();
-        return ptr.toDart() as T;
-      case Aabb3:
-        final ptr = Aabb3.stackAlloc();
-        return ptr.toDart() as T;
-      case TFilamentAsset:
-        final ptr = TFilamentAsset.stackAlloc();
-        return ptr.toDart() as T;
-      case double4x4:
-        final ptr = double4x4.stackAlloc();
-        return ptr.toDart() as T;
-      case double3:
-        final ptr = double3.stackAlloc();
+      case TMaterialProvider:
+        final ptr = TMaterialProvider.stackAlloc();
         return ptr.toDart() as T;
       case TMeshData:
         final ptr = TMeshData.stackAlloc();
         return ptr.toDart() as T;
-      case TLinearImage:
-        final ptr = TLinearImage.stackAlloc();
-        return ptr.toDart() as T;
-      case TKtx1Bundle:
-        final ptr = TKtx1Bundle.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderer:
-        final ptr = TRenderer.stackAlloc();
-        return ptr.toDart() as T;
-      case TSwapChain:
-        final ptr = TSwapChain.stackAlloc();
-        return ptr.toDart() as T;
-      case TTransformManager:
-        final ptr = TTransformManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderableManager:
-        final ptr = TRenderableManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TLightManager:
-        final ptr = TLightManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TEntityManager:
-        final ptr = TEntityManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TFence:
-        final ptr = TFence.stackAlloc();
-        return ptr.toDart() as T;
-      case TSkybox:
-        final ptr = TSkybox.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndirectLight:
-        final ptr = TIndirectLight.stackAlloc();
-        return ptr.toDart() as T;
-      case TDebugRegistry:
-        final ptr = TDebugRegistry.stackAlloc();
-        return ptr.toDart() as T;
-      case TMaterialProvider:
-        final ptr = TMaterialProvider.stackAlloc();
-        return ptr.toDart() as T;
-      case TVertexBufferBuilder:
-        final ptr = TVertexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TBufferObject:
-        final ptr = TBufferObject.stackAlloc();
-        return ptr.toDart() as T;
-      case TIndexBufferBuilder:
-        final ptr = TIndexBufferBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TBufferObjectBuilder:
-        final ptr = TBufferObjectBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TShadowOptions:
-        final ptr = TShadowOptions.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderManager:
-        final ptr = TRenderManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TAnimationManager:
-        final ptr = TAnimationManager.stackAlloc();
-        return ptr.toDart() as T;
-      case TRenderableBuilder:
-        final ptr = TRenderableBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientationBuilder:
-        final ptr = TSurfaceOrientationBuilder.stackAlloc();
-        return ptr.toDart() as T;
-      case TSurfaceOrientation:
-        final ptr = TSurfaceOrientation.stackAlloc();
+      case TMovementIntent:
+        final ptr = TMovementIntent.stackAlloc();
         return ptr.toDart() as T;
       case TMovementIntentExecutor:
         final ptr = TMovementIntentExecutor.stackAlloc();
         return ptr.toDart() as T;
-      case TMovementIntent:
-        final ptr = TMovementIntent.stackAlloc();
+      case TNameComponentManager:
+        final ptr = TNameComponentManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderManager:
+        final ptr = TRenderManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderTarget:
+        final ptr = TRenderTarget.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderableBuilder:
+        final ptr = TRenderableBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderableManager:
+        final ptr = TRenderableManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TRenderer:
+        final ptr = TRenderer.stackAlloc();
+        return ptr.toDart() as T;
+      case TScene:
+        final ptr = TScene.stackAlloc();
+        return ptr.toDart() as T;
+      case TSceneAsset:
+        final ptr = TSceneAsset.stackAlloc();
+        return ptr.toDart() as T;
+      case TShadowOptions:
+        final ptr = TShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TSkybox:
+        final ptr = TSkybox.stackAlloc();
+        return ptr.toDart() as T;
+      case TSoftShadowOptions:
+        final ptr = TSoftShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case TSsct:
+        final ptr = TSsct.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientation:
+        final ptr = TSurfaceOrientation.stackAlloc();
+        return ptr.toDart() as T;
+      case TSurfaceOrientationBuilder:
+        final ptr = TSurfaceOrientationBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TSwapChain:
+        final ptr = TSwapChain.stackAlloc();
+        return ptr.toDart() as T;
+      case TTexture:
+        final ptr = TTexture.stackAlloc();
+        return ptr.toDart() as T;
+      case TTextureSampler:
+        final ptr = TTextureSampler.stackAlloc();
+        return ptr.toDart() as T;
+      case TToneMapper:
+        final ptr = TToneMapper.stackAlloc();
+        return ptr.toDart() as T;
+      case TTransformManager:
+        final ptr = TTransformManager.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBuffer:
+        final ptr = TVertexBuffer.stackAlloc();
+        return ptr.toDart() as T;
+      case TVertexBufferBuilder:
+        final ptr = TVertexBufferBuilder.stackAlloc();
+        return ptr.toDart() as T;
+      case TView:
+        final ptr = TView.stackAlloc();
+        return ptr.toDart() as T;
+      case TViewport:
+        final ptr = TViewport.stackAlloc();
+        return ptr.toDart() as T;
+      case TVsmShadowOptions:
+        final ptr = TVsmShadowOptions.stackAlloc();
+        return ptr.toDart() as T;
+      case double3:
+        final ptr = double3.stackAlloc();
+        return ptr.toDart() as T;
+      case double4x4:
+        final ptr = double4x4.stackAlloc();
         return ptr.toDart() as T;
     }
     throw Exception("Unsupported type $T");
   }
 }
 
-extension NativeFunctionPointer0<T extends NativeType> on void Function() {
-  Pointer<NativeFunction<void Function()>> addFunction() {
-    return Pointer<NativeFunction<void Function()>>(
-      NativeLibrary.instance.addFunction<void Function()>(this.toJS, 'v'),
-    ).cast();
-  }
-}
-
-extension NativeFunctionPointer1<T extends NativeType> on void Function(Pointer<T>) {
+extension NativeFunctionPointer0<T extends NativeType> on void Function(Pointer<T>) {
   Pointer<NativeFunction<void Function(Pointer<TAnimationManager>)>> addFunction() {
     return Pointer<NativeFunction<void Function(Pointer<TAnimationManager>)>>(
       NativeLibrary.instance.addFunction<void Function(Pointer<TAnimationManager>)>(this.toJS, 'vp'),
@@ -11774,7 +11803,7 @@ extension NativeFunctionPointer1<T extends NativeType> on void Function(Pointer<
   }
 }
 
-extension NativeFunctionPointer17<T extends NativeType> on void Function(bool) {
+extension NativeFunctionPointer1<T extends NativeType> on void Function(bool) {
   Pointer<NativeFunction<void Function(bool)>> addFunction() {
     return Pointer<NativeFunction<void Function(bool)>>(
       NativeLibrary.instance.addFunction<void Function(bool)>(this.toJS, 'vi'),
@@ -11782,18 +11811,26 @@ extension NativeFunctionPointer17<T extends NativeType> on void Function(bool) {
   }
 }
 
-extension NativeFunctionPointer47<T extends NativeType> on void Function(int) {
-  Pointer<NativeFunction<void Function(int)>> addFunction() {
-    return Pointer<NativeFunction<void Function(int)>>(
-      NativeLibrary.instance.addFunction<void Function(int)>(this.toJS, 'vi'),
+extension NativeFunctionPointer18<T extends NativeType> on void Function(DartEntityId) {
+  Pointer<NativeFunction<void Function(DartEntityId)>> addFunction() {
+    return Pointer<NativeFunction<void Function(DartEntityId)>>(
+      NativeLibrary.instance.addFunction<void Function(DartEntityId)>(this.toJS, 'vi'),
     ).cast();
   }
 }
 
-extension NativeFunctionPointer61<T extends NativeType> on void Function(double) {
+extension NativeFunctionPointer24<T extends NativeType> on void Function(double) {
   Pointer<NativeFunction<void Function(double)>> addFunction() {
     return Pointer<NativeFunction<void Function(double)>>(
       NativeLibrary.instance.addFunction<void Function(double)>(this.toJS, 'vf'),
+    ).cast();
+  }
+}
+
+extension NativeFunctionPointer47<T extends NativeType> on void Function() {
+  Pointer<NativeFunction<void Function()>> addFunction() {
+    return Pointer<NativeFunction<void Function()>>(
+      NativeLibrary.instance.addFunction<void Function()>(this.toJS, 'v'),
     ).cast();
   }
 }


### PR DESCRIPTION
Use `sort: true` in the binding generation configs so that changes to header file orderings don't generate huge diffs in generated bindings. This adds a once-off churn to the bindings but will assist to keep future PRs small. 