### PR TITLE
fix: use native copy of bone update matrices 

### DIFF
--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -2885,10 +2885,13 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tRenderableManager);
+    // Snapshot borrowed FFI storage before returning to Dart. The task owns it.
+    std::vector<float> owned;
+    if (boneCount != 0) owned.assign(transforms, transforms + boneCount * 16);
     std::packaged_task<void()> lambda(
-        [=]() mutable
+        [=, owned = std::move(owned)]() mutable
         {
-          RenderableManager_setBonesFromMat4(tRenderableManager, entityId, transforms, boneCount, offset);
+          RenderableManager_setBonesFromMat4(tRenderableManager, entityId, owned.data(), boneCount, offset);
           PROXY(onComplete(requestId));
         });
     auto fut = rt->addTask(lambda);
@@ -2904,10 +2907,13 @@ extern "C"
       VoidCallback onComplete)
   {
     auto *rt = RT(tRenderableManager);
+    // Snapshot borrowed FFI storage before returning to Dart. The task owns it.
+    std::vector<float> owned;
+    if (boneCount != 0) owned.assign(bones, bones + boneCount * 8);
     std::packaged_task<void()> lambda(
-        [=]() mutable
+        [=, owned = std::move(owned)]() mutable
         {
-          RenderableManager_setBonesFromBone(tRenderableManager, entityId, bones, boneCount, offset);
+          RenderableManager_setBonesFromBone(tRenderableManager, entityId, owned.data(), boneCount, offset);
           PROXY(onComplete(requestId));
         });
     auto fut = rt->addTask(lambda);


### PR DESCRIPTION
This PR ensures native code copies the matrix/bone array when setting bone updates so that the Dart `.address` pointer is not accessed after the FFI method returns.
