### PR TITLE
fix(android): migrate to Flutter built-in Kotlin (drop KGP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changes
 
+- `thermion_flutter` (Android) migrates to Flutter's built-in Kotlin: the plugin
+  no longer applies the Kotlin Gradle Plugin itself. Minimum supported SDK is
+  now Flutter 3.44 / Dart 3.12.
 - `FilamentApp` exposes the native engine handle as a public
 - `TranslationAxisMaterial.createMaterialInstance` and `ToneMapper` factory methods
   now take the abstract `FilamentApp` instead of

--- a/thermion_flutter/thermion_flutter/android/build.gradle
+++ b/thermion_flutter/thermion_flutter/android/build.gradle
@@ -2,7 +2,6 @@ group 'dev.thermion.android'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace 'dev.thermion.android'
@@ -31,10 +28,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -58,8 +51,13 @@ android {
     }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
+}
+
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"
 }

--- a/thermion_flutter/thermion_flutter/pubspec.yaml
+++ b/thermion_flutter/thermion_flutter/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://thermion.dev
 repository: https://github.com/nmfisher/thermion
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes #315.

Flutter 3.44+ warns on every Android build that `thermion_flutter` applies the Kotlin Gradle Plugin (KGP), and says future versions will fail to build such plugins.

This follows Flutter's migration guide for plugin authors:
https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors

## Changes

`thermion_flutter/thermion_flutter/android/build.gradle`
- remove `ext.kotlin_version` and the `kotlin-gradle-plugin` classpath
- remove `apply plugin: 'kotlin-android'`
- replace `kotlinOptions { jvmTarget = '1.8' }` with `kotlin { compilerOptions { jvmTarget = JVM_1_8 } }`
- remove the explicit `kotlin-stdlib-jdk8` dependency (KGP adds the stdlib itself)
- keep `src/main/kotlin` and the coroutines dependencies

`thermion_flutter/thermion_flutter/pubspec.yaml`
- minimum SDK is now Flutter 3.44 / Dart 3.12, as the guide requires (`kotlin.compilerOptions` needs KGP 2.0, which Flutter enforces from 3.44)

`CHANGELOG.md`
- note the migration and the new minimum SDK

Flutter (or AGP 9 built-in Kotlin) now supplies the Kotlin plugin to the module, so the Kotlin sources still compile.

## Testing

Built a Flutter app (Flutter 3.44.7, AGP 9.0.1, KGP 2.3.20, `android.builtInKotlin=false`) against this branch with `flutter build apk --debug`. The build succeeds and `thermion_flutter` no longer appears in the KGP warning.
