### PR TITLE
fix: copy scene material-handle arrays before queueing creation

### DIFF
--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -1026,14 +1026,17 @@ extern "C"
       void (*callback)(TSceneAsset *))
   {
     auto *rt = RT(tEngine);
+    // Copy the handle array; the native objects retain their existing lifetimes.
+    std::vector<TMaterialInstance*> owned;
+    if (materialInstanceCount > 0) owned.assign(materialInstances, materialInstances + materialInstanceCount);
     std::packaged_task<void()> lambda(
-        [=]
+        [=, owned = std::move(owned)]() mutable
         {
           auto sceneAsset = SceneAsset_createFromBuffers(
               tEngine,
               tVertexBuffer,
               tIndexBuffer,
-              materialInstances,
+              owned.data(),
               materialInstanceCount,
               tPrimitiveType,
               vertexBufferStorageMode,
@@ -1050,10 +1053,13 @@ extern "C"
       void (*callback)(TSceneAsset *))
   {
     auto *rt = RT(asset);
+    // Copy the handle array; the native objects retain their existing lifetimes.
+    std::vector<TMaterialInstance*> owned;
+    if (materialInstanceCount > 0) owned.assign(tMaterialInstances, tMaterialInstances + materialInstanceCount);
     std::packaged_task<void()> lambda(
-        [=]
+        [=, owned = std::move(owned)]() mutable
         {
-          auto instanceAsset = SceneAsset_createInstance(asset, tMaterialInstances, materialInstanceCount);
+          auto instanceAsset = SceneAsset_createInstance(asset, owned.data(), materialInstanceCount);
 
           setOwner(instanceAsset, rt);          PROXY(callback(instanceAsset));
         });


### PR DESCRIPTION
This PR ensures native code copies the material-instance handle array before queueing scene or instance creation so that the Dart `.address` pointer is not accessed after the FFI call returns. #333 already handles the array retained by the asset after construction; this copy keeps the handles valid while the creation task is waiting to run.
