### PR TITLE
fix(thermion_dart): skip non-renderable children in setCastShadows/setReceiveShadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changes
 
+- `ThermionAsset.setCastShadows` / `setReceiveShadows` skip entities without a
+  renderable component (bones, empties, attachment nodes) instead of logging
+  `Error: invalid renderable` for each one.
 - `FilamentApp` exposes the native engine handle as a public
 - `TranslationAxisMaterial.createMaterialInstance` and `ToneMapper` factory methods
   now take the abstract `FilamentApp` instead of

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_asset.dart
@@ -373,16 +373,20 @@ class FFIAsset extends ThermionAsset<Pointer<TSceneAsset>> {
 
   //
   Future setCastShadows(bool castShadows) async {
-    await _app.renderableManager.setCastShadows(this.entity, castShadows);
-    for (final entity in await this.getChildEntities()) {
+    for (final entity in [this.entity, ...await this.getChildEntities()]) {
+      if (!_app.renderableManager.isRenderable(entity)) {
+        continue;
+      }
       await _app.renderableManager.setCastShadows(entity, castShadows);
     }
   }
 
   //
   Future setReceiveShadows(bool receiveShadows) async {
-    await _app.renderableManager.setReceiveShadows(this.entity, receiveShadows);
-    for (final entity in await this.getChildEntities()) {
+    for (final entity in [this.entity, ...await this.getChildEntities()]) {
+      if (!_app.renderableManager.isRenderable(entity)) {
+        continue;
+      }
       await _app.renderableManager.setReceiveShadows(entity, receiveShadows);
     }
   }


### PR DESCRIPTION
## The problem

`FFIAsset.setCastShadows` and `setReceiveShadows` call the renderable manager for the root entity and every child entity of the asset. Bones, empties and attachment nodes have no renderable component, so `TRenderableManager.cpp` logs `Error: invalid renderable` for each one.

`ThermionWidget` calls `asset.setCastShadows(true)` on every glb it loads, so every user sees this. A single skinned character (about 130 joints) prints ~460 lines of `Error: invalid renderable` on load.

## The fix

Skip entities that are not renderable, using `renderableManager.isRenderable`. This is the same check `getBoundingBox`, `getMaterialInstanceAt` and `setMaterialInstanceForAll` in the same file already make.

Behaviour for renderable entities is unchanged.

## Testing

Ran a Flutter app on an Android emulator that loads a skinned glTF character (131 joints) through `ThermionWidget`.

- before: 460 `Error: invalid renderable` lines in logcat on the first screen
- after: 0
