### PR TITLE
fix: copy glTF resource data before queueing its upload

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -1477,13 +1477,29 @@ external int GltfParser_parseBuffer(
 );
 
 @ffi.Native<
-  ffi.Void Function(ffi.Pointer<TGltfResourceLoader>, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Uint8>, ffi.Size)
+  ffi.Void Function(
+    ffi.Pointer<TGltfResourceLoader>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<
+      ffi.NativeFunction<
+        ffi.Void Function(ffi.Pointer<ffi.Void> buffer, ffi.Size length, ffi.Pointer<ffi.Void> userData)
+      >
+    >,
+    ffi.Pointer<ffi.Void>,
+  )
 >(isLeaf: true)
 external void GltfResourceLoader_addResourceData(
   ffi.Pointer<TGltfResourceLoader> tGltfResourceLoader,
   ffi.Pointer<ffi.Char> uri,
   ffi.Pointer<ffi.Uint8> data,
   int length,
+  ffi.Pointer<
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void> buffer, ffi.Size length, ffi.Pointer<ffi.Void> userData)>
+  >
+  onRelease,
+  ffi.Pointer<ffi.Void> userData,
 );
 
 @ffi.Native<

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -739,6 +739,9 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<Char> uri,
     Pointer<Uint8> data,
     size_t length,
+    Pointer<NativeFunction<void Function(PointerClass<Void> buffer, size_t length, PointerClass<Void> userData)>>
+    onRelease,
+    Pointer<Void> userData,
   );
   external void _GltfResourceLoader_addResourceDataRenderThread(
     Pointer<TGltfResourceLoader> tGltfResourceLoader,
@@ -4504,12 +4507,16 @@ void GltfResourceLoader_addResourceData(
   Pointer<Char> uri,
   Pointer<Uint8> data,
   Dartsize_t length,
+  Pointer<NativeFunction<void Function(Pointer<Void> buffer, size_t length, Pointer<Void> userData)>> onRelease,
+  Pointer<Void> userData,
 ) {
   final result = GeneratedBindings.instance._GltfResourceLoader_addResourceData(
     tGltfResourceLoader.cast(),
     uri,
     data,
     length,
+    onRelease.cast(),
+    userData,
   );
   return result;
 }
@@ -12037,7 +12044,7 @@ extension NativeFunctionPointer18<T extends NativeType> on void Function(DartEnt
   }
 }
 
