### PR TITLE
fix: reject incompatible material packages before loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,19 @@
 - camera/entity manipulation with mouse (desktop) and gestures (mobile)
 - skinning + morph animations
 
-Uses the Filament PBR engine (currently v1.69.1).
+Uses the Filament PBR engine.
+
+### Custom material compatibility
+
+After initializing Filament, `FilamentApp.instance!.materialVersion` gives the
+material format number reported by `matc --version`. This number is distinct
+from the Filament release version. Compile custom materials with `matc` from
+the same Filament release as the application.
+
+`createMaterial` rejects incompatible format versions and malformed chunk
+layouts with a Dart `FormatException` before calling Filament's material
+builder. It does not validate every payload or backend requirement; other
+invalid packages can still cause a native panic.
 
 ### Quickstart (Flutter)
 

--- a/thermion_dart/lib/src/bindings/src/js_interop.dart
+++ b/thermion_dart/lib/src/bindings/src/js_interop.dart
@@ -171,7 +171,6 @@ Pointer<T> allocate<T extends NativeType>(int byteCount) {
   switch (T) {
     case PointerClass:
     case Char:
-    case Uint8:
       return malloc(byteCount);
     default:
       throw Exception(T.toString());

--- a/thermion_dart/lib/src/bindings/src/js_interop.dart
+++ b/thermion_dart/lib/src/bindings/src/js_interop.dart
@@ -171,6 +171,7 @@ Pointer<T> allocate<T extends NativeType>(int byteCount) {
   switch (T) {
     case PointerClass:
     case Char:
+    case Uint8:
       return malloc(byteCount);
     default:
       throw Exception(T.toString());

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -888,6 +888,8 @@ external void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TIndirectLight>)>> onComplete,
 );
 
+/// Returns null for an invalid chunk layout or incompatible material version.
+/// Matching versions do not guarantee valid payloads or backend compatibility.
 @ffi.Native<ffi.Pointer<TMaterial> Function(ffi.Pointer<TEngine>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
 external ffi.Pointer<TMaterial> Engine_buildMaterial(
   ffi.Pointer<TEngine> tEngine,
@@ -2506,6 +2508,19 @@ external int Material_getBlendingMode(ffi.Pointer<TMaterial> material);
 
 @ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<TMaterial>)>(isLeaf: true)
 external int Material_getFeatureLevel(ffi.Pointer<TMaterial> tMaterial);
+
+/// Reads the material format version, or returns -1 for an invalid chunk layout
+/// or a missing, duplicate, or incorrectly sized MAT_VERS chunk.
+/// Checks chunk boundaries without parsing their payloads. A nonnegative result
+/// does not establish that the package is complete or valid for a given backend.
+/// Reads synchronously and does not retain data. No engine is required.
+@ffi.Native<ffi.Int64 Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external int Material_getPackageVersion(ffi.Pointer<ffi.Uint8> data, int length);
+
+/// Material package format version expected by the linked Filament build.
+/// This is distinct from the Filament release version.
+@ffi.Native<ffi.Uint32 Function()>(isLeaf: true)
+external int Material_getSupportedVersion();
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<TMaterial>, ffi.Pointer<ffi.Char>)>(isLeaf: true)
 external bool Material_hasParameter(ffi.Pointer<TMaterial> tMaterial, ffi.Pointer<ffi.Char> propertyName);

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -456,6 +456,9 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     double intensity,
     Pointer<NativeFunction<void Function(PointerClass<TIndirectLight>)>> onComplete,
   );
+
+  /// Returns null for an invalid chunk layout or incompatible material version.
+  /// Matching versions do not guarantee valid payloads or backend compatibility.
   external Pointer<TMaterial> _Engine_buildMaterial(
     Pointer<TEngine> tEngine,
     Pointer<Uint8> materialData,
@@ -1249,6 +1252,17 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   );
   external int _Material_getBlendingMode(Pointer<TMaterial> material);
   external int _Material_getFeatureLevel(Pointer<TMaterial> tMaterial);
+
+  /// Reads the material format version, or returns -1 for an invalid chunk layout
+  /// or a missing, duplicate, or incorrectly sized MAT_VERS chunk.
+  /// Checks chunk boundaries without parsing their payloads. A nonnegative result
+  /// does not establish that the package is complete or valid for a given backend.
+  /// Reads synchronously and does not retain data. No engine is required.
+  external JSBigInt _Material_getPackageVersion(Pointer<Uint8> data, size_t length);
+
+  /// Material package format version expected by the linked Filament build.
+  /// This is distinct from the Filament release version.
+  external int _Material_getSupportedVersion();
   external int _Material_hasParameter(Pointer<TMaterial> tMaterial, Pointer<Char> propertyName);
   external void _MeshData_dispose(Pointer<TMeshData> meshData);
   external void _MovementIntentExecutor_destroy(Pointer<TMovementIntentExecutor> executor);
@@ -3676,6 +3690,8 @@ void Engine_buildIndirectLightFromIrradianceTextureRenderThread(
   return result;
 }
 
+/// Returns null for an invalid chunk layout or incompatible material version.
+/// Matching versions do not guarantee valid payloads or backend compatibility.
 Pointer<TMaterial> Engine_buildMaterial(Pointer<TEngine> tEngine, Pointer<Uint8> materialData, Dartsize_t length) {
   final result = GeneratedBindings.instance._Engine_buildMaterial(tEngine.cast(), materialData, length);
   return Pointer<TMaterial>(result);
@@ -5804,6 +5820,23 @@ int Material_getBlendingMode(Pointer<TMaterial> material) {
 
 int Material_getFeatureLevel(Pointer<TMaterial> tMaterial) {
   final result = GeneratedBindings.instance._Material_getFeatureLevel(tMaterial.cast());
+  return result;
+}
+
+/// Reads the material format version, or returns -1 for an invalid chunk layout
+/// or a missing, duplicate, or incorrectly sized MAT_VERS chunk.
+/// Checks chunk boundaries without parsing their payloads. A nonnegative result
+/// does not establish that the package is complete or valid for a given backend.
+/// Reads synchronously and does not retain data. No engine is required.
+BigInt Material_getPackageVersion(Pointer<Uint8> data, Dartsize_t length) {
+  final result = GeneratedBindings.instance._Material_getPackageVersion(data, length);
+  return result.toDart;
+}
+
+/// Material package format version expected by the linked Filament build.
+/// This is distinct from the Filament release version.
+int Material_getSupportedVersion() {
+  final result = GeneratedBindings.instance._Material_getSupportedVersion();
   return result;
 }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -642,12 +642,11 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     if (data.isEmpty) {
       throw const FormatException('Material package is empty.');
     }
-    // Validate and build the same snapshot. The caller may reuse its Dart data
-    // while the render-thread task is pending; keep this copy until completion.
-    final package = allocate<Uint8>(data.length);
     try {
-      package.asTypedList(data.length).setAll(0, data);
-      final actualVersion = Material_getPackageVersion(package, data.length).toInt();
+      // Each .address is a separate synchronous borrow. The render-thread
+      // entry point snapshots in native code before returning, and the native
+      // builder checks that snapshot again before passing it to Filament.
+      final actualVersion = Material_getPackageVersion(data.address, data.length).toInt();
       if (actualVersion < 0) {
         throw const FormatException('Invalid material package chunk layout or version metadata.');
       }
@@ -659,14 +658,14 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
         );
       }
       final ptr = await withPointerCallback<TMaterial>((cb) {
-        Engine_buildMaterialRenderThread(engine, package, data.length, cb);
+        Engine_buildMaterialRenderThread(engine, data.address, data.length, cb);
       });
       if (ptr == nullptr) {
         throw StateError('Filament could not create the material.');
       }
       return FFIMaterial(ptr, this);
     } finally {
-      free(package);
+      if (FILAMENT_WASM) data.free();
     }
   }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -634,15 +634,40 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     return _boneOverlayMaterial!;
   }
 
