### PR TITLE
fix: separate KTX upload release from skybox and IBL setup

### DIFF
--- a/thermion_dart/lib/src/filament/src/implementation/ffi_ktx1_bundle.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_ktx1_bundle.dart
@@ -7,6 +7,11 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   final Pointer<TKtx1Bundle> pointer;
 
   final FFIFilamentApp _app;
+  bool _destroyed = false;
+
+  void _checkAlive() {
+    if (_destroyed) throw StateError("KTX bundle has been destroyed");
+  }
 
   FFIKtx1Bundle(this.pointer, this._app);
 
@@ -14,13 +19,14 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   ///
   ///
   bool isCubemap() {
+    _checkAlive();
     return Ktx1Bundle_isCubemap(pointer);
   }
 
-  ///
-  ///
-  ///
+  @override
   Future destroy() async {
+    if (_destroyed) return;
+    _destroyed = true;
     Ktx1Bundle_destroy(pointer);
   }
 
@@ -28,6 +34,7 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   ///
   ///
   Float32List getSphericalHarmonics() {
+    _checkAlive();
     final harmonics = makeFloat32List(27);
     Ktx1Bundle_getSphericalHarmonics(pointer, harmonics.address);
     return harmonics;
@@ -47,6 +54,7 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   }
 
   Future<Texture> createTexture({VoidCallback? onTextureUploadComplete, int? textureUploadCompleteRequestId}) async {
+    _checkAlive();
     final texturePtr = await withPointerCallback<TTexture>((cb) {
       Ktx1Reader_createTextureRenderThread(
         _app.engine,
@@ -56,6 +64,7 @@ class FFIKtx1Bundle extends Ktx1Bundle {
         cb,
       );
     });
+    if (texturePtr == nullptr) throw StateError("Failed to create KTX texture");
     return FFITexture(_app.engine, texturePtr, _app);
   }
 }

