### PR TITLE
fix: require ffigen_js standalone enum emission fix

### DIFF
--- a/thermion_dart/pubspec.yaml
+++ b/thermion_dart/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   path: ^1.9.0
   crypto: ^3.0.0
   image: ^4.3.0
-  ffigen_js: ^0.0.14-pre
+  ffigen_js: ^0.0.15-pre
   
 dev_dependencies:
   ffigen: ^18.1.0


### PR DESCRIPTION
Bump `ffigen_js` to ``0.0.15-pre`, which fixes root-level enum emission (earlier version dropped standalone enums such as `TSceneAssetGeometryCapability`, causing web compilation to fail).