-  //
+  @override
+  int get materialVersion => Material_getSupportedVersion();
+
+  @override
   Future<Material> createMaterial(Uint8List data) async {
-    var ptr = await withPointerCallback<TMaterial>((cb) {
-      Engine_buildMaterialRenderThread(engine, data.address, data.length, cb);
-    });
-    if (FILAMENT_WASM) {
-      data.free();
+    if (data.isEmpty) {
+      throw const FormatException('Material package is empty.');
     }
-    return FFIMaterial(ptr, this);
+    // Validate and build the same snapshot. The caller may reuse its Dart data
+    // while the render-thread task is pending; keep this copy until completion.
+    final package = allocate<Uint8>(data.length);
+    try {
+      package.asTypedList(data.length).setAll(0, data);
+      final actualVersion = Material_getPackageVersion(package, data.length).toInt();
+      if (actualVersion < 0) {
+        throw const FormatException('Invalid material package chunk layout or version metadata.');
+      }
+      final expectedVersion = materialVersion;
+      if (actualVersion != expectedVersion) {
+        throw FormatException(
+          'Material format version $actualVersion is incompatible with expected '
+          'version $expectedVersion. Recompile using matc from the same Filament release as this application.',
+        );
+      }
+      final ptr = await withPointerCallback<TMaterial>((cb) {
+        Engine_buildMaterialRenderThread(engine, package, data.length, cb);
+      });
+      if (ptr == nullptr) {
+        throw StateError('Filament could not create the material.');
+      }
+      return FFIMaterial(ptr, this);
+    } finally {
+      free(package);
+    }
   }
 
   //

--- a/thermion_dart/lib/src/filament/src/interface/filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/interface/filament_app.dart
@@ -125,7 +125,20 @@ abstract class FilamentApp<T> {
 
   Future<Material> createBoneOverlayMaterial();
 
-  //
+  /// Material package format version expected by the loaded native build.
+  ///
+  /// This is the number reported by `matc --version`, distinct from the
+  /// Filament release version.
+  int get materialVersion;
+
+  /// Creates a material from a compiled `.filamat` package, copying [data].
+  ///
+  /// Throws [FormatException] for malformed chunk boundaries, missing or invalid
+  /// version metadata, or a format version different from [materialVersion].
+  /// Compile materials with `matc` from the same Filament release as the application.
+  ///
+  /// This checks the package layout and version, not every payload or backend
+  /// requirement. Other invalid packages can still cause a native Filament panic.
   Future<Material> createMaterial(Uint8List data);
 
   //

--- a/thermion_dart/lib/src/filament/src/interface/filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/interface/filament_app.dart
@@ -131,7 +131,8 @@ abstract class FilamentApp<T> {
   /// Filament release version.
   int get materialVersion;
 
-  /// Creates a material from a compiled `.filamat` package, copying [data].
+  /// Creates a material from a compiled `.filamat` package. Native code copies
+  /// [data] before queuing the build, so the caller can reuse it after this call.
   ///
   /// Throws [FormatException] for malformed chunk boundaries, missing or invalid
   /// version metadata, or a format version different from [materialVersion].

--- a/thermion_dart/native/include/c_api/TEngine.h
+++ b/thermion_dart/native/include/c_api/TEngine.h
@@ -57,6 +57,8 @@ EMSCRIPTEN_KEEPALIVE void Engine_destroyFence(TEngine *tEngine, TFence *tFence);
 EMSCRIPTEN_KEEPALIVE void Engine_flushAndWait(TEngine *tEngine);
 EMSCRIPTEN_KEEPALIVE void Engine_execute(TEngine *tEngine);
     
+/// Returns null for an invalid chunk layout or incompatible material version.
+/// Matching versions do not guarantee valid payloads or backend compatibility.
 EMSCRIPTEN_KEEPALIVE TMaterial *Engine_buildMaterial(TEngine *tEngine, const uint8_t* materialData, size_t length);
 EMSCRIPTEN_KEEPALIVE void Engine_destroyMaterial(TEngine *tEngine, TMaterial *tMaterial);
 EMSCRIPTEN_KEEPALIVE void Engine_destroyMaterialInstance(TEngine *tEngine, TMaterialInstance *tMaterialInstance);
@@ -87,4 +89,3 @@ EMSCRIPTEN_KEEPALIVE bool DebugRegistry_getProperty_float(TDebugRegistry *tDebug
 #ifdef __cplusplus
 }
 #endif
-

--- a/thermion_dart/native/include/c_api/TMaterialPackage.h
+++ b/thermion_dart/native/include/c_api/TMaterialPackage.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "APIExport.h"
+#include "APIBoundaryTypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Material package format version expected by the linked Filament build.
+/// This is distinct from the Filament release version.
+EMSCRIPTEN_KEEPALIVE uint32_t Material_getSupportedVersion();
+
+/// Reads the material format version, or returns -1 for an invalid chunk layout
+/// or a missing, duplicate, or incorrectly sized MAT_VERS chunk.
+/// Checks chunk boundaries without parsing their payloads. A nonnegative result
+/// does not establish that the package is complete or valid for a given backend.
+/// Reads synchronously and does not retain data. No engine is required.
+EMSCRIPTEN_KEEPALIVE int64_t Material_getPackageVersion(const uint8_t *data, size_t length);
+
+#ifdef __cplusplus
+}
+#endif

--- a/thermion_dart/native/src/c_api/TEngine.cpp
+++ b/thermion_dart/native/src/c_api/TEngine.cpp
@@ -5,6 +5,7 @@
 #endif
 
 #include "c_api/TEngine.h"
+#include "c_api/TMaterialPackage.h"
 
 #include <filament/Camera.h>
 #include <backend/DriverEnums.h>
@@ -281,6 +282,12 @@ namespace thermion
 
         EMSCRIPTEN_KEEPALIVE TMaterial *Engine_buildMaterial(TEngine *tEngine, const uint8_t *materialData, size_t length)
         {
+            // Reject stale packages before Filament's parser can panic. Keep
+            // this check for native callers as well as Dart's preflight check.
+            if (Material_getPackageVersion(materialData, length) != Material_getSupportedVersion()) {
+                Log("Invalid material package layout or incompatible material version");
+                return nullptr;
+            }
             auto *engine = reinterpret_cast<Engine *>(tEngine);
             auto *material = Material::Builder()
                                  .package(materialData, length)

--- a/thermion_dart/native/src/c_api/TMaterialPackage.cpp
+++ b/thermion_dart/native/src/c_api/TMaterialPackage.cpp
@@ -1,0 +1,57 @@
+#include "c_api/TMaterialPackage.h"
+
+#include <filament/MaterialChunkType.h>
+#include <filament/MaterialEnums.h>
+
+namespace {
+
+// Filament's chunk container stores integers little-endian, without alignment.
+// Callers check the available byte count before reading.
+template<typename T>
+T readLittleEndian(const uint8_t *data) {
+    T value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        value |= static_cast<T>(data[i]) << (8 * i);
+    }
+    return value;
+}
+
+}
+
+extern "C" {
+
+EMSCRIPTEN_KEEPALIVE uint32_t Material_getSupportedVersion() {
+    return filament::MATERIAL_VERSION;
+}
+
+EMSCRIPTEN_KEEPALIVE int64_t Material_getPackageVersion(const uint8_t *data, size_t length) {
+    if (!data) {
+        return -1;
+    }
+
+    constexpr size_t headerSize = sizeof(uint64_t) + sizeof(uint32_t);
+    size_t offset = 0;
+    int64_t version = -1;
+    while (offset < length) {
+        if (length - offset < headerSize) {
+            return -1;
+        }
+        const auto type = readLittleEndian<uint64_t>(data + offset);
+        const auto size = readLittleEndian<uint32_t>(data + offset + sizeof(uint64_t));
+        offset += headerSize;
+        // Subtract before comparing so a corrupt size cannot wrap the offset.
+        if (size > length - offset) {
+            return -1;
+        }
+        if (type == filamat::MaterialVersion) {
+            if (version != -1 || size != sizeof(uint32_t)) {
+                return -1;
+            }
+            version = readLittleEndian<uint32_t>(data + offset);
+        }
+        offset += size;
+    }
+    return version;
+}
+
+}

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -606,7 +606,10 @@ extern "C"
         {
           auto material = Engine_buildMaterial(tEngine, owned.data(), length);
 
-          setOwner(material, rt);          PROXY(onComplete(material));
+          if (material) {
+            setOwner(material, rt);
+          }
+          PROXY(onComplete(material));
         });
     auto fut = rt->addTask(lambda);
   }