--- a/thermion_dart/lib/src/filament/src/interface/ktx1_bundle.dart
+++ b/thermion_dart/lib/src/filament/src/interface/ktx1_bundle.dart
@@ -6,9 +6,11 @@ abstract class Ktx1Bundle {
   ///
   bool isCubemap();
 
-  ///
-  ///
-  ///
+  /// Returns when the texture has been created, before upload data is necessarily
+  /// released. Keep this bundle alive until [onTextureUploadComplete] is called.
+  /// That callback signals buffer release;
+  /// this Future separately reports creation success or failure.
+  /// A failed creation Future alone does not make it safe to destroy the bundle.
   Future<Texture> createTexture({VoidCallback? onTextureUploadComplete, int? textureUploadCompleteRequestId});
 
   ///
@@ -16,8 +18,14 @@ abstract class Ktx1Bundle {
   ///
   Float32List getSphericalHarmonics();
 
+  /// Immediately frees this bundle and its native data. Repeated calls are harmless.
   ///
+  /// The caller must first wait for every queued creation/upload to release its
+  /// data, using the callback supplied to [createTexture]. Destroying the bundle
+  /// earlier is invalid and can make native code read freed memory.
+  /// This method does not wait for uploads or defer deletion.
   ///
-  ///
+  /// Textures created from the bundle are separate resources; call
+  /// [Texture.destroy] when each texture is no longer needed.
   Future destroy();
 }

--- a/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
+++ b/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
@@ -272,37 +272,45 @@ class ThermionViewerFFI extends ThermionViewer {
 
     var data = await _app.loadResource(skyboxPath);
 
-    final completer = Completer<void>();
     FFIKtx1Bundle? bundle;
-    late FFISkybox skybox;
-
-    final uploadFuture = withVoidCallback((requestId, onTextureUploadComplete) async {
+    Future<void>? uploadReleased;
+    FFITexture? texture;
+    FFISkybox? skybox;
+    try {
       bundle = await FFIKtx1Bundle.create(_app, data) as FFIKtx1Bundle;
-
-      _skyboxTexture =
-          await bundle!.createTexture(
-                onTextureUploadComplete: onTextureUploadComplete,
-                textureUploadCompleteRequestId: requestId,
-              )
-              as FFITexture;
-
-      skybox = await _app.buildSkybox(texture: _skyboxTexture) as FFISkybox;
-
+      late Future<Texture> textureCreated;
+      // This callback means only that native code released the pixel data.
+      // Keep async setup outside its dispatch closure: setup failure must not
+      // complete the release Future or trigger early bundle destruction.
+      uploadReleased = withVoidCallback((id, callback) {
+        textureCreated = bundle!.createTexture(onTextureUploadComplete: callback, textureUploadCompleteRequestId: id);
+      });
+      texture = await textureCreated as FFITexture;
+      skybox = await _app.buildSkybox(texture: texture) as FFISkybox;
       await scene.setSkybox(skybox);
-
-      completer.complete();
-    });
-
-    late final Future<void> trackedUploadFuture;
-    trackedUploadFuture = uploadFuture.whenComplete(() async {
-      await bundle?.destroy();
-      if (identical(_skyboxTextureUploadComplete, trackedUploadFuture)) {
-        _skyboxTextureUploadComplete = null;
+      _skyboxTexture = texture;
+      return skybox;
+    } catch (_) {
+      await skybox?.destroy();
+      if (uploadReleased != null) await _app.flush();
+      await texture?.destroy();
+      rethrow;
+    } finally {
+      if (bundle != null) {
+        final ownedBundle = bundle;
+        // Setup no longer uses the bundle. Cleanup still waits for the separate
+        // buffer-release callback, on both setup success and setup failure.
+        late final Future<void> cleanup;
+        cleanup = (uploadReleased ?? Future<void>.value()).then((_) async {
+          await ownedBundle.destroy();
+          if (identical(_skyboxTextureUploadComplete, cleanup)) {
+            _skyboxTextureUploadComplete = null;
+          }
+        });
+        _skyboxTextureUploadComplete = cleanup;
       }
-    });
-    _skyboxTextureUploadComplete = trackedUploadFuture;
-    await completer.future;
-    return skybox;
+      if (FILAMENT_WASM) data.free();
+    }
   }
 
   //
@@ -315,46 +323,48 @@ class ThermionViewerFFI extends ThermionViewer {
   Future<void> _loadIbl(String lightingPath, {double intensity = 30000, bool destroyExisting = true}) async {
     await _removeIbl(destroy: destroyExisting);
 
-    final completer = Completer<void>();
+    final data = await _app.loadResource(lightingPath);
     FFIKtx1Bundle? bundle;
-    final uploadFuture = withVoidCallback((requestId, onTextureUploadComplete) async {
-      var data = await _app.loadResource(lightingPath);
-
+    Future<void>? uploadReleased;
+    Texture? texture;
+    FFIIndirectLight? ibl;
+    try {
       bundle = await FFIKtx1Bundle.create(_app, data) as FFIKtx1Bundle;
-
-      final texture = await bundle!.createTexture(
-        onTextureUploadComplete: onTextureUploadComplete,
-        textureUploadCompleteRequestId: requestId,
-      );
-      final harmonics = bundle!.getSphericalHarmonics();
-
-      final ibl = await FFIIndirectLight.fromIrradianceHarmonics(
+      late Future<Texture> textureCreated;
+      uploadReleased = withVoidCallback((id, callback) {
+        textureCreated = bundle!.createTexture(onTextureUploadComplete: callback, textureUploadCompleteRequestId: id);
+      });
+      texture = await textureCreated;
+      final harmonics = bundle.getSphericalHarmonics();
+      ibl = await FFIIndirectLight.fromIrradianceHarmonics(
         _app,
         harmonics,
         reflectionsTexture: texture,
         intensity: intensity,
       );
-
       await scene.setIndirectLight(ibl);
-
-      if (FILAMENT_WASM) {
-        data.free();
+    } catch (_) {
+      if (ibl != null) {
+        await ibl.destroy(); // Also releases its owned reflection texture.
+      } else {
+        if (uploadReleased != null) await _app.flush();
+        await texture?.destroy();
       }
-
-      completer.complete();
-      _logger.info("IBL texture ready");
-    });
-
-    late final Future<void> trackedUploadFuture;
-    trackedUploadFuture = uploadFuture.whenComplete(() async {
-      await bundle?.destroy();
-      if (identical(_iblTextureUploadComplete, trackedUploadFuture)) {
-        _iblTextureUploadComplete = null;
+      rethrow;
+    } finally {
+      if (bundle != null) {
+        final ownedBundle = bundle;
+        late final Future<void> cleanup;
+        cleanup = (uploadReleased ?? Future<void>.value()).then((_) async {
+          await ownedBundle.destroy();
+          if (identical(_iblTextureUploadComplete, cleanup)) {
+            _iblTextureUploadComplete = null;
+          }
+        });
+        _iblTextureUploadComplete = cleanup;
       }
-      _logger.info("IBL texture upload complete");
-    });
-    _iblTextureUploadComplete = trackedUploadFuture;
-    await completer.future;
+      if (FILAMENT_WASM) data.free();
+    }
   }
 
   Future<void> _loadIblFromTexture(
@@ -407,10 +417,9 @@ class ThermionViewerFFI extends ThermionViewer {
     throw UnimplementedError();
   }
 
-  Future? _skyboxTextureUploadComplete;
+  Future<void>? _skyboxTextureUploadComplete;
+  Future<void>? _iblTextureUploadComplete;
   FFITexture? _skyboxTexture;
-
-  Future? _iblTextureUploadComplete;
 
   //
   @override

--- a/thermion_dart/native/include/c_api/TTexture.h
+++ b/thermion_dart/native/include/c_api/TTexture.h
@@ -261,6 +261,8 @@ EMSCRIPTEN_KEEPALIVE void Ktx1Bundle_getSphericalHarmonics(
 EMSCRIPTEN_KEEPALIVE bool Ktx1Bundle_isCubemap(
     TKtx1Bundle *tBundle
 );
+// Immediately frees the bundle and its data. The caller must wait until all
+// queued creation and upload buffers have finished using it before calling this.
 EMSCRIPTEN_KEEPALIVE void Ktx1Bundle_destroy(
     TKtx1Bundle *tBundle
 );

--- a/thermion_dart/native/test/rendering/CMakeLists.txt
+++ b/thermion_dart/native/test/rendering/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 project(thermion_scheduling_tests LANGUAGES CXX)
 
 find_package(Threads REQUIRED)
+add_library(upload_lifetime_fixture SHARED upload_lifetime_fixture.cpp)
+target_compile_features(upload_lifetime_fixture PRIVATE cxx_std_17)
+target_link_libraries(upload_lifetime_fixture PRIVATE Threads::Threads)
 add_executable(scheduling_test
     scheduling_test.cpp
     ../../src/rendering/FrameScheduler.cpp)

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -41,3 +41,34 @@ The gate extraction is reused by the web worker in #301. Task-error propagation
 is in #318; forwarding scheduler timestamps through Flutter into rendering is
 in #319. Normalizing native scheduler output alone does not replace the existing
 Dart wall-clock render timestamp. Browser dispatch/lifetime fixtures land in #301.
+
+## KTX upload lifetime tests
+
+The caller owns the KTX bundle. `destroy()` immediately deletes it and its data;
+calling it while queued creation or an upload still uses the data is invalid.
+Texture creation returns before buffer release is guaranteed. Keep the bundle
+alive until the upload-release callback arrives, then destroy it explicitly.
+Created textures have their own lifetime and must be destroyed separately.
+
+Skybox and IBL loaders keep setup and buffer-release Futures separate. Setup
+errors reach the public Future; bundle cleanup waits for buffer release even
+when setup fails. Successful loads do not add a GPU-completion wait. Removal
+and disposal flush pending work and wait for bundle cleanup, as before.
+Native C++ exception delivery to Dart is handled separately in #318.
+
+Native partial-submission failure handling is a separate change. This PR does
+not guarantee release notification if Filament fails during submission.
+Run the Dart integration tests from `thermion_dart/`:
+
+```sh
+THERMION_UPLOAD_LIFETIME_FIXTURE=/tmp/thermion-scheduling/libupload_lifetime_fixture.dylib \
+  dart test --concurrency=1 test/ktx_upload_lifetime_test.dart test/skybox_tests.dart
+```
+
+The fixture is built by the CMake commands above. On Linux use
+`libupload_lifetime_fixture.so`; on Windows use `Release/upload_lifetime_fixture.dll`
+and set the variable using your shell's syntax. The tests require a working GPU
+backend (Metal on macOS). They gate the worker to verify release is still pending,
+exercise cubemap/mipmapped/2D uploads followed by explicit bundle destruction,
+and check public skybox/IBL failure delivery. Dart's native build hook builds
+Thermion and obtains Filament.

--- a/thermion_dart/native/test/rendering/upload_lifetime_fixture.cpp
+++ b/thermion_dart/native/test/rendering/upload_lifetime_fixture.cpp
@@ -1,0 +1,17 @@
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#ifdef _WIN32
+#define TEST_EXPORT extern "C" __declspec(dllexport)
+#else
+#define TEST_EXPORT extern "C" __attribute__((visibility("default")))
+#endif
+
+// Hold the render worker so Dart can verify release has not yet been signalled.
+namespace { std::atomic<bool> releaseTask{false}; }
+TEST_EXPORT void resetTaskRelease() { releaseTask.store(false); }
+TEST_EXPORT void allowTaskToFinish() { releaseTask.store(true); }
+TEST_EXPORT void waitForTaskRelease() {
+    while (!releaseTask.load()) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+}

--- a/thermion_dart/test/ktx_upload_lifetime_test.dart
+++ b/thermion_dart/test/ktx_upload_lifetime_test.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/bindings/src/ffi.dart' as ffi;
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_ktx1_bundle.dart';
+
+// Owns no additional engine. Only the skybox builder is replaced, to fail after
+// the real native texture creation/upload has started.
+class FailingSkyboxApp extends FFIFilamentApp {
+  FailingSkyboxApp(FFIFilamentApp app)
+    : super(
+        app.engine,
+        app.gltfAssetLoader,
+        app.renderer,
+        app.transformManager.getNativeHandle(),
+        app.ubershaderMaterialProvider,
+        app.renderManager.getNativeHandle(),
+        app.renderThreadHandle,
+        app.nameComponentManager,
+        app.loadResource,
+        app.lightManager.getNativeHandle(),
+        app.renderableManager.getNativeHandle(),
+        app.animationManager.getNativeHandle(),
+      );
+
+  @override
+  Future<Skybox> buildSkybox({Texture? texture, bool showSun = false, double? intensity, int priority = 7}) async {
+    expect(texture, isNotNull);
+    throw StateError('skybox setup failed after texture creation');
+  }
+}
+
+void main() {
+  final fixturePath = Platform.environment['THERMION_UPLOAD_LIFETIME_FIXTURE'];
+  group('KTX upload lifetime', () {
+    late FFIFilamentApp app;
+    late Uint8List bytes;
+    late DynamicLibrary fixture;
+    setUpAll(() async {
+      fixture = DynamicLibrary.open(fixturePath!);
+      bytes = await File('../examples/assets/default_env_skybox.ktx').readAsBytes();
+      await FFIFilamentApp.create(
+        config: FFIFilamentConfig(
+          backend: Platform.isMacOS ? Backend.METAL : Backend.DEFAULT,
+          loadResource: (uri) async {
+            if (uri == 'missing') throw StateError('resource load failed');
+            return bytes;
+          },
+        ),
+      );
+      app = FilamentApp.instance! as FFIFilamentApp;
+    });
+    tearDownAll(() async {
+      await app.destroy();
+    });
+
+    test('caller waits for buffer release before destroying the bundle', () async {
+      final reset = fixture.lookupFunction<ffi.Void Function(), void Function()>('resetTaskRelease');
+      final release = fixture.lookupFunction<ffi.Void Function(), void Function()>('allowTaskToFinish');
+      final blocked = fixture.lookup<ffi.NativeFunction<ffi.Void Function()>>('waitForTaskRelease');
+      final bundle = await FFIKtx1Bundle.create(app, bytes);
+      reset();
+      ffi.RenderThread_addTask(blocked);
+      late Future<Texture> textureCreated;
+      var released = false;
+      final uploadReleased =
+          withVoidCallback((id, callback) {
+            textureCreated = bundle.createTexture(
+              onTextureUploadComplete: callback,
+              textureUploadCompleteRequestId: id,
+            );
+          }).then((_) {
+            released = true;
+          });
+      try {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(released, isFalse);
+        expect(bundle.isCubemap(), isTrue); // Caller still owns the data.
+      } finally {
+        release();
+      }
+      final texture = await textureCreated.timeout(const Duration(seconds: 5));
+      await app.flush();
+      await uploadReleased.timeout(const Duration(seconds: 5));
+      await bundle.destroy();
+      await bundle.destroy();
+      expect(bundle.isCubemap, throwsStateError);
+      expect(await texture.getWidth(), greaterThan(0)); // Texture is independent.
+      await texture.destroy();
+    });
+
+    test('skybox failure after texture creation reaches the public Future', () async {
+      final viewer = ThermionViewerFFI(app: FailingSkyboxApp(app));
+      await viewer.initialized;
+      try {
+        await expectLater(
+          viewer.loadSkybox('valid').timeout(const Duration(seconds: 5)),
+          throwsA(isA<StateError>().having((e) => e.message, 'message', 'skybox setup failed after texture creation')),
+        );
+        await app.flush();
+        expect(await viewer.getSkybox(), isNull);
+      } finally {
+        await viewer.dispose();
+      }
+    });
+
+    for (final asset in ['default_env_ibl.ktx', 'background.ktx']) {
+      test('$asset releases upload data before caller cleanup', () async {
+        final data = await File('../examples/assets/$asset').readAsBytes();
+        final bundle = await FFIKtx1Bundle.create(app, data);
+        late Future<Texture> textureCreated;
+        final uploadReleased = withVoidCallback((id, callback) {
+          textureCreated = bundle.createTexture(onTextureUploadComplete: callback, textureUploadCompleteRequestId: id);
+        });
+        final texture = await textureCreated.timeout(const Duration(seconds: 5));
+        try {
+          await app.flush();
+          await uploadReleased.timeout(const Duration(seconds: 5));
+          await bundle.destroy();
+          expect(await texture.getWidth(), greaterThan(0));
+        } finally {
+          await texture.destroy();
+        }
+      });
+    }
+
+    test('IBL resource failure reaches the public Future and permits another operation', () async {
+      final viewer = ThermionViewerFFI(app: app);
+      await viewer.initialized;
+      try {
+        await expectLater(
+          viewer.loadIbl('missing').timeout(const Duration(seconds: 5)),
+          throwsA(isA<StateError>().having((e) => e.message, 'message', 'resource load failed')),
+        );
+        await viewer.setBackgroundColor(0, 0, 0, 1).timeout(const Duration(seconds: 5));
+      } finally {
+        await viewer.dispose();
+      }
+    });
+  }, skip: fixturePath == null ? 'Set THERMION_UPLOAD_LIFETIME_FIXTURE; see native/test/rendering/README.md' : false);
+}


### PR DESCRIPTION
Skybox and IBL loading has two separate completion points: scene setup finishes, and native code releases the pixel data used by the upload. The original successful path already waited for the release callback before freeing its KTX bundle. The problem was that a setup failure could leave the public Future waiting forever; treating that failure as upload completion could also free pixel data too early.

This PR separates setup from release. The public Future reports setup success or failure. Cleanup waits until setup has stopped using the bundle and the upload callback says native code has released its data. Failed setup also destroys the partially created skybox/light and texture.

`Ktx1Bundle.destroy()` still immediately frees the caller-owned bundle and its data. It does not wait or defer deletion. Callers must wait for upload release first; created textures have a separate lifetime. Dart rejects use after destruction and makes repeated destruction harmless.

