### PR TITLE
fix: move skinning data to the build step for RenderableBuilder (and take copy)

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -2745,6 +2745,27 @@ external void RenderableBuilder_buildRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>> onComplete,
 );
 
+@ffi.Native<
+  ffi.Void Function(
+    ffi.Pointer<TRenderableBuilder>,
+    ffi.Pointer<TEngine>,
+    EntityId,
+    ffi.Size,
+    ffi.Pointer<ffi.Float>,
+    ffi.Bool,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>,
+  )
+>(isLeaf: true)
+external void RenderableBuilder_buildWithSkinningRenderThread(
+  ffi.Pointer<TRenderableBuilder> tBuilder,
+  ffi.Pointer<TEngine> tEngine,
+  int entityId,
+  int boneCount,
+  ffi.Pointer<ffi.Float> data,
+  bool boneData,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Int)>> onComplete,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderableBuilder>, ffi.Bool)>(isLeaf: true)
 external void RenderableBuilder_castShadows(ffi.Pointer<TRenderableBuilder> builder, bool enabled);
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1362,6 +1362,15 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     EntityId entityId,
     Pointer<NativeFunction<void Function(int)>> onComplete,
   );
+  external void _RenderableBuilder_buildWithSkinningRenderThread(
+    Pointer<TRenderableBuilder> tBuilder,
+    Pointer<TEngine> tEngine,
+    EntityId entityId,
+    size_t boneCount,
+    Pointer<Float32> data,
+    bool boneData,
+    Pointer<NativeFunction<void Function(int)>> onComplete,
+  );
   external void _RenderableBuilder_castShadows(Pointer<TRenderableBuilder> builder, bool enabled);
   external void _RenderableBuilder_channel(Pointer<TRenderableBuilder> builder, int channel);
   external Pointer<TRenderableBuilder> _RenderableBuilder_create(size_t primitiveCount);
