### PR TITLE
fix: (web/js) clean up pending web callbacks when dispatch fails

### DIFF
--- a/thermion_dart/lib/src/bindings/src/js_interop.dart
+++ b/thermion_dart/lib/src/bindings/src/js_interop.dart
@@ -81,7 +81,12 @@ Future<void> withVoidCallback(Function(int, Pointer<NativeFunction<Void Function
 
   _completers[requestId] = completer;
 
-  func.call(requestId, _voidCallbackPtr.cast());
+  try {
+    func.call(requestId, _voidCallbackPtr.cast());
+  } catch (_) {
+    _completers.remove(requestId);
+    rethrow;
+  }
   while (!completer.isCompleted) {
     _NativeLibrary.instance._execute_queue();
     await Future.delayed(Duration(milliseconds: 1));


### PR DESCRIPTION
When a web void-callback dispatch throws before completion, its Completer remains in the process-wide pending map. Remove the entry in the dispatch catch block and rethrow the original exception.
