### PR TITLE
fix: validate KTX input before texture upload

### DIFF
--- a/thermion_dart/bin/task_error_benchmark.dart
+++ b/thermion_dart/bin/task_error_benchmark.dart
@@ -1,0 +1,4 @@
+// dart build cli requires an entry point in bin/.
+import '../test/benchmarks/task_error_benchmark.dart' as benchmark;
+
+Future<void> main(List<String> args) => benchmark.main(args);

--- a/thermion_dart/bin/task_error_frame_benchmark.dart
+++ b/thermion_dart/bin/task_error_frame_benchmark.dart
@@ -1,0 +1,4 @@
+// dart build cli requires an entry point in bin/.
+import '../test/benchmarks/task_error_frame_benchmark.dart' as benchmark;
+
+Future<void> main(List<String> args) => benchmark.main(args);

--- a/thermion_dart/lib/src/bindings/src/ffi.dart
+++ b/thermion_dart/lib/src/bindings/src/ffi.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:thermion_dart/thermion_dart.dart';
 import 'void_callback_registry.dart';
+import 'native_task_errors.dart';
 export 'package:ffi/ffi.dart';
 export 'dart:ffi' hide Size;
 
@@ -116,6 +117,11 @@ extension PCBF on DartPickCallbackFunction {
 
 final _voidCallbackRegistry = VoidCallbackRegistry();
 
+// Callback helper contract (void and typed helpers below): dispatch one native
+// operation synchronously, with success/error as alternative final completions.
+// Do not reuse its callback for independent tasks or submit it after an await;
+// use another helper for that work. The registry delays cleanup after a Dart
+// dispatch error until any queued operation has delivered its final callback.
 Future<void> withVoidCallback(Function(int, Pointer<NativeFunction<Void Function(Int32)>>) func) =>
     _voidCallbackRegistry.invoke(func);
 
@@ -128,10 +134,11 @@ Future<Pointer<T>> withPointerCallback<T extends NativeType>(
     completer.complete(ptr.cast<T>());
   };
   final nativeCallable = NativeCallable<Void Function(Pointer<NativeType>)>.listener(callback);
-  func.call(nativeCallable.nativeFunction);
-  var ptr = await completer.future;
-  nativeCallable.close();
-  return ptr;
+  try {
+    return await nativeTaskErrors.invoke(completer, () => func.call(nativeCallable.nativeFunction));
+  } finally {
+    nativeCallable.close();
+  }
 }
 
 Future<bool> withBoolCallback(Function(Pointer<NativeFunction<Void Function(Bool)>>) func) async {
@@ -141,10 +148,11 @@ Future<bool> withBoolCallback(Function(Pointer<NativeFunction<Void Function(Bool
     completer.complete(result);
   };
   final nativeCallable = NativeCallable<Void Function(Bool)>.listener(callback);
-  func.call(nativeCallable.nativeFunction);
-  await completer.future;
-  nativeCallable.close();
-  return completer.future;
+  try {
+    return await nativeTaskErrors.invoke(completer, () => func.call(nativeCallable.nativeFunction));
+  } finally {
+    nativeCallable.close();
+  }
 }
 
 Future<double> withFloatCallback(Function(Pointer<NativeFunction<Void Function(Float)>>) func) async {
@@ -154,10 +162,11 @@ Future<double> withFloatCallback(Function(Pointer<NativeFunction<Void Function(F
     completer.complete(result);
   };
   final nativeCallable = NativeCallable<Void Function(Float)>.listener(callback);
-  func.call(nativeCallable.nativeFunction);
-  await completer.future;
-  nativeCallable.close();
-  return completer.future;
+  try {
+    return await nativeTaskErrors.invoke(completer, () => func.call(nativeCallable.nativeFunction));
+  } finally {
+    nativeCallable.close();
+  }
 }
 
 Future<int> withIntCallback(Function(Pointer<NativeFunction<Void Function(Int32)>>) func) async {
@@ -167,10 +176,11 @@ Future<int> withIntCallback(Function(Pointer<NativeFunction<Void Function(Int32)
     completer.complete(result);
   };
   final nativeCallable = NativeCallable<Void Function(Int32)>.listener(callback);
-  func.call(nativeCallable.nativeFunction);
-  await completer.future;
-  nativeCallable.close();
-  return completer.future;
+  try {
+    return await nativeTaskErrors.invoke(completer, () => func.call(nativeCallable.nativeFunction));
+  } finally {
+    nativeCallable.close();
+  }
 }
 
 Future<int> withUInt32Callback(Function(Pointer<NativeFunction<Void Function(Uint32)>>) func) async {
@@ -180,10 +190,11 @@ Future<int> withUInt32Callback(Function(Pointer<NativeFunction<Void Function(Uin
     completer.complete(result);
   };
   final nativeCallable = NativeCallable<Void Function(Uint32)>.listener(callback);
-  func.call(nativeCallable.nativeFunction);
-  await completer.future;
-  nativeCallable.close();
-  return completer.future;
+  try {
+    return await nativeTaskErrors.invoke(completer, () => func.call(nativeCallable.nativeFunction));
+  } finally {
+    nativeCallable.close();
+  }
 }
 
 Future<String> withCharPtrCallback(Function(Pointer<NativeFunction<Void Function(Pointer<Char>)>>) func) async {
@@ -193,10 +204,11 @@ Future<String> withCharPtrCallback(Function(Pointer<NativeFunction<Void Function
     completer.complete(result.cast<Utf8>().toDartString());
   };
   final nativeCallable = NativeCallable<Void Function(Pointer<Char>)>.listener(callback);
-  func.call(nativeCallable.nativeFunction);
-  await completer.future;
-  nativeCallable.close();
-  return completer.future;
+  try {
+    return await nativeTaskErrors.invoke(completer, () => func.call(nativeCallable.nativeFunction));
+  } finally {
+    nativeCallable.close();
+  }
 }
 
 extension FreeTypedData<T> on TypedData {

--- a/thermion_dart/lib/src/bindings/src/js_interop.dart
+++ b/thermion_dart/lib/src/bindings/src/js_interop.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'thermion_dart_js_interop.g.dart';
+import 'task_error_registry.dart';
 import 'dart:js_interop';
 
 export 'dart:typed_data';
@@ -65,106 +66,86 @@ extension VFCB on void Function() {
   }
 }
 
-int _lastRequestId = 0;
-final _completers = <int, Completer>{};
-void Function(int) _voidCallback = (int requestId) {
-  _completers[requestId]!.complete();
-  _completers.remove(requestId);
-};
+final _taskErrors = TaskErrorRegistry(
+  install: (requestId) => RenderThread_setTaskErrorCallback(requestId, _taskErrorCallbackPtr.cast()),
+  clear: () => RenderThread_setTaskErrorCallback(0, nullptr),
+);
 
-final _voidCallbackPtr = _voidCallback.addFunction();
+void _taskFailed(int requestId, Pointer<Char> message) {
+  try {
+    _taskErrors.fail(requestId, message == nullptr ? 'Native render task failed' : message.cast<Utf8>().toDartString());
+  } finally {
+    RenderThread_freeErrorMessage(message);
+  }
+}
+
+final _taskErrorCallbackPtr = addFunction<RenderTaskErrorCallbackFunction>(_taskFailed.toJS, 'vip');
+
+int _lastRequestId = 0;
+final _completers = <int, Completer<void>>{};
+void _completeVoid(int requestId) {
+  final completer = _completers.remove(requestId);
+  if (completer != null && !completer.isCompleted) completer.complete();
+}
+
+final _voidCallbackPtr = _completeVoid.addFunction();
+
+Future<T> _dispatch<T>(Completer<T> completer, FutureOr<void> Function() call) {
+  return _taskErrors.invoke(completer, call, pump: () => _NativeLibrary.instance._execute_queue());
+}
 
 Future<void> withVoidCallback(Function(int, Pointer<NativeFunction<Void Function(int)>>) func) async {
-  final completer = Completer();
-  var requestId = _lastRequestId;
-  _lastRequestId++;
-
+  while (_completers.containsKey(_lastRequestId)) {
+    _lastRequestId = (_lastRequestId + 1) & 0x7fffffff;
+  }
+  final requestId = _lastRequestId;
+  _lastRequestId = (_lastRequestId + 1) & 0x7fffffff;
+  final completer = Completer<void>();
   _completers[requestId] = completer;
 
   try {
-    func.call(requestId, _voidCallbackPtr.cast());
-  } catch (_) {
+    await _dispatch(completer, () => func.call(requestId, _voidCallbackPtr.cast()));
+  } finally {
     _completers.remove(requestId);
-    rethrow;
   }
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
-  await completer.future;
 }
 
 Future<Pointer<T>> withPointerCallback<T extends NativeType>(
   Function(Pointer<NativeFunction<Void Function(Pointer<T>)>>) func,
 ) async {
   final completer = Completer<Pointer<T>>();
-  // ignore: prefer_function_declarations_over_variables
-  void Function(Pointer<T>) callback = (Pointer<T> ptr) {
-    completer.complete(ptr.cast<T>());
-  };
+  void callback(Pointer<T> ptr) => completer.complete(ptr.cast<T>());
 
   final onComplete_interopFnPtr = callback.addFunction();
 
-  func.call(onComplete_interopFnPtr.cast());
-
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
+  try {
+    return await _dispatch(completer, () => func.call(onComplete_interopFnPtr.cast()));
+  } finally {
+    onComplete_interopFnPtr.dispose();
   }
-
-  var ptr = await completer.future;
-  onComplete_interopFnPtr.dispose();
-
-  return ptr;
 }
 
 Future<bool> withBoolCallback(Function(Pointer<NativeFunction<Void Function(Bool)>>) func) async {
   final completer = Completer<bool>();
-  // ignore: prefer_function_declarations_over_variables
-  void Function(int) callback = (int result) {
-    completer.complete(result == 1);
-  };
+  void callback(int result) => completer.complete(result == 1);
 
   final onComplete_interopFnPtr = callback.addFunction();
 
-  func.call(onComplete_interopFnPtr.cast());
-
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
-
-  return completer.future;
+  return _dispatch(completer, () => func.call(onComplete_interopFnPtr.cast()));
 }
 
 Future<double> withFloatCallback(void Function(Pointer<NativeFunction<void Function(double)>>) func) async {
   final completer = Completer<double>();
-  // ignore: prefer_function_declarations_over_variables
-  void Function(double) callback = (double result) {
-    completer.complete(result);
-  };
-  var ptr = callback.addFunction();
-  func.call(ptr);
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
-  return completer.future;
+  void callback(double result) => completer.complete(result);
+  final ptr = callback.addFunction();
+  return _dispatch(completer, () => func.call(ptr));
 }
 
 Future<int> withIntCallback(Function(Pointer<NativeFunction<void Function(int)>>) func) async {
   final completer = Completer<int>();
-  // ignore: prefer_function_declarations_over_variables
-  void Function(int) callback = (int result) {
-    completer.complete(result);
-  };
-  var ptr = callback.addFunction();
-  func.call(ptr);
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
-  return completer.future;
+  void callback(int result) => completer.complete(result);
+  final ptr = callback.addFunction();
+  return _dispatch(completer, () => func.call(ptr));
 }
 
 Pointer<T> allocate<T extends NativeType>(int byteCount) {
@@ -179,18 +160,16 @@ Pointer<T> allocate<T extends NativeType>(int byteCount) {
 
 Future<int> withUInt32Callback(Function(Pointer<NativeFunction<Void Function(int)>>) func) async {
   final completer = Completer<int>();
-  // ignore: prefer_function_declarations_over_variables
-  void Function(int) callback = (int result) {
-    completer.complete(result);
-  };
+  void callback(int result) => completer.complete(result);
   final ptr = callback.addFunction();
-  func.call(ptr.cast());
-  await completer.future;
-  return completer.future;
+  return _dispatch(completer, () => func.call(ptr.cast()));
 }
 
 Future<String> withCharPtrCallback(Function(Pointer<NativeFunction<Void Function(Pointer<Char>)>>) func) async {
-  throw UnimplementedError();
+  final completer = Completer<String>();
+  void callback(Pointer<Char> result) => completer.complete(result.cast<Utf8>().toDartString());
+  final ptr = callback.addFunction();
+  return _dispatch(completer, () => func.call(ptr.cast()));
 }
 
 extension DartBigIntExtension on int {

--- a/thermion_dart/lib/src/bindings/src/native_task_errors.dart
+++ b/thermion_dart/lib/src/bindings/src/native_task_errors.dart
@@ -1,0 +1,29 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'task_error_registry.dart';
+import 'thermion_dart_ffi.g.dart';
+
+// Reuse the trampoline for the isolate's lifetime, including late/duplicate
+// errors (the registry ignores retired IDs and the callback still frees their
+// messages). Pending requests keep the isolate alive; an idle listener does not
+// prevent CLI programs from exiting. Native workers must be stopped before the
+// owning isolate is explicitly killed. Closing a live trampoline is unsafe.
+final _errorCallback = NativeCallable<Void Function(Uint32, Pointer<Char>)>.listener((
+  int requestId,
+  Pointer<Char> message,
+) {
+  try {
+    nativeTaskErrors.fail(
+      requestId,
+      message == nullptr ? 'Native render task failed' : message.cast<Utf8>().toDartString(),
+    );
+  } finally {
+    RenderThread_freeErrorMessage(message);
+  }
+})..keepIsolateAlive = false;
+
+final TaskErrorRegistry nativeTaskErrors = TaskErrorRegistry(
+  install: (requestId) => RenderThread_setTaskErrorCallback(requestId, _errorCallback.nativeFunction),
+  clear: () => RenderThread_setTaskErrorCallback(0, nullptr),
+  onPendingChanged: (active) => _errorCallback.keepIsolateAlive = active,
+);

--- a/thermion_dart/lib/src/bindings/src/task_error_registry.dart
+++ b/thermion_dart/lib/src/bindings/src/task_error_registry.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+/// Matches error completions to the request that installed a native dispatch
+/// scope. Success callbacks retain their existing ABI and complete the same
+/// completer. Each scope is cleared before yielding back to the event loop.
+class TaskErrorRegistry {
+  TaskErrorRegistry({required this.install, required this.clear, this.onPendingChanged});
+
+  final void Function(int requestId) install;
+  final int Function() clear;
+
+  /// Called on transitions between idle and pending work. Native listeners use
+  /// this to keep their isolate alive only while a request is outstanding.
+  final void Function(bool active)? onPendingChanged;
+  final _pending = <int, void Function(Object)>{};
+  int _nextRequestId = 0;
+  int get pendingRequestCount => _pending.length;
+
+  void fail(int requestId, String message) {
+    _pending[requestId]?.call(StateError(message));
+  }
+
+  /// Native calls using this callback must be queued synchronously in dispatch.
+  /// The scope is cleared before yielding. Async orchestration belongs outside
+  /// the callback helper; calls after await need their own helper and scope.
+  ///
+  /// A Dart dispatch error is not native completion. If dispatch submitted work,
+  /// keep its callback, buffers, and (on web) completion pump alive until the
+  /// native success/error callback arrives. Native failures affect only their
+  /// own scope; awaiting a child Future propagates errors to its parent.
+  Future<T> invoke<T>(Completer<T> completer, FutureOr<void> Function() dispatch, {void Function()? pump}) async {
+    while (_pending.containsKey(_nextRequestId)) {
+      _nextRequestId = (_nextRequestId + 1) & 0x7fffffff;
+    }
+    final requestId = _nextRequestId;
+    _nextRequestId = (_nextRequestId + 1) & 0x7fffffff;
+    _pending[requestId] = (error) {
+      if (!completer.isCompleted) completer.completeError(error);
+    };
+    Object? dispatchError;
+    StackTrace? dispatchStack;
+    var queuedTasks = 0;
+    Future<void>? asyncDispatch;
+    void failedDispatch(Object error, StackTrace stack) {
+      dispatchError ??= error;
+      dispatchStack ??= stack;
+      if (queuedTasks == 0 && !completer.isCompleted) {
+        completer.completeError(error, stack);
+      }
+    }
+
+    try {
+      if (_pending.length == 1) onPendingChanged?.call(true);
+      var installed = false;
+      try {
+        install(requestId);
+        installed = true;
+        final result = dispatch();
+        if (result is Future<void>) asyncDispatch = result;
+      } catch (error, stack) {
+        // Read the scope's submission count before deciding whether it is safe
+        // to finish. Dispatch may have queued work before it threw.
+        dispatchError = error;
+        dispatchStack = stack;
+      } finally {
+        if (installed) queuedTasks = clear();
+      }
+      if (dispatchError != null) failedDispatch(dispatchError!, dispatchStack!);
+
+      Future<void> observeSetup() async {
+        try {
+          await asyncDispatch;
+        } catch (error, stack) {
+          failedDispatch(error, stack);
+        }
+      }
+
+      Future<void> poll() async {
+        while (!completer.isCompleted) {
+          try {
+            pump!();
+          } catch (error, stack) {
+            // A pump error cannot cancel queued native work. Keep draining it
+            // before callers can release callbacks or buffers on this Future.
+            failedDispatch(error, stack);
+          }
+          await Future<void>.delayed(const Duration(milliseconds: 1));
+        }
+      }
+
+      try {
+        if (asyncDispatch != null || pump != null) {
+          await Future.wait<void>([
+            completer.future.then<void>((_) {}),
+            if (asyncDispatch != null) observeSetup(),
+            if (pump != null) poll(),
+          ]);
+        }
+        final result = await completer.future;
+        if (dispatchError != null) Error.throwWithStackTrace(dispatchError!, dispatchStack!);
+        return result;
+      } catch (_) {
+        if (dispatchError != null) Error.throwWithStackTrace(dispatchError!, dispatchStack!);
+        rethrow;
+      }
+    } finally {
+      _pending.remove(requestId);
+      if (_pending.isEmpty) onPendingChanged?.call(false);
+    }
+  }
+}

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -2694,6 +2694,12 @@ external ffi.Pointer<ffi.Void> RenderThread_createForCanvas(ffi.Pointer<ffi.Char
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
 external void RenderThread_destroy(ffi.Pointer<ffi.Void> renderThread);
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Char>)>(isLeaf: true)
+external void RenderThread_freeErrorMessage(ffi.Pointer<ffi.Char> message);
+
+@ffi.Native<ffi.Uint32 Function(ffi.Uint32, RenderTaskErrorCallback)>(isLeaf: true)
+external int RenderThread_setTaskErrorCallback(int requestId, RenderTaskErrorCallback callback);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Size, ffi.Uint16)>(isLeaf: true)
 external void RenderableBuilder_blendOrder(ffi.Pointer<TRenderableBuilder> builder, int primitiveIndex, int order);
 
@@ -4996,6 +5002,10 @@ typedef DartPickCallbackFunction =
     void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
 
 const int ROTATION_INTENT_MASK = 2;
+
+typedef RenderTaskErrorCallback = ffi.Pointer<ffi.NativeFunction<RenderTaskErrorCallbackFunction>>;
+typedef RenderTaskErrorCallbackFunction = ffi.Void Function(ffi.Uint32 requestId, ffi.Pointer<ffi.Char> ownedMessage);
+typedef DartRenderTaskErrorCallbackFunction = void Function(int requestId, ffi.Pointer<ffi.Char> ownedMessage);
 
 const int SPRINT_INTENT_MASK = 8;
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1343,6 +1343,8 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external Pointer<Void> _RenderThread_create();
   external Pointer<Void> _RenderThread_createForCanvas(Pointer<Char> canvasSelector);
   external void _RenderThread_destroy(Pointer<Void> renderThread);
+  external void _RenderThread_freeErrorMessage(Pointer<Char> message);
+  external int _RenderThread_setTaskErrorCallback(int requestId, RenderTaskErrorCallback callback);
   external void _RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, size_t primitiveIndex, int order);
   external void _RenderableBuilder_boneIndicesAndWeights(
     Pointer<TRenderableBuilder> builder,
@@ -6082,6 +6084,19 @@ void RenderThread_destroy(Pointer<Void> renderThread) {
   return result;
 }
 
+void RenderThread_freeErrorMessage(Pointer<Char> message) {
+  final result = GeneratedBindings.instance._RenderThread_freeErrorMessage(message);
+  return result;
+}
+
+int RenderThread_setTaskErrorCallback(int requestId, DartRenderTaskErrorCallback callback) {
+  final result = GeneratedBindings.instance._RenderThread_setTaskErrorCallback(
+    requestId,
+    callback as Pointer<NativeFunction<RenderTaskErrorCallbackFunction>>,
+  );
+  return result;
+}
+
 void RenderableBuilder_blendOrder(Pointer<TRenderableBuilder> builder, Dartsize_t primitiveIndex, int order) {
   final result = GeneratedBindings.instance._RenderableBuilder_blendOrder(builder.cast(), primitiveIndex, order);
   return result;
@@ -9454,6 +9469,11 @@ typedef DartPickCallbackFunction =
     void Function(int requestId, DartEntityId entityId, double depth, double fragX, double fragY, double fragZ);
 
 const int ROTATION_INTENT_MASK = 2;
+
+typedef RenderTaskErrorCallback = Pointer<NativeFunction<RenderTaskErrorCallbackFunction>>;
+typedef DartRenderTaskErrorCallback = Pointer<NativeFunction<RenderTaskErrorCallbackFunction>>;
+typedef RenderTaskErrorCallbackFunction = void Function(int requestId, Pointer<Char> ownedMessage);
+typedef DartRenderTaskErrorCallbackFunction = void Function(int requestId, Pointer<Char> ownedMessage);
 
 const int SPRINT_INTENT_MASK = 8;
 

--- a/thermion_dart/lib/src/bindings/src/void_callback_registry.dart
+++ b/thermion_dart/lib/src/bindings/src/void_callback_registry.dart
@@ -1,19 +1,24 @@
 import 'dart:async';
 import 'dart:ffi';
 
+import 'native_task_errors.dart';
+
 /// Dispatches native void callbacks through one long-lived FFI trampoline.
 ///
 /// The registry owns pending completers only until native code invokes their
 /// request ID. A single trampoline is retained for the registry lifetime so
 /// concurrent native requests cannot call metadata from a collected
 /// [NativeCallable].
+/// The trampoline keeps the isolate alive while requests are pending, but an
+/// idle registry does not prevent process exit. Stop native workers before
+/// killing the owning isolate. close() requires all native callbacks to be done.
 class VoidCallbackRegistry {
   int _nextRequestId = 0;
   final _requests = <int, Completer<void>>{};
 
   late final NativeCallable<Void Function(Int32)> _nativeCallable = NativeCallable<Void Function(Int32)>.listener(
     _complete,
-  );
+  )..keepIsolateAlive = false;
 
   int get pendingRequestCount => _requests.length;
 
@@ -22,26 +27,31 @@ class VoidCallbackRegistry {
     // completers here retains every FFI request for the registry lifetime,
     // including one entry per rendered frame.
     final completer = _requests.remove(requestId);
-    completer?.complete();
+    if (completer != null && !completer.isCompleted) completer.complete();
   }
 
   Future<void> invoke(Function(int, Pointer<NativeFunction<Void Function(Int32)>>) dispatch) async {
+    while (_requests.containsKey(_nextRequestId)) {
+      _nextRequestId = (_nextRequestId + 1) & 0x7fffffff;
+    }
     final requestId = _nextRequestId;
-    _nextRequestId++;
+    _nextRequestId = (_nextRequestId + 1) & 0x7fffffff;
     final completer = Completer<void>();
     _requests[requestId] = completer;
 
     try {
-      dispatch.call(requestId, _nativeCallable.nativeFunction.cast());
-    } catch (_) {
+      _nativeCallable.keepIsolateAlive = true;
+      await nativeTaskErrors.invoke(completer, () {
+        return dispatch.call(requestId, _nativeCallable.nativeFunction.cast());
+      });
+    } finally {
       _requests.remove(requestId);
-      rethrow;
+      if (_requests.isEmpty) _nativeCallable.keepIsolateAlive = false;
     }
-
-    await completer.future;
   }
 
   void close() {
+    if (_requests.isNotEmpty) throw StateError('Cannot close a registry with pending callbacks');
     _nativeCallable.close();
   }
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -429,7 +429,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     NameComponentManager_destroy(nameComponentManager);
 
     await withVoidCallback((requestId, cb) => Engine_destroyRendererRenderThread(engine, renderer, requestId, cb));
-    await withVoidCallback((requestId, cb) async {
+    await withVoidCallback((requestId, cb) {
       Engine_destroyRenderThread(engine, requestId, cb);
     });
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_ktx1_bundle.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_ktx1_bundle.dart
@@ -7,6 +7,11 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   final Pointer<TKtx1Bundle> pointer;
 
   final FFIFilamentApp _app;
+  bool _destroyed = false;
+
+  void _checkAlive() {
+    if (_destroyed) throw StateError("KTX bundle has been destroyed");
+  }
 
   FFIKtx1Bundle(this.pointer, this._app);
 
@@ -14,13 +19,14 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   ///
   ///
   bool isCubemap() {
+    _checkAlive();
     return Ktx1Bundle_isCubemap(pointer);
   }
 
-  ///
-  ///
-  ///
+  @override
   Future destroy() async {
+    if (_destroyed) return;
+    _destroyed = true;
     Ktx1Bundle_destroy(pointer);
   }
 
@@ -28,6 +34,7 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   ///
   ///
   Float32List getSphericalHarmonics() {
+    _checkAlive();
     final harmonics = makeFloat32List(27);
     Ktx1Bundle_getSphericalHarmonics(pointer, harmonics.address);
     return harmonics;
@@ -47,6 +54,7 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   }
 
   Future<Texture> createTexture({VoidCallback? onTextureUploadComplete, int? textureUploadCompleteRequestId}) async {
+    _checkAlive();
     final texturePtr = await withPointerCallback<TTexture>((cb) {
       Ktx1Reader_createTextureRenderThread(
         _app.engine,
@@ -56,6 +64,7 @@ class FFIKtx1Bundle extends Ktx1Bundle {
         cb,
       );
     });
+    if (texturePtr == nullptr) throw StateError("Failed to create KTX texture");
     return FFITexture(_app.engine, texturePtr, _app);
   }
 }

--- a/thermion_dart/lib/src/filament/src/interface/ktx1_bundle.dart
+++ b/thermion_dart/lib/src/filament/src/interface/ktx1_bundle.dart
@@ -6,9 +6,11 @@ abstract class Ktx1Bundle {
   ///
   bool isCubemap();
 
-  ///
-  ///
-  ///
+  /// Returns when the texture has been created, before upload data is necessarily
+  /// released. Keep this bundle alive until [onTextureUploadComplete] is called.
+  /// That callback signals buffer release;
+  /// this Future separately reports creation success or failure.
+  /// A failed creation Future alone does not make it safe to destroy the bundle.
   Future<Texture> createTexture({VoidCallback? onTextureUploadComplete, int? textureUploadCompleteRequestId});
 
   ///
@@ -16,8 +18,14 @@ abstract class Ktx1Bundle {
   ///
   Float32List getSphericalHarmonics();
 
+  /// Immediately frees this bundle and its native data. Repeated calls are harmless.
   ///
+  /// The caller must first wait for every queued creation/upload to release its
+  /// data, using the callback supplied to [createTexture]. Destroying the bundle
+  /// earlier is invalid and can make native code read freed memory.
+  /// This method does not wait for uploads or defer deletion.
   ///
-  ///
+  /// Textures created from the bundle are separate resources; call
+  /// [Texture.destroy] when each texture is no longer needed.
   Future destroy();
 }

--- a/thermion_dart/lib/src/filament/src/interface/ktx1_bundle.dart
+++ b/thermion_dart/lib/src/filament/src/interface/ktx1_bundle.dart
@@ -8,7 +8,7 @@ abstract class Ktx1Bundle {
 
   /// Returns when the texture has been created, before upload data is necessarily
   /// released. Keep this bundle alive until [onTextureUploadComplete] is called.
-  /// That callback signals buffer release;
+  /// That callback signals buffer release, including after submission failure;
   /// this Future separately reports creation success or failure.
   /// A failed creation Future alone does not make it safe to destroy the bundle.
   Future<Texture> createTexture({VoidCallback? onTextureUploadComplete, int? textureUploadCompleteRequestId});

--- a/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
+++ b/thermion_dart/lib/src/viewer/src/ffi/src/thermion_viewer_ffi.dart
@@ -272,37 +272,45 @@ class ThermionViewerFFI extends ThermionViewer {
 
     var data = await _app.loadResource(skyboxPath);
 
-    final completer = Completer<void>();
     FFIKtx1Bundle? bundle;
-    late FFISkybox skybox;
-
-    final uploadFuture = withVoidCallback((requestId, onTextureUploadComplete) async {
+    Future<void>? uploadReleased;
+    FFITexture? texture;
+    FFISkybox? skybox;
+    try {
       bundle = await FFIKtx1Bundle.create(_app, data) as FFIKtx1Bundle;
-
-      _skyboxTexture =
-          await bundle!.createTexture(
-                onTextureUploadComplete: onTextureUploadComplete,
-                textureUploadCompleteRequestId: requestId,
-              )
-              as FFITexture;
-
-      skybox = await _app.buildSkybox(texture: _skyboxTexture) as FFISkybox;
-
+      late Future<Texture> textureCreated;
+      // This callback means only that native code released the pixel data.
+      // Keep async setup outside its dispatch closure: setup failure must not
+      // complete the release Future or trigger early bundle destruction.
+      uploadReleased = withVoidCallback((id, callback) {
+        textureCreated = bundle!.createTexture(onTextureUploadComplete: callback, textureUploadCompleteRequestId: id);
+      });
+      texture = await textureCreated as FFITexture;
+      skybox = await _app.buildSkybox(texture: texture) as FFISkybox;
       await scene.setSkybox(skybox);
-
-      completer.complete();
-    });
-
-    late final Future<void> trackedUploadFuture;
-    trackedUploadFuture = uploadFuture.whenComplete(() async {
-      await bundle?.destroy();
-      if (identical(_skyboxTextureUploadComplete, trackedUploadFuture)) {
-        _skyboxTextureUploadComplete = null;
+      _skyboxTexture = texture;
+      return skybox;
+    } catch (_) {
+      await skybox?.destroy();
+      if (uploadReleased != null) await _app.flush();
+      await texture?.destroy();
+      rethrow;
+    } finally {
+      if (bundle != null) {
+        final ownedBundle = bundle;
+        // Setup no longer uses the bundle. Cleanup still waits for the separate
+        // buffer-release callback, on both setup success and setup failure.
+        late final Future<void> cleanup;
+        cleanup = (uploadReleased ?? Future<void>.value()).then((_) async {
+          await ownedBundle.destroy();
+          if (identical(_skyboxTextureUploadComplete, cleanup)) {
+            _skyboxTextureUploadComplete = null;
+          }
+        });
+        _skyboxTextureUploadComplete = cleanup;
       }
-    });
-    _skyboxTextureUploadComplete = trackedUploadFuture;
-    await completer.future;
-    return skybox;
+      if (FILAMENT_WASM) data.free();
+    }
   }
 
   //
@@ -315,46 +323,48 @@ class ThermionViewerFFI extends ThermionViewer {
   Future<void> _loadIbl(String lightingPath, {double intensity = 30000, bool destroyExisting = true}) async {
     await _removeIbl(destroy: destroyExisting);
 
-    final completer = Completer<void>();
+    final data = await _app.loadResource(lightingPath);
     FFIKtx1Bundle? bundle;
-    final uploadFuture = withVoidCallback((requestId, onTextureUploadComplete) async {
-      var data = await _app.loadResource(lightingPath);
-
+    Future<void>? uploadReleased;
+    Texture? texture;
+    FFIIndirectLight? ibl;
+    try {
       bundle = await FFIKtx1Bundle.create(_app, data) as FFIKtx1Bundle;
-
-      final texture = await bundle!.createTexture(
-        onTextureUploadComplete: onTextureUploadComplete,
-        textureUploadCompleteRequestId: requestId,
-      );
-      final harmonics = bundle!.getSphericalHarmonics();
-
-      final ibl = await FFIIndirectLight.fromIrradianceHarmonics(
+      late Future<Texture> textureCreated;
+      uploadReleased = withVoidCallback((id, callback) {
+        textureCreated = bundle!.createTexture(onTextureUploadComplete: callback, textureUploadCompleteRequestId: id);
+      });
+      texture = await textureCreated;
+      final harmonics = bundle.getSphericalHarmonics();
+      ibl = await FFIIndirectLight.fromIrradianceHarmonics(
         _app,
         harmonics,
         reflectionsTexture: texture,
         intensity: intensity,
       );
-
       await scene.setIndirectLight(ibl);
-
-      if (FILAMENT_WASM) {
-        data.free();
+    } catch (_) {
+      if (ibl != null) {
+        await ibl.destroy(); // Also releases its owned reflection texture.
+      } else {
+        if (uploadReleased != null) await _app.flush();
+        await texture?.destroy();
       }
-
-      completer.complete();
-      _logger.info("IBL texture ready");
-    });
-
-    late final Future<void> trackedUploadFuture;
-    trackedUploadFuture = uploadFuture.whenComplete(() async {
-      await bundle?.destroy();
-      if (identical(_iblTextureUploadComplete, trackedUploadFuture)) {
-        _iblTextureUploadComplete = null;
+      rethrow;
+    } finally {
+      if (bundle != null) {
+        final ownedBundle = bundle;
+        late final Future<void> cleanup;
+        cleanup = (uploadReleased ?? Future<void>.value()).then((_) async {
+          await ownedBundle.destroy();
+          if (identical(_iblTextureUploadComplete, cleanup)) {
+            _iblTextureUploadComplete = null;
+          }
+        });
+        _iblTextureUploadComplete = cleanup;
       }
-      _logger.info("IBL texture upload complete");
-    });
-    _iblTextureUploadComplete = trackedUploadFuture;
-    await completer.future;
+      if (FILAMENT_WASM) data.free();
+    }
   }
 
   Future<void> _loadIblFromTexture(
@@ -407,10 +417,9 @@ class ThermionViewerFFI extends ThermionViewer {
     throw UnimplementedError();
   }
 
-  Future? _skyboxTextureUploadComplete;
+  Future<void>? _skyboxTextureUploadComplete;
+  Future<void>? _iblTextureUploadComplete;
   FFITexture? _skyboxTexture;
-
-  Future? _iblTextureUploadComplete;
 
   //
   @override

--- a/thermion_dart/native/include/c_api/TTexture.h
+++ b/thermion_dart/native/include/c_api/TTexture.h
@@ -261,6 +261,8 @@ EMSCRIPTEN_KEEPALIVE void Ktx1Bundle_getSphericalHarmonics(
 EMSCRIPTEN_KEEPALIVE bool Ktx1Bundle_isCubemap(
     TKtx1Bundle *tBundle
 );
+// Immediately frees the bundle and its data. The caller must wait until all
+// queued creation and upload buffers have finished using it before calling this.
 EMSCRIPTEN_KEEPALIVE void Ktx1Bundle_destroy(
     TKtx1Bundle *tBundle
 );

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -21,6 +21,23 @@ namespace thermion
         typedef int32_t EntityId;
         typedef void (*FilamentRenderCallback)(void *const owner);
 
+        typedef void (*RenderTaskErrorCallback)(uint32_t requestId, const char *ownedMessage);
+        // Push only around a synchronous dispatch on the current calling thread;
+        // a null callback pops that scope. Queued callback tasks capture the scope,
+        // including synchronous parents. Do not retain thread-local scope across
+        // an await or move it between calling threads.
+        // Popping returns the number of tasks submitted directly in this scope.
+        // Dart uses this to retain callbacks if dispatch throws after enqueueing.
+        // Nested scopes report their own errors; parents observe their Dart Futures.
+        // Reports C++ exceptions escaping task bodies, not crashes or errors stored
+        // in packaged-task futures. Success/error are alternative completions for
+        // a request; receivers must ignore errors for already completed IDs.
+        // The callback must remain valid until native workers have stopped. Each
+        // message is receiver-owned and must be freed with the function below,
+        // including late errors. It can be null if message allocation fails.
+        EMSCRIPTEN_KEEPALIVE uint32_t RenderThread_setTaskErrorCallback(uint32_t requestId, RenderTaskErrorCallback callback);
+        EMSCRIPTEN_KEEPALIVE void RenderThread_freeErrorMessage(const char *message);
+
         EMSCRIPTEN_KEEPALIVE void* RenderThread_create();
         // Creates a RenderThread that transfers the given canvas element
         // (CSS selector) to its worker — one thread per viewer on web.

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "rendering/TaskError.hpp"
+
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -62,6 +64,8 @@ public:
      * 
      * @param pt The packaged task to be executed
      * @return std::future<Rt> Future for the task result
+     * Exceptions are stored in this C++ future, not reported through the Dart
+     * error scope. Use addDetachedTask for C API work completed by callbacks.
      */
     template <class Rt>
     auto addTask(std::packaged_task<Rt()>& pt) -> std::future<Rt>;
@@ -129,9 +133,18 @@ private:
     void runNativeLoop();
     #endif
 
+    // A task carries the error scope that was installed when it was enqueued,
+    // so a failure on the worker reaches the Dart future that awaits it.
+    struct Task {
+        std::function<void()> work;
+        TaskErrorContext error;
+    };
+    void executeTask(Task& task);
+    void reportError(TaskErrorContext context, const char* message) const;
+
     std::mutex _taskMutex;
     std::condition_variable _cv;
-    std::deque<std::function<void()>> _tasks;
+    std::deque<Task> _tasks;
     std::chrono::high_resolution_clock::time_point _lastFrameTime;
     int _frameCount = 0;
     float _accumulatedTime = 0.0f;
@@ -154,11 +167,15 @@ private:
 template <class Rt>
 auto RenderThread::addTask(std::packaged_task<Rt()>& pt) -> std::future<Rt> {
     auto ret = pt.get_future();
+    // The caller's error scope is the one installed by the synchronous FFI
+    // dispatch; it is popped before Dart awaits, so capture it now.
+    const auto error = currentTaskError;
     {
         std::lock_guard<std::mutex> lock(_taskMutex);
-        _tasks.push_back([pt = std::make_shared<std::packaged_task<Rt()>>(
+        _tasks.push_back(Task{[pt = std::make_shared<std::packaged_task<Rt()>>(
                              std::move(pt))]
-                        { (*pt)(); });
+                        { (*pt)(); }, error});
+        if (currentTaskError.callback) ++currentTaskError.queuedTasks;
     }
     #ifndef __EMSCRIPTEN__
     _cv.notify_one();
@@ -170,10 +187,12 @@ template <class Fn>
 void RenderThread::addDetachedTask(Fn&& fn) {
     // Construct outside the critical section since std::function may need to
     // allocate for a large capture.
-    std::function<void()> task(std::forward<Fn>(fn));
+    std::function<void()> work(std::forward<Fn>(fn));
+    const auto error = currentTaskError;
     {
         std::lock_guard<std::mutex> lock(_taskMutex);
-        _tasks.push_back(std::move(task));
+        _tasks.push_back(Task{std::move(work), error});
+        if (currentTaskError.callback) ++currentTaskError.queuedTasks;
     }
     #ifndef __EMSCRIPTEN__
     _cv.notify_one();

--- a/thermion_dart/native/include/rendering/TaskError.hpp
+++ b/thermion_dart/native/include/rendering/TaskError.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+
+namespace thermion {
+
+// A dispatch scope belongs to the calling native thread. Dart installs it only
+// around a synchronous FFI call and clears it before awaiting its completion.
+// Tasks copy this context when enqueued. The parent chain describes synchronous
+// nesting, not an async operation tree; Dart Futures propagate async setup errors.
+struct TaskErrorContext {
+    using Callback = void (*)(uint32_t requestId, const char* ownedMessage);
+    uint32_t requestId = 0;
+    Callback callback = nullptr;
+    std::shared_ptr<const TaskErrorContext> parent;
+    uint32_t queuedTasks = 0;
+};
+
+inline thread_local TaskErrorContext currentTaskError;
+
+inline void pushTaskErrorContext(uint32_t requestId, TaskErrorContext::Callback callback) {
+    auto parent = currentTaskError.callback
+        ? std::make_shared<TaskErrorContext>(currentTaskError) : nullptr;
+    currentTaskError = {requestId, callback, std::move(parent)};
+}
+
+inline uint32_t popTaskErrorContext() {
+    const auto queued = currentTaskError.queuedTasks;
+    currentTaskError = currentTaskError.parent ? *currentTaskError.parent : TaskErrorContext{};
+    return queued;
+}
+
+class TaskErrorScope {
+public:
+    explicit TaskErrorScope(TaskErrorContext context) : _previous(currentTaskError) {
+        currentTaskError = context;
+    }
+    ~TaskErrorScope() { currentTaskError = _previous; }
+private:
+    TaskErrorContext _previous;
+};
+
+} // namespace thermion

--- a/thermion_dart/native/include/rendering/UploadCompletion.hpp
+++ b/thermion_dart/native/include/rendering/UploadCompletion.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace thermion {
+
+// Counts release notifications only. It never owns or deletes upload data.
+// The initial token covers submission itself, so an early buffer completion
+// cannot fire the callback while later mip levels are still being submitted.
+class UploadCompletion {
+public:
+    using Callback = void (*)(int32_t);
+    UploadCompletion(Callback callback, uint32_t requestId)
+        : _callback(callback), _requestId(requestId) {}
+
+    void addBuffer() noexcept { _pending.fetch_add(1, std::memory_order_relaxed); }
+
+    // Called once per descriptor release, and once when submission ends,
+    // including when submission throws. No token is added for unsubmitted mips.
+    void release() noexcept {
+        if (_pending.fetch_sub(1, std::memory_order_acq_rel) != 1) return;
+        const auto callback = _callback;
+        const auto requestId = _requestId;
+        delete this;
+        if (callback) callback(requestId);
+    }
+
+private:
+    ~UploadCompletion() = default;
+    std::atomic<uint32_t> _pending{1};
+    Callback _callback;
+    uint32_t _requestId;
+};
+
+} // namespace thermion

--- a/thermion_dart/native/src/c_api/TTexture.cpp
+++ b/thermion_dart/native/src/c_api/TTexture.cpp
@@ -103,8 +103,16 @@ namespace thermion
 
         EMSCRIPTEN_KEEPALIVE TKtx1Bundle *Ktx1Bundle_create(uint8_t *ktxData, size_t length)
         {
-            auto *bundle = new image::Ktx1Bundle(ktxData, static_cast<uint32_t>(length));
-            return reinterpret_cast<TKtx1Bundle *>(bundle);
+            try {
+                return reinterpret_cast<TKtx1Bundle *>(
+                    new image::Ktx1Bundle(ktxData, static_cast<uint32_t>(length)));
+            } catch (const std::exception& error) {
+                Log("KTX bundle creation failed: %s", error.what());
+                return nullptr;
+            } catch (...) {
+                Log("KTX bundle creation failed");
+                return nullptr;
+            }
         }
 
         EMSCRIPTEN_KEEPALIVE bool Ktx1Bundle_isCubemap(TKtx1Bundle *tBundle)
@@ -202,21 +210,25 @@ namespace thermion
                 const auto& info = bundle->getInfo();
                 const auto mipCount = bundle->getNumMipLevels();
                 const uint32_t faces = bundle->isCubemap() ? 6 : 1;
+                if (mipCount == 0 || mipCount > 255 || info.pixelWidth == 0 || info.pixelHeight == 0) {
+                    throw std::runtime_error("Invalid KTX texture dimensions or mip count");
+                }
 
                 struct Level { uint8_t* data; uint32_t faceBytes; };
                 std::vector<Level> levels;
                 for (uint32_t mip = 0; mip < mipCount; ++mip) {
                     uint8_t* data = nullptr;
                     uint32_t bytes = 0;
-                    if (!bundle->getBlob({mip, 0, 0}, &data, &bytes)) {
+                    if (!bundle->getBlob({mip, 0, 0}, &data, &bytes) || !data || !bytes) {
                         throw std::runtime_error("Missing KTX mip data");
                     }
-                    // Preserve the reader's check that every face exists before
-                    // submitting buffers. Ktx1Bundle stores faces consecutively.
+                    // Ktx1Bundle stores cubemap faces consecutively. Validate every
+                    // face before submitting any buffer, including its byte size.
                     for (uint32_t face = 1; face < faces; ++face) {
                         uint8_t* faceData = nullptr;
                         uint32_t faceBytes = 0;
-                        if (!bundle->getBlob({mip, 0, face}, &faceData, &faceBytes)) {
+                        if (!bundle->getBlob({mip, 0, face}, &faceData, &faceBytes) ||
+                                faceBytes != bytes || reinterpret_cast<uintptr_t>(faceData) != reinterpret_cast<uintptr_t>(data) + size_t(face) * bytes) {
                             throw std::runtime_error("Invalid KTX cubemap face data");
                         }
                     }

--- a/thermion_dart/native/src/c_api/TTexture.cpp
+++ b/thermion_dart/native/src/c_api/TTexture.cpp
@@ -20,6 +20,8 @@
 #include <ktxreader/Ktx2Reader.h>
 
 #include "c_api/TTexture.h"
+#include "rendering/UploadCompletion.hpp"
+#include <stdexcept>
 
 #include "Log.hpp"
 
@@ -186,27 +188,76 @@ namespace thermion
 
             auto *bundle = reinterpret_cast<image::Ktx1Bundle *>(tBundle);
 
-            std::vector<void *> *callbackData = new std::vector<void *>{
-                reinterpret_cast<void *>(onTextureUploadComplete),
-                reinterpret_cast<void *>(requestId)};
+            UploadCompletion* completion;
+            try {
+                completion = new UploadCompletion(onTextureUploadComplete, requestId);
+            } catch (...) {
+                // No buffers were submitted if bookkeeping allocation failed.
+                if (onTextureUploadComplete) onTextureUploadComplete(requestId);
+                throw;
+            }
+            filament::Texture* texture = nullptr;
+            try {
+                namespace reader = ktxreader::Ktx1Reader;
+                const auto& info = bundle->getInfo();
+                const auto mipCount = bundle->getNumMipLevels();
+                const uint32_t faces = bundle->isCubemap() ? 6 : 1;
 
-            auto *texture =
-                ktxreader::Ktx1Reader::createTexture(
-                    engine, *bundle, false, [](void *userdata)
-                    {
-                        std::vector<void*>* vec = (std::vector<void*>*)userdata;
-                        
-                        void *callbackPtr = vec->at(0);
-                        uintptr_t requestId = (uintptr_t)vec->at(1);
+                struct Level { uint8_t* data; uint32_t faceBytes; };
+                std::vector<Level> levels;
+                for (uint32_t mip = 0; mip < mipCount; ++mip) {
+                    uint8_t* data = nullptr;
+                    uint32_t bytes = 0;
+                    if (!bundle->getBlob({mip, 0, 0}, &data, &bytes)) {
+                        throw std::runtime_error("Missing KTX mip data");
+                    }
+                    // Preserve the reader's check that every face exists before
+                    // submitting buffers. Ktx1Bundle stores faces consecutively.
+                    for (uint32_t face = 1; face < faces; ++face) {
+                        uint8_t* faceData = nullptr;
+                        uint32_t faceBytes = 0;
+                        if (!bundle->getBlob({mip, 0, face}, &faceData, &faceBytes)) {
+                            throw std::runtime_error("Invalid KTX cubemap face data");
+                        }
+                    }
+                    levels.push_back({data, bytes});
+                }
 
-                        delete vec;
-                        
-                        if (callbackPtr)
-                        {
-                            auto callback = ((VoidCallback)callbackPtr);
-                            callback(requestId);
-                        } },
-                    (void *)callbackData);
+                texture = filament::Texture::Builder()
+                    .width(info.pixelWidth).height(info.pixelHeight)
+                    .levels(static_cast<uint8_t>(mipCount))
+                    .sampler(faces == 6 ? filament::Texture::Sampler::SAMPLER_CUBEMAP
+                                       : filament::Texture::Sampler::SAMPLER_2D)
+                    .format(reader::toTextureFormat(info)).build(*engine);
+                if (!texture) throw std::runtime_error("Failed to create KTX texture");
+                for (uint32_t mip = 0; mip < mipCount; ++mip) {
+                    const auto level = levels[mip];
+                    const size_t bytes = size_t(level.faceBytes) * faces;
+                    filament::Texture::PixelBufferDescriptor pixels = reader::isCompressed(info)
+                        ? filament::Texture::PixelBufferDescriptor(level.data, bytes,
+                            reader::toCompressedPixelDataType(info), level.faceBytes, nullptr)
+                        : filament::Texture::PixelBufferDescriptor(level.data, bytes,
+                            reader::toPixelDataFormat(info), reader::toPixelDataType(info));
+                    // Descriptor construction/format conversion may fail before
+                    // this point. Register only a successfully constructed buffer.
+                    // setCallback is noexcept and does not allocate.
+                    completion->addBuffer();
+                    pixels.setCallback([](void*, size_t, void* user) {
+                        static_cast<UploadCompletion*>(user)->release();
+                    }, completion);
+                    if (faces == 6) {
+                        texture->setImage(*engine, mip, 0, 0, 0,
+                            texture->getWidth(mip), texture->getHeight(mip), faces, std::move(pixels));
+                    } else {
+                        texture->setImage(*engine, mip, std::move(pixels));
+                    }
+                }
+            } catch (...) {
+                if (texture) engine->destroy(texture);
+                completion->release(); // End submission; existing buffers may remain.
+                throw;
+            }
+            completion->release();
             return reinterpret_cast<TTexture *>(texture);
         }
 

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -61,6 +61,23 @@ using namespace std::chrono_literals;
 #endif
 extern "C"
 {
+  // Callback-based operations use addDetachedTask: the worker catches failures
+  // and reports the dispatch's error scope. packaged_task would store failures
+  // in a C++ future that these wrappers never consume, leaving Dart waiting.
+  // Invoke success callbacks only after the operation's work has succeeded.
+  EMSCRIPTEN_KEEPALIVE uint32_t RenderThread_setTaskErrorCallback(
+      uint32_t requestId, RenderTaskErrorCallback callback) {
+    if (callback) {
+      pushTaskErrorContext(requestId, callback);
+      return 0;
+    }
+    return popTaskErrorContext();
+  }
+
+  EMSCRIPTEN_KEEPALIVE void RenderThread_freeErrorMessage(const char* message) {
+    std::free(const_cast<char*>(message));
+  }
+
 
   // ─────────────────────────────────────────────────────────────────────────
   // Owner-keyed thread registry.
@@ -263,12 +280,11 @@ extern "C"
   EMSCRIPTEN_KEEPALIVE void RenderThread_addTask(void (*task)())
   {
     auto *rt = RT(nullptr);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           task();
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderManager)
@@ -319,13 +335,13 @@ extern "C"
     uint32_t requestId, VoidCallback onComplete) {
     auto *rt = RT(tRenderer);
 
-      std::packaged_task<void()> lambda(
+      rt->addDetachedTask(
         [=]() mutable
         {
           RenderManager_setRenderable(tRenderer, tSwapChain, tViews, numViews);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
+
 
     }
 
@@ -360,13 +376,12 @@ extern "C"
     VoidCallback onComplete)
   {
     auto *rt = RT(tRenderManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderManager_addAnimationManager(tRenderManager, tAnimationManager);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderManager_removeAnimationManagerRenderThread(
@@ -376,13 +391,12 @@ extern "C"
     VoidCallback onComplete)
   {
     auto *rt = RT(tRenderManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderManager_removeAnimationManager(tRenderManager, tAnimationManager);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderManager_removeSwapChainRenderThread(
@@ -392,13 +406,12 @@ extern "C"
     VoidCallback onComplete)
   {
     auto *rt = RT(tRenderManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderManager_removeSwapChain(tRenderManager, tSwapChain);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createRenderThread(
@@ -411,290 +424,267 @@ extern "C"
   {
     auto *rt = RT(nullptr);
 
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *engine = Engine_create(backend, platform, sharedContext, stereoscopicEyeCount, disableHandleUseAfterFreeCheck);
 
           setOwner(engine, rt);          PROXY(onComplete(engine));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createRendererRenderThread(TEngine *tEngine, void (*onComplete)(TRenderer *))
   {
     auto *rt = RT(tEngine);
 
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *renderer = Engine_createRenderer(tEngine);
 
           setOwner(renderer, rt);          PROXY(onComplete(renderer));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createSwapChainRenderThread(TEngine *tEngine, void *window, uint64_t flags, void (*onComplete)(TSwapChain *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto swapChain = Engine_createSwapChain(tEngine, window, flags);
           PROXY(onComplete(swapChain));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createHeadlessSwapChainRenderThread(TEngine *tEngine, uint32_t width, uint32_t height, uint64_t flags, void (*onComplete)(TSwapChain *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto swapChain = Engine_createHeadlessSwapChain(tEngine, width, height, flags);
           PROXY(onComplete(swapChain));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroySwapChainRenderThread(TEngine *tEngine, TSwapChain *tSwapChain, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroySwapChain(tEngine, tSwapChain);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyRendererRenderThread(TEngine *tEngine, TRenderer *tRenderer, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyRenderer(tEngine, tRenderer);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyViewRenderThread(TEngine *tEngine, TView *tView, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyView(tEngine, tView);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroySceneRenderThread(TEngine *tEngine, TScene *tScene, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyScene(tEngine, tScene);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createCameraRenderThread(TEngine *tEngine, EntityId entityId, void (*onComplete)(TCamera *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto camera = Engine_createCamera(tEngine, entityId);
 
           setOwner(camera, rt);          PROXY(onComplete(camera));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyCameraRenderThread(TEngine *tEngine, TCamera *tCamera, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyCamera(tEngine, tCamera);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createViewRenderThread(TEngine *tEngine, void (*onComplete)(TView *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *view = Engine_createView(tEngine);
 
           setOwner(view, rt);          PROXY(onComplete(view));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyRenderThread(TEngine *tEngine, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroy(tEngine);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyTextureRenderThread(TEngine *engine, TTexture *tTexture, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(engine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyTexture(engine, tTexture);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroySkyboxRenderThread(TEngine *tEngine, TSkybox *tSkybox, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroySkybox(tEngine, tSkybox);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyIndirectLightRenderThread(TEngine *tEngine, TIndirectLight *tIndirectLight, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyIndirectLight(tEngine, tIndirectLight);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_buildMaterialRenderThread(TEngine *tEngine, const uint8_t *materialData, size_t length, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto material = Engine_buildMaterial(tEngine, materialData, length);
 
           setOwner(material, rt);          PROXY(onComplete(material));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyMaterialRenderThread(TEngine *tEngine, TMaterial *tMaterial, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyMaterial(tEngine, tMaterial);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyMaterialInstanceRenderThread(TEngine *tEngine, TMaterialInstance *tMaterialInstance, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyMaterialInstance(tEngine, tMaterialInstance);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_createFenceRenderThread(TEngine *tEngine, void (*onComplete)(TFence *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *fence = Engine_createFence(tEngine);
 
           setOwner(fence, rt);          PROXY(onComplete(fence));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Fence_waitAndDestroyRenderThread(TFence *tFence, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tFence);
     
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Fence_waitAndDestroy(tFence);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyFenceRenderThread(TEngine *tEngine, TFence *tFence, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_destroyFence(tEngine, tFence);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_flushAndWaitRenderThread(TEngine *tEngine, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_flushAndWait(tEngine);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_executeRenderThread(TEngine *tEngine, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Engine_execute(tEngine);
-          std::packaged_task<void()> callback(
+          rt->addDetachedTask(
           [=]() mutable
           { 
             PROXY(onComplete(requestId));
           });
-          rt->addTask(callback);
         });
-    auto fut = rt->addTask(lambda);
+
   }
 
   EMSCRIPTEN_KEEPALIVE void execute_queue()
@@ -708,25 +698,23 @@ extern "C"
   EMSCRIPTEN_KEEPALIVE void Engine_buildSkyboxRenderThread(TEngine *tEngine, TTexture *tTexture, bool showSun, float intensity, uint8_t priority, void (*onComplete)(TSkybox *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *skybox = Engine_buildSkybox(tEngine, tTexture, showSun, intensity, priority);
           PROXY(onComplete(skybox));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_buildColoredSkyboxRenderThread(TEngine *tEngine, float r, float g, float b, float a, bool showSun, float intensity, uint8_t priority, void (*onComplete)(TSkybox *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *skybox = Engine_buildColoredSkybox(tEngine, r, g, b, a, showSun, intensity, priority);
           PROXY(onComplete(skybox));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
@@ -736,13 +724,12 @@ extern "C"
     float intensity,
     void (*onComplete)(TIndirectLight *)) {
     auto *rt = RT(tEngine);
-      std::packaged_task<void()> lambda(
+      rt->addDetachedTask(
           [=]() mutable
           {
             auto *indirectLight = Engine_buildIndirectLightFromIrradianceTexture(tEngine, tReflectionsTexture, tIrradianceTexture, intensity);
             PROXY(onComplete(indirectLight));
           });
-      auto fut = rt->addTask(lambda);
   }
   
   EMSCRIPTEN_KEEPALIVE void Engine_buildIndirectLightFromIrradianceHarmonicsRenderThread(
@@ -752,61 +739,56 @@ extern "C"
     float intensity,
     void (*onComplete)(TIndirectLight *)) {
     auto *rt = RT(tEngine);
-      std::packaged_task<void()> lambda(
+      rt->addDetachedTask(
           [=]() mutable
           {
             auto *indirectLight = Engine_buildIndirectLightFromIrradianceHarmonics(tEngine, tReflectionsTexture, harmonics, intensity);
             PROXY(onComplete(indirectLight));
           });
-      auto fut = rt->addTask(lambda);
   }
 
 
   EMSCRIPTEN_KEEPALIVE void Renderer_beginFrameRenderThread(TRenderer *tRenderer, TSwapChain *tSwapChain, uint64_t frameTimeInNanos, void (*onComplete)(bool))
   {
     auto *rt = RT(tRenderer);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto result = Renderer_beginFrame(tRenderer, tSwapChain, frameTimeInNanos);
           PROXY(onComplete(result));
         });
-    auto fut = rt->addTask(lambda);
   }
   EMSCRIPTEN_KEEPALIVE void Renderer_endFrameRenderThread(TRenderer *tRenderer, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tRenderer);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Renderer_endFrame(tRenderer);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Renderer_renderRenderThread(TRenderer *tRenderer, TView *tView, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tRenderer);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Renderer_render(tRenderer, tView);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Renderer_renderStandaloneViewRenderThread(TRenderer *tRenderer, TView *tView, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tRenderer);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Renderer_renderStandaloneView(tRenderer, tView);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Renderer_setClearOptionsRenderThread(
@@ -820,13 +802,12 @@ extern "C"
       bool discard, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tRenderer);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Renderer_setClearOptions(tRenderer, clearR, clearG, clearB, clearA, clearStencil, clear, discard);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Renderer_readPixelsRenderThread(
@@ -840,117 +821,108 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tRenderer);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Renderer_readPixels(tRenderer, width, height, xOffset, yOffset, tRenderTarget, tPixelBufferFormat, tPixelDataType, out, outLength);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createImageMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *instance = Material_createImageMaterial(tEngine);
 
           setOwner(instance, rt);          PROXY(onComplete(instance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createGizmoMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *instance = Material_createGizmoMaterial(tEngine);
 
           setOwner(instance, rt);          PROXY(onComplete(instance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createSilhouetteMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *instance = Material_createSilhouetteMaterial(tEngine);
 
           setOwner(instance, rt);          PROXY(onComplete(instance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createEdgeOutlineMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *instance = Material_createEdgeOutlineMaterial(tEngine);
 
           setOwner(instance, rt);          PROXY(onComplete(instance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createWireframeMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *instance = Material_createWireframeMaterial(tEngine);
 
           setOwner(instance, rt);          PROXY(onComplete(instance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createTranslationAxisMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *instance = Material_createTranslationAxisMaterial(tEngine);
 
           setOwner(instance, rt);          PROXY(onComplete(instance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createBoneOverlayMaterialRenderThread(TEngine *tEngine, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *instance = Material_createBoneOverlayMaterial(tEngine);
 
           setOwner(instance, rt);          PROXY(onComplete(instance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Material_createInstanceRenderThread(TMaterial *tMaterial, void (*onComplete)(TMaterialInstance *))
   {
     auto *rt = RT(tMaterial);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *instance = Material_createInstance(tMaterial);
 
           setOwner(instance, rt);          PROXY(onComplete(instance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void MaterialInstance_setParameterTextureRenderThread(
@@ -962,25 +934,23 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tMaterialInstance);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           MaterialInstance_setParameterTexture(tMaterialInstance, propertyName, tTexture, tSampler);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_destroyRenderThread(TSceneAsset *tSceneAsset, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tSceneAsset);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           SceneAsset_destroy(tSceneAsset);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
 
@@ -993,7 +963,7 @@ extern "C"
       void (*onComplete)(TSceneAsset *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           auto sceneAsset = SceneAsset_createFromFilamentAsset(
@@ -1002,7 +972,6 @@ extern "C"
 
           setOwner(sceneAsset, rt);          PROXY(onComplete(sceneAsset));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_createFromBuffersRenderThread(
@@ -1017,7 +986,7 @@ extern "C"
       void (*callback)(TSceneAsset *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           auto sceneAsset = SceneAsset_createFromBuffers(
@@ -1032,7 +1001,6 @@ extern "C"
 
           setOwner(sceneAsset, rt);          PROXY(callback(sceneAsset));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_createInstanceRenderThread(
@@ -1041,40 +1009,37 @@ extern "C"
       void (*callback)(TSceneAsset *))
   {
     auto *rt = RT(asset);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           auto instanceAsset = SceneAsset_createInstance(asset, tMaterialInstances, materialInstanceCount);
 
           setOwner(instanceAsset, rt);          PROXY(callback(instanceAsset));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_releaseSourceDataRenderThread(
       TSceneAsset *tSceneAsset, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tSceneAsset);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           SceneAsset_releaseSourceData(tSceneAsset);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_setFlatShadingRenderThread(
       TSceneAsset *tSceneAsset, bool flatShading, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tSceneAsset);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           SceneAsset_setFlatShading(tSceneAsset, flatShading);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void MaterialProvider_createMaterialInstanceRenderThread(
@@ -1120,7 +1085,7 @@ extern "C"
       void (*callback)(TMaterialInstance *))
   {
     auto *rt = RT(tMaterialProvider);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           auto materialInstance = MaterialProvider_createMaterialInstance(
@@ -1165,185 +1130,170 @@ extern "C"
               hasVolume);
           PROXY(callback(materialInstance));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_createRenderThread(void (*onComplete)(TColorGradingBuilder *))
   {
     auto *rt = RT(nullptr);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *builder = ColorGradingBuilder_create();
 
           setOwner(builder, rt);          PROXY(onComplete(builder));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_buildRenderThread(TColorGradingBuilder *tBuilder, TEngine *tEngine, void (*onComplete)(TColorGrading *))
   {
     auto *rt = RT(tBuilder);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *colorGrading = ColorGradingBuilder_build(tBuilder, tEngine);
           PROXY(onComplete(colorGrading));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ColorGradingBuilder_destroyRenderThread(TColorGradingBuilder *tBuilder, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tBuilder);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           ColorGradingBuilder_destroy(tBuilder);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createLinearRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createLinear(tEngine);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createACESRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createACES(tEngine);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createACESLegacyRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createACESLegacy(tEngine);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createFilmicRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createFilmic(tEngine);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createPBRNeutralRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createPBRNeutral(tEngine);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createAGXRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createAGX(tEngine);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createAGXWithLookRenderThread(TEngine *tEngine, int look, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createAGXWithLook(tEngine, look);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createGenericRenderThread(TEngine *tEngine, float contrast, float midGrayIn, float midGrayOut, float hdrMax, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createGeneric(tEngine, contrast, midGrayIn, midGrayOut, hdrMax);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_createDisplayRangeRenderThread(TEngine *tEngine, void (*onComplete)(TToneMapper *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *toneMapper = ToneMapper_createDisplayRange(tEngine);
 
           setOwner(toneMapper, rt);          PROXY(onComplete(toneMapper));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void ToneMapper_destroyRenderThread(TToneMapper *tToneMapper, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tToneMapper);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           ToneMapper_destroy(tToneMapper);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Engine_destroyColorGradingRenderThread(TEngine *tEngine, TColorGrading *tColorGrading, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           Engine_destroyColorGrading(tEngine, tColorGrading);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_pickRenderThread(TView *tView, uint32_t requestId, uint32_t x, uint32_t y, PickCallback callback)
@@ -1357,336 +1307,308 @@ extern "C"
   EMSCRIPTEN_KEEPALIVE void View_setColorGradingRenderThread(TView *tView, TColorGrading *tColorGrading, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setColorGrading(tView, tColorGrading);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setBloomRenderThread(TView *tView, bool enabled, double strength, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setBloom(tView, enabled, strength);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setCameraRenderThread(TView *tView, TCamera *tCamera, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setCamera(tView, tCamera);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_getNameRenderThread(TView *tView, void (*onComplete)(const char *))
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           auto name = View_getName(tView);
           PROXY(onComplete(name));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setNameRenderThread(TView *tView, const char *name, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setName(tView, name);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setViewportRenderThread(TView *tView, uint32_t width, uint32_t height, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setViewport(tView, width, height);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setRenderTargetRenderThread(TView *tView, TRenderTarget *tRenderTarget, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setRenderTarget(tView, tRenderTarget);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setAntiAliasingRenderThread(TView *tView, bool msaa, bool fxaa, bool taa, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setAntiAliasing(tView, msaa, fxaa, taa);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setPostProcessingRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setPostProcessing(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setFrustumCullingEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setFrustumCullingEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setStencilBufferEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setStencilBufferEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setDitheringEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setDitheringEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setRenderQualityRenderThread(TView *tView, int qualityLevel, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setRenderQuality(tView, static_cast<TQualityLevel>(qualityLevel));
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setSceneRenderThread(TView *tView, TScene *tScene, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setScene(tView, tScene);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setLayerEnabledRenderThread(TView *tView, int layer, bool visible, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setLayerEnabled(tView, layer, visible);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setBlendModeRenderThread(TView *tView, int blendMode, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setBlendMode(tView, static_cast<TBlendMode>(blendMode));
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setFogOptionsRenderThread(TView *tView, TFogOptions tFogOptions, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setFogOptions(tView, tFogOptions);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setAmbientOcclusionOptionsRenderThread(TView *tView, TAmbientOcclusionOptions options, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setAmbientOcclusionOptions(tView, options);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setFrontFaceWindingInvertedRenderThread(TView *tView, bool inverted, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setFrontFaceWindingInverted(tView, inverted);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setShadowsEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setShadowsEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setShadowTypeRenderThread(TView *tView, int shadowType, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setShadowType(tView, shadowType);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setSoftShadowOptionsRenderThread(TView *tView, TSoftShadowOptions options, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setSoftShadowOptions(tView, options);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setVsmShadowOptionsRenderThread(TView *tView, TVsmShadowOptions options, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setVsmShadowOptions(tView, options);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void View_setTransparentPickingEnabledRenderThread(TView *tView, bool enabled, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tView);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]
         {
           View_setTransparentPickingEnabled(tView, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_resetToRestPoseRenderThread(TAnimationManager *tAnimationManager, TSceneAsset *tSceneAsset, uint32_t requestId, VoidCallback onComplete) {
     auto *rt = RT(tAnimationManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           AnimationManager_resetToRestPose(tAnimationManager, tSceneAsset);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_createRenderThread(TEngine *tEngine, void (*onComplete)(TAnimationManager *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *animationManager = AnimationManager_create(tEngine);
 
           setOwner(animationManager, rt);          PROXY(onComplete(animationManager));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_destroyRenderThread(TAnimationManager *tAnimationManager, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tAnimationManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           AnimationManager_destroy(tAnimationManager);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_updateRenderThread(TAnimationManager *tAnimationManager, uint64_t frameTimeInNanos, uint32_t requestId, VoidCallback onComplete) {
     auto *rt = RT(tAnimationManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           AnimationManager_update(tAnimationManager, frameTimeInNanos);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   // setGltfAnimationTime applies morph-target channels via the backend
@@ -1702,13 +1624,12 @@ extern "C"
       uint32_t requestId,
       VoidCallback onComplete) {
     auto *rt = RT(tAnimationManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           AnimationManager_setGltfAnimationTime(tAnimationManager, tSceneAsset, animationIndex, timeInSeconds);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_updateBoneMatricesRenderThread(
@@ -1717,13 +1638,12 @@ extern "C"
       void (*callback)(bool))
   {
     auto *rt = RT(tAnimationManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           bool result = AnimationManager_updateBoneMatrices(tAnimationManager, sceneAsset);
           PROXY(callback(result));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void AnimationManager_setMorphTargetWeightsRenderThread(
@@ -1739,7 +1659,7 @@ extern "C"
     if (valid && numWeights > 0) {
       weights.assign(morphData, morphData + numWeights);
     }
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=, weights = std::move(weights)]() mutable
         {
           const bool result = valid && (weights.empty() ||
@@ -1747,93 +1667,85 @@ extern "C"
                   tAnimationManager, entityId, weights.data(), static_cast<int>(weights.size())));
           PROXY(callback(result));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_createEmptyRenderThread(uint32_t width, uint32_t height, uint32_t channel, void (*onComplete)(TLinearImage *))
   {
     auto *rt = RT(nullptr);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto image = Image_createEmpty(width, height, channel);
 
           setOwner(image, rt);          PROXY(onComplete(image));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_decodeRenderThread(uint8_t *data, size_t length, const char *name, bool alpha, void (*onComplete)(TLinearImage *))
   {
     auto *rt = RT(data);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto image = Image_decode(data, length, name, alpha);
 
           setOwner(image, rt);          PROXY(onComplete(image));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_getBytesRenderThread(TLinearImage *tLinearImage, void (*onComplete)(float *))
   {
     auto *rt = RT(tLinearImage);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto bytes = Image_getBytes(tLinearImage);
           PROXY(onComplete(bytes));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_destroyRenderThread(TLinearImage *tLinearImage, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tLinearImage);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Image_destroy(tLinearImage);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_getWidthRenderThread(TLinearImage *tLinearImage, void (*onComplete)(uint32_t))
   {
     auto *rt = RT(tLinearImage);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto width = Image_getWidth(tLinearImage);
           PROXY(onComplete(width));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_getHeightRenderThread(TLinearImage *tLinearImage, void (*onComplete)(uint32_t))
   {
     auto *rt = RT(tLinearImage);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto height = Image_getHeight(tLinearImage);
           PROXY(onComplete(height));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Image_getChannelsRenderThread(TLinearImage *tLinearImage, void (*onComplete)(uint32_t))
   {
     auto *rt = RT(tLinearImage);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto channels = Image_getChannels(tLinearImage);
           PROXY(onComplete(channels));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Texture_buildRenderThread(
@@ -1848,36 +1760,33 @@ extern "C"
       TTextureFormat format, void (*onComplete)(TTexture *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *texture = Texture_build(tEngine, width, height, depth, levels, tUsage, import, sampler, format);
 
           setOwner(texture, rt);          PROXY(onComplete(texture));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Texture_setExternalImageRenderThread(TEngine *tEngine, TTexture *tTexture, void *externalImage, uint32_t requestId, VoidCallback onComplete) {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Texture_setExternalImage(tEngine, tTexture, externalImage);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Texture_generateMipMapsRenderThread(TTexture *tTexture, TEngine *tEngine, uint32_t requestId, VoidCallback onComplete) {
     auto *rt = RT(tTexture);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Texture_generateMipMaps(tTexture, tEngine);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   #ifdef EMSCRIPTEN
@@ -1907,14 +1816,13 @@ extern "C"
     TEngine *tEngine, uint8_t* data, size_t size, void (*onComplete)(TTexture *)) {
     auto *rt = RT(tEngine);
     std::vector<uint8_t> bytes(data, data + size);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [tEngine, bytes = std::move(bytes), onComplete, rt]() mutable
         {
           auto *texture = Ktx2Reader_createTexture(tEngine, bytes.data(), bytes.size());
           setOwner(texture, rt);
           PROXY(onComplete(texture));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Ktx1Reader_createTextureRenderThread(
@@ -1928,7 +1836,7 @@ extern "C"
             };
         }
       #endif
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           #ifdef EMSCRIPTEN
@@ -1939,7 +1847,6 @@ extern "C"
           setOwner(texture, rt);
           PROXY(onComplete(texture));
         });
-    auto fut = rt->addTask(lambda);
   }
 
 
@@ -1949,13 +1856,12 @@ extern "C"
                                                           void (*onComplete)(bool))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           bool result = Texture_loadImage(tEngine, tTexture, tImage, bufferFormat, pixelDataType, level);
           PROXY(onComplete(result));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Texture_setImageRenderThread(
@@ -1975,7 +1881,7 @@ extern "C"
       void (*onComplete)(bool))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           bool result = Texture_setImage(
@@ -1994,19 +1900,17 @@ extern "C"
               pixelDataType);
           PROXY(onComplete(result));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderTarget_getColorTextureRenderThread(TRenderTarget *tRenderTarget, void (*onComplete)(TTexture *))
   {
     auto *rt = RT(tRenderTarget);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto texture = RenderTarget_getColorTexture(tRenderTarget);
           PROXY(onComplete(texture));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderTarget_createRenderThread(
@@ -2019,14 +1923,13 @@ extern "C"
     auto color = reinterpret_cast<filament::Texture *>(tColor);
     auto depth = reinterpret_cast<filament::Texture *>(tDepth);
 
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto texture = RenderTarget_create(tEngine, tColor, tDepth);
 
           setOwner(texture, rt);          PROXY(onComplete(texture));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderTarget_destroyRenderThread(
@@ -2035,26 +1938,24 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderTarget_destroy(tEngine, tRenderTarget);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_createRenderThread(void (*onComplete)(TTextureSampler *))
   {
     auto *rt = RT(nullptr);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto sampler = TextureSampler_create();
 
           setOwner(sampler, rt);          PROXY(onComplete(sampler));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_createWithFilteringRenderThread(
@@ -2066,14 +1967,13 @@ extern "C"
       void (*onComplete)(TTextureSampler *))
   {
     auto *rt = RT(nullptr);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto sampler = TextureSampler_createWithFiltering(minFilter, magFilter, wrapS, wrapT, wrapR);
 
           setOwner(sampler, rt);          PROXY(onComplete(sampler));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_createWithComparisonRenderThread(
@@ -2082,14 +1982,13 @@ extern "C"
       void (*onComplete)(TTextureSampler *))
   {
     auto *rt = RT(nullptr);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto sampler = TextureSampler_createWithComparison(compareMode, compareFunc);
 
           setOwner(sampler, rt);          PROXY(onComplete(sampler));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setMinFilterRenderThread(
@@ -2098,13 +1997,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(sampler);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TextureSampler_setMinFilter(sampler, filter);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setMagFilterRenderThread(
@@ -2113,13 +2011,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(sampler);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TextureSampler_setMagFilter(sampler, filter);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setWrapModeSRenderThread(
@@ -2128,13 +2025,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(sampler);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TextureSampler_setWrapModeS(sampler, mode);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setWrapModeTRenderThread(
@@ -2143,13 +2039,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(sampler);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TextureSampler_setWrapModeT(sampler, mode);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setWrapModeRRenderThread(
@@ -2158,13 +2053,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(sampler);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TextureSampler_setWrapModeR(sampler, mode);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setAnisotropyRenderThread(
@@ -2173,13 +2067,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(sampler);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TextureSampler_setAnisotropy(sampler, anisotropy);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_setCompareModeRenderThread(
@@ -2189,13 +2082,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(sampler);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TextureSampler_setCompareMode(sampler, mode, func);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TextureSampler_destroyRenderThread(
@@ -2203,13 +2095,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(sampler);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TextureSampler_destroy(sampler);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfAssetLoader_createRenderThread(
@@ -2219,14 +2110,13 @@ extern "C"
     void (*callback)(TGltfAssetLoader *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
       [=]() mutable
       {
         auto loader = GltfAssetLoader_create(tEngine, tMaterialProvider, tNameComponentManager);
 
           setOwner(loader, rt);        PROXY(callback(loader));
       });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfAssetLoader_destroyRenderThread(
@@ -2235,50 +2125,46 @@ extern "C"
     VoidCallback onComplete)
   {
     auto *rt = RT(tAssetLoader);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
       [=]() mutable
       {
         GltfAssetLoader_destroy(tAssetLoader);
         PROXY(onComplete(requestId));
       });
-    auto fut = rt->addTask(lambda);
   }
   
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_createRenderThread(TEngine *tEngine, void (*callback)(TGltfResourceLoader *)) {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
       [=]() mutable
       {
         auto loader = GltfResourceLoader_create(tEngine);
 
           setOwner(loader, rt);        PROXY(callback(loader));
       });
-    auto fut = rt->addTask(lambda);
   }
 
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_destroyRenderThread(TEngine *tEngine, TGltfResourceLoader *tResourceLoader, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           GltfResourceLoader_destroy(tEngine, tResourceLoader);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_loadResourcesRenderThread(TGltfResourceLoader *tGltfResourceLoader, TFilamentAsset *tFilamentAsset, void (*callback)(bool))
   {
     auto *rt = RT(tGltfResourceLoader);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto result = GltfResourceLoader_loadResources(tGltfResourceLoader, tFilamentAsset);
           PROXY(callback(result));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_addResourceDataRenderThread(
@@ -2289,13 +2175,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tGltfResourceLoader);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           GltfResourceLoader_addResourceData(tGltfResourceLoader, uri, data, length);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_asyncBeginLoadRenderThread(
@@ -2304,25 +2189,23 @@ extern "C"
       void (*callback)(bool))
   {
     auto *rt = RT(tGltfResourceLoader);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto result = GltfResourceLoader_asyncBeginLoad(tGltfResourceLoader, tFilamentAsset);
           PROXY(callback(result));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_asyncUpdateLoadRenderThread(
       TGltfResourceLoader *tGltfResourceLoader)
   {
     auto *rt = RT(tGltfResourceLoader);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           GltfResourceLoader_asyncUpdateLoad(tGltfResourceLoader);
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_asyncGetLoadProgressRenderThread(
@@ -2330,13 +2213,12 @@ extern "C"
       void (*callback)(float))
   {
     auto *rt = RT(tGltfResourceLoader);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto result = GltfResourceLoader_asyncGetLoadProgress(tGltfResourceLoader);
           PROXY(callback(result));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void GltfAssetLoader_loadRenderThread(
@@ -2348,110 +2230,101 @@ extern "C"
       void (*callback)(TFilamentAsset *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto loader = GltfAssetLoader_load(tEngine, tAssetLoader, data, length, numInstances);
 
           setOwner(loader, rt);          PROXY(callback(loader));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_addFilamentAssetRenderThread(TScene *tScene, TFilamentAsset *tAsset, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tScene);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Scene_addFilamentAsset(tScene, tAsset);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void FilamentAsset_getWireframeRenderThread(TFilamentAsset *tFilamentAsset, void (*onComplete)(EntityId))
   {
     auto *rt = RT(tFilamentAsset);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto entityId = FilamentAsset_getWireframe(tFilamentAsset);
           PROXY(onComplete(entityId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_addEntityRenderThread(TScene *tScene, EntityId entityId, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tScene);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Scene_addEntity(tScene, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_removeEntityRenderThread(TScene *tScene, EntityId entityId, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tScene);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Scene_removeEntity(tScene, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_addToSceneRenderThread(TSceneAsset *tSceneAsset, TScene *tScene, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tSceneAsset);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           SceneAsset_addToScene(tSceneAsset, tScene);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void SceneAsset_removeFromSceneRenderThread(TSceneAsset *tSceneAsset, TScene *tScene, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tSceneAsset);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           SceneAsset_removeFromScene(tSceneAsset, tScene);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_setSkyboxRenderThread(TScene *tScene, TSkybox *tSkybox, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tScene);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Scene_setSkybox(tScene, tSkybox);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Scene_setIndirectLightRenderThread(TScene *tScene, TIndirectLight *tIndirectLight, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tScene);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           Scene_setIndirectLight(tScene, tIndirectLight);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void Gizmo_createRenderThread(
@@ -2465,14 +2338,13 @@ extern "C"
       void (*callback)(TGizmo *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *gizmo = Gizmo_create(tEngine, tAssetLoader, tGltfResourceLoader, tNameComponentManager, tView, tMaterial, tGizmoType);
 
           setOwner(gizmo, rt);          PROXY(callback(gizmo));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void VertexBufferBuilder_buildRenderThread(
@@ -2481,14 +2353,13 @@ extern "C"
       void (*onComplete)(TVertexBuffer *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *vertexBuffer = VertexBufferBuilder_build(tBuilder, tEngine);
 
           setOwner(vertexBuffer, rt);          PROXY(onComplete(vertexBuffer));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void VertexBuffer_destroyRenderThread(
@@ -2498,13 +2369,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           VertexBuffer_destroy(tEngine, tBuffer);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void VertexBuffer_setBufferAtRenderThread(
@@ -2522,7 +2392,7 @@ extern "C"
     auto *buffer = new std::vector<uint8_t>(sizeInBytes);
     std::copy(static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + sizeInBytes, buffer->begin());
 
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           // Create a BufferDescriptor with a callback to delete the vector
@@ -2542,7 +2412,6 @@ extern "C"
 
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void VertexBuffer_setBufferObjectAtRenderThread(
@@ -2554,11 +2423,10 @@ extern "C"
       VoidCallback onComplete)
   {
     auto* rt = RT(tEngine);
-    std::packaged_task<void()> lambda([=]() mutable {
+    rt->addDetachedTask([=]() mutable {
       VertexBuffer_setBufferObjectAt(tEngine, tBuffer, bufferIndex, tBufferObject);
       PROXY(onComplete(requestId));
     });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void BufferObjectBuilder_buildRenderThread(
@@ -2567,12 +2435,11 @@ extern "C"
       void (*onComplete)(TBufferObject*))
   {
     auto* rt = RT(tEngine);
-    std::packaged_task<void()> lambda([=]() mutable {
+    rt->addDetachedTask([=]() mutable {
       auto* buffer = BufferObjectBuilder_build(tBuilder, tEngine);
       setOwner(buffer, rt);
       PROXY(onComplete(buffer));
     });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void BufferObject_setBufferRenderThread(
@@ -2587,7 +2454,7 @@ extern "C"
     auto* rt = RT(tEngine);
     auto* copy = new std::vector<uint8_t>(sizeInBytes);
     std::copy(static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + sizeInBytes, copy->begin());
-    std::packaged_task<void()> lambda([=]() mutable {
+    rt->addDetachedTask([=]() mutable {
       auto* engine = reinterpret_cast<filament::Engine*>(tEngine);
       auto* buffer = reinterpret_cast<filament::BufferObject*>(tBuffer);
       buffer->setBuffer(
@@ -2602,7 +2469,6 @@ extern "C"
           byteOffset);
       PROXY(onComplete(requestId));
     });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void BufferObject_destroyRenderThread(
@@ -2612,11 +2478,10 @@ extern "C"
       VoidCallback onComplete)
   {
     auto* rt = RT(tEngine);
-    std::packaged_task<void()> lambda([=]() mutable {
+    rt->addDetachedTask([=]() mutable {
       BufferObject_destroy(tEngine, tBuffer);
       PROXY(onComplete(requestId));
     });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void IndexBufferBuilder_buildRenderThread(
@@ -2625,14 +2490,13 @@ extern "C"
       void (*onComplete)(TIndexBuffer *))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *indexBuffer = IndexBufferBuilder_build(tBuilder, tEngine);
 
           setOwner(indexBuffer, rt);          PROXY(onComplete(indexBuffer));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void IndexBuffer_destroyRenderThread(
@@ -2642,13 +2506,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           IndexBuffer_destroy(tEngine, tBuffer);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void IndexBuffer_setBufferRenderThread(
@@ -2665,7 +2528,7 @@ extern "C"
     auto *buffer = new std::vector<uint8_t>(sizeInBytes);
     std::copy(static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + sizeInBytes, buffer->begin());
 
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           // Create a BufferDescriptor with a callback to delete the vector
@@ -2685,7 +2548,6 @@ extern "C"
 
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableBuilder_buildRenderThread(
@@ -2695,7 +2557,7 @@ extern "C"
       void (*onComplete)(int))
   {
     auto *rt = RT(tEngine);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto *builder = reinterpret_cast<filament::RenderableManager::Builder*>(tBuilder);
@@ -2705,31 +2567,28 @@ extern "C"
           auto result = builder->build(*engine, entity);
           PROXY(onComplete(static_cast<int>(result)));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void EntityManager_createEntityRenderThread(TEntityManager *tEntityManager, void (*onComplete)(EntityId))
   {
     auto *rt = RT(tEntityManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           auto entityId = EntityManager_createEntity(tEntityManager);
           PROXY(onComplete(entityId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void EntityManager_destroyEntityRenderThread(TEntityManager *tEntityManager, EntityId entityId, uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tEntityManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           EntityManager_destroyEntity(tEntityManager, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TransformManager_setTransformRenderThread(
@@ -2740,13 +2599,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tTransformManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TransformManager_setTransform(tTransformManager, entityId, transform);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TransformManager_setTransformNativeRenderThread(
@@ -2789,13 +2647,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tTransformManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TransformManager_setParent(tTransformManager, child, parent, preserveScaling);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TransformManager_createComponentRenderThread(
@@ -2805,13 +2662,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tTransformManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TransformManager_createComponent(tTransformManager, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void TransformManager_removeComponentRenderThread(
@@ -2821,13 +2677,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tTransformManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           TransformManager_removeComponent(tTransformManager, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableManager_destroyEntityRenderThread(
@@ -2837,13 +2692,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tRenderableManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderableManager_destroyEntity(tRenderableManager, entityId);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   // Copy the caller-owned payload before returning across the FFI boundary.
@@ -2863,7 +2717,7 @@ extern "C"
     if (count > 0) {
       ownedWeights.assign(weights, weights + count);
     }
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=, ownedWeights = std::move(ownedWeights)]() mutable
         {
           if (!ownedWeights.empty()) {
@@ -2872,7 +2726,6 @@ extern "C"
           }
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableManager_setBonesFromMat4RenderThread(
@@ -2885,13 +2738,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tRenderableManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderableManager_setBonesFromMat4(tRenderableManager, entityId, transforms, boneCount, offset);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableManager_setBonesFromBoneRenderThread(
@@ -2904,13 +2756,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tRenderableManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderableManager_setBonesFromBone(tRenderableManager, entityId, bones, boneCount, offset);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   // The lambda captures only scalars and pointers to filament-owned objects,
@@ -2928,14 +2779,13 @@ extern "C"
       void (*callback)(bool))
   {
     auto *rt = RT(tRenderableManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           bool result = RenderableManager_setGeometryAtNonIndexed(
               tRenderableManager, entityId, primitiveIndex, type, tVertices, offset, count);
           PROXY(callback(result));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   // Shadow flags MUST be applied on the render thread — Filament's
@@ -2950,13 +2800,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tRenderableManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderableManager_setCastShadows(tRenderableManager, entityId, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderableManager_setReceiveShadowsRenderThread(
@@ -2967,13 +2816,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tRenderableManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           RenderableManager_setReceiveShadows(tRenderableManager, entityId, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void LightManager_setShadowCasterRenderThread(
@@ -2984,13 +2832,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tLightManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           LightManager_setShadowCaster(tLightManager, entityId, enabled);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
   EMSCRIPTEN_KEEPALIVE void LightManager_setShadowOptionsRenderThread(
@@ -3001,13 +2848,12 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tLightManager);
-    std::packaged_task<void()> lambda(
+    rt->addDetachedTask(
         [=]() mutable
         {
           LightManager_setShadowOptions(tLightManager, entityId, options);
           PROXY(onComplete(requestId));
         });
-    auto fut = rt->addTask(lambda);
   }
 
 }

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -1,6 +1,9 @@
 #include "rendering/RenderThread.hpp"
+#ifdef __EMSCRIPTEN__
 #include "rendering/RenderManager.hpp"
+#endif
 
+#include <cstring>
 #include <functional>
 #include <stdlib.h>
 #include <time.h>
@@ -119,7 +122,7 @@ RenderThread::~RenderThread()
     // each task under the queue mutex so the worker and destructor cannot
     // concurrently mutate the deque.
     while (true) {
-        std::function<void()> task;
+        Task task;
         {
             std::lock_guard<std::mutex> lock(_taskMutex);
             if (_tasks.empty()) {
@@ -128,7 +131,7 @@ RenderThread::~RenderThread()
             task = std::move(_tasks.front());
             _tasks.pop_front();
         }
-        task();
+        executeTask(task);
     }
 
     // pthread_join from the browser main thread is fundamentally restricted in
@@ -170,7 +173,7 @@ void RenderThread::iter() {
         auto task = std::move(_tasks.front());
         _tasks.pop_front();
         taskLock.unlock();
-        task();
+        executeTask(task);
         taskLock.lock();
     }
     taskLock.unlock();
@@ -206,10 +209,48 @@ void RenderThread::runNativeLoop() {
         auto task = std::move(_tasks.front());
         _tasks.pop_front();
         taskLock.unlock();
-        task();
+        executeTask(task);
         taskLock.lock();
     }
 }
 #endif
+
+void RenderThread::executeTask(Task& task) {
+    TaskErrorScope scope(task.error);
+    try {
+        task.work();
+    } catch (const std::exception& error) {
+        reportError(task.error, error.what());
+    } catch (...) {
+        reportError(task.error, "Unknown native task exception");
+    }
+}
+
+void RenderThread::reportError(TaskErrorContext context, const char* message) const {
+    Log("RenderThread task failed: %s", message);
+    // An inner task finishing does not prove its parent has stopped using its
+    // callback. Report only this request; Dart propagates awaited child errors.
+    if (context.callback) {
+        const size_t length = std::strlen(message) + 1;
+        auto* ownedMessage = static_cast<char*>(std::malloc(length));
+        if (ownedMessage) std::memcpy(ownedMessage, message, length);
+        const auto callback = context.callback;
+        const auto requestId = context.requestId;
+#ifdef __EMSCRIPTEN__
+        // Dart awaits from the browser main thread, which drains the proxying
+        // queue between event-loop turns; delivering there keeps the failure on
+        // the thread that owns the completer.
+        if (pthread_equal(pthread_self(), outer)) {
+            callback(requestId, ownedMessage);
+        } else {
+            queue.proxySync(outer, [callback, requestId, ownedMessage] {
+                callback(requestId, ownedMessage);
+            });
+        }
+#else
+        callback(requestId, ownedMessage);
+#endif
+    }
+}
 
 } // namespace thermion

--- a/thermion_dart/native/test/rendering/CMakeLists.txt
+++ b/thermion_dart/native/test/rendering/CMakeLists.txt
@@ -5,8 +5,12 @@ find_package(Threads REQUIRED)
 add_library(upload_lifetime_fixture SHARED upload_lifetime_fixture.cpp)
 target_compile_features(upload_lifetime_fixture PRIVATE cxx_std_17)
 target_link_libraries(upload_lifetime_fixture PRIVATE Threads::Threads)
+add_library(task_error_fixture SHARED task_error_fixture.cpp)
+target_compile_features(task_error_fixture PRIVATE cxx_std_17)
+
 add_executable(scheduling_test
     scheduling_test.cpp
+    ../../src/rendering/RenderThread.cpp
     ../../src/rendering/FrameScheduler.cpp)
 target_compile_features(scheduling_test PRIVATE cxx_std_17)
 target_include_directories(scheduling_test PRIVATE ../../include)

--- a/thermion_dart/native/test/rendering/CMakeLists.txt
+++ b/thermion_dart/native/test/rendering/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 project(thermion_scheduling_tests LANGUAGES CXX)
 
 find_package(Threads REQUIRED)
+add_library(upload_lifetime_fixture SHARED upload_lifetime_fixture.cpp)
+target_compile_features(upload_lifetime_fixture PRIVATE cxx_std_17)
+target_link_libraries(upload_lifetime_fixture PRIVATE Threads::Threads)
 add_executable(scheduling_test
     scheduling_test.cpp
     ../../src/rendering/FrameScheduler.cpp)

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -12,6 +12,9 @@ ctest --test-dir /tmp/thermion-scheduling -C Release --output-on-failure
 
 Coverage:
 
+- Ordered task dispatch, exception reporting, nested error scopes, and repeated
+  worker shutdown.
+
 - Gate totals under regular 60, 90, 120, and 144 Hz source ticks; alternating
   1/2-vsync gaps for 60 fps on 90 Hz; the 1 ms early-admission boundary; zero
   timestamps, stalls, rate changes, unlimited mode, and reset.
@@ -41,6 +44,62 @@ The gate extraction is reused by the web worker in #301. Task-error propagation
 is in #318; forwarding scheduler timestamps through Flutter into rendering is
 in #319. Normalizing native scheduler output alone does not replace the existing
 Dart wall-clock render timestamp. Browser dispatch/lifetime fixtures land in #301.
+
+## Task error tests
+
+Callback-based C API operations queue ordinary tasks. If their work throws a C++
+exception before the success callback, the worker reports the captured request ID
+and Dart completes its Future with a `StateError`. C++ callers that use
+`std::packaged_task` still receive errors in their C++ futures. Neither path
+recovers from crashes or process termination.
+
+Each callback helper represents one native operation with one terminal success
+or error callback. Queue that operation synchronously inside the dispatch
+closure. Native requests after an `await` need their own callback helper and
+scope. A native error completes only its own scope; awaiting a child Future
+propagates its error through Dart without invalidating a parent's callback.
+
+Popping a native scope returns the number of tasks it queued. If Dart setup
+fails after queueing work, the helper waits for native completion before
+rethrowing the setup error. This keeps typed callbacks and caller-owned buffers
+alive while native code can still use them. Web keeps pumping completions during
+that wait. Async setup is also observed to completion before cleanup. Tasks
+retain their existing FIFO order; this does not wait for GPU completion.
+
+The shared native error/void listeners remain allocated for the isolate's lifetime
+so late callbacks cannot call a closed trampoline. They keep the isolate alive
+only while requests are pending. Applications must stop native workers before
+explicitly killing the isolate. Late errors are ignored by request ID, but their
+message buffers are still freed.
+
+Run the Dart regressions from `thermion_dart/`:
+
+```sh
+dart test test/task_error_registry_test.dart
+THERMION_TASK_ERROR_FIXTURE=/tmp/thermion-scheduling/libtask_error_fixture.dylib \
+  dart test --concurrency=1 test/native_task_errors_test.dart test/ffi_void_callback_test.dart \
+    test/ktx_task_errors_test.dart
+```
+
+The CMake build above produces the fixture library. On Linux use
+`libtask_error_fixture.so`; on Windows use `Release/task_error_fixture.dll` and
+set the environment variable using your shell's syntax. The native integration
+test skips when the variable is absent. Dart's native build hook also builds
+Thermion and obtains its Filament dependencies for these tests.
+
+The fixture throws inside the production `RenderThread_addTask` path, checks
+typed/void error delivery and subsequent worker progress, and tests that a child
+process exits naturally after shutdown. Queued callbacks are also checked after
+Dart dispatch throws, to verify that callback cleanup waits for native work.
+A nested failure must leave a separate upload-release callback pending. The KTX
+error test uses a real engine and verifies Filament texture creation failure reports both the
+creation error and buffer release before the caller destroys the bundle.
+Pure-Dart tests cover polling with sync
+and async setup, setup/pump errors, nested scopes, duplicate errors, and listener
+keep-alive transitions. These are manual tests; no workflow is added.
+
+For the release-mode callback and headless frame performance comparison, see
+the [benchmark report and reproduction instructions](../../../test/benchmarks/README.md).
 
 ## KTX upload lifetime tests
 

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -56,8 +56,6 @@ when setup fails. Successful loads do not add a GPU-completion wait. Removal
 and disposal flush pending work and wait for bundle cleanup, as before.
 Native C++ exception delivery to Dart is handled separately in #318.
 
-Native partial-submission failure handling is a separate change. This PR does
-not guarantee release notification if Filament fails during submission.
 Run the Dart integration tests from `thermion_dart/`:
 
 ```sh
@@ -72,3 +70,24 @@ backend (Metal on macOS). They gate the worker to verify release is still pendin
 exercise cubemap/mipmapped/2D uploads followed by explicit bundle destruction,
 and check public skybox/IBL failure delivery. Dart's native build hook builds
 Thermion and obtains Filament.
+
+## Native KTX upload completion
+
+Thermion submits KTX mip buffers itself so that completion counts buffers that
+were actually constructed, including when later submission throws. This replaces
+the call to Filament's `Ktx1Reader::createTexture`; it continues to use Filament's
+format mapping, texture builder, and upload API. The cost is maintaining the upload
+loop here. Fixing completion in Filament's reader and updating the dependency is
+an alternative that would avoid this duplication.
+
+The completion record owns no bundle or pixel data. An initial token covers
+submission; each constructed pixel buffer adds one token before submission. The
+release callback runs after submission ends and every buffer releases its token.
+An exception destroys the incomplete texture but leaves release tracking alive
+until outstanding buffers finish. There are no smart pointers or per-buffer
+allocations for this tracking.
+
+The C++ suite above covers zero buffers, partial submission failure, and a buffer
+finishing before later buffers are submitted. The Dart upload suite covers real
+2D, cubemap, and mipmapped uploads. Native exception delivery to Dart additionally
+requires the task-error change; completion tracking itself does not deliver errors.

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -41,3 +41,34 @@ The gate extraction is reused by the web worker in #301. Task-error propagation
 is in #318; forwarding scheduler timestamps through Flutter into rendering is
 in #319. Normalizing native scheduler output alone does not replace the existing
 Dart wall-clock render timestamp. Browser dispatch/lifetime fixtures land in #301.
+
+## KTX upload lifetime tests
+
+The caller owns the KTX bundle. `destroy()` immediately deletes it and its data;
+calling it while queued creation or an upload still uses the data is invalid.
+Texture creation returns before buffer release is guaranteed. Keep the bundle
+alive until the upload-release callback arrives, then destroy it explicitly.
+Created textures have their own lifetime and must be destroyed separately.
+
+Skybox and IBL loaders keep setup and buffer-release Futures separate. Setup
+errors reach the public Future; bundle cleanup waits for buffer release even
+when setup fails. Successful loads do not add a GPU-completion wait. Removal
+and disposal flush pending work and wait for bundle cleanup, as before.
+Native C++ exception delivery to Dart is handled separately in #318.
+
+Native partial-submission failure handling is a separate change. This PR does
+not guarantee release notification if Filament fails during submission.
+Run the Dart integration tests from `thermion_dart/`:
+
+```sh
+THERMION_UPLOAD_LIFETIME_FIXTURE=/tmp/thermion-scheduling/libupload_lifetime_fixture.dylib \
+  dart test --concurrency=1 test/ktx_upload_lifetime_test.dart test/skybox_tests.dart
+```
+
+The fixture is built by the CMake commands above. On Linux use
+`libupload_lifetime_fixture.so`; on Windows use `Release/upload_lifetime_fixture.dll`
+and set the variable using your shell's syntax. The tests require a working GPU
+backend (Metal on macOS). They gate the worker to verify release is still pending,
+exercise cubemap/mipmapped/2D uploads followed by explicit bundle destruction,
+and check public skybox/IBL failure delivery. Dart's native build hook builds
+Thermion and obtains Filament.

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -150,3 +150,22 @@ The C++ suite above covers zero buffers, partial submission failure, and a buffe
 finishing before later buffers are submitted. The Dart upload suite covers real
 2D, cubemap, and mipmapped uploads. Native exception delivery to Dart additionally
 requires the task-error change; completion tracking itself does not deliver errors.
+
+## KTX input validation
+
+KTX preflight rejects zero dimensions, mip counts that do not fit the texture
+builder's 8-bit argument, empty mip data, and mismatched or noncontiguous cubemap
+faces before submitting pixel data. Bundle decoding catches native exceptions
+and returns null, which the Dart wrapper reports as a decode error. This is input
+validation, separate from upload completion and skybox/IBL cleanup.
+
+With the same GPU and task-error setup above, run:
+
+```sh
+THERMION_TASK_ERROR_FIXTURE=/tmp/thermion-scheduling/libtask_error_fixture.dylib \
+  dart test --concurrency=1 test/ktx_input_validation_test.dart test/ktx_task_errors_test.dart
+```
+
+These regressions cover a truncated header and zero width/height, including
+release before caller cleanup. They do not directly exercise the mip-count bound
+or malformed in-memory cubemap layout.

--- a/thermion_dart/native/test/rendering/scheduling_test.cpp
+++ b/thermion_dart/native/test/rendering/scheduling_test.cpp
@@ -1,9 +1,13 @@
 #include "rendering/FrameRateGate.hpp"
 #include "rendering/FrameScheduler.hpp"
+#include "rendering/RenderThread.hpp"
 #include "rendering/UploadCompletion.hpp"
 
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
+#include <future>
+#include <vector>
 #include <iostream>
 #include <limits>
 #include <stdexcept>
@@ -170,6 +174,28 @@ protected:
 };
 #endif
 
+static std::vector<uint32_t> errors;
+static void taskFailed(uint32_t id, const char* message) {
+    require(message && std::string(message).find("expected") != std::string::npos,
+            "error lost its message");
+    errors.push_back(id);
+    std::free(const_cast<char*>(message));
+}
+
+static void testTaskErrors() {
+    RenderThread thread;
+    pushTaskErrorContext(7, taskFailed);
+    pushTaskErrorContext(8, taskFailed);
+    thread.addDetachedTask([] { throw std::runtime_error("expected scoped failure"); });
+    require(popTaskErrorContext() == 1, "scope lost its queued task count");
+    require(currentTaskError.requestId == 7, "nested error scope did not restore parent");
+    require(popTaskErrorContext() == 0, "inner task counted against its parent");
+    require(!currentTaskError.callback, "error context leaked into unrelated dispatch");
+    std::packaged_task<void()> barrier([] {});
+    thread.addTask(barrier).get();
+    require(errors == std::vector<uint32_t>({8}), "inner error incorrectly settled its parent");
+}
+
 static int uploadCompletions = 0;
 static void uploadReleased(int32_t id) {
     require(id == 42, "upload lost its callback ID");
@@ -200,8 +226,38 @@ static void testUploadCompletion() {
     require(uploadCompletions == 3, "successful upload did not signal exactly once");
 }
 
+static void testQueue() {
+    std::vector<int> order;
+    {
+        RenderThread thread;
+        for (int i = 0; i < 10000; ++i) {
+            thread.addDetachedTask([&order, i] { order.push_back(i); });
+        }
+        thread.addDetachedTask([] { throw std::runtime_error("expected detached-task test error"); });
+        thread.addDetachedTask([&order] { order.push_back(10000); });
+        std::packaged_task<void()> failed([] { throw std::runtime_error("expected packaged error"); });
+        auto result = thread.addTask(failed);
+        try {
+            result.get();
+            require(false, "packaged exception was lost");
+        } catch (const std::runtime_error& error) {
+            require(std::string(error.what()) == "expected packaged error", "wrong packaged error");
+        }
+    }
+    require(order.size() == 10001, "shutdown failed to drain tasks or worker died on exception");
+    for (size_t i = 0; i < order.size(); ++i) require(order[i] == int(i), "FIFO order changed");
+    // Exercise transitions between an idle queue and shutdown repeatedly.
+    for (int i = 0; i < 1000; ++i) {
+        RenderThread thread;
+        std::packaged_task<void()> task([] {});
+        thread.addTask(task).get();
+    }
+}
+
 int main() {
+    testQueue();
     testUploadCompletion();
+    testTaskErrors();
     testRateGate();
     testFrameTime();
 #if __APPLE__ && TARGET_OS_OSX

--- a/thermion_dart/native/test/rendering/scheduling_test.cpp
+++ b/thermion_dart/native/test/rendering/scheduling_test.cpp
@@ -1,5 +1,6 @@
 #include "rendering/FrameRateGate.hpp"
 #include "rendering/FrameScheduler.hpp"
+#include "rendering/UploadCompletion.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -169,7 +170,38 @@ protected:
 };
 #endif
 
+static int uploadCompletions = 0;
+static void uploadReleased(int32_t id) {
+    require(id == 42, "upload lost its callback ID");
+    ++uploadCompletions;
+}
+
+static void testUploadCompletion() {
+    uploadCompletions = 0;
+    auto* empty = new UploadCompletion(uploadReleased, 42);
+    empty->release(); // Validation failed before any buffer was submitted.
+    require(uploadCompletions == 1, "empty submission did not release");
+
+    auto* partial = new UploadCompletion(uploadReleased, 42);
+    partial->addBuffer();
+    partial->release(); // A later mip failed; submission has ended.
+    require(uploadCompletions == 1, "partial upload signalled before buffer release");
+    partial->release(); // The only submitted buffer is now done.
+    require(uploadCompletions == 2, "partial upload did not signal exactly once");
+
+    auto* early = new UploadCompletion(uploadReleased, 42);
+    early->addBuffer();
+    early->release(); // First buffer completes while submission is still active.
+    require(uploadCompletions == 2, "early buffer ended an active submission");
+    early->addBuffer();
+    early->release(); // Submission ends.
+    require(uploadCompletions == 2, "later buffer was not counted");
+    early->release();
+    require(uploadCompletions == 3, "successful upload did not signal exactly once");
+}
+
 int main() {
+    testUploadCompletion();
     testRateGate();
     testFrameTime();
 #if __APPLE__ && TARGET_OS_OSX

--- a/thermion_dart/native/test/rendering/task_error_fixture.cpp
+++ b/thermion_dart/native/test/rendering/task_error_fixture.cpp
@@ -1,0 +1,17 @@
+#include <stdexcept>
+
+#ifdef _WIN32
+#define TEST_EXPORT extern "C" __declspec(dllexport)
+#else
+#define TEST_EXPORT extern "C" __attribute__((visibility("default")))
+#endif
+
+// Passed to the production RenderThread_addTask by the Dart integration tests.
+// Throw on the render worker, never across a Dart-to-native FFI call.
+TEST_EXPORT void throwTaskError() {
+    throw std::runtime_error("expected native task failure");
+}
+
+TEST_EXPORT void throwUnknownTaskError() {
+    throw 42;
+}

--- a/thermion_dart/native/test/rendering/upload_lifetime_fixture.cpp
+++ b/thermion_dart/native/test/rendering/upload_lifetime_fixture.cpp
@@ -1,0 +1,17 @@
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#ifdef _WIN32
+#define TEST_EXPORT extern "C" __declspec(dllexport)
+#else
+#define TEST_EXPORT extern "C" __attribute__((visibility("default")))
+#endif
+
+// Hold the render worker so Dart can verify release has not yet been signalled.
+namespace { std::atomic<bool> releaseTask{false}; }
+TEST_EXPORT void resetTaskRelease() { releaseTask.store(false); }
+TEST_EXPORT void allowTaskToFinish() { releaseTask.store(true); }
+TEST_EXPORT void waitForTaskRelease() {
+    while (!releaseTask.load()) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+}

--- a/thermion_dart/test/benchmarks/README.md
+++ b/thermion_dart/test/benchmarks/README.md
@@ -1,0 +1,140 @@
+# PR318 callback benchmarks
+
+These are manual benchmarks. They do not add a workflow or disable error
+handling in release builds.
+
+The recorded results compare `6b0511732` with `87b9d280a`. They predate the
+subsequent callback and KTX upload lifetime fixes and do not measure the final
+PR implementation. Use the same procedure to compare later revisions.
+
+Benchmark implementations, this report, and raw results live in
+`test/benchmarks/`. The two small launchers in `bin/` are required because
+`dart build cli` only accepts entry points in that directory.
+
+## Reproduce
+
+Use the same benchmark sources and dependency lockfile in two checkouts: the
+PR's base (`6b0511732`) and the reviewed PR (`87b9d280a`). Run from each
+checkout's `thermion_dart` directory. Dart 3.12.1 was used for the recorded run.
+
+```sh
+dart pub get
+dart build cli -t bin/task_error_benchmark.dart -o /tmp/thermion-bench-VERSION
+dart build cli -t bin/task_error_frame_benchmark.dart -o /tmp/thermion-frame-bench-VERSION
+```
+
+Replace VERSION with `base` or `pr`. `dart build cli` creates an AOT executable
+and bundles its native library; `dart compile exe` alone does not bundle this
+package's native assets. The native build hook defaults to release mode; verify
+`-O3` in `.dart_tool/thermion_dart/log/build.log` and leave tracing disabled.
+
+After both builds finish, run each pair sequentially, reversing their order on
+alternate pairs. Do not build or run other benchmarks at the same time.
+
+```sh
+/usr/bin/time -l /tmp/thermion-bench-base/bundle/bin/task_error_benchmark 65536
+/usr/bin/time -l /tmp/thermion-bench-pr/bundle/bin/task_error_benchmark 65536
+/usr/bin/time -l /tmp/thermion-frame-bench-base/bundle/bin/task_error_frame_benchmark 3
+/usr/bin/time -l /tmp/thermion-frame-bench-pr/bundle/bin/task_error_frame_benchmark 3
+```
+
+The supplied programs use Metal and require GPU access. `/usr/bin/time -l` is
+the macOS command used to record process CPU time and peak resident memory.
+The last stdout line is machine-readable JSON. The base retains an idle Dart
+listener, so both programs explicitly exit after native shutdown.
+
+## Method
+
+- Hardware/software: Apple M2 Pro, macOS 26.6.2, Apple clang 21.0.0, Dart 3.12.1
+  AOT, Filament 1.75.0 release libraries. Both checkouts used identical lockfiles
+  and benchmark sources. Native tracing was off.
+- Callback runs: eight pairs; 2,048 warm-up requests and 65,536 measured requests
+  per scenario/concurrency setting. Five operations, each with one or 32 requests
+  in flight. Concurrent requests run in bounded batches of 32.
+- Each callback sample includes Dart dispatch, native queueing/work where
+  applicable, listener delivery, and Future completion. Per-request timing and
+  sample collection are enabled equally in both versions. Throughput includes
+  this measurement overhead and batch coordination.
+- Immediate callbacks bypass the native worker. Image-width queries and parent
+  updates use wrappers converted from packaged tasks to detached tasks by the
+  PR. Transform updates and empty frame submissions already used detached tasks
+  on the base. Empty frames have no attached views or GPU rendering work.
+- Headless scene: six pairs; one unlit cube at 512x512, post-processing disabled. Dart
+  timers pace submissions at 60/120 Hz. Each case warms up for one second and
+  measures three seconds. The update-heavy case submits 100 transforms to 100
+  separate entities in one concurrent batch before each frame. Those entities
+  have transform components but are not additional renderables.
+- Frame samples measure the updates plus `app.render()` completion, excluding
+  the pacing wait. This is CPU submission latency, not GPU completion or physical
+  presentation time. The harness flushes the engine after measurements and
+  releases its material before destroying the engine.
+
+## Callback results
+
+Median of the eight per-run averages, in microseconds per operation. Lower is
+better. With 32 requests, this is elapsed batch time divided by request count,
+not the latency experienced by each individual request.
+
+| Operation | In flight | Base µs/op | PR µs/op | Change |
+|---|---:|---:|---:|---:|
+| Immediate void callback | 1 | 1.00 | 1.42 | +42.3% |
+| Image width query | 1 | 10.18 | 10.92 | +7.2% |
+| Parent update | 1 | 9.59 | 9.98 | +4.0% |
+| Transform update | 1 | 9.44 | 10.11 | +7.0% |
+| Empty frame submission | 1 | 9.73 | 10.27 | +5.6% |
+| Immediate void callback | 32 | 0.86 | 1.41 | +64.2% |
+| Image width query | 32 | 2.42 | 2.71 | +12.0% |
+| Parent update | 32 | 1.95 | 1.68 | -13.8% |
+| Transform update | 32 | 1.78 | 2.14 | +20.4% |
+| Empty frame submission | 32 | 1.81 | 1.76 | -2.7% |
+
+The native sequential operations add approximately 0.4–0.7 µs/op when comparing
+these medians. The immediate callback isolates a clear cost in the Dart/FFI
+completion machinery. Removing packaged tasks offsets that cost for concurrent
+parent updates. The small apparent concurrent empty-frame improvement is within
+run-to-run variation and should not be treated as a demonstrated speedup.
+
+Median process CPU time for the full callback workload (655,360 measured requests
+plus warm-up/setup/teardown) rose from 3.81 to 4.09 seconds, approximately 7.2%.
+Median peak RSS was 74.56 versus 74.61 MiB. RSS does not measure allocation rate
+or garbage-collection frequency; neither was profiled here.
+
+Raw results, including per-run p50/p95/p99 latencies, executable hashes, and
+process resource statistics: [callback JSON](pr318-macos-arm64-micro.json).
+
+## Headless frame results
+
+Median of six per-run percentiles, in microseconds. Each version measured
+1,080 frames per 60 Hz case and 2,160 frames per 120 Hz case.
+
+| Target | Updates/frame | Base p50 | PR p50 | Base p95 | PR p95 | Base p99 | PR p99 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| 60 Hz | 0 | 82.58 | 82.33 | 147.13 | 130.83 | 354.73 | 298.54 |
+| 60 Hz | 100 | 269.15 | 273.35 | 461.42 | 533.21 | 735.13 | 765.67 |
+| 120 Hz | 0 | 62.56 | 62.77 | 133.77 | 111.10 | 260.29 | 180.42 |
+| 120 Hz | 100 | 237.46 | 216.50 | 532.35 | 446.54 | 1290.48 | 727.06 |
+
+There was no consistent frame-submission regression in this small scene. At
+60 Hz with 100 updates, median work rose by about 4 µs and p95 by 72 µs; the
+120 Hz case moved in the opposite direction. These mixed results do not prove
+an improvement and are compatible with background scheduling noise obscuring
+the smaller request-tracking cost.
+
+The scheduled completion deadline was missed 15 times on the base and 9 times
+on the PR across 6,480 measured frames per version. This includes timer wake-up
+lateness, so it is not a count of dropped display frames. The largest median
+p95 submission time was 0.53 ms, compared with an 8.33 ms budget at 120 Hz.
+
+Raw results: [frame JSON](pr318-macos-arm64-frame.json).
+
+## Limits
+
+These are measurements on one desktop Mac, with normal background OS activity.
+Repeating and alternating runs reduces drift but does not eliminate scheduling
+noise. Tail latency and small differences need particular caution. No mobile
+device, Emscripten/browser, battery, GPU-timing, or display-presentation benchmark
+was run. No FPS claim can be inferred from the empty-frame microbenchmark.
+
+Error delivery is required behavior in release builds. These measurements can
+guide reducing request bookkeeping or batching updates; turning error delivery
+off would reintroduce requests that hang when native work throws.

--- a/thermion_dart/test/benchmarks/pr318-macos-arm64-frame.json
+++ b/thermion_dart/test/benchmarks/pr318-macos-arm64-frame.json
@@ -1,0 +1,602 @@
+{
+  "kind": "frame",
+  "platform": "macOS-26.6.2-arm64-arm-64bit-Mach-O",
+  "runs": [
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 81.833,
+          "p95_us": 152.209,
+          "p99_us": 320.625,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 319.833,
+          "p95_us": 587.541,
+          "p99_us": 1106.708,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 67.25,
+          "p95_us": 170.833,
+          "p99_us": 536.292,
+          "deadline_misses": 5
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 243.875,
+          "p95_us": 635.458,
+          "p99_us": 1523.333,
+          "deadline_misses": 3
+        }
+      ],
+      "pair": 0,
+      "version": "base",
+      "wall_s": 17.081850416958332,
+      "user_s": 0.54,
+      "sys_s": 0.53,
+      "peak_rss_bytes": 74317824,
+      "time_output": "       17.05 real         0.54 user         0.53 sys\n            74317824  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4635  page reclaims\n                 393  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   2  voluntary context switches\n               52181  involuntary context switches\n          4051106535  instructions retired\n          3256817148  cycles elapsed\n            63423112  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 87.917,
+          "p95_us": 260.792,
+          "p99_us": 754.0,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 306.417,
+          "p95_us": 760.958,
+          "p99_us": 4073.917,
+          "deadline_misses": 1
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 64.958,
+          "p95_us": 255.083,
+          "p99_us": 1701.875,
+          "deadline_misses": 4
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 289.875,
+          "p95_us": 680.042,
+          "p99_us": 1244.0,
+          "deadline_misses": 4
+        }
+      ],
+      "pair": 0,
+      "version": "pr",
+      "wall_s": 16.939644792000763,
+      "user_s": 0.6,
+      "sys_s": 0.53,
+      "peak_rss_bytes": 74170368,
+      "time_output": "       16.88 real         0.60 user         0.53 sys\n            74170368  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4642  page reclaims\n                 399  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   3  voluntary context switches\n               42471  involuntary context switches\n          4296658218  instructions retired\n          3015169815  cycles elapsed\n            63242912  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 92.334,
+          "p95_us": 139.833,
+          "p99_us": 321.125,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 302.167,
+          "p95_us": 694.583,
+          "p99_us": 808.542,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 72.333,
+          "p95_us": 167.583,
+          "p99_us": 208.209,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 232.042,
+          "p95_us": 544.458,
+          "p99_us": 838.542,
+          "deadline_misses": 0
+        }
+      ],
+      "pair": 1,
+      "version": "pr",
+      "wall_s": 16.108396083000116,
+      "user_s": 0.58,
+      "sys_s": 0.52,
+      "peak_rss_bytes": 73793536,
+      "time_output": "       16.05 real         0.58 user         0.52 sys\n            73793536  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4610  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   1  voluntary context switches\n               40177  involuntary context switches\n          4255555229  instructions retired\n          2924144337  cycles elapsed\n            62931568  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 96.458,
+          "p95_us": 300.25,
+          "p99_us": 388.833,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 232.5,
+          "p95_us": 436.958,
+          "p99_us": 975.792,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 57.875,
+          "p95_us": 96.708,
+          "p99_us": 125.75,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 204.708,
+          "p95_us": 385.292,
+          "p99_us": 778.958,
+          "deadline_misses": 0
+        }
+      ],
+      "pair": 1,
+      "version": "base",
+      "wall_s": 16.080590958008543,
+      "user_s": 0.49,
+      "sys_s": 0.53,
+      "peak_rss_bytes": 73908224,
+      "time_output": "       16.04 real         0.49 user         0.53 sys\n            73908224  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4614  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   5  voluntary context switches\n               47129  involuntary context switches\n          3948391136  instructions retired\n          2866353779  cycles elapsed\n            63013512  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 83.334,
+          "p95_us": 131.292,
+          "p99_us": 223.167,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 232.083,
+          "p95_us": 416.833,
+          "p99_us": 526.708,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 49.458,
+          "p95_us": 86.292,
+          "p99_us": 141.209,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 185.958,
+          "p95_us": 411.209,
+          "p99_us": 3462.541,
+          "deadline_misses": 5
+        }
+      ],
+      "pair": 2,
+      "version": "base",
+      "wall_s": 16.061677916906774,
+      "user_s": 0.41,
+      "sys_s": 0.44,
+      "peak_rss_bytes": 73875456,
+      "time_output": "       16.03 real         0.41 user         0.44 sys\n            73875456  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4610  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                  14  voluntary context switches\n               45599  involuntary context switches\n          3919885436  instructions retired\n          2541004570  cycles elapsed\n            63029896  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 60.208,
+          "p95_us": 116.625,
+          "p99_us": 204.0,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 186.625,
+          "p95_us": 417.417,
+          "p99_us": 767.5,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 47.417,
+          "p95_us": 90.625,
+          "p99_us": 133.208,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 168.792,
+          "p95_us": 389.375,
+          "p99_us": 606.625,
+          "deadline_misses": 0
+        }
+      ],
+      "pair": 2,
+      "version": "pr",
+      "wall_s": 16.051259999978356,
+      "user_s": 0.4,
+      "sys_s": 0.41,
+      "peak_rss_bytes": 73973760,
+      "time_output": "       16.01 real         0.40 user         0.41 sys\n            73973760  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4620  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   2  voluntary context switches\n               39458  involuntary context switches\n          4237903933  instructions retired\n          2369735484  cycles elapsed\n            63095456  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 78.833,
+          "p95_us": 135.5,
+          "p99_us": 284.916,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 218.834,
+          "p95_us": 491.792,
+          "p99_us": 618.041,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 62.416,
+          "p95_us": 108.625,
+          "p99_us": 238.625,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 192.167,
+          "p95_us": 384.125,
+          "p99_us": 517.916,
+          "deadline_misses": 0
+        }
+      ],
+      "pair": 3,
+      "version": "pr",
+      "wall_s": 16.02471270901151,
+      "user_s": 0.45,
+      "sys_s": 0.45,
+      "peak_rss_bytes": 74006528,
+      "time_output": "       16.00 real         0.45 user         0.45 sys\n            74006528  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4624  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n               39911  involuntary context switches\n          4244990309  instructions retired\n          2599912647  cycles elapsed\n            63111840  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 83.916,
+          "p95_us": 203.916,
+          "p99_us": 428.25,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 260.667,
+          "p95_us": 542.875,
+          "p99_us": 764.917,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 88.292,
+          "p95_us": 195.709,
+          "p99_us": 326.875,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 368.083,
+          "p95_us": 842.583,
+          "p99_us": 1057.625,
+          "deadline_misses": 0
+        }
+      ],
+      "pair": 3,
+      "version": "base",
+      "wall_s": 16.061559665948153,
+      "user_s": 0.65,
+      "sys_s": 0.66,
+      "peak_rss_bytes": 73842688,
+      "time_output": "       16.02 real         0.65 user         0.66 sys\n            73842688  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4605  page reclaims\n                 396  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   1  voluntary context switches\n               46915  involuntary context switches\n          3959664515  instructions retired\n          2650546861  cycles elapsed\n            62948000  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 71.125,
+          "p95_us": 103.125,
+          "p99_us": 236.75,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 277.625,
+          "p95_us": 480.0,
+          "p99_us": 705.334,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 57.166,
+          "p95_us": 95.208,
+          "p99_us": 193.708,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 231.041,
+          "p95_us": 429.25,
+          "p99_us": 494.084,
+          "deadline_misses": 0
+        }
+      ],
+      "pair": 4,
+      "version": "base",
+      "wall_s": 16.034561749896966,
+      "user_s": 0.45,
+      "sys_s": 0.49,
+      "peak_rss_bytes": 73629696,
+      "time_output": "       16.02 real         0.45 user         0.49 sys\n            73629696  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4589  page reclaims\n                 398  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   1  voluntary context switches\n               47690  involuntary context switches\n          3977842282  instructions retired\n          2239649672  cycles elapsed\n            62735008  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 74.167,
+          "p95_us": 115.042,
+          "p99_us": 185.958,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 269.083,
+          "p95_us": 553.709,
+          "p99_us": 763.834,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 63.125,
+          "p95_us": 113.583,
+          "p99_us": 139.625,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 205.25,
+          "p95_us": 451.208,
+          "p99_us": 984.625,
+          "deadline_misses": 0
+        }
+      ],
+      "pair": 4,
+      "version": "pr",
+      "wall_s": 16.057407708023675,
+      "user_s": 0.49,
+      "sys_s": 0.47,
+      "peak_rss_bytes": 74072064,
+      "time_output": "       16.01 real         0.49 user         0.47 sys\n            74072064  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4627  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n               39263  involuntary context switches\n          4224185842  instructions retired\n          2424342678  cycles elapsed\n            63144608  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 85.833,
+          "p95_us": 126.166,
+          "p99_us": 312.167,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 277.625,
+          "p95_us": 512.709,
+          "p99_us": 606.333,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 58.0,
+          "p95_us": 98.833,
+          "p99_us": 152.625,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 227.75,
+          "p95_us": 441.875,
+          "p99_us": 615.584,
+          "deadline_misses": 0
+        }
+      ],
+      "pair": 5,
+      "version": "pr",
+      "wall_s": 16.045640208991244,
+      "user_s": 0.49,
+      "sys_s": 0.46,
+      "peak_rss_bytes": 73777152,
+      "time_output": "       16.02 real         0.49 user         0.46 sys\n            73777152  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4608  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n               41260  involuntary context switches\n          4268340983  instructions retired\n          2862851951  cycles elapsed\n            62816904  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "fps": 60,
+          "updates": 0,
+          "frames": 180,
+          "p50_us": 79.625,
+          "p95_us": 142.042,
+          "p99_us": 448.125,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 60,
+          "updates": 100,
+          "frames": 180,
+          "p50_us": 282.833,
+          "p95_us": 442.833,
+          "p99_us": 690.666,
+          "deadline_misses": 0
+        },
+        {
+          "fps": 120,
+          "updates": 0,
+          "frames": 360,
+          "p50_us": 72.084,
+          "p95_us": 175.25,
+          "p99_us": 528.458,
+          "deadline_misses": 1
+        },
+        {
+          "fps": 120,
+          "updates": 100,
+          "frames": 360,
+          "p50_us": 288.125,
+          "p95_us": 700.292,
+          "p99_us": 1996.959,
+          "deadline_misses": 1
+        }
+      ],
+      "pair": 5,
+      "version": "base",
+      "wall_s": 16.084112499956973,
+      "user_s": 0.55,
+      "sys_s": 0.56,
+      "peak_rss_bytes": 73711616,
+      "time_output": "       16.03 real         0.55 user         0.56 sys\n            73711616  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4603  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n               48281  involuntary context switches\n          3971245854  instructions retired\n          3013860457  cycles elapsed\n            62882464  peak memory footprint\n"
+    }
+  ],
+  "binaries": {
+    "base": {
+      "path": "/private/tmp/thermion-frame-bench-base/bundle/bin/task_error_frame_benchmark",
+      "sha256": "ed91f54f8371b6c4123416d429d0f11659682b93daca8ba9d18ac9f51b9bd419",
+      "native_library_sha256": "07504ce6fad52db99ac4725cb71051b785ec63376ba4302f4aa02a8669a5b428"
+    },
+    "pr": {
+      "path": "/private/tmp/thermion-frame-bench-pr/bundle/bin/task_error_frame_benchmark",
+      "sha256": "9c0a0b89445fbc7b86ad6ee9854467e67587f64f424e2f41c6f58fb17d66b232",
+      "native_library_sha256": "0250818a63b7c856aa5f4b148ea9dd6274597cf8f301a912f1a82c1e0af3ce70"
+    }
+  },
+  "base_commit": "6b0511732",
+  "pr_commit": "87b9d280a",
+  "compiler": "Apple clang 21.0.0, -O3; Dart 3.12.1 AOT via dart build cli",
+  "native_backend": "Metal, headless 512x512 unlit cube",
+  "date": "2026-09-09",
+  "hardware": "Apple M2 Pro",
+  "os": "macOS 26.6.2 (25G83)",
+  "benchmark_source_sha256": "cc8b2cc722a24795aeb432b9fdacb07d14874f46a3321c0b2a468ef79c76ab83"
+}

--- a/thermion_dart/test/benchmarks/pr318-macos-arm64-micro.json
+++ b/thermion_dart/test/benchmarks/pr318-macos-arm64-micro.json
@@ -1,0 +1,1818 @@
+{
+  "kind": "micro",
+  "platform": "macOS-26.6.2-arm64-arm-64bit-Mach-O",
+  "runs": [
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 66219.084,
+          "ns_per_op": 1010.4230346679688,
+          "p50_us": 0.792,
+          "p95_us": 1.042,
+          "p99_us": 1.833
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 76387.0,
+          "ns_per_op": 1165.5731201171875,
+          "p50_us": 12.333,
+          "p95_us": 34.958,
+          "p99_us": 85.834
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 681543.125,
+          "ns_per_op": 10399.52278137207,
+          "p50_us": 9.583,
+          "p95_us": 16.958,
+          "p99_us": 25.416
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 160736.583,
+          "ns_per_op": 2452.6456146240234,
+          "p50_us": 38.375,
+          "p95_us": 90.125,
+          "p99_us": 119.417
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 634541.875,
+          "ns_per_op": 9682.340621948242,
+          "p50_us": 8.417,
+          "p95_us": 16.0,
+          "p99_us": 23.833
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 129656.083,
+          "ns_per_op": 1978.3948211669922,
+          "p50_us": 27.75,
+          "p95_us": 77.916,
+          "p99_us": 117.25
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 674340.583,
+          "ns_per_op": 10289.620712280273,
+          "p50_us": 8.667,
+          "p95_us": 18.708,
+          "p99_us": 34.042
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 132527.584,
+          "ns_per_op": 2022.21044921875,
+          "p50_us": 29.0,
+          "p95_us": 82.375,
+          "p99_us": 121.625
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 627123.042,
+          "ns_per_op": 9569.138214111328,
+          "p50_us": 8.583,
+          "p95_us": 17.25,
+          "p99_us": 27.125
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 131557.042,
+          "ns_per_op": 2007.4011535644531,
+          "p50_us": 28.708,
+          "p95_us": 79.166,
+          "p99_us": 134.542
+        }
+      ],
+      "pair": 0,
+      "version": "base",
+      "wall_s": 4.732398374937475,
+      "user_s": 2.23,
+      "sys_s": 1.62,
+      "peak_rss_bytes": 78266368,
+      "time_output": "        4.72 real         2.23 user         1.62 sys\n            78266368  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4755  page reclaims\n                 399  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                  17  voluntary context switches\n              617590  involuntary context switches\n         25673777539  instructions retired\n         11091632212  cycles elapsed\n            57918112  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 94247.0,
+          "ns_per_op": 1438.0950927734375,
+          "p50_us": 1.167,
+          "p95_us": 1.5,
+          "p99_us": 5.25
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 101346.792,
+          "ns_per_op": 1546.4293212890625,
+          "p50_us": 19.542,
+          "p95_us": 37.0,
+          "p99_us": 86.209
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 780850.625,
+          "ns_per_op": 11914.834976196289,
+          "p50_us": 9.833,
+          "p95_us": 19.625,
+          "p99_us": 35.417
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 183274.875,
+          "ns_per_op": 2796.5526580810547,
+          "p50_us": 38.667,
+          "p95_us": 101.209,
+          "p99_us": 190.25
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 677172.25,
+          "ns_per_op": 10332.828521728516,
+          "p50_us": 9.375,
+          "p95_us": 16.792,
+          "p99_us": 23.916
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 120179.791,
+          "ns_per_op": 1833.798080444336,
+          "p50_us": 26.75,
+          "p95_us": 67.958,
+          "p99_us": 101.291
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 672268.75,
+          "ns_per_op": 10258.007049560547,
+          "p50_us": 9.292,
+          "p95_us": 14.917,
+          "p99_us": 23.583
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 128963.25,
+          "ns_per_op": 1967.8230285644531,
+          "p50_us": 27.5,
+          "p95_us": 75.333,
+          "p99_us": 114.291
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 677073.75,
+          "ns_per_op": 10331.32553100586,
+          "p50_us": 9.333,
+          "p95_us": 16.5,
+          "p99_us": 23.792
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 113004.958,
+          "ns_per_op": 1724.3188171386719,
+          "p50_us": 25.5,
+          "p95_us": 52.042,
+          "p99_us": 88.792
+        }
+      ],
+      "pair": 0,
+      "version": "pr",
+      "wall_s": 3.9391377080464736,
+      "user_s": 2.61,
+      "sys_s": 1.53,
+      "peak_rss_bytes": 84230144,
+      "time_output": "        3.93 real         2.61 user         1.53 sys\n            84230144  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                5124  page reclaims\n                 393  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   1  voluntary context switches\n              588460  involuntary context switches\n         27456659298  instructions retired\n         11799879838  cycles elapsed\n            63767176  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 156643.792,
+          "ns_per_op": 2390.194580078125,
+          "p50_us": 1.167,
+          "p95_us": 2.75,
+          "p99_us": 4.458
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 87651.333,
+          "ns_per_op": 1337.4532012939453,
+          "p50_us": 19.458,
+          "p95_us": 35.958,
+          "p99_us": 88.25
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 709041.334,
+          "ns_per_op": 10819.11215209961,
+          "p50_us": 9.75,
+          "p95_us": 16.084,
+          "p99_us": 24.875
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 236396.792,
+          "ns_per_op": 3607.1287841796875,
+          "p50_us": 53.25,
+          "p95_us": 134.167,
+          "p99_us": 218.416
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 652876.667,
+          "ns_per_op": 9962.107345581055,
+          "p50_us": 9.166,
+          "p95_us": 16.375,
+          "p99_us": 23.833
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 110236.459,
+          "ns_per_op": 1682.0748748779297,
+          "p50_us": 25.542,
+          "p95_us": 80.167,
+          "p99_us": 102.292
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 724471.541,
+          "ns_per_op": 11054.55842590332,
+          "p50_us": 9.334,
+          "p95_us": 18.417,
+          "p99_us": 31.459
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 186687.667,
+          "ns_per_op": 2848.627731323242,
+          "p50_us": 28.916,
+          "p95_us": 114.292,
+          "p99_us": 191.167
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 699098.333,
+          "ns_per_op": 10667.393997192383,
+          "p50_us": 9.333,
+          "p95_us": 18.458,
+          "p99_us": 31.917
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 156878.209,
+          "ns_per_op": 2393.771499633789,
+          "p50_us": 26.666,
+          "p95_us": 98.333,
+          "p99_us": 190.5
+        }
+      ],
+      "pair": 1,
+      "version": "pr",
+      "wall_s": 3.9984478330006823,
+      "user_s": 2.62,
+      "sys_s": 1.6,
+      "peak_rss_bytes": 78348288,
+      "time_output": "        3.99 real         2.62 user         1.60 sys\n            78348288  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4766  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              600278  involuntary context switches\n         27893737275  instructions retired\n         12056698025  cycles elapsed\n            57901728  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 63642.292,
+          "ns_per_op": 971.1043090820312,
+          "p50_us": 0.792,
+          "p95_us": 1.0,
+          "p99_us": 1.167
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 55477.708,
+          "ns_per_op": 846.5226440429688,
+          "p50_us": 12.375,
+          "p95_us": 19.25,
+          "p99_us": 59.083
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 804305.75,
+          "ns_per_op": 12272.73178100586,
+          "p50_us": 9.625,
+          "p95_us": 20.5,
+          "p99_us": 34.458
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 211831.417,
+          "ns_per_op": 3232.2909088134766,
+          "p50_us": 46.625,
+          "p95_us": 123.542,
+          "p99_us": 179.75
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 637336.583,
+          "ns_per_op": 9724.984481811523,
+          "p50_us": 7.209,
+          "p95_us": 19.25,
+          "p99_us": 33.125
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 116852.959,
+          "ns_per_op": 1783.034652709961,
+          "p50_us": 24.625,
+          "p95_us": 67.542,
+          "p99_us": 108.5
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 615671.166,
+          "ns_per_op": 9394.396453857422,
+          "p50_us": 6.958,
+          "p95_us": 17.75,
+          "p99_us": 28.125
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 117545.542,
+          "ns_per_op": 1793.6026306152344,
+          "p50_us": 26.834,
+          "p95_us": 72.583,
+          "p99_us": 107.417
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 677744.791,
+          "ns_per_op": 10341.564804077148,
+          "p50_us": 6.917,
+          "p95_us": 20.666,
+          "p99_us": 40.208
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 176558.625,
+          "ns_per_op": 2694.070816040039,
+          "p50_us": 27.375,
+          "p95_us": 107.375,
+          "p99_us": 203.834
+        }
+      ],
+      "pair": 1,
+      "version": "base",
+      "wall_s": 3.8623029169393703,
+      "user_s": 2.13,
+      "sys_s": 1.85,
+      "peak_rss_bytes": 77561856,
+      "time_output": "        3.85 real         2.13 user         1.85 sys\n            77561856  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4724  page reclaims\n                 394  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   8  voluntary context switches\n              625771  involuntary context switches\n         25736986664  instructions retired\n         12404938677  cycles elapsed\n            57246368  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 78614.417,
+          "ns_per_op": 1199.560806274414,
+          "p50_us": 0.834,
+          "p95_us": 1.791,
+          "p99_us": 1.959
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 71035.166,
+          "ns_per_op": 1083.9106140136719,
+          "p50_us": 12.792,
+          "p95_us": 45.625,
+          "p99_us": 96.584
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 732892.042,
+          "ns_per_op": 11183.04507446289,
+          "p50_us": 9.584,
+          "p95_us": 21.875,
+          "p99_us": 42.083
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 156552.458,
+          "ns_per_op": 2388.8009338378906,
+          "p50_us": 37.292,
+          "p95_us": 89.834,
+          "p99_us": 123.084
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 639078.708,
+          "ns_per_op": 9751.567199707031,
+          "p50_us": 8.875,
+          "p95_us": 16.459,
+          "p99_us": 24.875
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 113389.208,
+          "ns_per_op": 1730.1820068359375,
+          "p50_us": 23.958,
+          "p95_us": 62.167,
+          "p99_us": 92.208
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 690220.0,
+          "ns_per_op": 10531.92138671875,
+          "p50_us": 6.167,
+          "p95_us": 20.125,
+          "p99_us": 42.209
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 130844.75,
+          "ns_per_op": 1996.5324401855469,
+          "p50_us": 28.208,
+          "p95_us": 83.334,
+          "p99_us": 122.292
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 648455.166,
+          "ns_per_op": 9894.640594482422,
+          "p50_us": 8.667,
+          "p95_us": 16.666,
+          "p99_us": 25.083
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 107511.083,
+          "ns_per_op": 1640.4889373779297,
+          "p50_us": 20.708,
+          "p95_us": 61.792,
+          "p99_us": 94.583
+        }
+      ],
+      "pair": 2,
+      "version": "base",
+      "wall_s": 3.7798335410188884,
+      "user_s": 2.18,
+      "sys_s": 1.67,
+      "peak_rss_bytes": 78233600,
+      "time_output": "        3.77 real         2.18 user         1.67 sys\n            78233600  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4757  page reclaims\n                 398  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              619106  involuntary context switches\n         25631767629  instructions retired\n         11485079870  cycles elapsed\n            57819784  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 90303.459,
+          "ns_per_op": 1377.9214324951172,
+          "p50_us": 1.167,
+          "p95_us": 1.417,
+          "p99_us": 1.792
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 88199.25,
+          "ns_per_op": 1345.8137512207031,
+          "p50_us": 19.584,
+          "p95_us": 36.333,
+          "p99_us": 85.125
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 684668.167,
+          "ns_per_op": 10447.207138061523,
+          "p50_us": 6.833,
+          "p95_us": 19.5,
+          "p99_us": 35.375
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 220080.042,
+          "ns_per_op": 3358.1549377441406,
+          "p50_us": 43.375,
+          "p95_us": 138.083,
+          "p99_us": 215.041
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 657938.709,
+          "ns_per_op": 10039.34797668457,
+          "p50_us": 8.083,
+          "p95_us": 19.459,
+          "p99_us": 34.0
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 114684.083,
+          "ns_per_op": 1749.9402313232422,
+          "p50_us": 23.208,
+          "p95_us": 75.167,
+          "p99_us": 127.833
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 669451.209,
+          "ns_per_op": 10215.014785766602,
+          "p50_us": 6.333,
+          "p95_us": 20.542,
+          "p99_us": 41.959
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 209683.333,
+          "ns_per_op": 3199.5137481689453,
+          "p50_us": 33.25,
+          "p95_us": 158.042,
+          "p99_us": 300.125
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 757560.375,
+          "ns_per_op": 11559.453964233398,
+          "p50_us": 7.625,
+          "p95_us": 25.417,
+          "p99_us": 44.417
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 229204.834,
+          "ns_per_op": 3497.388214111328,
+          "p50_us": 28.292,
+          "p95_us": 164.917,
+          "p99_us": 387.417
+        }
+      ],
+      "pair": 2,
+      "version": "pr",
+      "wall_s": 4.048434250056744,
+      "user_s": 2.38,
+      "sys_s": 1.84,
+      "peak_rss_bytes": 78168064,
+      "time_output": "        4.03 real         2.38 user         1.84 sys\n            78168064  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4746  page reclaims\n                 398  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   2  voluntary context switches\n              618683  involuntary context switches\n         28214599014  instructions retired\n         13298441377  cycles elapsed\n            57770656  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 113285.666,
+          "ns_per_op": 1728.6020812988281,
+          "p50_us": 1.208,
+          "p95_us": 2.792,
+          "p99_us": 5.792
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 98741.666,
+          "ns_per_op": 1506.6782531738281,
+          "p50_us": 20.084,
+          "p95_us": 56.917,
+          "p99_us": 108.75
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 859433.041,
+          "ns_per_op": 13113.907485961914,
+          "p50_us": 9.0,
+          "p95_us": 26.5,
+          "p99_us": 52.083
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 172019.25,
+          "ns_per_op": 2624.805450439453,
+          "p50_us": 36.0,
+          "p95_us": 93.833,
+          "p99_us": 148.708
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 650511.041,
+          "ns_per_op": 9926.010757446289,
+          "p50_us": 8.5,
+          "p95_us": 17.625,
+          "p99_us": 28.792
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 109723.583,
+          "ns_per_op": 1674.249008178711,
+          "p50_us": 23.083,
+          "p95_us": 74.667,
+          "p99_us": 130.792
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 645375.667,
+          "ns_per_op": 9847.651168823242,
+          "p50_us": 7.375,
+          "p95_us": 18.166,
+          "p99_us": 29.042
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 114804.625,
+          "ns_per_op": 1751.779556274414,
+          "p50_us": 24.792,
+          "p95_us": 77.708,
+          "p99_us": 120.958
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 546872.875,
+          "ns_per_op": 8344.61784362793,
+          "p50_us": 6.334,
+          "p95_us": 15.959,
+          "p99_us": 21.5
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 114310.791,
+          "ns_per_op": 1744.2442474365234,
+          "p50_us": 24.459,
+          "p95_us": 82.292,
+          "p99_us": 117.333
+        }
+      ],
+      "pair": 3,
+      "version": "pr",
+      "wall_s": 3.6647487500449643,
+      "user_s": 2.36,
+      "sys_s": 1.63,
+      "peak_rss_bytes": 78135296,
+      "time_output": "        3.65 real         2.36 user         1.63 sys\n            78135296  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4752  page reclaims\n                 393  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              590033  involuntary context switches\n         27767116730  instructions retired\n         12396776520  cycles elapsed\n            57705120  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 93093.875,
+          "ns_per_op": 1420.4998016357422,
+          "p50_us": 0.833,
+          "p95_us": 1.709,
+          "p99_us": 1.959
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 94018.958,
+          "ns_per_op": 1434.6154479980469,
+          "p50_us": 12.833,
+          "p95_us": 40.667,
+          "p99_us": 122.125
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 709751.75,
+          "ns_per_op": 10829.952239990234,
+          "p50_us": 9.75,
+          "p95_us": 19.458,
+          "p99_us": 33.209
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 161684.709,
+          "ns_per_op": 2467.1128692626953,
+          "p50_us": 36.625,
+          "p95_us": 94.833,
+          "p99_us": 129.666
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 640955.834,
+          "ns_per_op": 9780.209869384766,
+          "p50_us": 6.459,
+          "p95_us": 17.334,
+          "p99_us": 28.041
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 127114.375,
+          "ns_per_op": 1939.6114349365234,
+          "p50_us": 25.708,
+          "p95_us": 78.125,
+          "p99_us": 127.75
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 638599.917,
+          "ns_per_op": 9744.261428833008,
+          "p50_us": 8.292,
+          "p95_us": 17.917,
+          "p99_us": 29.583
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 109470.541,
+          "ns_per_op": 1670.3878936767578,
+          "p50_us": 20.417,
+          "p95_us": 62.084,
+          "p99_us": 105.708
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 654815.125,
+          "ns_per_op": 9991.68586730957,
+          "p50_us": 6.083,
+          "p95_us": 19.0,
+          "p99_us": 56.209
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 98044.167,
+          "ns_per_op": 1496.0352630615234,
+          "p50_us": 18.708,
+          "p95_us": 53.791,
+          "p99_us": 80.584
+        }
+      ],
+      "pair": 3,
+      "version": "base",
+      "wall_s": 3.622222666046582,
+      "user_s": 2.12,
+      "sys_s": 1.65,
+      "peak_rss_bytes": 78299136,
+      "time_output": "        3.61 real         2.12 user         1.65 sys\n            78299136  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4771  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              615645  involuntary context switches\n         25734742251  instructions retired\n         11422667306  cycles elapsed\n            58049184  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 64786.958,
+          "ns_per_op": 988.5705261230469,
+          "p50_us": 0.833,
+          "p95_us": 0.917,
+          "p99_us": 1.125
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 53489.208,
+          "ns_per_op": 816.1805419921875,
+          "p50_us": 12.416,
+          "p95_us": 15.958,
+          "p99_us": 52.125
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 582381.208,
+          "ns_per_op": 8886.432006835938,
+          "p50_us": 6.75,
+          "p95_us": 17.209,
+          "p99_us": 21.75
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 152651.0,
+          "ns_per_op": 2329.2694091796875,
+          "p50_us": 36.625,
+          "p95_us": 86.5,
+          "p99_us": 117.875
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 601207.917,
+          "ns_per_op": 9173.704788208008,
+          "p50_us": 8.583,
+          "p95_us": 16.208,
+          "p99_us": 25.417
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 116934.75,
+          "ns_per_op": 1784.2826843261719,
+          "p50_us": 26.125,
+          "p95_us": 69.375,
+          "p99_us": 99.791
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 592900.375,
+          "ns_per_op": 9046.941757202148,
+          "p50_us": 8.458,
+          "p95_us": 12.917,
+          "p99_us": 21.792
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 114799.5,
+          "ns_per_op": 1751.7013549804688,
+          "p50_us": 21.417,
+          "p95_us": 75.916,
+          "p99_us": 129.0
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 564054.208,
+          "ns_per_op": 8606.7841796875,
+          "p50_us": 7.125,
+          "p95_us": 16.75,
+          "p99_us": 25.042
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 122017.875,
+          "ns_per_op": 1861.8450164794922,
+          "p50_us": 26.334,
+          "p95_us": 79.125,
+          "p99_us": 112.0
+        }
+      ],
+      "pair": 4,
+      "version": "base",
+      "wall_s": 3.1888351250672713,
+      "user_s": 2.08,
+      "sys_s": 1.51,
+      "peak_rss_bytes": 78135296,
+      "time_output": "        3.18 real         2.08 user         1.51 sys\n            78135296  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4749  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              616961  involuntary context switches\n         25723760707  instructions retired\n         10747407668  cycles elapsed\n            57688736  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 101498.292,
+          "ns_per_op": 1548.7410278320312,
+          "p50_us": 1.208,
+          "p95_us": 2.584,
+          "p99_us": 2.958
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 96889.292,
+          "ns_per_op": 1478.4132690429688,
+          "p50_us": 20.083,
+          "p95_us": 50.166,
+          "p99_us": 94.75
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 717904.541,
+          "ns_per_op": 10954.353958129883,
+          "p50_us": 7.333,
+          "p95_us": 21.292,
+          "p99_us": 38.583
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 191455.75,
+          "ns_per_op": 2921.3829040527344,
+          "p50_us": 38.75,
+          "p95_us": 109.125,
+          "p99_us": 176.792
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 654963.959,
+          "ns_per_op": 9993.956893920898,
+          "p50_us": 9.375,
+          "p95_us": 17.208,
+          "p99_us": 24.5
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 110855.625,
+          "ns_per_op": 1691.5225982666016,
+          "p50_us": 25.458,
+          "p95_us": 83.709,
+          "p99_us": 106.5
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 649919.042,
+          "ns_per_op": 9916.977569580078,
+          "p50_us": 9.375,
+          "p95_us": 16.375,
+          "p99_us": 27.834
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 145929.75,
+          "ns_per_op": 2226.7112731933594,
+          "p50_us": 27.542,
+          "p95_us": 103.875,
+          "p99_us": 166.458
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 669328.375,
+          "ns_per_op": 10213.140487670898,
+          "p50_us": 9.417,
+          "p95_us": 17.375,
+          "p99_us": 27.167
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 116317.25,
+          "ns_per_op": 1774.8603820800781,
+          "p50_us": 25.25,
+          "p95_us": 85.667,
+          "p99_us": 116.625
+        }
+      ],
+      "pair": 4,
+      "version": "pr",
+      "wall_s": 3.694563415949233,
+      "user_s": 2.52,
+      "sys_s": 1.59,
+      "peak_rss_bytes": 78151680,
+      "time_output": "        3.69 real         2.52 user         1.59 sys\n            78151680  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4750  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              593489  involuntary context switches\n         27810087600  instructions retired\n         12023977600  cycles elapsed\n            57705120  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 88779.041,
+          "ns_per_op": 1354.660659790039,
+          "p50_us": 1.167,
+          "p95_us": 1.375,
+          "p99_us": 1.666
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 88019.167,
+          "ns_per_op": 1343.065902709961,
+          "p50_us": 19.708,
+          "p95_us": 34.375,
+          "p99_us": 90.333
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 719979.75,
+          "ns_per_op": 10986.019134521484,
+          "p50_us": 9.709,
+          "p95_us": 20.125,
+          "p99_us": 38.583
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 172222.417,
+          "ns_per_op": 2627.905532836914,
+          "p50_us": 39.625,
+          "p95_us": 95.458,
+          "p99_us": 146.625
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 626750.458,
+          "ns_per_op": 9563.453033447266,
+          "p50_us": 6.916,
+          "p95_us": 17.417,
+          "p99_us": 26.833
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 100017.416,
+          "ns_per_op": 1526.1446533203125,
+          "p50_us": 23.042,
+          "p95_us": 52.5,
+          "p99_us": 74.375
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 755371.291,
+          "ns_per_op": 11526.051193237305,
+          "p50_us": 6.75,
+          "p95_us": 22.791,
+          "p99_us": 60.917
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 174701.0,
+          "ns_per_op": 2665.7257080078125,
+          "p50_us": 25.834,
+          "p95_us": 85.542,
+          "p99_us": 307.542
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 698624.792,
+          "ns_per_op": 10660.168334960938,
+          "p50_us": 7.5,
+          "p95_us": 20.041,
+          "p99_us": 33.167
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 120572.958,
+          "ns_per_op": 1839.7973327636719,
+          "p50_us": 24.625,
+          "p95_us": 68.541,
+          "p99_us": 105.417
+        }
+      ],
+      "pair": 5,
+      "version": "pr",
+      "wall_s": 3.7666898330207914,
+      "user_s": 2.36,
+      "sys_s": 1.7,
+      "peak_rss_bytes": 83836928,
+      "time_output": "        3.76 real         2.36 user         1.70 sys\n            83836928  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                5096  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              590337  involuntary context switches\n         27539168519  instructions retired\n         12730562080  cycles elapsed\n            63341168  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 67636.375,
+          "ns_per_op": 1032.0491790771484,
+          "p50_us": 0.833,
+          "p95_us": 0.917,
+          "p99_us": 1.792
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 57254.916,
+          "ns_per_op": 873.6406860351562,
+          "p50_us": 12.5,
+          "p95_us": 19.375,
+          "p99_us": 62.292
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 616297.667,
+          "ns_per_op": 9403.956100463867,
+          "p50_us": 6.875,
+          "p95_us": 18.625,
+          "p99_us": 25.166
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 166631.917,
+          "ns_per_op": 2542.601272583008,
+          "p50_us": 34.833,
+          "p95_us": 100.542,
+          "p99_us": 162.166
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 623035.75,
+          "ns_per_op": 9506.771087646484,
+          "p50_us": 8.75,
+          "p95_us": 17.167,
+          "p99_us": 26.458
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 135447.208,
+          "ns_per_op": 2066.7603759765625,
+          "p50_us": 26.5,
+          "p95_us": 84.75,
+          "p99_us": 132.334
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 622117.958,
+          "ns_per_op": 9492.766693115234,
+          "p50_us": 7.542,
+          "p95_us": 18.042,
+          "p99_us": 28.916
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 133862.292,
+          "ns_per_op": 2042.5764770507812,
+          "p50_us": 28.25,
+          "p95_us": 88.958,
+          "p99_us": 135.0
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 714392.125,
+          "ns_per_op": 10900.758743286133,
+          "p50_us": 8.875,
+          "p95_us": 18.083,
+          "p99_us": 30.959
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 120562.084,
+          "ns_per_op": 1839.6314086914062,
+          "p50_us": 25.75,
+          "p95_us": 72.917,
+          "p99_us": 107.833
+        }
+      ],
+      "pair": 5,
+      "version": "base",
+      "wall_s": 3.4879269170342013,
+      "user_s": 2.16,
+      "sys_s": 1.69,
+      "peak_rss_bytes": 78364672,
+      "time_output": "        3.48 real         2.16 user         1.69 sys\n            78364672  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4760  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              618673  involuntary context switches\n         25663523676  instructions retired\n         11698035683  cycles elapsed\n            57934496  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 63931.917,
+          "ns_per_op": 975.5236358642578,
+          "p50_us": 0.792,
+          "p95_us": 0.958,
+          "p99_us": 1.166
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 53799.125,
+          "ns_per_op": 820.9095001220703,
+          "p50_us": 12.208,
+          "p95_us": 17.792,
+          "p99_us": 52.417
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 652685.75,
+          "ns_per_op": 9959.19418334961,
+          "p50_us": 9.625,
+          "p95_us": 13.75,
+          "p99_us": 21.042
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 142219.375,
+          "ns_per_op": 2170.095443725586,
+          "p50_us": 35.5,
+          "p95_us": 71.875,
+          "p99_us": 103.458
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 608858.375,
+          "ns_per_op": 9290.441513061523,
+          "p50_us": 8.791,
+          "p95_us": 12.75,
+          "p99_us": 21.417
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 128128.0,
+          "ns_per_op": 1955.078125,
+          "p50_us": 28.209,
+          "p95_us": 75.916,
+          "p99_us": 109.083
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 582582.166,
+          "ns_per_op": 8889.49838256836,
+          "p50_us": 8.459,
+          "p95_us": 13.417,
+          "p99_us": 21.541
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 115308.042,
+          "ns_per_op": 1759.4610900878906,
+          "p50_us": 26.25,
+          "p95_us": 67.792,
+          "p99_us": 95.417
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 572430.5,
+          "ns_per_op": 8734.596252441406,
+          "p50_us": 8.541,
+          "p95_us": 11.958,
+          "p99_us": 18.0
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 116367.792,
+          "ns_per_op": 1775.631591796875,
+          "p50_us": 25.5,
+          "p95_us": 63.917,
+          "p99_us": 94.084
+        }
+      ],
+      "pair": 6,
+      "version": "base",
+      "wall_s": 3.243821917101741,
+      "user_s": 2.19,
+      "sys_s": 1.47,
+      "peak_rss_bytes": 78036992,
+      "time_output": "        3.24 real         2.19 user         1.47 sys\n            78036992  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4744  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              611864  involuntary context switches\n         25597488809  instructions retired\n         10308014260  cycles elapsed\n            57574024  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 92178.917,
+          "ns_per_op": 1406.5386505126953,
+          "p50_us": 1.167,
+          "p95_us": 1.417,
+          "p99_us": 2.625
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 97149.5,
+          "ns_per_op": 1482.3837280273438,
+          "p50_us": 20.0,
+          "p95_us": 48.584,
+          "p99_us": 88.917
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 712857.625,
+          "ns_per_op": 10877.344131469727,
+          "p50_us": 9.833,
+          "p95_us": 16.0,
+          "p99_us": 23.917
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 154015.084,
+          "ns_per_op": 2350.0836791992188,
+          "p50_us": 37.625,
+          "p95_us": 80.541,
+          "p99_us": 107.834
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 657993.083,
+          "ns_per_op": 10040.177658081055,
+          "p50_us": 9.25,
+          "p95_us": 13.084,
+          "p99_us": 22.25
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 108777.125,
+          "ns_per_op": 1659.8072052001953,
+          "p50_us": 25.083,
+          "p95_us": 78.958,
+          "p99_us": 104.875
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 654997.375,
+          "ns_per_op": 9994.466781616211,
+          "p50_us": 9.25,
+          "p95_us": 15.0,
+          "p99_us": 24.625
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 108706.25,
+          "ns_per_op": 1658.7257385253906,
+          "p50_us": 25.791,
+          "p95_us": 80.083,
+          "p99_us": 99.875
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 623304.042,
+          "ns_per_op": 9510.86489868164,
+          "p50_us": 9.208,
+          "p95_us": 12.416,
+          "p99_us": 18.875
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 110418.542,
+          "ns_per_op": 1684.8532409667969,
+          "p50_us": 25.125,
+          "p95_us": 81.625,
+          "p99_us": 106.416
+        }
+      ],
+      "pair": 6,
+      "version": "pr",
+      "wall_s": 3.538750290987082,
+      "user_s": 2.5,
+      "sys_s": 1.42,
+      "peak_rss_bytes": 78135296,
+      "time_output": "        3.53 real         2.50 user         1.42 sys\n            78135296  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4751  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              581297  involuntary context switches\n         27579769244  instructions retired\n         10980631564  cycles elapsed\n            57672328  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 87606.209,
+          "ns_per_op": 1336.764663696289,
+          "p50_us": 1.166,
+          "p95_us": 1.375,
+          "p99_us": 1.959
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 82958.084,
+          "ns_per_op": 1265.8399047851562,
+          "p50_us": 19.084,
+          "p95_us": 27.583,
+          "p99_us": 74.25
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 712784.125,
+          "ns_per_op": 10876.222610473633,
+          "p50_us": 9.833,
+          "p95_us": 13.625,
+          "p99_us": 22.666
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 159835.083,
+          "ns_per_op": 2438.8898162841797,
+          "p50_us": 36.25,
+          "p95_us": 86.0,
+          "p99_us": 124.042
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 623969.167,
+          "ns_per_op": 9521.013900756836,
+          "p50_us": 9.25,
+          "p95_us": 13.5,
+          "p99_us": 20.958
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 102783.208,
+          "ns_per_op": 1568.3472900390625,
+          "p50_us": 24.208,
+          "p95_us": 76.625,
+          "p99_us": 96.791
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 604841.416,
+          "ns_per_op": 9229.147583007812,
+          "p50_us": 9.167,
+          "p95_us": 11.917,
+          "p99_us": 17.5
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 134426.834,
+          "ns_per_op": 2051.190704345703,
+          "p50_us": 25.584,
+          "p95_us": 90.875,
+          "p99_us": 160.5
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 631460.75,
+          "ns_per_op": 9635.326385498047,
+          "p50_us": 9.25,
+          "p95_us": 13.875,
+          "p99_us": 24.667
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 113083.209,
+          "ns_per_op": 1725.5128326416016,
+          "p50_us": 25.0,
+          "p95_us": 84.333,
+          "p99_us": 112.167
+        }
+      ],
+      "pair": 7,
+      "version": "pr",
+      "wall_s": 3.4640018329955637,
+      "user_s": 2.47,
+      "sys_s": 1.37,
+      "peak_rss_bytes": 78299136,
+      "time_output": "        3.46 real         2.47 user         1.37 sys\n            78299136  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4760  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              578629  involuntary context switches\n         27559281143  instructions retired\n         10770068601  cycles elapsed\n            57836192  peak memory footprint\n"
+    },
+    {
+      "dart": "3.12.1 (stable) (Tue May 26 01:02:21 2026 -0700) on \"macos_arm64\"",
+      "results": [
+        {
+          "scenario": "immediate_void",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 61391.333,
+          "ns_per_op": 936.7574005126953,
+          "p50_us": 0.792,
+          "p95_us": 0.958,
+          "p99_us": 1.083
+        },
+        {
+          "scenario": "immediate_void",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 52424.375,
+          "ns_per_op": 799.9324798583984,
+          "p50_us": 12.209,
+          "p95_us": 16.208,
+          "p99_us": 49.417
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 649360.0,
+          "ns_per_op": 9908.447265625,
+          "p50_us": 9.667,
+          "p95_us": 13.042,
+          "p99_us": 20.5
+        },
+        {
+          "scenario": "image_width",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 145468.291,
+          "ns_per_op": 2219.669967651367,
+          "p50_us": 35.0,
+          "p95_us": 80.084,
+          "p99_us": 109.75
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 616710.333,
+          "ns_per_op": 9410.252883911133,
+          "p50_us": 8.875,
+          "p95_us": 12.75,
+          "p99_us": 21.708
+        },
+        {
+          "scenario": "set_parent",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 130221.125,
+          "ns_per_op": 1987.0166778564453,
+          "p50_us": 27.959,
+          "p95_us": 80.167,
+          "p99_us": 117.458
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 587699.375,
+          "ns_per_op": 8967.580795288086,
+          "p50_us": 8.583,
+          "p95_us": 12.625,
+          "p99_us": 19.5
+        },
+        {
+          "scenario": "set_transform",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 107783.791,
+          "ns_per_op": 1644.650131225586,
+          "p50_us": 23.75,
+          "p95_us": 54.791,
+          "p99_us": 84.209
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 1,
+          "count": 65536,
+          "elapsed_us": 577851.5,
+          "ns_per_op": 8817.314147949219,
+          "p50_us": 8.625,
+          "p95_us": 11.666,
+          "p99_us": 17.417
+        },
+        {
+          "scenario": "render_empty",
+          "concurrency": 32,
+          "count": 65536,
+          "elapsed_us": 107954.542,
+          "ns_per_op": 1647.2555847167969,
+          "p50_us": 23.708,
+          "p95_us": 61.083,
+          "p99_us": 86.625
+        }
+      ],
+      "pair": 7,
+      "version": "base",
+      "wall_s": 3.24188124993816,
+      "user_s": 2.19,
+      "sys_s": 1.46,
+      "peak_rss_bytes": 77987840,
+      "time_output": "        3.23 real         2.19 user         1.46 sys\n            77987840  maximum resident set size\n                   0  average shared memory size\n                   0  average unshared data size\n                   0  average unshared stack size\n                4738  page reclaims\n                 391  page faults\n                   0  swaps\n                   0  block input operations\n                   0  block output operations\n                   0  messages sent\n                   0  messages received\n                   0  signals received\n                   0  voluntary context switches\n              612379  involuntary context switches\n         25628081428  instructions retired\n         10265237759  cycles elapsed\n            57508464  peak memory footprint\n"
+    }
+  ],
+  "binaries": {
+    "base": {
+      "path": "/private/tmp/thermion-bench-base/bundle/bin/task_error_benchmark",
+      "sha256": "709b4f84ab09b29c250e97eeef08b2ec61622d433bca2ece8485e0384660cbda",
+      "native_library_sha256": "07504ce6fad52db99ac4725cb71051b785ec63376ba4302f4aa02a8669a5b428"
+    },
+    "pr": {
+      "path": "/private/tmp/thermion-bench-pr/bundle/bin/task_error_benchmark",
+      "sha256": "ad22cbef8da04750cf16bf856c9549caa123662adbc57f92dc9127af01af7533",
+      "native_library_sha256": "0250818a63b7c856aa5f4b148ea9dd6274597cf8f301a912f1a82c1e0af3ce70"
+    }
+  },
+  "base_commit": "6b0511732",
+  "pr_commit": "87b9d280a",
+  "compiler": "Apple clang 21.0.0, -O3; Dart 3.12.1 AOT via dart build cli",
+  "native_backend": "Metal (no attached views in microbenchmarks)",
+  "date": "2026-09-09",
+  "hardware": "Apple M2 Pro",
+  "os": "macOS 26.6.2 (25G83)",
+  "benchmark_source_sha256": "59c5522a44c8aed2a16de3861251a0255b79d0ac6cbc79aad05ec95b364107fa"
+}

--- a/thermion_dart/test/benchmarks/task_error_benchmark.dart
+++ b/thermion_dart/test/benchmarks/task_error_benchmark.dart
@@ -1,0 +1,111 @@
+// Manual success-path benchmark. Compile this identical file in the PR and its
+// base checkout with `dart build cli`; do not compare debug/JIT timings.
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:thermion_dart/src/bindings/src/ffi.dart';
+
+Future<Map<String, Object>> measure(String name, Future<void> Function() operation, int concurrency, int count) async {
+  Future<void> batch(int size) async {
+    if (size == 1) {
+      await operation();
+    } else {
+      await Future.wait(List.generate(size, (_) => operation()));
+    }
+  }
+
+  for (var i = 0; i < 2048; i += concurrency) {
+    await batch(concurrency);
+  }
+  final clock = Stopwatch()..start();
+  final latency = <int>[];
+  Future<void> timed() async {
+    final start = clock.elapsedTicks;
+    await operation();
+    latency.add(clock.elapsedTicks - start);
+  }
+
+  // Fixed-size batches bound the queue and the number of live callbacks.
+  for (var i = 0; i < count; i += concurrency) {
+    if (concurrency == 1) {
+      await timed();
+    } else {
+      await Future.wait(List.generate(concurrency, (_) => timed()));
+    }
+  }
+  clock.stop();
+  latency.sort();
+  double percentile(double p) => latency[((latency.length - 1) * p).round()] * 1e6 / clock.frequency;
+  return {
+    'scenario': name,
+    'concurrency': concurrency,
+    'count': latency.length,
+    'elapsed_us': clock.elapsedTicks * 1e6 / clock.frequency,
+    'ns_per_op': clock.elapsedTicks * 1e9 / clock.frequency / latency.length,
+    'p50_us': percentile(.50),
+    'p95_us': percentile(.95),
+    'p99_us': percentile(.99),
+  };
+}
+
+Future<void> main(List<String> args) async {
+  final count = args.isEmpty ? 32768 : int.parse(args.first);
+  if (count % 32 != 0) throw ArgumentError('Count must be divisible by 32');
+  final thread = RenderThread_create();
+  final engine = await withPointerCallback<TEngine>(
+    (cb) => Engine_createRenderThread(TBackend.BACKEND_METAL, nullptr, nullptr, 1, false, cb),
+  );
+  if (engine == nullptr) throw StateError("Engine creation failed");
+  final entities = Engine_getEntityManager(engine);
+  final transforms = Engine_getTransformManager(engine);
+  final entity = await withIntCallback((cb) => EntityManager_createEntityRenderThread(entities, cb));
+  await withVoidCallback((id, cb) => TransformManager_createComponentRenderThread(transforms, entity, id, cb));
+  final matrix = calloc<Double>(16);
+  for (final i in [0, 5, 10, 15]) {
+    matrix[i] = 1;
+  }
+  final image = await withPointerCallback<TLinearImage>((cb) => Image_createEmptyRenderThread(1, 1, 4, cb));
+  final renderer = await withPointerCallback<TRenderer>((cb) => Engine_createRendererRenderThread(engine, cb));
+  final manager = RenderManager_create(engine, renderer);
+  final frameClock = Stopwatch()..start();
+  final scenarios = <String, Future<void> Function()>{
+    // This isolates Dart tracking and FFI listener delivery; no worker is used.
+    'immediate_void': () => withVoidCallback((id, cb) => cb.asFunction<void Function(int)>()(id)),
+    'image_width': () async {
+      final width = await withUInt32Callback((cb) => Image_getWidthRenderThread(image, cb));
+      if (width != 1) throw StateError('Unexpected image width: $width');
+    },
+    // This wrapper used packaged_task on the base and detached tasks on the PR.
+    'set_parent': () =>
+        withVoidCallback((id, cb) => TransformManager_setParentRenderThread(transforms, entity, 0, false, id, cb)),
+    // These two wrappers already used detached tasks on the base.
+    'set_transform': () => withVoidCallback(
+      (id, cb) => TransformManager_setTransformFromBufferRenderThread(transforms, entity, matrix, id, cb),
+    ),
+    'render_empty': () => withVoidCallback(
+      (id, cb) => RenderManager_renderRenderThread(manager, frameClock.elapsedMicroseconds * 1000, id, cb),
+    ),
+  };
+  final results = <Map<String, Object>>[];
+  try {
+    for (final scenario in scenarios.entries) {
+      for (final concurrency in [1, 32]) {
+        results.add(await measure(scenario.key, scenario.value, concurrency, count));
+      }
+    }
+  } finally {
+    RenderManager_destroy(manager);
+    await withVoidCallback((id, cb) => Engine_destroyRendererRenderThread(engine, renderer, id, cb));
+    await withVoidCallback((id, cb) => Image_destroyRenderThread(image, id, cb));
+    await withVoidCallback((id, cb) => TransformManager_removeComponentRenderThread(transforms, entity, id, cb));
+    await withVoidCallback((id, cb) => EntityManager_destroyEntityRenderThread(entities, entity, id, cb));
+    calloc.free(matrix);
+    await withVoidCallback((id, cb) => Engine_destroyRenderThread(engine, id, cb));
+    RenderThread_destroy(thread);
+  }
+  print(jsonEncode({'dart': Platform.version, 'results': results}));
+  // The base's shared void listener otherwise keeps the process alive. All work
+  // has completed and the native worker has joined before either version exits.
+  exit(0);
+}

--- a/thermion_dart/test/benchmarks/task_error_frame_benchmark.dart
+++ b/thermion_dart/test/benchmarks/task_error_frame_benchmark.dart
@@ -1,0 +1,117 @@
+// Manual headless Metal benchmark: submission latency, not display presentation.
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:thermion_dart/src/bindings/src/ffi.dart' show TransformManager_setTransformFromBufferRenderThread;
+
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+Future<void> main(List<String> args) async {
+  Timer(const Duration(seconds: 60), () {
+    stderr.writeln("Benchmark timed out");
+    exit(2);
+  });
+  try {
+    await run(args);
+  } catch (error, stack) {
+    stderr.writeln("$error\n$stack");
+    exit(1);
+  }
+}
+
+Future<void> run(List<String> args) async {
+  final seconds = args.isEmpty ? 3 : int.parse(args.first);
+  await FFIFilamentApp.create(config: FFIFilamentConfig(backend: Backend.METAL));
+  print("Engine ready");
+  final app = FilamentApp.instance! as FFIFilamentApp;
+  final viewer = ThermionViewerFFI(app: app);
+  await viewer.initialized;
+  print("Viewer ready");
+  final swapchain = await app.createHeadlessSwapChain(512, 512);
+  await app.renderManager.attach(viewer.view, swapchain);
+  await viewer.view.setViewport(512, 512);
+  await viewer.setPostProcessing(false);
+  final camera = await viewer.getActiveCamera();
+  await camera.setLensProjection(near: .1, far: 100, aspect: 1, focalLength: 28);
+  await camera.lookAt(Vector3(0, 2, 5));
+  final material = await app.createUbershaderMaterialInstance(unlit: true);
+  await material.setParameterFloat4('baseColorFactor', 1, .3, .1, 1);
+  final cube = await viewer.createGeometry(GeometryUtils.cube(), materialInstances: [material]);
+  await viewer.setRendering(true);
+
+  print("Scene ready");
+  final entities = <int>[];
+  for (var i = 0; i < 100; i++) {
+    entities.add(await app.createEntity());
+  }
+  final transforms = Engine_getTransformManager(app.engine);
+  final matrix = calloc<Double>(16);
+  for (final i in [0, 5, 10, 15]) {
+    matrix[i] = 1;
+  }
+  final results = <Map<String, Object>>[];
+  try {
+    for (final fps in [60, 120]) {
+      for (final updates in [0, 100]) {
+        print("Starting $fps Hz, $updates updates");
+        final clock = Stopwatch()..start();
+        final workUs = <double>[];
+        var deadlineMisses = 0;
+        final warmup = fps;
+        final count = fps * seconds;
+        for (var frame = 0; frame < warmup + count; frame++) {
+          final due = (frame * 1000000 / fps).round();
+          final wait = due - clock.elapsedMicroseconds;
+          if (wait > 0) await Future<void>.delayed(Duration(microseconds: wait));
+          final start = clock.elapsedTicks;
+          matrix[12] = (frame % 100) / 100;
+          await Future.wait([
+            for (var i = 0; i < updates; i++)
+              withVoidCallback(
+                (id, cb) =>
+                    TransformManager_setTransformFromBufferRenderThread(transforms, entities[i], matrix, id, cb),
+              ),
+          ]);
+          await app.render();
+          if (frame >= warmup) {
+            workUs.add((clock.elapsedTicks - start) * 1e6 / clock.frequency);
+            if (clock.elapsedMicroseconds > due + 1000000 / fps) deadlineMisses++;
+          }
+        }
+        workUs.sort();
+        double percentile(double p) => workUs[((workUs.length - 1) * p).round()];
+        results.add({
+          'fps': fps,
+          'updates': updates,
+          'frames': count,
+          'p50_us': percentile(.5),
+          'p95_us': percentile(.95),
+          'p99_us': percentile(.99),
+          'deadline_misses': deadlineMisses,
+        });
+      }
+    }
+    print("Measurements complete; flushing");
+    await app.flush();
+    print("Flush complete");
+  } finally {
+    calloc.free(matrix);
+    for (final entity in entities) {
+      await app.destroyEntity(entity);
+    }
+    print("Entities destroyed");
+    await viewer.destroyAsset(cube);
+    print("Cube destroyed");
+    await material.destroy();
+    print("Material destroyed");
+    await viewer.dispose();
+    print("Viewer destroyed");
+    await app.destroySwapChain(swapchain);
+    print("Swapchain destroyed");
+    await app.destroy();
+    print("App destroyed");
+  }
+  print(jsonEncode({'dart': Platform.version, 'results': results}));
+  exit(0);
+}

--- a/thermion_dart/test/fixtures/task_error_exit.dart
+++ b/thermion_dart/test/fixtures/task_error_exit.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+import 'package:thermion_dart/src/bindings/src/ffi.dart';
+
+// Deliberately return from main instead of calling exit(): a leaked listener
+// keeps this process alive and makes the parent regression test time out.
+Future<void> main(List<String> args) async {
+  final fixture = DynamicLibrary.open(args.single);
+  final fail = fixture.lookup<NativeFunction<Void Function()>>('throwTaskError');
+  final thread = RenderThread_create();
+  try {
+    var failed = false;
+    try {
+      await withIntCallback((_) => RenderThread_addTask(fail));
+    } on StateError {
+      failed = true;
+    }
+    if (!failed) throw StateError('Native exception was lost');
+    await withVoidCallback((id, callback) {
+      callback.asFunction<void Function(int)>()(id);
+    });
+  } finally {
+    // Stop the worker before allowing its owning Dart isolate to go away.
+    RenderThread_destroy(thread);
+  }
+  print('native workers stopped');
+}

--- a/thermion_dart/test/ktx_input_validation_test.dart
+++ b/thermion_dart/test/ktx_input_validation_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_ktx1_bundle.dart';
+
+void main() {
+  group(
+    'KTX input validation',
+    () {
+      late FFIFilamentApp app;
+      late Uint8List source;
+      setUpAll(() async {
+        source = await File('../examples/assets/default_env_skybox.ktx').readAsBytes();
+        await FFIFilamentApp.create(
+          config: FFIFilamentConfig(backend: Platform.isMacOS ? Backend.METAL : Backend.DEFAULT),
+        );
+        app = FilamentApp.instance! as FFIFilamentApp;
+      });
+      tearDownAll(() async => app.destroy());
+
+      test('truncated header reports a Dart decode error', () async {
+        await expectLater(
+          FFIKtx1Bundle.create(app, Uint8List(12)),
+          throwsA(
+            isA<Exception>().having((error) => error.toString(), 'message', contains('Failed to decode KTX texture')),
+          ),
+        );
+        // A rejected input must not prevent the next bundle from being decoded.
+        final bundle = await FFIKtx1Bundle.create(app, source);
+        await bundle.destroy();
+      });
+
+      for (final field in {'width': 36, 'height': 40}.entries) {
+        test('zero ${field.key} releases data and reports the preflight error', () async {
+          final data = Uint8List.fromList(source);
+          data.buffer.asByteData().setUint32(field.value, 0, Endian.little);
+          final bundle = await FFIKtx1Bundle.create(app, data);
+          late Future<Texture> created;
+          final released = withVoidCallback((id, callback) {
+            created = bundle.createTexture(onTextureUploadComplete: callback, textureUploadCompleteRequestId: id);
+          });
+          try {
+            await expectLater(
+              created.timeout(const Duration(seconds: 5)),
+              throwsA(
+                isA<StateError>().having(
+                  (error) => error.message,
+                  'message',
+                  'Invalid KTX texture dimensions or mip count',
+                ),
+              ),
+            );
+          } finally {
+            await released.timeout(const Duration(seconds: 5));
+            await bundle.destroy();
+          }
+        });
+      }
+    },
+    skip: Platform.environment['THERMION_TASK_ERROR_FIXTURE'] == null
+        ? 'Set THERMION_TASK_ERROR_FIXTURE; see native/test/rendering/README.md'
+        : false,
+  );
+}

--- a/thermion_dart/test/ktx_task_errors_test.dart
+++ b/thermion_dart/test/ktx_task_errors_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_ktx1_bundle.dart';
+
+// Tests the boundary between native upload release and #318's native
+// exception delivery. Requires a working GPU backend, like the upload suite.
+void main() {
+  test(
+    'Filament texture failure reports creation error and releases unused data',
+    () async {
+      await FFIFilamentApp.create(
+        config: FFIFilamentConfig(backend: Platform.isMacOS ? Backend.METAL : Backend.DEFAULT),
+      );
+      final app = FilamentApp.instance! as FFIFilamentApp;
+      try {
+        final data = await File('../examples/assets/default_env_skybox.ktx').readAsBytes();
+        // The KTX1 header's pixelWidth is at offset 36. Keep the existing mip
+        // payload intact and exercise Filament's existing texture dimension check,
+        // without depending on Thermion's separate KTX validation change.
+        data.buffer.asByteData(data.offsetInBytes, data.length).setUint32(36, 0, Endian.little);
+        final bundle = await FFIKtx1Bundle.create(app, data);
+        late Future<Texture> textureCreated;
+        final uploadReleased = withVoidCallback((id, callback) {
+          textureCreated = bundle.createTexture(onTextureUploadComplete: callback, textureUploadCompleteRequestId: id);
+        });
+        try {
+          await expectLater(
+            textureCreated.timeout(const Duration(seconds: 5)),
+            throwsA(
+              isA<StateError>().having(
+                (error) => error.message,
+                'message',
+                contains('invalid dimensions'),
+              ),
+            ),
+          );
+        } finally {
+          await uploadReleased.timeout(const Duration(seconds: 5));
+          await bundle.destroy();
+        }
+      } finally {
+        await app.destroy();
+      }
+    },
+    skip: Platform.environment['THERMION_TASK_ERROR_FIXTURE'] == null
+        ? 'Set THERMION_TASK_ERROR_FIXTURE; see native/test/rendering/README.md'
+        : false,
+  );
+}

--- a/thermion_dart/test/ktx_task_errors_test.dart
+++ b/thermion_dart/test/ktx_task_errors_test.dart
@@ -18,8 +18,8 @@ void main() {
       try {
         final data = await File('../examples/assets/default_env_skybox.ktx').readAsBytes();
         // The KTX1 header's pixelWidth is at offset 36. Keep the existing mip
-        // payload intact and exercise Filament's existing texture dimension check,
-        // without depending on Thermion's separate KTX validation change.
+        // payload intact and exercise texture dimension rejection. Both Filament
+        // and Thermion's KTX preflight reject this before pixel submission.
         data.buffer.asByteData(data.offsetInBytes, data.length).setUint32(36, 0, Endian.little);
         final bundle = await FFIKtx1Bundle.create(app, data);
         late Future<Texture> textureCreated;
@@ -29,13 +29,7 @@ void main() {
         try {
           await expectLater(
             textureCreated.timeout(const Duration(seconds: 5)),
-            throwsA(
-              isA<StateError>().having(
-                (error) => error.message,
-                'message',
-                contains('invalid dimensions'),
-              ),
-            ),
+            throwsA(isA<StateError>().having((error) => error.message, 'message', contains('dimensions'))),
           );
         } finally {
           await uploadReleased.timeout(const Duration(seconds: 5));

--- a/thermion_dart/test/ktx_upload_lifetime_test.dart
+++ b/thermion_dart/test/ktx_upload_lifetime_test.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/bindings/src/ffi.dart' as ffi;
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_ktx1_bundle.dart';
+
+// Owns no additional engine. Only the skybox builder is replaced, to fail after
+// the real native texture creation/upload has started.
+class FailingSkyboxApp extends FFIFilamentApp {
+  FailingSkyboxApp(FFIFilamentApp app)
+    : super(
+        app.engine,
+        app.gltfAssetLoader,
+        app.renderer,
+        app.transformManager.getNativeHandle(),
+        app.ubershaderMaterialProvider,
+        app.renderManager.getNativeHandle(),
+        app.renderThreadHandle,
+        app.nameComponentManager,
+        app.loadResource,
+        app.lightManager.getNativeHandle(),
+        app.renderableManager.getNativeHandle(),
+        app.animationManager.getNativeHandle(),
+      );
+
+  @override
+  Future<Skybox> buildSkybox({Texture? texture, bool showSun = false, double? intensity, int priority = 7}) async {
+    expect(texture, isNotNull);
+    throw StateError('skybox setup failed after texture creation');
+  }
+}
+
+void main() {
+  final fixturePath = Platform.environment['THERMION_UPLOAD_LIFETIME_FIXTURE'];
+  group('KTX upload lifetime', () {
+    late FFIFilamentApp app;
+    late Uint8List bytes;
+    late DynamicLibrary fixture;
+    setUpAll(() async {
+      fixture = DynamicLibrary.open(fixturePath!);
+      bytes = await File('../examples/assets/default_env_skybox.ktx').readAsBytes();
+      await FFIFilamentApp.create(
+        config: FFIFilamentConfig(
+          backend: Platform.isMacOS ? Backend.METAL : Backend.DEFAULT,
+          loadResource: (uri) async {
+            if (uri == 'missing') throw StateError('resource load failed');
+            return bytes;
+          },
+        ),
+      );
+      app = FilamentApp.instance! as FFIFilamentApp;
+    });
+    tearDownAll(() async {
+      await app.destroy();
+    });
+
+    test('caller waits for buffer release before destroying the bundle', () async {
+      final reset = fixture.lookupFunction<ffi.Void Function(), void Function()>('resetTaskRelease');
+      final release = fixture.lookupFunction<ffi.Void Function(), void Function()>('allowTaskToFinish');
+      final blocked = fixture.lookup<ffi.NativeFunction<ffi.Void Function()>>('waitForTaskRelease');
+      final bundle = await FFIKtx1Bundle.create(app, bytes);
+      reset();
+      ffi.RenderThread_addTask(blocked);
+      late Future<Texture> textureCreated;
+      var released = false;
+      final uploadReleased =
+          withVoidCallback((id, callback) {
+            textureCreated = bundle.createTexture(
+              onTextureUploadComplete: callback,
+              textureUploadCompleteRequestId: id,
+            );
+          }).then((_) {
+            released = true;
+          });
+      try {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(released, isFalse);
+        expect(bundle.isCubemap(), isTrue); // Caller still owns the data.
+      } finally {
+        release();
+      }
+      final texture = await textureCreated.timeout(const Duration(seconds: 5));
+      await app.flush();
+      await uploadReleased.timeout(const Duration(seconds: 5));
+      await bundle.destroy();
+      await bundle.destroy();
+      expect(bundle.isCubemap, throwsStateError);
+      expect(await texture.getWidth(), greaterThan(0)); // Texture is independent.
+      await texture.destroy();
+    });
+
+    test('skybox failure after texture creation reaches the public Future', () async {
+      final viewer = ThermionViewerFFI(app: FailingSkyboxApp(app));
+      await viewer.initialized;
+      try {
+        await expectLater(
+          viewer.loadSkybox('valid').timeout(const Duration(seconds: 5)),
+          throwsA(isA<StateError>().having((e) => e.message, 'message', 'skybox setup failed after texture creation')),
+        );
+        await app.flush();
+        expect(await viewer.getSkybox(), isNull);
+      } finally {
+        await viewer.dispose();
+      }
+    });
+
+    for (final asset in ['default_env_ibl.ktx', 'background.ktx']) {
+      test('$asset releases upload data before caller cleanup', () async {
+        final data = await File('../examples/assets/$asset').readAsBytes();
+        final bundle = await FFIKtx1Bundle.create(app, data);
+        late Future<Texture> textureCreated;
+        final uploadReleased = withVoidCallback((id, callback) {
+          textureCreated = bundle.createTexture(onTextureUploadComplete: callback, textureUploadCompleteRequestId: id);
+        });
+        final texture = await textureCreated.timeout(const Duration(seconds: 5));
+        try {
+          await app.flush();
+          await uploadReleased.timeout(const Duration(seconds: 5));
+          await bundle.destroy();
+          expect(await texture.getWidth(), greaterThan(0));
+        } finally {
+          await texture.destroy();
+        }
+      });
+    }
+
+    test('IBL resource failure reaches the public Future and permits another operation', () async {
+      final viewer = ThermionViewerFFI(app: app);
+      await viewer.initialized;
+      try {
+        await expectLater(
+          viewer.loadIbl('missing').timeout(const Duration(seconds: 5)),
+          throwsA(isA<StateError>().having((e) => e.message, 'message', 'resource load failed')),
+        );
+        await viewer.setBackgroundColor(0, 0, 0, 1).timeout(const Duration(seconds: 5));
+      } finally {
+        await viewer.dispose();
+      }
+    });
+  }, skip: fixturePath == null ? 'Set THERMION_UPLOAD_LIFETIME_FIXTURE; see native/test/rendering/README.md' : false);
+}

--- a/thermion_dart/test/native_task_errors_test.dart
+++ b/thermion_dart/test/native_task_errors_test.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:thermion_dart/src/bindings/src/ffi.dart';
+import 'package:thermion_dart/src/bindings/src/native_task_errors.dart';
+
+// Build native/test/rendering and point this variable at its fixture library.
+// Keeping deliberate native exceptions in the fixture avoids adding test-only
+// entry points to Thermion's public C API.
+void main() {
+  final fixturePath = Platform.environment['THERMION_TASK_ERROR_FIXTURE'];
+  group(
+    'native task errors',
+    () {
+      late DynamicLibrary fixture;
+      late Pointer<NativeFunction<Void Function()>> fail;
+      late Pointer<Void> thread;
+
+      setUpAll(() {
+        fixture = DynamicLibrary.open(fixturePath!);
+        fail = fixture.lookup<NativeFunction<Void Function()>>('throwTaskError');
+      });
+      setUp(() {
+        thread = RenderThread_create();
+      });
+      tearDown(() {
+        RenderThread_destroy(thread);
+      });
+
+      test('callback C API task failures reach typed and void Dart futures', () async {
+        final expected = throwsA(
+          isA<StateError>().having((error) => error.message, 'message', 'expected native task failure'),
+        );
+        await expectLater(withIntCallback((_) => RenderThread_addTask(fail)), expected);
+        await expectLater(withBoolCallback((_) => RenderThread_addTask(fail)), expected);
+        await expectLater(withPointerCallback<Void>((_) => RenderThread_addTask(fail)), expected);
+        await expectLater(withVoidCallback((_, __) => RenderThread_addTask(fail)), expected);
+        expect(nativeTaskErrors.pendingRequestCount, 0);
+
+        // The same worker must execute another task after those failures.
+        final done = Completer<void>();
+        final success = NativeCallable<Void Function()>.listener(() => done.complete());
+        try {
+          await nativeTaskErrors.invoke(done, () => RenderThread_addTask(success.nativeFunction));
+        } finally {
+          success.close();
+        }
+      });
+
+      for (final asyncFailure in [false, true]) {
+        test('typed callback survives dispatch failure after enqueue: async=$asyncFailure', () async {
+          late Pointer<NativeFunction<Void Function(Int32)>> resultCallback;
+          var delivered = false;
+          final nativeWork = NativeCallable<Void Function()>.listener(() {
+            resultCallback.asFunction<void Function(int)>()(42);
+            delivered = true;
+          });
+          try {
+            await expectLater(
+              withIntCallback((cb) {
+                resultCallback = cb;
+                RenderThread_addTask(nativeWork.nativeFunction);
+                if (asyncFailure) return Future<void>.error(StateError('Dart dispatch failed'));
+                throw StateError('Dart dispatch failed');
+              }),
+              throwsA(isA<StateError>().having((e) => e.message, 'message', 'Dart dispatch failed')),
+            );
+            expect(delivered, isTrue);
+            expect(nativeTaskErrors.pendingRequestCount, 0);
+          } finally {
+            nativeWork.close();
+          }
+        });
+      }
+
+      test('a child failure does not complete the separate upload-release callback', () async {
+        late Future<int> creation;
+        late void Function() finishUpload;
+        var released = false;
+        final uploadReleased =
+            withVoidCallback((id, callback) {
+              finishUpload = () => callback.asFunction<void Function(int)>()(id);
+              creation = withIntCallback((_) => RenderThread_addTask(fail));
+            }).then((_) {
+              released = true;
+            });
+        try {
+          await expectLater(creation, throwsA(isA<StateError>()));
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          expect(released, isFalse);
+          expect(nativeTaskErrors.pendingRequestCount, 1);
+        } finally {
+          finishUpload();
+          await uploadReleased;
+        }
+        expect(nativeTaskErrors.pendingRequestCount, 0);
+      });
+
+      test('unknown C++ exceptions also settle the Dart request', () async {
+        final unknown = fixture.lookup<NativeFunction<Void Function()>>('throwUnknownTaskError');
+        await expectLater(
+          withIntCallback((_) => RenderThread_addTask(unknown)),
+          throwsA(isA<StateError>().having((error) => error.message, 'message', 'Unknown native task exception')),
+        );
+        expect(nativeTaskErrors.pendingRequestCount, 0);
+      });
+
+      test('idle callback listeners allow a standalone process to exit', () async {
+        final process = await Process.start(Platform.resolvedExecutable, [
+          'run',
+          'test/fixtures/task_error_exit.dart',
+          fixturePath!,
+        ]);
+        final ready = Completer<void>();
+        final output = StringBuffer();
+        final stdout = process.stdout.transform(utf8.decoder).transform(const LineSplitter()).forEach((line) {
+          output.writeln(line);
+          if (line == 'native workers stopped' && !ready.isCompleted) ready.complete();
+        });
+        final stderr = process.stderr.transform(utf8.decoder).join();
+        final exited = process.exitCode.then((code) {
+          if (!ready.isCompleted) ready.completeError(StateError('Child exited before finishing requests: $code'));
+          return code;
+        });
+        try {
+          // Allow the Dart native build hook to run before measuring shutdown.
+          await ready.future.timeout(const Duration(minutes: 3));
+          final code = await exited.timeout(const Duration(seconds: 5));
+          await stdout;
+          expect(code, 0, reason: '$output\n${await stderr}');
+        } finally {
+          process.kill();
+        }
+      }, timeout: const Timeout(Duration(minutes: 4)));
+    },
+    skip: fixturePath == null ? 'Set THERMION_TASK_ERROR_FIXTURE; see native/test/rendering/README.md' : false,
+  );
+}

--- a/thermion_dart/test/task_error_registry_test.dart
+++ b/thermion_dart/test/task_error_registry_test.dart
@@ -1,0 +1,246 @@
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:thermion_dart/src/bindings/src/task_error_registry.dart';
+
+void main() {
+  for (final asyncSetup in [false, true]) {
+    test('polls native completions with async setup=$asyncSetup', () async {
+      final scopes = <int>[];
+      final callbacks = <void Function()>[];
+      final registry = TaskErrorRegistry(
+        install: scopes.add,
+        clear: () {
+          scopes.removeLast();
+          return 0;
+        },
+      );
+      final done = Completer<int>();
+      var pumps = 0;
+      final future = registry.invoke(
+        done,
+        asyncSetup
+            ? () async {
+                callbacks.add(() => done.complete(42));
+              }
+            : () {
+                callbacks.add(() => done.complete(42));
+              },
+        pump: () {
+          expect(scopes, isEmpty, reason: 'pumping must not retain the dispatch scope');
+          pumps++;
+          if (callbacks.isNotEmpty) callbacks.removeAt(0)();
+        },
+      );
+      expect(await future.timeout(const Duration(seconds: 1)), 42);
+      expect(pumps, greaterThan(0));
+      expect(registry.pendingRequestCount, 0);
+    });
+  }
+
+  test('setup failure stops polling and releases listener keep-alive', () async {
+    final active = <bool>[];
+    final registry = TaskErrorRegistry(install: (_) {}, clear: () => 0, onPendingChanged: active.add);
+    var pumps = 0;
+    final future = registry.invoke(
+      Completer<void>(),
+      () async {
+        await Future<void>.delayed(Duration.zero);
+        throw StateError('setup failed');
+      },
+      pump: () {
+        pumps++;
+      },
+    );
+    await expectLater(future, throwsA(isA<StateError>()));
+    final stoppedAt = pumps;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(pumps, stoppedAt);
+    expect(registry.pendingRequestCount, 0);
+    expect(active, [true, false]);
+  });
+
+  test('pump failure settles the request', () async {
+    final registry = TaskErrorRegistry(install: (_) {}, clear: () => 0);
+    final done = Completer<void>();
+    await expectLater(
+      registry.invoke(
+        done,
+        () {},
+        pump: () {
+          throw StateError('proxy queue failed');
+        },
+      ),
+      throwsA(isA<StateError>()),
+    );
+    expect(done.isCompleted, isTrue);
+    expect(registry.pendingRequestCount, 0);
+  });
+
+  for (final asyncFailure in [false, true]) {
+    test('dispatch failure retains queued callback: async=$asyncFailure', () async {
+      final active = <bool>[];
+      final done = Completer<int>();
+      final registry = TaskErrorRegistry(install: (_) {}, clear: () => 1, onPendingChanged: active.add);
+      var returned = false;
+      var pumps = 0;
+      final future = registry.invoke(
+        done,
+        () {
+          if (asyncFailure) return Future<void>.error(StateError('setup failed after enqueue'));
+          throw StateError('setup failed after enqueue');
+        },
+        pump: () {
+          pumps++;
+        },
+      );
+      final assertion = expectLater(
+        future.whenComplete(() {
+          returned = true;
+        }),
+        throwsA(isA<StateError>()),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(returned, isFalse);
+      expect(done.isCompleted, isFalse);
+      expect(registry.pendingRequestCount, 1);
+      expect(active, [true]);
+      expect(pumps, greaterThan(1));
+      done.complete(42);
+      await assertion;
+      expect(active, [true, false]);
+      expect(registry.pendingRequestCount, 0);
+    });
+  }
+
+  test('listener stays active until all concurrent requests settle', () async {
+    final active = <bool>[];
+    final registry = TaskErrorRegistry(install: (_) {}, clear: () => 0, onPendingChanged: active.add);
+    final first = Completer<void>();
+    final second = Completer<void>();
+    final a = registry.invoke(first, () {});
+    final b = registry.invoke(second, () {});
+    second.complete();
+    await b;
+    expect(active, [true]);
+    first.complete();
+    await a;
+    expect(active, [true, false]);
+  });
+
+  test('typed errors settle and release requests, including late duplicates', () async {
+    final scopes = <int>[];
+    final registry = TaskErrorRegistry(
+      install: scopes.add,
+      clear: () {
+        scopes.removeLast();
+        return 0;
+      },
+    );
+    final result = Completer<int>();
+    late int requestId;
+    final future = registry.invoke(result, () {
+      requestId = scopes.single;
+    });
+    expect(scopes, isEmpty);
+    final assertion = expectLater(future, throwsA(isA<StateError>()));
+    registry.fail(requestId, 'typed operation failed');
+    await assertion;
+    expect(registry.pendingRequestCount, 0);
+    registry.fail(requestId, 'late duplicate');
+  });
+
+  test('success and synchronous dispatch errors always release scopes', () async {
+    final scopes = <int>[];
+    final registry = TaskErrorRegistry(
+      install: scopes.add,
+      clear: () {
+        scopes.removeLast();
+        return 0;
+      },
+    );
+    final success = Completer<String>();
+    expect(await registry.invoke(success, () => success.complete('done')), 'done');
+    await expectLater(
+      registry.invoke(Completer<void>(), () => throw StateError('dispatch failed')),
+      throwsA(isA<StateError>()),
+    );
+    expect(scopes, isEmpty);
+    expect(registry.pendingRequestCount, 0);
+  });
+
+  test('nested dispatch scopes and out-of-order completions stay distinct', () async {
+    final scopes = <int>[];
+    final registry = TaskErrorRegistry(
+      install: scopes.add,
+      clear: () {
+        scopes.removeLast();
+        return 0;
+      },
+    );
+    final outer = Completer<void>();
+    final inner = Completer<int>();
+    late int outerId;
+    late int innerId;
+    late Future<int> innerFuture;
+    final outerFuture = registry.invoke(outer, () {
+      outerId = scopes.single;
+      innerFuture = registry.invoke(inner, () {
+        expect(scopes.length, 2);
+        innerId = scopes.last;
+      });
+      expect(scopes.single, outerId);
+    });
+    expect(scopes, isEmpty);
+    final outerAssertion = expectLater(outerFuture, throwsA(isA<StateError>()));
+    final innerAssertion = expectLater(innerFuture, throwsA(isA<StateError>()));
+    registry.fail(innerId, 'shared native operation failed');
+    registry.fail(outerId, 'shared native operation failed');
+    await Future.wait([outerAssertion, innerAssertion]);
+    expect(registry.pendingRequestCount, 0);
+  });
+
+  test('async dispatch failures settle requests without leaking native scopes', () async {
+    final scopes = <int>[];
+    final registry = TaskErrorRegistry(
+      install: scopes.add,
+      clear: () {
+        scopes.removeLast();
+        return 0;
+      },
+    );
+    final future = registry.invoke(Completer<void>(), () async {
+      expect(scopes, hasLength(1));
+      await Future<void>.delayed(Duration.zero);
+      expect(scopes, isEmpty);
+      throw StateError('upload setup failed');
+    });
+    expect(scopes, isEmpty);
+    await expectLater(future, throwsA(isA<StateError>()));
+    expect(registry.pendingRequestCount, 0);
+  });
+
+  test('native failure waits for dispatch to stop using its callback', () async {
+    final scopes = <int>[];
+    final registry = TaskErrorRegistry(
+      install: scopes.add,
+      clear: () {
+        scopes.removeLast();
+        return 0;
+      },
+    );
+    final setup = Completer<void>();
+    late int requestId;
+    final future = registry.invoke(Completer<void>(), () {
+      requestId = scopes.single;
+      return setup.future;
+    });
+    final assertion = expectLater(future, throwsA(isA<StateError>()));
+    registry.fail(requestId, 'native failure during setup');
+    await Future<void>.delayed(Duration.zero);
+    expect(registry.pendingRequestCount, 1);
+    setup.completeError(StateError('late setup failure must be observed'));
+    await assertion;
+    expect(registry.pendingRequestCount, 0);
+    await Future<void>.delayed(Duration.zero);
+  });
+}


### PR DESCRIPTION
Validate KTX input before starting texture uploads, and turn native bundle-decoding exceptions into the existing Dart decode error.

This adds explicit checks for zero dimensions, mip counts outside the texture builder's 8-bit range, missing/empty mip data, and inconsistent cubemap face sizes or layout. `Ktx1Bundle_create()` catches decoding exceptions and returns null; the Dart wrapper already reports that as a decode failure.

These checks were previously bundled into #323. They are now a separate review decision. Filament already rejects zero texture dimensions; this PR adds an earlier KTX-specific error and the other preflight checks.

## Dependencies

Stacked on #318 so its tests can observe native exceptions as Dart errors. It also inherits native upload completion from #325, ensuring that rejected input produces a release notification. #301 does not depend on this PR, and the normal cleanup/error/web sequence can merge without it.

## Validation

All four native Dart regressions pass with macOS Metal. They cover a truncated header, recovery with a valid bundle, zero width/height, and release before explicit bundle destruction. The mip-count bound and malformed in-memory cubemap layout are not directly covered. Test commands are in the [manual guide](thermion_dart/native/test/rendering/README.md#ktx-input-validation).