--- a/thermion_dart/test/material_package_test.dart
+++ b/thermion_dart/test/material_package_test.dart
@@ -102,7 +102,11 @@ void main() {
             isA<FormatException>()
                 .having((e) => e.message, 'actual version', contains('$version'))
                 .having((e) => e.message, 'expected version', contains('${app.materialVersion}'))
-                .having((e) => e.message, 'matching compiler', contains('Recompile using matc from the same Filament release')),
+                .having(
+                  (e) => e.message,
+                  'matching compiler',
+                  contains('Recompile using matc from the same Filament release'),
+                ),
           ),
         );
       }

--- a/thermion_dart/test/material_package_test.dart
+++ b/thermion_dart/test/material_package_test.dart
@@ -1,0 +1,150 @@
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+import 'src/test_io.dart';
+
+int readPackageVersion(Uint8List bytes) {
+  final data = allocate<Uint8>(bytes.length);
+  try {
+    data.asTypedList(bytes.length).setAll(0, bytes);
+    return Material_getPackageVersion(data, bytes.length).toInt();
+  } finally {
+    free(data);
+  }
+}
+
+void main() {
+  late Uint8List validPackage;
+  late Uint8List versionChunk;
+
+  setUpAll(() async {
+    await initTestBindings();
+    validPackage = await loadResourceBytes('../examples/assets/solidcolor.filamat');
+    // The committed fixture starts with MAT_VERS, stored as a little-endian
+    // uint64 chunk tag, a uint32 payload length, then the uint32 version.
+    expect(validPackage.sublist(0, 8), 'SREV_TAM'.codeUnits);
+    expect(ByteData.sublistView(validPackage).getUint32(8, Endian.little), 4);
+    versionChunk = Uint8List.fromList(validPackage.sublist(0, 16));
+  });
+
+  Uint8List withVersion(int version) {
+    final bytes = Uint8List.fromList(validPackage);
+    ByteData.sublistView(bytes).setUint32(12, version, Endian.little);
+    return bytes;
+  }
+
+  Map<String, Uint8List> malformedPackages() {
+    final oversized = Uint8List.fromList(versionChunk);
+    ByteData.sublistView(oversized).setUint32(8, 0xffffffff, Endian.little);
+    final shortVersion = Uint8List.fromList(versionChunk.sublist(0, 15));
+    ByteData.sublistView(shortVersion).setUint32(8, 3, Endian.little);
+    final longVersion = Uint8List.fromList([...versionChunk, 0]);
+    ByteData.sublistView(longVersion).setUint32(8, 5, Endian.little);
+    return {
+      'empty': Uint8List(0),
+      'truncated header': Uint8List.fromList(versionChunk.sublist(0, 11)),
+      'truncated payload': Uint8List.fromList(versionChunk.sublist(0, 15)),
+      'oversized chunk': oversized,
+      'short version': shortVersion,
+      'long version': longVersion,
+      'missing version': Uint8List.fromList(validPackage.sublist(16)),
+      'duplicate version': Uint8List.fromList([...validPackage, ...versionChunk]),
+      'trailing partial header': Uint8List.fromList([...validPackage, 0]),
+    };
+  }
+
+  group('material package metadata', () {
+    test('native version matches a package built with the bundled compiler', () {
+      final fixtureVersion = ByteData.sublistView(validPackage).getUint32(12, Endian.little);
+      expect(Material_getSupportedVersion(), fixtureVersion);
+      expect(readPackageVersion(validPackage), fixtureVersion);
+    });
+
+    test('finds version after another chunk at an unaligned offset', () {
+      // A well-formed unknown chunk with a one-byte payload, then MAT_VERS.
+      final prefix = Uint8List(13);
+      prefix.setRange(0, 8, 'UNKNOWN '.codeUnits.reversed);
+      ByteData.sublistView(prefix).setUint32(8, 1, Endian.little);
+      expect(readPackageVersion(Uint8List.fromList([...prefix, ...versionChunk])), Material_getSupportedVersion());
+    });
+
+    test('distinguishes all uint32 versions from the malformed sentinel', () {
+      for (final version in [0, 69, 0x80000000, 0xffffffff]) {
+        expect(readPackageVersion(withVersion(version)), version);
+      }
+      expect(Material_getPackageVersion(nullptr, 0).toInt(), -1);
+    });
+
+    test('rejects malformed chunk layouts and ambiguous version metadata', () {
+      for (final entry in malformedPackages().entries) {
+        expect(readPackageVersion(entry.value), -1, reason: entry.key);
+      }
+    });
+  });
+
+  group('material creation', () {
+    late FFIFilamentApp app;
+    setUpAll(() async {
+      await FFIFilamentApp.create(
+        config: FFIFilamentConfig(backend: defaultTestBackend, loadResource: loadResourceBytes),
+      );
+      app = FilamentApp.instance! as FFIFilamentApp;
+    });
+    tearDownAll(() => app.destroy());
+
+    test('reports stale and future formats through the public Dart Future', () async {
+      expect(app.materialVersion, Material_getSupportedVersion());
+      for (final version in [69, 0xffffffff]) {
+        await expectLater(
+          app.createMaterial(withVersion(version)).timeout(const Duration(seconds: 5)),
+          throwsA(
+            isA<FormatException>()
+                .having((e) => e.message, 'actual version', contains('$version'))
+                .having((e) => e.message, 'expected version', contains('${app.materialVersion}'))
+                .having((e) => e.message, 'matching compiler', contains('Recompile using matc from the same Filament release')),
+          ),
+        );
+      }
+      // Rejection must leave the engine usable, with no pending completion.
+      final material = await app.createMaterial(validPackage).timeout(const Duration(seconds: 5));
+      await material.destroy();
+    });
+
+    test('rejects malformed packages through the public Dart Future', () async {
+      for (final entry in malformedPackages().entries) {
+        await expectLater(
+          app.createMaterial(entry.value).timeout(const Duration(seconds: 5)),
+          throwsFormatException,
+          reason: entry.key,
+        );
+      }
+    });
+
+    test('native render-thread path completes with null for rejected packages', () async {
+      for (final bytes in [withVersion(69), ...malformedPackages().values.where((bytes) => bytes.isNotEmpty)]) {
+        final data = allocate<Uint8>(bytes.length);
+        try {
+          data.asTypedList(bytes.length).setAll(0, bytes);
+          final material = await withPointerCallback<TMaterial>((callback) {
+            Engine_buildMaterialRenderThread(app.engine, data, bytes.length, callback);
+          }).timeout(const Duration(seconds: 5));
+          expect(material, nullptr);
+        } finally {
+          free(data);
+        }
+      }
+      final material = await app.createMaterial(validPackage).timeout(const Duration(seconds: 5));
+      await material.destroy();
+    });
+
+    test('builds the checked snapshot even if the caller reuses its data', () async {
+      final bytes = Uint8List.fromList(validPackage);
+      final created = app.createMaterial(bytes);
+      bytes.fillRange(0, bytes.length, 0);
+      final material = await created.timeout(const Duration(seconds: 5));
+      expect(bytes.every((byte) => byte == 0), isTrue);
+      await material.destroy();
+    });
+  });
+}

