### PR TITLE
fix: copy material data before queueing their native build

### DIFF
--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -596,10 +596,13 @@ extern "C"
   EMSCRIPTEN_KEEPALIVE void Engine_buildMaterialRenderThread(TEngine *tEngine, const uint8_t *materialData, size_t length, void (*onComplete)(TMaterial *))
   {
     auto *rt = RT(tEngine);
+    // Snapshot borrowed FFI storage before returning to Dart. The task owns it.
+    std::vector<uint8_t> owned;
+    if (length != 0) owned.assign(materialData, materialData + length);
     std::packaged_task<void()> lambda(
-        [=]() mutable
+        [=, owned = std::move(owned)]() mutable
         {
-          auto material = Engine_buildMaterial(tEngine, materialData, length);
+          auto material = Engine_buildMaterial(tEngine, owned.data(), length);
 
           setOwner(material, rt);          PROXY(onComplete(material));
         });

--- a/thermion_dart/test/material_input_snapshot_test.dart
+++ b/thermion_dart/test/material_input_snapshot_test.dart
@@ -9,48 +9,44 @@ import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.d
 // THERMION_UPLOAD_LIFETIME_FIXTURE. No production-only test hooks are needed.
 void main() {
   final fixturePath = Platform.environment['THERMION_UPLOAD_LIFETIME_FIXTURE'];
-  group(
-    'material input snapshot',
-    () {
-      late FFIFilamentApp app;
-      late void Function() reset;
-      late void Function() release;
-      late Pointer<ffi.NativeFunction<ffi.Void Function()>> wait;
+  group('material input snapshot', () {
+    late FFIFilamentApp app;
+    late void Function() reset;
+    late void Function() release;
+    late Pointer<ffi.NativeFunction<ffi.Void Function()>> wait;
 
-      setUpAll(() async {
-        final fixture = DynamicLibrary.open(fixturePath!);
-        reset = fixture.lookupFunction<ffi.Void Function(), void Function()>('resetTaskRelease');
-        release = fixture.lookupFunction<ffi.Void Function(), void Function()>('allowTaskToFinish');
-        wait = fixture.lookup('waitForTaskRelease');
-        await FFIFilamentApp.create(
-          config: FFIFilamentConfig(
-            backend: Platform.isMacOS ? Backend.METAL : Backend.DEFAULT,
-            loadResource: (uri) => File(uri).readAsBytes(),
-          ),
-        );
-        app = FilamentApp.instance! as FFIFilamentApp;
-      });
-      tearDownAll(() => app.destroy());
+    setUpAll(() async {
+      final fixture = DynamicLibrary.open(fixturePath!);
+      reset = fixture.lookupFunction<ffi.Void Function(), void Function()>('resetTaskRelease');
+      release = fixture.lookupFunction<ffi.Void Function(), void Function()>('allowTaskToFinish');
+      wait = fixture.lookup('waitForTaskRelease');
+      await FFIFilamentApp.create(
+        config: FFIFilamentConfig(
+          backend: Platform.isMacOS ? Backend.METAL : Backend.DEFAULT,
+          loadResource: (uri) => File(uri).readAsBytes(),
+        ),
+      );
+      app = FilamentApp.instance! as FFIFilamentApp;
+    });
+    tearDownAll(() => app.destroy());
 
-      test('material package survives source overwrite while the worker is blocked', () async {
-        final bytes = await File('../examples/assets/solidcolor.filamat').readAsBytes();
-        reset();
-        ffi.RenderThread_addTask(wait);
-        late Future<Material> pending;
-        try {
-          pending = app.createMaterial(bytes);
-          bytes.fillRange(0, bytes.length, 0xa5);
-          // Force other Dart allocations while the native task still cannot read.
-          for (var i = 0; i < 100; i++) {
-            expect(Uint8List(8192).length, 8192);
-          }
-        } finally {
-          release();
+    test('material package survives source overwrite while the worker is blocked', () async {
+      final bytes = await File('../examples/assets/solidcolor.filamat').readAsBytes();
+      reset();
+      ffi.RenderThread_addTask(wait);
+      late Future<Material> pending;
+      try {
+        pending = app.createMaterial(bytes);
+        bytes.fillRange(0, bytes.length, 0xa5);
+        // Force other Dart allocations while the native task still cannot read.
+        for (var i = 0; i < 100; i++) {
+          expect(Uint8List(8192).length, 8192);
         }
-        final material = await pending.timeout(const Duration(seconds: 5));
-        await material.destroy();
-      });
-    },
-    skip: fixturePath == null ? 'Set THERMION_UPLOAD_LIFETIME_FIXTURE to the native fixture library' : false,
-  );
+      } finally {
+        release();
+      }
+      final material = await pending.timeout(const Duration(seconds: 5));
+      await material.destroy();
+    });
+  }, skip: fixturePath == null ? 'Set THERMION_UPLOAD_LIFETIME_FIXTURE to the native fixture library' : false);
 }

--- a/thermion_dart/test/material_input_snapshot_test.dart
+++ b/thermion_dart/test/material_input_snapshot_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'package:thermion_dart/src/bindings/src/ffi.dart' as ffi;
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+// Build native/test/rendering's upload_lifetime_fixture and set its path in
+// THERMION_UPLOAD_LIFETIME_FIXTURE. No production-only test hooks are needed.
+void main() {
+  final fixturePath = Platform.environment['THERMION_UPLOAD_LIFETIME_FIXTURE'];
+  group(
+    'material input snapshot',
+    () {
+      late FFIFilamentApp app;
+      late void Function() reset;
+      late void Function() release;
+      late Pointer<ffi.NativeFunction<ffi.Void Function()>> wait;
+
+      setUpAll(() async {
+        final fixture = DynamicLibrary.open(fixturePath!);
+        reset = fixture.lookupFunction<ffi.Void Function(), void Function()>('resetTaskRelease');
+        release = fixture.lookupFunction<ffi.Void Function(), void Function()>('allowTaskToFinish');
+        wait = fixture.lookup('waitForTaskRelease');
+        await FFIFilamentApp.create(
+          config: FFIFilamentConfig(
+            backend: Platform.isMacOS ? Backend.METAL : Backend.DEFAULT,
+            loadResource: (uri) => File(uri).readAsBytes(),
+          ),
+        );
+        app = FilamentApp.instance! as FFIFilamentApp;
+      });
+      tearDownAll(() => app.destroy());
+
+      test('material package survives source overwrite while the worker is blocked', () async {
+        final bytes = await File('../examples/assets/solidcolor.filamat').readAsBytes();
+        reset();
+        ffi.RenderThread_addTask(wait);
+        late Future<Material> pending;
+        try {
+          pending = app.createMaterial(bytes);
+          bytes.fillRange(0, bytes.length, 0xa5);
+          // Force other Dart allocations while the native task still cannot read.
+          for (var i = 0; i < 100; i++) {
+            expect(Uint8List(8192).length, 8192);
+          }
+        } finally {
+          release();
+        }
+        final material = await pending.timeout(const Duration(seconds: 5));
+        await material.destroy();
+      });
+    },
+    skip: fixturePath == null ? 'Set THERMION_UPLOAD_LIFETIME_FIXTURE to the native fixture library' : false,
+  );
+}


### PR DESCRIPTION
This PR ensures that material package data is copied when `createMaterial` is called so the pointer obtained through Dart `.address` is not accessed after the FFI call returns.