@@ -6135,6 +6144,27 @@ void RenderableBuilder_buildRenderThread(
     tBuilder.cast(),
     tEngine.cast(),
     entityId,
+    onComplete.cast(),
+  );
+  return result;
+}
+
+void RenderableBuilder_buildWithSkinningRenderThread(
+  Pointer<TRenderableBuilder> tBuilder,
+  Pointer<TEngine> tEngine,
+  DartEntityId entityId,
+  Dartsize_t boneCount,
+  Pointer<Float32> data,
+  bool boneData,
+  Pointer<NativeFunction<void Function(int)>> onComplete,
+) {
+  final result = GeneratedBindings.instance._RenderableBuilder_buildWithSkinningRenderThread(
+    tBuilder.cast(),
+    tEngine.cast(),
+    entityId,
+    boneCount,
+    data,
+    boneData,
     onComplete.cast(),
   );
   return result;

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_renderable_manager.dart
@@ -432,6 +432,11 @@ class FFIRenderableBuilder implements RenderableBuilder {
   bindings.Pointer<TRenderableBuilder>? _builderPtr;
   final FFIFilamentApp _app;
   bool _isBuilt = false;
+  int _boneCount = 0;
+  // Keep the existing setter-time conversions in Dart. Borrow their addresses
+  // only when build() submits the data for a native copy.
+  Float32List? _skinningMatrices;
+  Float32List? _skinningBones;
 
   FFIRenderableBuilder(int primitiveCount, this._app) {
     _builderPtr = bindings.RenderableBuilder_create(primitiveCount);
@@ -590,33 +595,15 @@ class FFIRenderableBuilder implements RenderableBuilder {
   @override
   void skinning(int boneCount, List<Matrix4> transforms) {
     _checkNotBuilt();
-    final transformsData = BoneData.matricesToFloat32List(transforms);
-    final transformsPtr = makeFloat32List(transformsData.length);
-    for (int i = 0; i < transformsData.length; i++) {
-      transformsPtr[i] = transformsData[i];
-    }
-
-    bindings.RenderableBuilder_skinningFromMat4(_builderPtr!, boneCount, transformsPtr.address);
-
-    if (FILAMENT_WASM) {
-      transformsPtr.free();
-    }
+    _boneCount = boneCount;
+    _skinningMatrices = BoneData.matricesToFloat32List(transforms);
   }
 
   @override
   void skinningFromBone(int boneCount, List<BoneData> bones) {
     _checkNotBuilt();
-    final bonesData = BoneData.toFloat32List(bones);
-    final bonesPtr = makeFloat32List(bonesData.length);
-    for (int i = 0; i < bonesData.length; i++) {
-      bonesPtr[i] = bonesData[i];
-    }
-
-    bindings.RenderableBuilder_skinningFromBone(_builderPtr!, boneCount, bonesPtr.address);
-
-    if (FILAMENT_WASM) {
-      bonesPtr.free();
-    }
+    _boneCount = boneCount;
+    _skinningBones = BoneData.toFloat32List(bones);
   }
 
   @override
@@ -655,14 +642,38 @@ class FFIRenderableBuilder implements RenderableBuilder {
   Future<bool> build(ThermionEntity entity) async {
     _checkNotBuilt();
 
-    final result = await withIntCallback(
-      (cb) => bindings.RenderableBuilder_buildRenderThread(_builderPtr!, _app.engine, entity, cb.cast()),
-    );
+    // Filament prefers Bone data when both skinning overloads have been used.
+    final skinningData = _skinningBones ?? _skinningMatrices;
+    final int result;
+    if (skinningData == null) {
+      result = await withIntCallback(
+        (cb) => bindings.RenderableBuilder_buildRenderThread(_builderPtr!, _app.engine, entity, cb.cast()),
+      );
+    } else {
+      result = await withIntCallback((cb) {
+        // Web needs a WASM-memory view for FFI; native borrows the Dart list directly.
+        final stack = FILAMENT_WASM ? stackSave() : nullptr;
+        final input = FILAMENT_WASM ? (makeFloat32List(skinningData.length)..setAll(0, skinningData)) : skinningData;
+        bindings.RenderableBuilder_buildWithSkinningRenderThread(
+          _builderPtr!,
+          _app.engine,
+          entity,
+          _boneCount,
+          input.address,
+          _skinningBones != null,
+          cb.cast(),
+        );
+        // The native function has copied the data before returning.
+        if (FILAMENT_WASM) stackRestore(stack);
+      });
+    }
 
     // Clean up the builder
     bindings.RenderableBuilder_destroy(_builderPtr!);
     _builderPtr = null;
     _isBuilt = true;
+    _skinningMatrices = null;
+    _skinningBones = null;
 
     // Result: 0 = Success, -1 = Error
     return result == 0;

--- a/thermion_dart/native/include/c_api/TRenderableManager.h
+++ b/thermion_dart/native/include/c_api/TRenderableManager.h
@@ -109,6 +109,8 @@ extern "C"
     EMSCRIPTEN_KEEPALIVE void RenderableBuilder_instances(TRenderableBuilder *builder, size_t instanceCount);
 
     // Skinning
+    // These synchronous setters borrow the arrays until build(). Dart submits
+    // its inputs through buildWithSkinningRenderThread instead.
     EMSCRIPTEN_KEEPALIVE void RenderableBuilder_skinningFromMat4(TRenderableBuilder *builder, size_t boneCount, const float *transforms);
     EMSCRIPTEN_KEEPALIVE void RenderableBuilder_skinningFromBone(TRenderableBuilder *builder, size_t boneCount, const float *bones);
     EMSCRIPTEN_KEEPALIVE void RenderableBuilder_enableSkinningBuffers(TRenderableBuilder *builder, bool enabled);

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -476,6 +476,20 @@ namespace thermion
             void (*onComplete)(int)
         );
 
+        // Copy skinning data before returning, then apply it and build in one
+        // render-thread task. data contains boneCount * 8 floats for Bone data,
+        // or boneCount * 16 floats for matrices. The task releases the copy.
+        // Keep tBuilder alive until onComplete, as with buildRenderThread.
+        EMSCRIPTEN_KEEPALIVE void RenderableBuilder_buildWithSkinningRenderThread(
+            TRenderableBuilder *tBuilder,
+            TEngine *tEngine,
+            EntityId entityId,
+            size_t boneCount,
+            const float *data,
+            bool boneData,
+            void (*onComplete)(int)
+        );
+
         EMSCRIPTEN_KEEPALIVE void EntityManager_createEntityRenderThread(TEntityManager *tEntityManager, void (*onComplete)(EntityId));
         EMSCRIPTEN_KEEPALIVE void EntityManager_destroyEntityRenderThread(TEntityManager *tEntityManager, EntityId entityId, uint32_t requestId, VoidCallback onComplete);
 

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <algorithm>
 #include <atomic>
+#include <cstring>
 #include <math/mat4.h>
 #include <functional>
 #include <mutex>
@@ -2738,6 +2739,38 @@ extern "C"
 
           auto result = builder->build(*engine, entity);
           PROXY(onComplete(static_cast<int>(result)));
+        });
+    auto fut = rt->addTask(lambda);
+  }
+
+  EMSCRIPTEN_KEEPALIVE void RenderableBuilder_buildWithSkinningRenderThread(
+      TRenderableBuilder *tBuilder,
+      TEngine *tEngine,
+      EntityId entityId,
+      size_t boneCount,
+      const float *data,
+      bool boneData,
+      void (*onComplete)(int))
+  {
+    auto *rt = RT(tEngine);
+    // Use typed storage for Filament's alignment requirements. Only the selected
+    // representation allocates; Dart's borrowed pointer is consumed here.
+    std::vector<filament::math::mat4f> matrices(boneData ? 0 : boneCount);
+    std::vector<filament::RenderableManager::Bone> bones(boneData ? boneCount : 0);
+    if (!matrices.empty()) std::memcpy(matrices.data(), data, matrices.size() * sizeof(matrices[0]));
+    if (!bones.empty()) std::memcpy(bones.data(), data, bones.size() * sizeof(bones[0]));
+    std::packaged_task<void()> lambda(
+        [=, matrices = std::move(matrices), bones = std::move(bones)]() mutable
+        {
+          auto *builder = reinterpret_cast<filament::RenderableManager::Builder*>(tBuilder);
+          if (boneData) {
+            builder->skinning(boneCount, bones.data());
+          } else {
+            builder->skinning(boneCount, matrices.data());
+          }
+          // Filament reads the pointers during build(), while the task owns them.
+          auto result = RenderableBuilder_build(tBuilder, tEngine, entityId);
+          PROXY(onComplete(result));
         });
     auto fut = rt->addTask(lambda);
   }

--- a/thermion_dart/test/renderable_manager_tests.dart
+++ b/thermion_dart/test/renderable_manager_tests.dart
@@ -353,94 +353,144 @@ void main() async {
       );
     });
 
