### PR TITLE
refactor: minimize runtime exceptions in preparation for building without C++ exceptions

### DIFF
--- a/thermion_dart/native/src/opengl/linux/LinuxOpenGLContext.cpp
+++ b/thermion_dart/native/src/opengl/linux/LinuxOpenGLContext.cpp
@@ -4,7 +4,9 @@
 #include <condition_variable>
 #include <deque>
 #include <functional>
-#include <future>
+#if defined(__cpp_exceptions)
+#include <exception>
+#endif
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -384,22 +386,49 @@ private:
     }
 
     void RunOnEglThread(std::function<void()> task) {
-        auto completed = std::make_shared<std::promise<void>>();
-        auto result = completed->get_future();
+        // This call waits for the task, so its completion state can live on
+        // the stack. The wrapper signals completion even when a task returns
+        // early after reporting an EGL/GBM error through its result or _lastError.
+        std::mutex completionMutex;
+        std::condition_variable completionReady;
+        bool completed = false;
+#if defined(__cpp_exceptions)
+        // Preserve forwarding to the caller while exceptions are enabled.
+        // Builds without exceptions report EGL/GBM failures via results instead.
+        std::exception_ptr error;
+#endif
         {
             std::lock_guard<std::mutex> lock(_taskMutex);
             _tasks.emplace_back(
-                [task = std::move(task), completed = std::move(completed)]() {
+                [task = std::move(task), &completionMutex, &completionReady, &completed
+#if defined(__cpp_exceptions)
+                 , &error
+#endif
+                ]() {
+#if defined(__cpp_exceptions)
                     try {
                         task();
-                        completed->set_value();
                     } catch (...) {
-                        completed->set_exception(std::current_exception());
+                        error = std::current_exception();
                     }
+#else
+                    task();
+#endif
+                    std::lock_guard<std::mutex> lock(completionMutex);
+                    completed = true;
+                    // Notify while holding the lock: the caller must not
+                    // destroy completionReady before notify_one finishes.
+                    completionReady.notify_one();
                 });
         }
         _taskReady.notify_one();
-        result.get();
+        std::unique_lock<std::mutex> lock(completionMutex);
+        completionReady.wait(lock, [&completed]() { return completed; });
+#if defined(__cpp_exceptions)
+        if (error) {
+            std::rethrow_exception(error);
+        }
+#endif
     }
 
     void StopEglThread() {

--- a/thermion_dart/native/src/vulkan/VulkanUtils.cpp
+++ b/thermion_dart/native/src/vulkan/VulkanUtils.cpp
@@ -1,3 +1,5 @@
+#include <utils/Panic.h>
+
 #include "vulkan/VulkanUtils.h"
 
 #include "Log.hpp"
@@ -184,7 +186,7 @@ uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties, V
         }
     }
     
-    throw std::runtime_error("Failed to find suitable memory type");
+    PANIC_POSTCONDITION("Failed to find suitable memory type");
 }
 
 
@@ -263,7 +265,7 @@ uint32_t findGraphicsQueueFamily(VkPhysicalDevice physicalDevice) {
         }
     }
 
-    throw std::runtime_error("Failed to find graphics queue family");
+    PANIC_POSTCONDITION("Failed to find graphics queue family");
 }
 
 
@@ -303,7 +305,7 @@ CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physic
     poolInfo.queueFamilyIndex = resources.queueFamilyIndex;
 
     if (vkCreateCommandPool(device, &poolInfo, nullptr, &resources.commandPool) != VK_SUCCESS) {
-        throw std::runtime_error("Failed to create command pool");
+        PANIC_POSTCONDITION("Failed to create command pool");
     }
 
     return resources;