--- a/thermion_dart/test/material_package_test.dart
+++ b/thermion_dart/test/material_package_test.dart
@@ -5,12 +5,10 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.d
 import 'src/test_io.dart';
 
 int readPackageVersion(Uint8List bytes) {
-  final data = allocate<Uint8>(bytes.length);
   try {
-    data.asTypedList(bytes.length).setAll(0, bytes);
-    return Material_getPackageVersion(data, bytes.length).toInt();
+    return Material_getPackageVersion(bytes.address, bytes.length).toInt();
   } finally {
-    free(data);
+    if (FILAMENT_WASM) bytes.free();
   }
 }
 
@@ -127,15 +125,13 @@ void main() {
 
     test('native render-thread path completes with null for rejected packages', () async {
       for (final bytes in [withVersion(69), ...malformedPackages().values.where((bytes) => bytes.isNotEmpty)]) {
-        final data = allocate<Uint8>(bytes.length);
         try {
-          data.asTypedList(bytes.length).setAll(0, bytes);
           final material = await withPointerCallback<TMaterial>((callback) {
-            Engine_buildMaterialRenderThread(app.engine, data, bytes.length, callback);
+            Engine_buildMaterialRenderThread(app.engine, bytes.address, bytes.length, callback);
           }).timeout(const Duration(seconds: 5));
           expect(material, nullptr);
         } finally {
-          free(data);
+          if (FILAMENT_WASM) bytes.free();
         }
       }
       final material = await app.createMaterial(validPackage).timeout(const Duration(seconds: 5));


### PR DESCRIPTION
A stale `.filamat` can make Filament panic and terminate the application before Thermion can return an error. This PR checks the material format version before calling Filament's builder, so `createMaterial` completes with a Dart `FormatException` for incompatible packages.

For example, loading a format-69 material against the existing Filament 1.75.0 build now reports:

```text
Material format version 69 is incompatible with expected version 75.
Recompile using matc from the same Filament release as this application.
```

`FilamentApp.materialVersion` exposes the format number reported by `matc --version`. It comes from Filament's `MATERIAL_VERSION` through a native accessor. It is a material format number, not a Filament release version. Note that material version is separate from the Filament release-version constant added in #327 (not every Filament release version increment will change the material version).

A small native reader walks the package's chunk headers using Filament's chunk tag constant. It checks boundaries, reads the version wherever the chunk appears, and rejects missing, duplicate or incorrectly sized version metadata. Dart uses that reader to provide a useful error message. `Engine_buildMaterial` also checks it so native callers receive null for these failures, and the render-thread callback still completes normally.

This is a version/layout check, not a complete material validator (matching versions do not establish valid shader payloads, required chunks or backend compatibility; those other failures may still cause a Filament panic). The fix works with C++ exceptions disabled and does not attempt panic recovery.
