### PR TITLE
refactor: glTF scene assets must own their retained material-handle arrays

### DIFF
--- a/thermion_dart/native/include/scene/GltfSceneAsset.hpp
+++ b/thermion_dart/native/include/scene/GltfSceneAsset.hpp
@@ -72,7 +72,7 @@ namespace thermion
 
         MaterialInstance **getMaterialInstances() override
         {
-            return _materialInstances;
+            return _materialInstances.data();
         }
 
         size_t getMaterialInstanceCount() override
@@ -209,7 +209,8 @@ namespace thermion
         gltfio::AssetLoader *_assetLoader;
         Engine *_engine;
         utils::NameComponentManager *_ncm;
-        MaterialInstance **_materialInstances = nullptr;
+        // Own the handle array; the material objects remain caller-owned.
+        std::vector<MaterialInstance*> _materialInstances;
         size_t _materialInstanceCount = 0;
         std::vector<std::unique_ptr<GltfSceneAssetInstance>> _instances;
 

--- a/thermion_dart/native/include/scene/GltfSceneAssetInstance.hpp
+++ b/thermion_dart/native/include/scene/GltfSceneAssetInstance.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -34,9 +35,10 @@ namespace thermion
             int instanceIndex = -1) : _instanceOwner(instanceOwner),
                                         _ncm(ncm), 
                                       _instance(instance),
-                                      _materialInstances(materialInstances),
+                                      _materialInstances(materialInstanceCount),
                                       _materialInstanceCount(materialInstanceCount)
         {
+            if (materialInstanceCount) std::copy_n(materialInstances, materialInstanceCount, _materialInstances.data());
         }
 
         ~GltfSceneAssetInstance();
@@ -69,7 +71,7 @@ namespace thermion
 
         MaterialInstance **getMaterialInstances() override
         {
-            return _materialInstances;
+            return _materialInstances.data();
         }
 
         size_t getMaterialInstanceCount() override
@@ -154,7 +156,8 @@ namespace thermion
         filament::Engine *_engine;
         utils::NameComponentManager *_ncm;
         gltfio::FilamentInstance *_instance;
-        MaterialInstance **_materialInstances = std::nullptr_t();
+        // Own the handle array; the material objects remain caller-owned.
+        std::vector<MaterialInstance*> _materialInstances;
         size_t _materialInstanceCount = 0;
         GltfSceneAsset *_instanceOwner = std::nullptr_t();
     };

--- a/thermion_dart/native/include/scene/GltfSceneAssetInstance.hpp
+++ b/thermion_dart/native/include/scene/GltfSceneAssetInstance.hpp
@@ -35,6 +35,9 @@ namespace thermion
             int instanceIndex = -1) : _instanceOwner(instanceOwner),
                                         _ncm(ncm), 
                                       _instance(instance),
+                                      // Create materialInstanceCount null pointer slots for copy_n below.
+                                      // Our own array stays valid after the caller releases theirs.
+                                      // No MaterialInstance objects are created or owned here.
                                       _materialInstances(materialInstanceCount),
                                       _materialInstanceCount(materialInstanceCount)
         {

--- a/thermion_dart/native/src/scene/GltfSceneAsset.cpp
+++ b/thermion_dart/native/src/scene/GltfSceneAsset.cpp
@@ -43,6 +43,9 @@ namespace thermion
                                         _assetLoader(assetLoader),
                                         _engine(engine),
                                         _ncm(ncm),
+                                        // Create materialInstanceCount null pointer slots for copy_n below.
+                                        // Our own array stays valid after the caller releases theirs.
+                                        // No MaterialInstance objects are created or owned here.
                                         _materialInstances(materialInstanceCount),
                                         _materialInstanceCount(materialInstanceCount)
     {

--- a/thermion_dart/native/src/scene/GltfSceneAsset.cpp
+++ b/thermion_dart/native/src/scene/GltfSceneAsset.cpp
@@ -43,9 +43,10 @@ namespace thermion
                                         _assetLoader(assetLoader),
                                         _engine(engine),
                                         _ncm(ncm),
-                                        _materialInstances(materialInstances),
+                                        _materialInstances(materialInstanceCount),
                                         _materialInstanceCount(materialInstanceCount)
     {
+        if (materialInstanceCount) std::copy_n(materialInstances, materialInstanceCount, _materialInstances.data());
         const bool requiresUnwelded =
             (requiredGeometryCapabilities &
              (SCENE_ASSET_GEOMETRY_CAPABILITY_BARYCENTRICS |


### PR DESCRIPTION
`GltfSceneAsset` and `GltfSceneAssetInstance` should copy the material-instance arrays and manage their lifetime to avoid the risk of later returning an array that has already been released. Note this does not affect the lifetime of the material instances themselves (the array is a container for `MaterialInstance *` pointers).

