### PR TITLE
fix: build surface orientations with one synchronous input borrow

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -3752,6 +3752,49 @@ external void SurfaceOrientationBuilder_uvs(
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientationBuilder>, ffi.Size)>(isLeaf: true)
 external void SurfaceOrientationBuilder_vertexCount(ffi.Pointer<TSurfaceOrientationBuilder> builder, int count);
 
+@ffi.Native<
+  ffi.Pointer<TSurfaceOrientation> Function(
+    ffi.Size,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Pointer<ffi.Float>,
+    ffi.Size,
+    ffi.Size,
+    ffi.Size,
+    ffi.Pointer<ffi.Uint32>,
+    ffi.Size,
+    ffi.Pointer<ffi.Uint16>,
+    ffi.Size,
+  )
+>(isLeaf: true)
+external ffi.Pointer<TSurfaceOrientation> SurfaceOrientation_build(
+  int vertexCount,
+  ffi.Pointer<ffi.Float> normals,
+  int normalsLength,
+  int normalStride,
+  ffi.Pointer<ffi.Float> tangents,
+  int tangentsLength,
+  int tangentStride,
+  ffi.Pointer<ffi.Float> uvs,
+  int uvsLength,
+  int uvStride,
+  ffi.Pointer<ffi.Float> positions,
+  int positionsLength,
+  int positionStride,
+  int triangleCount,
+  ffi.Pointer<ffi.Uint32> triangles32,
+  int triangles32Length,
+  ffi.Pointer<ffi.Uint16> triangles16,
+  int triangles16Length,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TSurfaceOrientation>)>(isLeaf: true)
 external void SurfaceOrientation_destroy(ffi.Pointer<TSurfaceOrientation> orientation);
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1897,6 +1897,26 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     size_t stride,
   );
   external void _SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, size_t count);