-extension NativeFunctionPointer24<T extends NativeType> on void Function(double) {
+extension NativeFunctionPointer25<T extends NativeType> on void Function(double) {
   Pointer<NativeFunction<void Function(double)>> addFunction() {
     return Pointer<NativeFunction<void Function(double)>>(
       NativeLibrary.instance.addFunction<void Function(double)>(this.toJS, 'vf'),
@@ -12045,7 +12052,7 @@ extension NativeFunctionPointer24<T extends NativeType> on void Function(double)
   }
 }
 
-extension NativeFunctionPointer47<T extends NativeType> on void Function() {
+extension NativeFunctionPointer48<T extends NativeType> on void Function() {
   Pointer<NativeFunction<void Function()>> addFunction() {
     return Pointer<NativeFunction<void Function()>>(
       NativeLibrary.instance.addFunction<void Function()>(this.toJS, 'v'),

--- a/thermion_dart/native/include/ResourceUpload.hpp
+++ b/thermion_dart/native/include/ResourceUpload.hpp
@@ -1,9 +1,0 @@
-#pragma once
-#include <vector>
-#include "c_api/TGltfResourceLoader.h"
-
-namespace thermion {
-// Filament releases the owned bytes through its descriptor callback.
-void GltfResourceLoader_addResourceDataOwned(TGltfResourceLoader*, const char* uri,
-    std::vector<uint8_t>&& data);
-}

--- a/thermion_dart/native/include/ResourceUpload.hpp
+++ b/thermion_dart/native/include/ResourceUpload.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <vector>
+#include "c_api/TGltfResourceLoader.h"
+
+namespace thermion {
+// Filament releases the owned bytes through its descriptor callback.
+void GltfResourceLoader_addResourceDataOwned(TGltfResourceLoader*, const char* uri,
+    std::vector<uint8_t>&& data);
+}

--- a/thermion_dart/native/include/c_api/TGltfResourceLoader.h
+++ b/thermion_dart/native/include/c_api/TGltfResourceLoader.h
@@ -13,7 +13,13 @@ EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_destroy(TEngine *tEngine, TGltfReso
 EMSCRIPTEN_KEEPALIVE bool GltfResourceLoader_asyncBeginLoad(TGltfResourceLoader *tGltfResourceLoader, TFilamentAsset *tFilamentAsset);
 EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_asyncUpdateLoad(TGltfResourceLoader *tGltfResourceLoader);
 EMSCRIPTEN_KEEPALIVE float GltfResourceLoader_asyncGetLoadProgress(TGltfResourceLoader *tGltfResourceLoader);
-EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_addResourceData(TGltfResourceLoader *tGltfResourceLoader, const char *uri, uint8_t *data, size_t length);
+// Submits data without copying. Filament retains it after this call returns.
+// onRelease(data, length, userData) is responsible for releasing its storage;
+// keep the buffer and any callback context valid until that callback runs.
+// The release callback may run on a native thread.
+EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_addResourceData(
+    TGltfResourceLoader *tGltfResourceLoader, const char *uri, uint8_t *data, size_t length,
+    void (*onRelease)(void *buffer, size_t length, void *userData), void *userData);
 EMSCRIPTEN_KEEPALIVE bool GltfResourceLoader_loadResources(TGltfResourceLoader *tGltfResourceLoader, TFilamentAsset *tFilamentAsset);
 
 

--- a/thermion_dart/native/src/c_api/TGltfResourceLoader.cpp
+++ b/thermion_dart/native/src/c_api/TGltfResourceLoader.cpp
@@ -1,3 +1,4 @@
+#include "ResourceUpload.hpp"
  
 
 #include "c_api/TGltfResourceLoader.h"
@@ -56,16 +57,21 @@ EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_destroy(TEngine *tEngine, TGltfReso
     delete gltfResourceLoader;
 }
 
-EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_addResourceData(TGltfResourceLoader *tGltfResourceLoader, const char *uri, uint8_t *data, size_t length) {
-    TRACE("Adding data (length %d) for glTF resource URI %s", length, uri);
-    auto *gltfResourceLoader = reinterpret_cast<gltfio::ResourceLoader *>(tGltfResourceLoader);
-    auto *vec = new std::vector<uint8_t>(data, data + length);
+EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_addResourceData(TGltfResourceLoader *loader, const char *uri, uint8_t *data, size_t length) {
+    GltfResourceLoader_addResourceDataOwned(loader, uri, std::vector<uint8_t>(data, data + length));
+}
+
+} // extern "C"
+void GltfResourceLoader_addResourceDataOwned(TGltfResourceLoader *loader, const char *uri, std::vector<uint8_t>&& data) {
+    TRACE("Adding data (length %d) for glTF resource URI %s", data.size(), uri);
+    auto *gltfResourceLoader = reinterpret_cast<filament::gltfio::ResourceLoader *>(loader);
+    auto *vec = new std::vector<uint8_t>(std::move(data));
     gltfResourceLoader->addResourceData(uri, {
-        vec->data(),
-        vec->size(),
+        vec->data(), vec->size(),
         [](void *, size_t, void *user) { delete static_cast<std::vector<uint8_t>*>(user); },
         vec});
 }
+extern "C" {
 
 EMSCRIPTEN_KEEPALIVE bool GltfResourceLoader_loadResources(TGltfResourceLoader *tGltfResourceLoader, TFilamentAsset *tFilamentAsset) {    
     auto *gltfResourceLoader = reinterpret_cast<gltfio::ResourceLoader *>(tGltfResourceLoader);

--- a/thermion_dart/native/src/c_api/TGltfResourceLoader.cpp
+++ b/thermion_dart/native/src/c_api/TGltfResourceLoader.cpp
@@ -1,9 +1,6 @@
-#include "ResourceUpload.hpp"
  
 
 #include "c_api/TGltfResourceLoader.h"
-
-#include <vector>
 
 #include <filament/Engine.h>
 #include <filament/Fence.h>
@@ -57,21 +54,13 @@ EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_destroy(TEngine *tEngine, TGltfReso
     delete gltfResourceLoader;
 }
 
-EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_addResourceData(TGltfResourceLoader *loader, const char *uri, uint8_t *data, size_t length) {
-    GltfResourceLoader_addResourceDataOwned(loader, uri, std::vector<uint8_t>(data, data + length));
-}
-
-} // extern "C"
-void GltfResourceLoader_addResourceDataOwned(TGltfResourceLoader *loader, const char *uri, std::vector<uint8_t>&& data) {
-    TRACE("Adding data (length %d) for glTF resource URI %s", data.size(), uri);
+EMSCRIPTEN_KEEPALIVE void GltfResourceLoader_addResourceData(
+    TGltfResourceLoader *loader, const char *uri, uint8_t *data, size_t length,
+    void (*onRelease)(void *, size_t, void *), void *userData) {
+    TRACE("Adding data (length %d) for glTF resource URI %s", length, uri);
     auto *gltfResourceLoader = reinterpret_cast<filament::gltfio::ResourceLoader *>(loader);
-    auto *vec = new std::vector<uint8_t>(std::move(data));
-    gltfResourceLoader->addResourceData(uri, {
-        vec->data(), vec->size(),
-        [](void *, size_t, void *user) { delete static_cast<std::vector<uint8_t>*>(user); },
-        vec});
+    gltfResourceLoader->addResourceData(uri, {data, length, onRelease, userData});
 }
-extern "C" {
 
 EMSCRIPTEN_KEEPALIVE bool GltfResourceLoader_loadResources(TGltfResourceLoader *tGltfResourceLoader, TFilamentAsset *tFilamentAsset) {    
     auto *gltfResourceLoader = reinterpret_cast<gltfio::ResourceLoader *>(tGltfResourceLoader);

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -1,4 +1,3 @@
-#include "ResourceUpload.hpp"
 #include <atomic>
 #include <math/mat4.h>
 #include <functional>
@@ -2290,12 +2289,20 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tGltfResourceLoader);
+    // Copy borrowed Dart bytes before returning from this FFI call.
     std::vector<uint8_t> owned(data, data + length);
     std::string ownedUri(uri);
     std::packaged_task<void()> lambda(
         [=, owned = std::move(owned), ownedUri = std::move(ownedUri)]() mutable
         {
-          GltfResourceLoader_addResourceDataOwned(tGltfResourceLoader, ownedUri.c_str(), std::move(owned));
+          // Move the snapshot into storage that outlives this task. Filament's
+          // release callback deletes it when Filament releases the resource bytes.
+          auto *buffer = new std::vector<uint8_t>(std::move(owned));
+          GltfResourceLoader_addResourceData(
+              tGltfResourceLoader, ownedUri.c_str(), buffer->data(), buffer->size(),
+              [](void *, size_t, void *userData) {
+                delete static_cast<std::vector<uint8_t>*>(userData);
+              }, buffer);
           PROXY(onComplete(requestId));
         });
     auto fut = rt->addTask(lambda);

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -1,3 +1,4 @@
+#include "ResourceUpload.hpp"
 #include <atomic>
 #include <math/mat4.h>
 #include <functional>
@@ -2289,10 +2290,12 @@ extern "C"
       uint32_t requestId, VoidCallback onComplete)
   {
     auto *rt = RT(tGltfResourceLoader);
+    std::vector<uint8_t> owned(data, data + length);
+    std::string ownedUri(uri);
     std::packaged_task<void()> lambda(
-        [=]() mutable
+        [=, owned = std::move(owned), ownedUri = std::move(ownedUri)]() mutable
         {
-          GltfResourceLoader_addResourceData(tGltfResourceLoader, uri, data, length);
+          GltfResourceLoader_addResourceDataOwned(tGltfResourceLoader, ownedUri.c_str(), std::move(owned));
           PROXY(onComplete(requestId));
         });
     auto fut = rt->addTask(lambda);


### PR DESCRIPTION
This PR moves responsibility for copying gltf resource data from `GltfResourceLoader_addResourceData` to `GltfResourceLoader_addResourceDataRenderThread`. This is because we need to safely copy this data before the FFI call returns. The assumption is that, if later we decide to invoke `GltfResourceLoader_addResourceData` directly from Dart, this will be treated as a leaf call and therefore the Dart typed_data buffer can be passed directly without a copy.