@@ -329,7 +331,7 @@ void readVkImageToBitmap(
     VkBuffer stagingBuffer;
     VkResult result = vkCreateBuffer(device, &bufferInfo, nullptr, &stagingBuffer);
     if (result != VK_SUCCESS) {
-        throw std::runtime_error("Failed to create staging buffer");
+        PANIC_POSTCONDITION("Failed to create staging buffer");
     }
 
     // Get memory requirements and properties
@@ -354,7 +356,7 @@ void readVkImageToBitmap(
 
     if (memoryTypeIndex == -1) {
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to find suitable memory type");
+        PANIC_POSTCONDITION("Failed to find suitable memory type");
     }
 
     // Allocate memory
@@ -367,7 +369,7 @@ void readVkImageToBitmap(
     result = vkAllocateMemory(device, &allocInfo, nullptr, &stagingMemory);
     if (result != VK_SUCCESS) {
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to allocate staging memory");
+        PANIC_POSTCONDITION("Failed to allocate staging memory");
     }
 
     // Bind memory to buffer
@@ -375,7 +377,7 @@ void readVkImageToBitmap(
     if (result != VK_SUCCESS) {
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to bind buffer memory");
+        PANIC_POSTCONDITION("Failed to bind buffer memory");
     }
 
     // Create command buffer
@@ -390,7 +392,7 @@ void readVkImageToBitmap(
     if (result != VK_SUCCESS) {
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to allocate command buffer");
+        PANIC_POSTCONDITION("Failed to allocate command buffer");
     }
 
     // Begin command buffer
@@ -403,7 +405,7 @@ void readVkImageToBitmap(
         vkFreeCommandBuffers(device, commandPool, 1, &cmdBuffer);
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to begin command buffer");
+        PANIC_POSTCONDITION("Failed to begin command buffer");
     }
 
     // Transition image layout for transfer
@@ -475,7 +477,7 @@ void readVkImageToBitmap(
         vkFreeCommandBuffers(device, commandPool, 1, &cmdBuffer);
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to end command buffer");
+        PANIC_POSTCONDITION("Failed to end command buffer");
     }
 
     // Submit command buffer
@@ -494,7 +496,7 @@ void readVkImageToBitmap(
         vkFreeCommandBuffers(device, commandPool, 1, &cmdBuffer);
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to create fence");
+        PANIC_POSTCONDITION("Failed to create fence");
     }
 
     // Submit with fence
@@ -504,7 +506,7 @@ void readVkImageToBitmap(
         vkFreeCommandBuffers(device, commandPool, 1, &cmdBuffer);
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to submit queue");
+        PANIC_POSTCONDITION("Failed to submit queue");
     }
 
     // Wait for the command buffer to complete execution
@@ -514,7 +516,7 @@ void readVkImageToBitmap(
         vkFreeCommandBuffers(device, commandPool, 1, &cmdBuffer);
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to wait for fence");
+        PANIC_POSTCONDITION("Failed to wait for fence");
     }
 
     // Now safe to map memory and read data
@@ -525,7 +527,7 @@ void readVkImageToBitmap(
         vkFreeCommandBuffers(device, commandPool, 1, &cmdBuffer);
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to map memory");
+        PANIC_POSTCONDITION("Failed to map memory");
     }
 
     // Create bitmap header
@@ -550,7 +552,7 @@ void readVkImageToBitmap(
         vkFreeCommandBuffers(device, commandPool, 1, &cmdBuffer);
         vkFreeMemory(device, stagingMemory, nullptr);
         vkDestroyBuffer(device, stagingBuffer, nullptr);
-        throw std::runtime_error("Failed to open output file");
+        PANIC_POSTCONDITION("Failed to open output file");
     }
 
     file.write(reinterpret_cast<char*>(&header), sizeof(header));
@@ -666,7 +668,7 @@ void createDeviceWithGraphicsQueue(VkPhysicalDevice physicalDevice, uint32_t& qu
     createInfo.pEnabledFeatures = &deviceFeatures;
     
     if (vkCreateDevice(physicalDevice, &createInfo, nullptr, device) != VK_SUCCESS) {
-        throw std::runtime_error("Failed to create logical device");
+        PANIC_POSTCONDITION("Failed to create logical device");
     }
 }
 

--- a/thermion_dart/native/src/vulkan/linux/LinuxVulkanUtils.cpp
+++ b/thermion_dart/native/src/vulkan/linux/LinuxVulkanUtils.cpp
@@ -1,7 +1,8 @@
+#include <utils/Panic.h>
+
 #include <iostream>
 #include <vector>
 #include <string>
-#include <stdexcept>
 #include <cstring>
 #include <drm/drm_fourcc.h>
 
@@ -53,7 +54,7 @@ uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties, V
         }
     }
 
-    throw std::runtime_error("Failed to find suitable memory type");
+    PANIC_POSTCONDITION("Failed to find suitable memory type");
 }
 
 // Modified memory type selection function with more detailed requirements checking
@@ -203,7 +204,7 @@ uint32_t findGraphicsQueueFamily(VkPhysicalDevice physicalDevice) {
         }
     }
 
-    throw std::runtime_error("Failed to find graphics queue family");
+    PANIC_POSTCONDITION("Failed to find graphics queue family");
 }
 
 CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physicalDevice) {
@@ -241,7 +242,7 @@ CommandResources createCommandResources(VkDevice device, VkPhysicalDevice physic
     poolInfo.queueFamilyIndex = resources.queueFamilyIndex;
 
     if (vkCreateCommandPool(device, &poolInfo, nullptr, &resources.commandPool) != VK_SUCCESS) {
-        throw std::runtime_error("Failed to create command pool");
+        PANIC_POSTCONDITION("Failed to create command pool");
     }
 
     return resources;

--- a/thermion_dart/native/src/vulkan/windows/WindowsVulkanContext.cpp
+++ b/thermion_dart/native/src/vulkan/windows/WindowsVulkanContext.cpp
@@ -1,3 +1,5 @@
+#include <utils/Panic.h>
+
 
 #include "d3d/D3DContext.h"
 
@@ -637,7 +639,7 @@ class WindowsVulkanContext::Impl {
 
             VkResult result = bluevk::vkCreateBuffer(device, &bufferInfo, nullptr, &stagingBuffer);
             if (result != VK_SUCCESS) {
-                throw std::runtime_error("Failed to create staging buffer");
+                PANIC_POSTCONDITION("Failed to create staging buffer");
             }
 
             // Get memory requirements and allocate
@@ -656,14 +658,14 @@ class WindowsVulkanContext::Impl {
             result = bluevk::vkAllocateMemory(device, &allocInfo, nullptr, &stagingBufferMemory);
             if (result != VK_SUCCESS) {
                 bluevk::vkDestroyBuffer(device, stagingBuffer, nullptr);
-                throw std::runtime_error("Failed to allocate staging buffer memory");
+                PANIC_POSTCONDITION("Failed to allocate staging buffer memory");
             }
 
             result = bluevk::vkBindBufferMemory(device, stagingBuffer, stagingBufferMemory, 0);
             if (result != VK_SUCCESS) {
                 vkFreeMemory(device, stagingBufferMemory, nullptr);
                 vkDestroyBuffer(device, stagingBuffer, nullptr);
-                throw std::runtime_error("Failed to bind buffer memory");
+                PANIC_POSTCONDITION("Failed to bind buffer memory");
             }
 
             // Create command buffer
@@ -676,7 +678,7 @@ class WindowsVulkanContext::Impl {
             VkCommandBuffer commandBuffer;
             result = bluevk::vkAllocateCommandBuffers(device, &cmdBufAllocInfo, &commandBuffer);
             if (result != VK_SUCCESS) {
-                throw std::runtime_error("Failed to allocate command buffer");
+                PANIC_POSTCONDITION("Failed to allocate command buffer");
             }
 
             // Begin command buffer
@@ -686,7 +688,7 @@ class WindowsVulkanContext::Impl {
 
             result = bluevk::vkBeginCommandBuffer(commandBuffer, &beginInfo);
             if (result != VK_SUCCESS) {
-                throw std::runtime_error("Failed to begin command buffer");
+                PANIC_POSTCONDITION("Failed to begin command buffer");
             }
 
             // Transition image layout for transfer with proper sync
@@ -754,7 +756,7 @@ class WindowsVulkanContext::Impl {
 
             result = bluevk::vkEndCommandBuffer(commandBuffer);
             if (result != VK_SUCCESS) {
-                throw std::runtime_error("Failed to end command buffer");
+                PANIC_POSTCONDITION("Failed to end command buffer");
             }
 
             // Submit command buffer with fence for synchronization
@@ -764,7 +766,7 @@ class WindowsVulkanContext::Impl {
             VkFence fence;
             result = bluevk::vkCreateFence(device, &fenceInfo, nullptr, &fence);
             if (result != VK_SUCCESS) {
-                throw std::runtime_error("Failed to create fence");
+                PANIC_POSTCONDITION("Failed to create fence");
             }
 
             VkSubmitInfo submitInfo{};
@@ -775,21 +777,21 @@ class WindowsVulkanContext::Impl {
             result = bluevk::vkQueueSubmit(queue, 1, &submitInfo, fence);
             if (result != VK_SUCCESS) {
                 bluevk::vkDestroyFence(device, fence, nullptr);
-                throw std::runtime_error("Failed to submit queue");
+                PANIC_POSTCONDITION("Failed to submit queue");
             }
 
             // Wait for the command buffer to complete with timeout
             result = bluevk::vkWaitForFences(device, 1, &fence, VK_TRUE, 5000000000); // 5 second timeout
             if (result != VK_SUCCESS) {
                 bluevk::vkDestroyFence(device, fence, nullptr);
-                throw std::runtime_error("Failed to wait for fence");
+                PANIC_POSTCONDITION("Failed to wait for fence");
             }
 
             // Map memory and copy data
             void* data;
             result = bluevk::vkMapMemory(device, stagingBufferMemory, 0, bufferSize, 0, &data);
             if (result != VK_SUCCESS) {
-                throw std::runtime_error("Failed to map memory");
+                PANIC_POSTCONDITION("Failed to map memory");
             }
 
             outPixels.resize(bufferSize);

--- a/thermion_dart/native/test/rendering/scheduling_test.cpp
+++ b/thermion_dart/native/test/rendering/scheduling_test.cpp
@@ -5,14 +5,17 @@
 #include <chrono>
 #include <iostream>
 #include <limits>
-#include <stdexcept>
+#include <cstdlib>
 #include <utility>
 
 using namespace thermion;
 using namespace std::chrono_literals;
 
 static void require(bool condition, const char* message) {
-    if (!condition) throw std::runtime_error(message);
+    if (!condition) {
+        std::cerr << message << std::endl;
+        std::abort();
+    }
 }
 
 static void testRateGate() {

--- a/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
+++ b/thermion_dart/native/web/src/cpp/ThermionWebApi.cpp
@@ -82,11 +82,6 @@ extern "C"
       std::cout << "Failed to make WebGL context current"<< std::endl;
     } else { 
       std::cout << "Made WebGL context current"<< std::endl;
-      // try {
-      //   glClearColor(0.0, 0.0, 1.0, 1.0);
-      // } catch(...) {
-      //   std::cout << "Caught err"<< std::endl;
-      // }
       glClear(GL_COLOR_BUFFER_BIT);
     }
     std::cout << "Returning context" << std::endl;


### PR DESCRIPTION
This PR removes certain runtime C++ exceptions (or introduces compile-time guards) in anticipation of a follow-up follow-up PR that will disable C++ exceptions entirely. 

EGL tasks still run on the EGL thread, and each caller still waits for its task to finish. A mutex and condition variable replace the heap-allocated promise. The completion state lives on the waiting caller's stack. When exceptions are enabled, a task exception is captured and rethrown on the caller, preserving the existing behavior. That forwarding code is omitted by the compiler when exceptions are disabled. Ordinary EGL/GBM errors continue to use their existing result values and error messages.

Vulkan helpers use Filament's `PANIC_POSTCONDITION` instead of directly throwing `std::runtime_error`. This follows Filament's build setting: it throws a Filament postcondition exception when exceptions are enabled, and aborts when they are disabled. This changes the exception type; it does not add recovery or turn these failures into Dart errors.

The scheduling test's failure helper now prints its diagnostic and aborts, so the test can also compile without exceptions. An obsolete commented-out WebGL try/catch example is removed.