+  external Pointer<TSurfaceOrientation> _SurfaceOrientation_build(
+    size_t vertexCount,
+    Pointer<Float32> normals,
+    size_t normalsLength,
+    size_t normalStride,
+    Pointer<Float32> tangents,
+    size_t tangentsLength,
+    size_t tangentStride,
+    Pointer<Float32> uvs,
+    size_t uvsLength,
+    size_t uvStride,
+    Pointer<Float32> positions,
+    size_t positionsLength,
+    size_t positionStride,
+    size_t triangleCount,
+    Pointer<Uint32> triangles32,
+    size_t triangles32Length,
+    Pointer<Uint16> triangles16,
+    size_t triangles16Length,
+  );
   external void _SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation);
   external void _SurfaceOrientation_getQuats_float4(
     Pointer<TSurfaceOrientation> orientation,
@@ -7564,6 +7584,49 @@ void SurfaceOrientationBuilder_uvs(
 void SurfaceOrientationBuilder_vertexCount(Pointer<TSurfaceOrientationBuilder> builder, Dartsize_t count) {
   final result = GeneratedBindings.instance._SurfaceOrientationBuilder_vertexCount(builder.cast(), count);
   return result;
+}
+
+Pointer<TSurfaceOrientation> SurfaceOrientation_build(
+  Dartsize_t vertexCount,
+  Pointer<Float32> normals,
+  Dartsize_t normalsLength,
+  Dartsize_t normalStride,
+  Pointer<Float32> tangents,
+  Dartsize_t tangentsLength,
+  Dartsize_t tangentStride,
+  Pointer<Float32> uvs,
+  Dartsize_t uvsLength,
+  Dartsize_t uvStride,
+  Pointer<Float32> positions,
+  Dartsize_t positionsLength,
+  Dartsize_t positionStride,
+  Dartsize_t triangleCount,
+  Pointer<Uint32> triangles32,
+  Dartsize_t triangles32Length,
+  Pointer<Uint16> triangles16,
+  Dartsize_t triangles16Length,
+) {
+  final result = GeneratedBindings.instance._SurfaceOrientation_build(
+    vertexCount,
+    normals,
+    normalsLength,
+    normalStride,
+    tangents,
+    tangentsLength,
+    tangentStride,
+    uvs,
+    uvsLength,
+    uvStride,
+    positions,
+    positionsLength,
+    positionStride,
+    triangleCount,
+    triangles32,
+    triangles32Length,
+    triangles16,
+    triangles16Length,
+  );
+  return Pointer<TSurfaceOrientation>(result);
 }
 
 void SurfaceOrientation_destroy(Pointer<TSurfaceOrientation> orientation) {

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_surface_orientation.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_surface_orientation.dart
@@ -58,86 +58,129 @@ class FFISurfaceOrientation extends SurfaceOrientation {
 
 /// FFI implementation of SurfaceOrientationBuilder for native platforms.
 class FFISurfaceOrientationBuilder implements SurfaceOrientationBuilder {
-  bindings.Pointer<bindings.TSurfaceOrientationBuilder>? _builderPtr;
   bool _isBuilt = false;
-
-  FFISurfaceOrientationBuilder() {
-    _builderPtr = bindings.SurfaceOrientationBuilder_create();
-  }
+  int _vertexCount = 0;
+  int _triangleCount = 0;
+  Float32List? _normals, _tangents, _uvs, _positions;
+  Uint32List? _triangles32;
+  Uint16List? _triangles16;
+  int _normalStride = 0, _tangentStride = 0, _uvStride = 0, _positionStride = 0;
+  static final _emptyFloats = Float32List(0);
+  static final _emptyIndices32 = Uint32List(0);
+  static final _emptyIndices16 = Uint16List(0);
 
   void _checkNotBuilt() {
     if (_isBuilt) {
       throw StateError('Builder has already been built and cannot be reused');
-    }
-    if (_builderPtr == null || _builderPtr == bindings.nullptr) {
-      throw StateError('Builder pointer is null');
     }
   }
 
   @override
   void vertexCount(int count) {
     _checkNotBuilt();
-    bindings.SurfaceOrientationBuilder_vertexCount(_builderPtr!, count);
+    _vertexCount = count;
   }
 
   @override
   void normals(Float32List normals, {int stride = 0}) {
     _checkNotBuilt();
-    final byteData = normals.asUint8List();
-    bindings.SurfaceOrientationBuilder_normals(_builderPtr!, byteData.address.cast<bindings.Float>(), stride);
+    _normals = normals;
+    _normalStride = stride;
   }
 
   @override
   void tangents(Float32List tangents, {int stride = 0}) {
     _checkNotBuilt();
-    final byteData = tangents.asUint8List();
-    bindings.SurfaceOrientationBuilder_tangents(_builderPtr!, byteData.address.cast<bindings.Float>(), stride);
+    _tangents = tangents;
+    _tangentStride = stride;
   }
 
   @override
   void uvs(Float32List uvs, {int stride = 0}) {
     _checkNotBuilt();
-    final byteData = uvs.asUint8List();
-    bindings.SurfaceOrientationBuilder_uvs(_builderPtr!, byteData.address.cast<bindings.Float>(), stride);
+    _uvs = uvs;
+    _uvStride = stride;
   }
 
   @override
   void positions(Float32List positions, {int stride = 0}) {
     _checkNotBuilt();
-    final byteData = positions.asUint8List();
-    bindings.SurfaceOrientationBuilder_positions(_builderPtr!, byteData.address.cast<bindings.Float>(), stride);
+    _positions = positions;
+    _positionStride = stride;
   }
 
   @override
   void triangleCount(int count) {
     _checkNotBuilt();
-    bindings.SurfaceOrientationBuilder_triangleCount(_builderPtr!, count);
+    _triangleCount = count;
   }
 
   @override
   void trianglesUint32(Uint32List triangles) {
     _checkNotBuilt();
-    final byteData = triangles.asUint8List();
-    bindings.SurfaceOrientationBuilder_triangles_uint(_builderPtr!, byteData.address.cast<bindings.Uint32>());
+    _triangles32 = triangles;
   }
 
   @override
   void trianglesUint16(Uint16List triangles) {
     _checkNotBuilt();
-    final byteData = triangles.asUint8List();
-    bindings.SurfaceOrientationBuilder_triangles_ushort(_builderPtr!, byteData.address.cast<bindings.Uint16>());
+    _triangles16 = triangles;
   }
 
   @override
   Future<SurfaceOrientation> build() async {
     _checkNotBuilt();
 
-    final orientationPtr = bindings.SurfaceOrientationBuilder_build(_builderPtr!);
+    // Optional inputs use empty lists so every .address stays a direct FFI
+    // argument. Their zero lengths tell native code to omit those inputs.
+    // Web needs temporary WASM views; native Dart borrows the retained lists.
+    final stack = bindings.FILAMENT_WASM ? bindings.stackSave() : bindings.nullptr;
+    Float32List floatInput(Float32List? input) {
+      final data = input ?? _emptyFloats;
+      return bindings.FILAMENT_WASM ? (bindings.makeFloat32List(data.length)..setAll(0, data)) : data;
+    }
 
-    bindings.SurfaceOrientationBuilder_destroy(_builderPtr!);
-    _builderPtr = null;
-    _isBuilt = true;
-
-    return FFISurfaceOrientation(orientationPtr);
+    try {
+      final normals = floatInput(_normals);
+      final tangents = floatInput(_tangents);
+      final uvs = floatInput(_uvs);
+      final positions = floatInput(_positions);
+      final indices32 = _triangles32 ?? _emptyIndices32;
+      final indices16 = _triangles16 ?? _emptyIndices16;
+      final triangles32 = bindings.FILAMENT_WASM
+          ? (bindings.makeUint32List(indices32.length)..setAll(0, indices32))
+          : indices32;
+      final triangles16 = bindings.FILAMENT_WASM
+          ? (bindings.makeUint16List(indices16.length)..setAll(0, indices16))
+          : indices16;
+      final orientationPtr = bindings.SurfaceOrientation_build(
+        _vertexCount,
+        normals.address,
+        normals.length,
+        _normalStride,
+        tangents.address,
+        tangents.length,
+        _tangentStride,
+        uvs.address,
+        uvs.length,
+        _uvStride,
+        positions.address,
+        positions.length,
+        _positionStride,
+        _triangleCount,
+        triangles32.address,
+        triangles32.length,
+        triangles16.address,
+        triangles16.length,
+      );
+      _isBuilt = true;
+      _normals = _tangents = _uvs = _positions = null;
+      _triangles32 = null;
+      _triangles16 = null;
+      return FFISurfaceOrientation(orientationPtr);
+    } finally {
+      // All input reads finish before returning; no stack storage spans an await.
+      if (bindings.FILAMENT_WASM) bindings.stackRestore(stack);
+    }
   }
 }

--- a/thermion_dart/lib/src/filament/src/interface/surface_orientation.dart
+++ b/thermion_dart/lib/src/filament/src/interface/surface_orientation.dart
@@ -55,6 +55,12 @@ abstract class SurfaceOrientation {
 
 /// Builder for creating SurfaceOrientation instances.
 ///
+/// Input setters retain the supplied lists. Their contents are read when
+/// [build] is called, so edits made before building affect the result. Building
+/// consumes the builder; subsequent edits to the inputs do not affect the
+/// generated orientation. Keep externally allocated input storage valid until
+/// building finishes.
+///
 /// The builder allows you to configure the input data needed to generate
 /// tangent space quaternions. At a minimum, you must provide the vertex count.
 /// You can supply data in various combinations:

--- a/thermion_dart/native/include/c_api/TSurfaceOrientation.h
+++ b/thermion_dart/native/include/c_api/TSurfaceOrientation.h
@@ -16,6 +16,20 @@ extern "C"
     // Create a surface orientation builder
     EMSCRIPTEN_KEEPALIVE TSurfaceOrientationBuilder* SurfaceOrientationBuilder_create();
 
+    // Configure and build synchronously. Input lengths are scalar element counts;
+    // a zero length omits that input. Strides are in bytes. No input pointers are
+    // retained after this call returns, so Dart can borrow them with .address.
+    EMSCRIPTEN_KEEPALIVE TSurfaceOrientation* SurfaceOrientation_build(
+        size_t vertexCount,
+        const float* normals, size_t normalsLength, size_t normalStride,
+        const float* tangents, size_t tangentsLength, size_t tangentStride,
+        const float* uvs, size_t uvsLength, size_t uvStride,
+        const float* positions, size_t positionsLength, size_t positionStride,
+        size_t triangleCount,
+        const uint32_t* triangles32, size_t triangles32Length,
+        const uint16_t* triangles16, size_t triangles16Length
+    );
+
     // Configure the builder
     EMSCRIPTEN_KEEPALIVE void SurfaceOrientationBuilder_vertexCount(TSurfaceOrientationBuilder* builder, size_t count);
     EMSCRIPTEN_KEEPALIVE void SurfaceOrientationBuilder_normals(

--- a/thermion_dart/native/src/c_api/TSurfaceOrientation.cpp
+++ b/thermion_dart/native/src/c_api/TSurfaceOrientation.cpp
@@ -21,6 +21,28 @@ namespace thermion
             return reinterpret_cast<TSurfaceOrientationBuilder*>(builder);
         }
 
+        EMSCRIPTEN_KEEPALIVE TSurfaceOrientation* SurfaceOrientation_build(
+            size_t vertexCount,
+            const float* normals, size_t normalsLength, size_t normalStride,
+            const float* tangents, size_t tangentsLength, size_t tangentStride,
+            const float* uvs, size_t uvsLength, size_t uvStride,
+            const float* positions, size_t positionsLength, size_t positionStride,
+            size_t triangleCount,
+            const uint32_t* triangles32, size_t triangles32Length,
+            const uint16_t* triangles16, size_t triangles16Length
+        ) {
+            SurfaceOrientation::Builder builder;
+            builder.vertexCount(vertexCount).triangleCount(triangleCount);
+            if (normalsLength) builder.normals(reinterpret_cast<const float3*>(normals), normalStride);
+            if (tangentsLength) builder.tangents(reinterpret_cast<const float4*>(tangents), tangentStride);
+            if (uvsLength) builder.uvs(reinterpret_cast<const float2*>(uvs), uvStride);
+            if (positionsLength) builder.positions(reinterpret_cast<const float3*>(positions), positionStride);
+            if (triangles32Length) builder.triangles(reinterpret_cast<const uint3*>(triangles32));
+            if (triangles16Length) builder.triangles(reinterpret_cast<const ushort3*>(triangles16));
+            // Filament consumes the borrowed inputs while this FFI call is active.
+            return reinterpret_cast<TSurfaceOrientation*>(builder.build());
+        }
+
         EMSCRIPTEN_KEEPALIVE void SurfaceOrientationBuilder_vertexCount(TSurfaceOrientationBuilder* tBuilder, size_t count) {
             auto* builder = reinterpret_cast<SurfaceOrientation::Builder*>(tBuilder);
             builder->vertexCount(count);

--- a/thermion_dart/test/surface_buffer_lifetime_test.dart
+++ b/thermion_dart/test/surface_buffer_lifetime_test.dart
@@ -1,0 +1,93 @@
+import 'package:test/test.dart';
+import 'package:thermion_dart/src/filament/src/implementation/ffi_surface_orientation.dart';
+import 'src/test_io.dart';
+import 'package:thermion_dart/src/filament/src/interface/surface_orientation.dart';
+
+void main() {
+  setUpAll(initTestBindings);
+
+  for (final withTangents in [false, true]) {
+    test('build reads current normals${withTangents ? " and tangents" : ""}', () async {
+      Future<List<double>> build(bool configureBeforeEdits) async {
+        // The subview and padding exercise both the input offset and byte stride.
+        final storage = Float32List.fromList([99, 0, 0, 1, 99, 0, 1, 0, 99]);
+        final normals = Float32List.sublistView(storage, 1);
+        final tangents = Float32List.fromList([1, 0, 0, 1, 1, 0, 0, 1]);
+        final builder = FFISurfaceOrientationBuilder();
+        void configure() {
+          builder.normals(normals, stride: 16);
+          if (withTangents) builder.tangents(tangents);
+          // Counts may be configured after the data setters.
+          builder.vertexCount(2);
+        }
+
+        if (configureBeforeEdits) configure();
+        await Future<void>.delayed(Duration.zero);
+        normals.setAll(0, [1, 0, 0, 99, 0, 0, 1, 99]);
+        tangents.setAll(0, [0, 1, 0, 1, 0, 1, 0, -1]);
+        if (!configureBeforeEdits) configure();
+        final orientation = await builder.build();
+        // A completed orientation must no longer depend on the input arrays.
+        normals.fillRange(0, normals.length, 0);
+        tangents.fillRange(0, tangents.length, 0);
+        try {
+          final quats = await orientation.getQuats(QuaternionFormat.FLOAT4, 2) as Float32List;
+          expect(quats.every((value) => value.isFinite), true);
+          return quats.toList();
+        } finally {
+          await orientation.destroy();
+        }
+      }
+
+      expect(await build(true), await build(false));
+    });
+  }
+
+  for (final shortIndices in [false, true]) {
+    test('build reads current positions, UVs and ${shortIndices ? 16 : 32}-bit triangles', () async {
+      Future<List<double>> build(bool configureBeforeEdits) async {
+        final positions = Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+        final normals = Float32List.fromList([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+        final uvs = Float32List.fromList([0, 0, 1, 0, 0, 1]);
+        final indices32 = Uint32List.fromList([0, 1, 2]);
+        final indices16 = Uint16List.fromList([0, 1, 2]);
+        final builder = FFISurfaceOrientationBuilder();
+        void configure() {
+          builder.positions(positions);
+          builder.normals(normals);
+          builder.uvs(uvs);
+          if (shortIndices) {
+            builder.trianglesUint16(indices16);
+          } else {
+            builder.trianglesUint32(indices32);
+          }
+          builder.vertexCount(3);
+          builder.triangleCount(1);
+        }
+
+        if (configureBeforeEdits) configure();
+        await Future<void>.delayed(Duration.zero);
+        positions.setAll(0, [0, 0, 0, 0, 1, 0, -1, 0, 0]);
+        uvs.setAll(0, [0, 0, 0, 1, 1, 0]);
+        indices16.setAll(0, [2, 0, 1]);
+        indices32.setAll(0, [2, 0, 1]);
+        if (!configureBeforeEdits) configure();
+        final orientation = await builder.build();
+        positions.fillRange(0, positions.length, 0);
+        normals.fillRange(0, normals.length, 0);
+        uvs.fillRange(0, uvs.length, 0);
+        indices16.fillRange(0, 3, 0);
+        indices32.fillRange(0, 3, 0);
+        try {
+          final quats = await orientation.getQuats(QuaternionFormat.FLOAT4, 3) as Float32List;
+          expect(quats.every((value) => value.isFinite), true);
+          return quats.toList();
+        } finally {
+          await orientation.destroy();
+        }
+      }
+
+      expect(await build(true), await build(false));
+    });
+  }
+}


### PR DESCRIPTION
This PR keeps the surface-orientation input lists in Dart until `build()` is called, then passes them to one synchronous native call that configures the Filament builder and builds the orientation. All input reads finish before the FFI call returns, so no native builder wrapper or input copies are needed on native Dart. Edits to the lists before `build()` affect the result; edits after building do not. Web uses temporary WASM input buffers for the synchronous call.