-    test('create skinned geometry with two bones', () async {
-      await ViewerBuilder(testHelper).setRenderTargetEnabled(true).setBackgroundColor(kGrey).execute((result) async {
-        final app = FilamentApp.instance!;
-        final renderableManager = app.renderableManager;
+    for (final inputType in ['matrices', 'bones', 'both']) {
+      test('create skinned geometry with two bones ($inputType)', () async {
+        await ViewerBuilder(testHelper).setRenderTargetEnabled(true).setBackgroundColor(kGrey).execute((result) async {
+          final app = FilamentApp.instance!;
+          final renderableManager = app.renderableManager;
 
-        // Build a skinned quad: bone 0 owns the bottom half (verts 0,1),
-        // bone 1 owns the top half (verts 2,3).
-        final vertexBuffer =
-            await (renderableManager.createVertexBufferBuilder()
-                  ..bufferCount(3)
-                  ..vertexCount(4)
-                  ..attribute(VertexAttribute.POSITION, 0, VertexAttributeType.FLOAT3)
-                  ..attribute(VertexAttribute.BONE_INDICES, 1, VertexAttributeType.UBYTE4)
-                  ..attribute(VertexAttribute.BONE_WEIGHTS, 2, VertexAttributeType.FLOAT4))
-                .build();
+          // Build a skinned quad: bone 0 owns the bottom half (verts 0,1),
+          // bone 1 owns the top half (verts 2,3).
+          final vertexBuffer =
+              await (renderableManager.createVertexBufferBuilder()
+                    ..bufferCount(3)
+                    ..vertexCount(4)
+                    ..attribute(VertexAttribute.POSITION, 0, VertexAttributeType.FLOAT3)
+                    ..attribute(VertexAttribute.BONE_INDICES, 1, VertexAttributeType.UBYTE4)
+                    ..attribute(VertexAttribute.BONE_WEIGHTS, 2, VertexAttributeType.FLOAT4))
+                  .build();
 
-        final indexBuffer =
-            await (renderableManager.createIndexBufferBuilder()
-                  ..indexCount(6)
-                  ..bufferType(IndexType.USHORT))
-                .build();
+          final indexBuffer =
+              await (renderableManager.createIndexBufferBuilder()
+                    ..indexCount(6)
+                    ..bufferType(IndexType.USHORT))
+                  .build();
 
-        final positions = Float32List.fromList([
-          -0.5, -0.5, 0.0, // vertex 0 (bottom-left)
-          0.5, -0.5, 0.0, // vertex 1 (bottom-right)
-          0.5, 0.5, 0.0, // vertex 2 (top-right)
-          -0.5, 0.5, 0.0, // vertex 3 (top-left)
-        ]);
-        await vertexBuffer.setBufferAt(0, positions);
+          final positions = Float32List.fromList([
+            -0.5, -0.5, 0.0, // vertex 0 (bottom-left)
+            0.5, -0.5, 0.0, // vertex 1 (bottom-right)
+            0.5, 0.5, 0.0, // vertex 2 (top-right)
+            -0.5, 0.5, 0.0, // vertex 3 (top-left)
+          ]);
+          await vertexBuffer.setBufferAt(0, positions);
 
-        final boneIndices = Uint8List.fromList([
-          0, 0, 0, 0, // vertex 0: bone 0
-          0, 0, 0, 0, // vertex 1: bone 0
-          1, 0, 0, 0, // vertex 2: bone 1
-          1, 0, 0, 0, // vertex 3: bone 1
-        ]);
-        await vertexBuffer.setBufferAt(1, boneIndices);
+          final boneIndices = Uint8List.fromList([
+            0, 0, 0, 0, // vertex 0: bone 0
+            0, 0, 0, 0, // vertex 1: bone 0
+            1, 0, 0, 0, // vertex 2: bone 1
+            1, 0, 0, 0, // vertex 3: bone 1
+          ]);
+          // Use a supported typed-data view on web; the UBYTE4 bytes are unchanged.
+          await vertexBuffer.setBufferAt(1, boneIndices.buffer.asUint16List());
 
-        final boneWeights = Float32List.fromList([
-          1.0, 0.0, 0.0, 0.0, // vertex 0: 100% bone 0
-          1.0, 0.0, 0.0, 0.0, // vertex 1: 100% bone 0
-          1.0, 0.0, 0.0, 0.0, // vertex 2: 100% bone 1
-          1.0, 0.0, 0.0, 0.0, // vertex 3: 100% bone 1
-        ]);
-        await vertexBuffer.setBufferAt(2, boneWeights);
+          final boneWeights = Float32List.fromList([
+            1.0, 0.0, 0.0, 0.0, // vertex 0: 100% bone 0
+            1.0, 0.0, 0.0, 0.0, // vertex 1: 100% bone 0
+            1.0, 0.0, 0.0, 0.0, // vertex 2: 100% bone 1
+            1.0, 0.0, 0.0, 0.0, // vertex 3: 100% bone 1
+          ]);
+          await vertexBuffer.setBufferAt(2, boneWeights);
 
-        await indexBuffer.setBuffer(Uint16List.fromList([0, 1, 2, 2, 3, 0]));
+          await indexBuffer.setBuffer(Uint16List.fromList([0, 1, 2, 2, 3, 0]));
 
-        final material = await app.createUnlitMaterialInstance();
-        await material.setParameterFloat4("baseColorFactor", 1.0, 0.5, 0.0, 1.0); // Orange
+          final material = await app.createUnlitMaterialInstance();
+          await material.setParameterFloat4("baseColorFactor", 1.0, 0.5, 0.0, 1.0); // Orange
 
-        final entity = await app.createEntity();
-        final renderableBuilder = renderableManager.createBuilder(1)
-          ..boundingBox(Aabb3.minMax(Vector3(-0.5, -0.5, 0.0), Vector3(0.5, 0.5, 0.0)))
-          ..geometry(0, PrimitiveType.TRIANGLES, vertexBuffer, indexBuffer, 0, 6)
-          ..material(0, material)
-          ..skinning(2, [Matrix4.identity(), Matrix4.identity()]);
+          final entity = await app.createEntity();
+          final renderableBuilder = renderableManager.createBuilder(1)
+            ..boundingBox(Aabb3.minMax(Vector3(-0.5, -0.5, 0.0), Vector3(0.5, 0.5, 0.0)))
+            ..geometry(0, PrimitiveType.TRIANGLES, vertexBuffer, indexBuffer, 0, 6)
+            ..material(0, material);
 
-        final success = await renderableBuilder.build(entity);
-        expect(success, true);
+          final transforms = [Matrix4.identity(), Matrix4.identity()];
+          final initialBones = [BoneData.identity(), BoneData.identity()];
+          if (inputType == 'matrices') {
+            renderableBuilder.skinning(2, transforms);
+          } else {
+            renderableBuilder.skinningFromBone(2, initialBones);
+          }
+          // The setters must preserve their values until build(), even when the
+          // caller changes the original objects and yields before building.
+          for (final transform in transforms) {
+            transform.setTranslation(Vector3(100, 0, 0));
+          }
+          for (final bone in initialBones) {
+            bone.translation.x = 100;
+          }
+          if (inputType == 'both') {
+            // Preserve Filament's Bone-over-matrix precedence, even when the
+            // matrix setter is called last with a pose outside the camera view.
+            renderableBuilder.skinning(2, transforms);
+          }
+          await Future<void>.delayed(Duration.zero);
 
-        final scene = await result.viewer.view.getScene();
-        await scene.addEntity(entity);
+          final success = await renderableBuilder.build(entity);
+          expect(success, true);
 
-        final camera = await result.viewer.view.getCamera();
-        await camera.lookAt(Vector3(0, 0, 2), focus: Vector3.zero(), up: Vector3(0, 1, 0));
+          final scene = await result.viewer.view.getScene();
+          await scene.addEntity(entity);
 
-        // Initial pose: both bones identity.
-        await testHelper.capture(result.viewer.view, "skinned_initial_pose");
+          final camera = await result.viewer.view.getCamera();
+          await camera.lookAt(Vector3(0, 0, 2), focus: Vector3.zero(), up: Vector3(0, 1, 0));
 
-        // Rotate bone 1 (top half) ~45 degrees around Z.
-        await renderableManager.setBonesFromMat4(entity, [Matrix4.identity(), Matrix4.rotationZ(0.78)]);
-        await testHelper.capture(result.viewer.view, "skinned_after_bone_rotation");
+          // Initial pose: both bones identity.
+          final initial = await testHelper.capture(result.viewer.view, "skinned_initial_pose_$inputType");
+          int foregroundPixelCount(Uint8List buffer) {
+            final pixels = buffer.buffer.asFloat32List(buffer.offsetInBytes, buffer.lengthInBytes ~/ 4);
+            var count = 0;
+            for (var i = 0; i < pixels.length; i += 4) {
+              // Compare against the grey background in the corner, independently
+              // of the material's colour or the backend's colour conversion.
+              final difference =
+                  (pixels[i] - pixels[0]).abs() + (pixels[i + 1] - pixels[1]).abs() + (pixels[i + 2] - pixels[2]).abs();
+              if (difference > 0.2) count++;
+            }
+            return count;
+          }
 
-        expect(renderableManager.isRenderable(entity), true);
+          expect(
+            foregroundPixelCount(initial[result.viewer.view]!),
+            greaterThan(100),
+            reason: 'The original identity pose must remain visible',
+          );
 
-        // Same update via BoneData (quaternion+translation) path.
-        final boneData = [
-          BoneData(rotation: Quaternion.identity(), translation: Vector3.zero()),
-          BoneData(rotation: Quaternion.axisAngle(Vector3(0, 0, 1), 1.57), translation: Vector3(0.0, 0.5, 0.0)),
-        ];
-        await renderableManager.setBonesFromBone(entity, boneData);
-        await testHelper.capture(result.viewer.view, "skinned_after_bonedata_update");
+          // Rotate bone 1 (top half) ~45 degrees around Z.
+          await renderableManager.setBonesFromMat4(entity, [Matrix4.identity(), Matrix4.rotationZ(0.78)]);
+          await testHelper.capture(result.viewer.view, "skinned_after_bone_rotation");
 
-        await vertexBuffer.destroy();
-        await indexBuffer.destroy();
+          expect(renderableManager.isRenderable(entity), true);
+
+          // Same update via BoneData (quaternion+translation) path.
+          final boneData = [
+            BoneData(rotation: Quaternion.identity(), translation: Vector3.zero()),
+            BoneData(rotation: Quaternion.axisAngle(Vector3(0, 0, 1), 1.57), translation: Vector3(0.0, 0.5, 0.0)),
+          ];
+          await renderableManager.setBonesFromBone(entity, boneData);
+          await testHelper.capture(result.viewer.view, "skinned_after_bonedata_update");
+
+          await renderableManager.setBonesFromMat4(entity, transforms);
+          final moved = await testHelper.capture(result.viewer.view, null);
+          expect(
+            foregroundPixelCount(moved[result.viewer.view]!),
+            0,
+            reason: 'Using the mutated transforms must move the mesh outside the view',
+          );
+
+          await vertexBuffer.destroy();
+          await indexBuffer.destroy();
+        });
       });
-    });
+    }
 
     test('morph target operations', () async {
       // Note: This test uses a cube which doesn't have morph targets,


### PR DESCRIPTION
This PR keeps the converted matrix/bone data in Dart until `build()` is called. Native code then copies it before the FFI call returns, so the Dart `.address` pointer is not accessed later. The queued task applies the skinning data and builds the renderable together, then releases the copy.
