### PR TITLE
Complete pixel capture after GPU readback into native storage

### DIFF
--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -3205,6 +3205,9 @@ external void Renderer_beginFrameRenderThread(
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>> onComplete,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Uint8>, ffi.Pointer<ffi.Uint8>, ffi.Size)>(isLeaf: true)
+external void Renderer_copyPixelsAndRelease(ffi.Pointer<ffi.Uint8> pixels, ffi.Pointer<ffi.Uint8> out, int length);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>)>(isLeaf: true)
 external void Renderer_endFrame(ffi.Pointer<TRenderer> tRenderer);
 
@@ -3221,8 +3224,8 @@ external void Renderer_endFrameRenderThread(ffi.Pointer<TRenderer> tRenderer, in
     ffi.Pointer<TRenderTarget>,
     ffi.UnsignedInt,
     ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
     ffi.Size,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Uint8>)>>,
   )
 >(isLeaf: true)
 external void Renderer_readPixels(
@@ -3234,8 +3237,8 @@ external void Renderer_readPixels(
   ffi.Pointer<TRenderTarget> tRenderTarget,
   int tPixelBufferFormat,
   int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
   int outLength,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Uint8>)>> onComplete,
 );
 
 @ffi.Native<
@@ -3248,10 +3251,8 @@ external void Renderer_readPixels(
     ffi.Pointer<TRenderTarget>,
     ffi.UnsignedInt,
     ffi.UnsignedInt,
-    ffi.Pointer<ffi.Uint8>,
     ffi.Size,
-    ffi.Uint32,
-    VoidCallback,
+    ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Uint8>)>>,
   )
 >(isLeaf: true)
 external void Renderer_readPixelsRenderThread(
@@ -3263,10 +3264,8 @@ external void Renderer_readPixelsRenderThread(
   ffi.Pointer<TRenderTarget> tRenderTarget,
   int tPixelBufferFormat,
   int tPixelDataType,
-  ffi.Pointer<ffi.Uint8> out,
   int outLength,
-  int requestId,
-  VoidCallback onComplete,
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Uint8>)>> onComplete,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderer>, ffi.Pointer<TView>)>(isLeaf: true)

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1631,6 +1631,7 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     JSBigInt frameTimeInNanos,
     Pointer<NativeFunction<void Function(bool)>> onComplete,
   );
+  external void _Renderer_copyPixelsAndRelease(Pointer<Uint8> pixels, Pointer<Uint8> out, size_t length);
   external void _Renderer_endFrame(Pointer<TRenderer> tRenderer);
   external void _Renderer_endFrameRenderThread(Pointer<TRenderer> tRenderer, int requestId, VoidCallback onComplete);
   external void _Renderer_readPixels(
@@ -1642,8 +1643,8 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TRenderTarget> tRenderTarget,
     int tPixelBufferFormat,
     int tPixelDataType,
-    Pointer<Uint8> out,
     size_t outLength,
+    Pointer<NativeFunction<void Function(PointerClass<Uint8>)>> onComplete,
   );
   external void _Renderer_readPixelsRenderThread(
     Pointer<TRenderer> tRenderer,
@@ -1654,10 +1655,8 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     Pointer<TRenderTarget> tRenderTarget,
     int tPixelBufferFormat,
     int tPixelDataType,
-    Pointer<Uint8> out,
     size_t outLength,
-    int requestId,
-    VoidCallback onComplete,
+    Pointer<NativeFunction<void Function(PointerClass<Uint8>)>> onComplete,
   );
   external void _Renderer_render(Pointer<TRenderer> tRenderer, Pointer<TView> tView);
   external void _Renderer_renderRenderThread(
@@ -6827,6 +6826,11 @@ void Renderer_beginFrameRenderThread(
   return result;
 }
 
+void Renderer_copyPixelsAndRelease(Pointer<Uint8> pixels, Pointer<Uint8> out, Dartsize_t length) {
+  final result = GeneratedBindings.instance._Renderer_copyPixelsAndRelease(pixels, out, length);
+  return result;
+}
+
 void Renderer_endFrame(Pointer<TRenderer> tRenderer) {
   final result = GeneratedBindings.instance._Renderer_endFrame(tRenderer.cast());
   return result;
@@ -6850,8 +6854,8 @@ void Renderer_readPixels(
   Pointer<TRenderTarget> tRenderTarget,
   int tPixelBufferFormat,
   int tPixelDataType,
-  Pointer<Uint8> out,
   Dartsize_t outLength,
+  Pointer<NativeFunction<void Function(Pointer<Uint8>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Renderer_readPixels(
     tRenderer.cast(),
@@ -6862,8 +6866,8 @@ void Renderer_readPixels(
     tRenderTarget.cast(),
     tPixelBufferFormat,
     tPixelDataType,
-    out,
     outLength,
+    onComplete.cast(),
   );
   return result;
 }
@@ -6877,10 +6881,8 @@ void Renderer_readPixelsRenderThread(
   Pointer<TRenderTarget> tRenderTarget,
   int tPixelBufferFormat,
   int tPixelDataType,
-  Pointer<Uint8> out,
   Dartsize_t outLength,
-  int requestId,
-  DartVoidCallback onComplete,
+  Pointer<NativeFunction<void Function(Pointer<Uint8>)>> onComplete,
 ) {
   final result = GeneratedBindings.instance._Renderer_readPixelsRenderThread(
     tRenderer.cast(),
@@ -6891,10 +6893,8 @@ void Renderer_readPixelsRenderThread(
     tRenderTarget.cast(),
     tPixelBufferFormat,
     tPixelDataType,
-    out,
     outLength,
-    requestId,
-    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+    onComplete.cast(),
   );
   return result;
 }

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -959,7 +959,7 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       throw Exception("Failed to begin frame");
     }
 
-    final pixelBuffers = <(View, Uint8List)>[];
+    final pendingReadbacks = <Future<(View, Uint8List)>>[];
 
     final views = <View>[];
     if (view != null) {
@@ -980,17 +980,6 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     }
 
     _logger.finest("Starting capture for ${views.length} views");
-
-    late Pointer stackPtr;
-    if (FILAMENT_WASM) {
-      stackPtr = stackSave();
-    }
-
-    // Per-view "was this read as UBYTE for a FLOAT request?" flags. The
-    // downgrade-on-web rule depends on the framebuffer being read from
-    // (RGBA8 swapchain/RT → must use UBYTE; FLOAT RT → must use FLOAT),
-    // so we compute it per-view and inflate back to FLOAT in the return.
-    final inflateFromUByte = <bool>[];
 
     for (var viewIndex = 0; viewIndex < views.length; viewIndex++) {
       final view = views[viewIndex];
@@ -1015,7 +1004,6 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       }
       final readAsUByteForFloat = FILAMENT_SINGLE_THREADED && pixelDataType == PixelDataType.FLOAT && !rtIsFloat;
       final readType = readAsUByteForFloat ? PixelDataType.UBYTE : pixelDataType;
-      inflateFromUByte.add(readAsUByteForFloat);
 
       beforeRender?.call(view);
 
@@ -1042,7 +1030,6 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
       }
 
       final numBytes = viewport.width * viewport.height * numChannels * channelSizeInBytes;
-      final pixelBuffer = makeUint8List(numBytes);
 
       if (render) {
         await withVoidCallback((requestId, cb) {
@@ -1057,23 +1044,49 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
         );
       }
 
-      await withVoidCallback((requestId, cb) {
-        Renderer_readPixelsRenderThread(
-          renderer,
-          viewport.width,
-          viewport.height,
-          0,
-          0,
-          renderTarget == null ? nullptr : renderTarget.getNativeHandle(),
-          pixelDataFormat.value,
-          readType.value,
-          pixelBuffer.address,
-          pixelBuffer.length,
-          requestId,
-          cb,
-        );
-      });
-      pixelBuffers.add((view, pixelBuffer));
+      // Keep submitting the frame: waiting here would prevent the GPU from
+      // receiving the endFrame/flush needed to finish this readback.
+      pendingReadbacks.add(
+        withPointerCallback<Uint8>((cb) {
+          Renderer_readPixelsRenderThread(
+            renderer,
+            viewport.width,
+            viewport.height,
+            0,
+            0,
+            renderTarget == null ? nullptr : renderTarget.getNativeHandle(),
+            pixelDataFormat.value,
+            readType.value,
+            numBytes,
+            cb,
+          );
+        }).then((pixels) {
+          // Allocate the final output only after Filament has finished. On web,
+          // makeUint8List may use the WASM stack: finish copying/converting it
+          // synchronously, before any await can restore or reuse that stack.
+          final stack = FILAMENT_WASM ? stackSave() : null;
+          final pixelBuffer = makeUint8List(numBytes);
+          try {
+            Renderer_copyPixelsAndRelease(pixels, pixelBuffer.address, numBytes);
+            if (!FILAMENT_WASM) return (view, pixelBuffer);
+            if (readAsUByteForFloat) {
+              // Existing WebGL RGBA8 -> FLOAT result conversion.
+              final floats = Float32List(numBytes);
+              for (var j = 0; j < numBytes; j++) {
+                floats[j] = pixelBuffer[j] / 255.0;
+              }
+              return (view, Uint8List.view(floats.buffer));
+            }
+            // Transfer the WASM result into managed browser storage.
+            return (view, Uint8List.fromList(pixelBuffer));
+          } finally {
+            if (FILAMENT_WASM) {
+              pixelBuffer.free();
+              stackRestore(stack!);
+            }
+          }
+        }),
+      );
     }
 
     await withVoidCallback((requestId, cb) {
@@ -1082,13 +1095,8 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
     await flush();
 
-    // on web/WebGL backend, the callback in readPixels isn't actually
-    // fired until a subsequent render call (and possibly the presentation to
-    // the canvas when the render thread yields).
-    // We need to wait at least one frame before the pixel buffer is populated;
-    // by this point, we've called setRendering(true), but this is actually
-    // synchronous, so we'll add a ~2 frame delay to wait for this to be
-    // available.
+    // WebGL needs another frame to poll readback fences. Completion below,
+    // rather than a timed delay, determines when the bytes are ready.
     if (FILAMENT_SINGLE_THREADED) {
       await withBoolCallback(
         (cb) => Renderer_beginFrameRenderThread(renderer, swapChain!.getNativeHandle(), 0.toBigInt, cb),
@@ -1102,42 +1110,15 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
         Renderer_endFrameRenderThread(renderer, requestId, cb);
       });
       await flush();
-
-      await Future.delayed(Duration(milliseconds: 33));
-
-      // now copy the pixel buffer into a GC'd Uint8List and destroy the
-      // manually allocated buffer so invokers don't have to worry about taking
-      // ownership of malloc memory
-      final result = <(View, Uint8List)>[];
-      for (var i = 0; i < pixelBuffers.length; i++) {
-        final (view, raw) = pixelBuffers[i];
-        final Uint8List out;
-        if (inflateFromUByte[i]) {
-          // Inflate the 8-bit readback to the float buffer callers expect:
-          // one float32 in [0,1] per source byte.
-          final floats = Float32List(raw.length);
-          for (var j = 0; j < raw.length; j++) {
-            floats[j] = raw[j] / 255.0;
-          }
-          out = floats.asUint8List();
-        } else {
-          out = Uint8List.fromList(raw);
-        }
-        raw.free();
-        result.add((view, out));
-      }
-
-      if (FILAMENT_WASM) {
-        stackRestore(stackPtr);
-      }
-      return result;
     }
 
-    if (pauseTicking) {
-      RenderManager_setPaused(renderManager.getNativeHandle(), false);
+    try {
+      return await Future.wait(pendingReadbacks);
+    } finally {
+      if (pauseTicking) {
+        RenderManager_setPaused(renderManager.getNativeHandle(), false);
+      }
     }
-
-    return pixelBuffers;
   }
 
   //

--- a/thermion_dart/native/include/ReadPixels.hpp
+++ b/thermion_dart/native/include/ReadPixels.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <functional>
+#include "c_api/TRenderer.h"
+
+namespace thermion {
+// Called on the renderer's thread. Completion transfers the native pixel buffer
+// to the consumer only after Filament has finished writing it.
+void Renderer_readPixelsOwned(TRenderer*, uint32_t width, uint32_t height,
+    uint32_t x, uint32_t y, TRenderTarget*, TPixelDataFormat, TPixelDataType,
+    size_t length, std::function<void(uint8_t*)> onComplete);
+}

--- a/thermion_dart/native/include/c_api/TRenderer.h
+++ b/thermion_dart/native/include/c_api/TRenderer.h
@@ -15,15 +15,21 @@ EMSCRIPTEN_KEEPALIVE bool Renderer_beginFrame(TRenderer *tRenderer, TSwapChain *
 EMSCRIPTEN_KEEPALIVE void Renderer_endFrame(TRenderer *tRenderer);
 EMSCRIPTEN_KEEPALIVE void Renderer_render(TRenderer *tRenderer, TView *tView);
 EMSCRIPTEN_KEEPALIVE void Renderer_renderStandaloneView(TRenderer *tRenderer, TView *tView);
+// Completion transfers a native buffer after Filament finishes writing it.
+// Submit/end/flush the frame before waiting. Release the result exactly once
+// with Renderer_copyPixelsAndRelease, using the same length as this request.
 EMSCRIPTEN_KEEPALIVE void Renderer_readPixels(
     TRenderer *tRenderer,
     uint32_t width, uint32_t height, uint32_t xOffset, uint32_t yOffset,
     TRenderTarget *tRenderTarget,
     TPixelDataFormat tPixelBufferFormat,
     TPixelDataType tPixelDataType,
-    uint8_t *out,
-    size_t outLength
+    size_t outLength,
+    void (*onComplete)(uint8_t*)
 );
+// Synchronously copies a completed readback into out and releases its storage.
+// out must have length bytes. Neither pointer may be used by another call.
+EMSCRIPTEN_KEEPALIVE void Renderer_copyPixelsAndRelease(uint8_t *pixels, uint8_t *out, size_t length);
 EMSCRIPTEN_KEEPALIVE void Renderer_setFrameInterval(
     TRenderer *tRenderer,
     float headRoomRatio,

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -101,15 +101,16 @@ namespace thermion
         EMSCRIPTEN_KEEPALIVE void Renderer_endFrameRenderThread(TRenderer *tRenderer, uint32_t requestId,  VoidCallback onComplete);
         EMSCRIPTEN_KEEPALIVE void Renderer_renderRenderThread(TRenderer *tRenderer, TView *tView, uint32_t requestId,  VoidCallback onComplete);
         EMSCRIPTEN_KEEPALIVE void Renderer_renderStandaloneViewRenderThread(TRenderer *tRenderer, TView *tView, uint32_t requestId,  VoidCallback onComplete);
+        // Completion transfers native-owned pixels after the GPU read completes.
+        // End and flush the frame before awaiting it; copy/release via Renderer_copyPixelsAndRelease.
         EMSCRIPTEN_KEEPALIVE void Renderer_readPixelsRenderThread(
             TRenderer *tRenderer,
             uint32_t width, uint32_t height, uint32_t xOffset, uint32_t yOffset,
             TRenderTarget *tRenderTarget,
             TPixelDataFormat tPixelBufferFormat,
             TPixelDataType tPixelDataType,
-            uint8_t *out,
             size_t outLength,
-            uint32_t requestId,  VoidCallback onComplete);
+            void (*onComplete)(uint8_t*));
 
         EMSCRIPTEN_KEEPALIVE void Material_createInstanceRenderThread(TMaterial *tMaterial, void (*onComplete)(TMaterialInstance *));
         EMSCRIPTEN_KEEPALIVE void MaterialInstance_setParameterTextureRenderThread(TMaterialInstance *tMaterialInstance, const char *propertyName, TTexture* tTexture, TTextureSampler* tSampler, uint32_t requestId, VoidCallback onComplete);

--- a/thermion_dart/native/src/c_api/TRenderer.cpp
+++ b/thermion_dart/native/src/c_api/TRenderer.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+#include "ReadPixels.hpp"
 #ifdef _WIN32
 #include "ThermionWin32.h"
 #endif
@@ -77,57 +79,62 @@ EMSCRIPTEN_KEEPALIVE void Renderer_setFrameRateOptions(
     renderer->setFrameRateOptions(fro);
 }
 
-class CaptureCallbackHandler : public filament::backend::CallbackHandler
-{
-  void post(void *user, Callback callback)
-  {
-    callback(user);
-    delete this;
-  }
+EMSCRIPTEN_KEEPALIVE void Renderer_readPixels(
+    TRenderer *renderer,
+    uint32_t width, uint32_t height, uint32_t x, uint32_t y,
+    TRenderTarget *target, TPixelDataFormat format, TPixelDataType type,
+    size_t length, void (*onComplete)(uint8_t*)) {
+    Renderer_readPixelsOwned(renderer, width, height, x, y, target, format, type,
+        length, onComplete);
+}
+
+EMSCRIPTEN_KEEPALIVE void Renderer_copyPixelsAndRelease(uint8_t *pixels, uint8_t *out, size_t length) {
+    // The only write into Dart storage occurs synchronously in this FFI call.
+    std::memcpy(out, pixels, length);
+    delete[] pixels;
+}
+
+} // extern "C"
+
+class PixelReadback : public filament::backend::CallbackHandler {
+public:
+    explicit PixelReadback(size_t length, std::function<void(uint8_t*)> completion)
+        : pixels(new uint8_t[length]), onComplete(std::move(completion)) {}
+    uint8_t *pixels;
+    std::function<void(uint8_t*)> onComplete;
+
+    void post(void *user, Callback callback) override {
+        callback(user);
+        delete this;
+    }
 };
 
-
-EMSCRIPTEN_KEEPALIVE void Renderer_readPixels(
+void Renderer_readPixelsOwned(
     TRenderer *tRenderer,
-    uint32_t width, uint32_t height, uint32_t xOffset, uint32_t yOffset,
-    TRenderTarget *tRenderTarget,
-    TPixelDataFormat tPixelBufferFormat,
-    TPixelDataType tPixelDataType,
-    uint8_t *out, 
-    size_t outLength) {
-    
+    uint32_t width, uint32_t height, uint32_t x, uint32_t y,
+    TRenderTarget *tRenderTarget, TPixelDataFormat format, TPixelDataType type,
+    size_t length, std::function<void(uint8_t*)> onComplete) {
     auto *renderer = reinterpret_cast<filament::Renderer *>(tRenderer);
-    auto *renderTarget = reinterpret_cast<filament::RenderTarget *>(tRenderTarget);
-
-    filament::backend::PixelDataFormat pixelBufferFormat = static_cast<filament::backend::PixelDataFormat>(tPixelBufferFormat);
-    filament::backend::PixelDataType pixelDataType = static_cast<filament::backend::PixelDataType>(tPixelDataType);
-
-    auto *dispatcher = new CaptureCallbackHandler();
-    auto callback = [](void *buf, size_t size, void *data)
-    {
-      
-    };
-
-
-    auto pbd = filament::Texture::PixelBufferDescriptor(
-        out, outLength,
-        pixelBufferFormat,
-        pixelDataType,
-        dispatcher,
-        callback,
-        out
-    );
-
-    if(renderTarget) {
-        renderer->readPixels(renderTarget, xOffset, yOffset, width, height, std::move(pbd));
+    auto *target = reinterpret_cast<filament::RenderTarget *>(tRenderTarget);
+    auto *readback = new PixelReadback(length, std::move(onComplete));
+    filament::Texture::PixelBufferDescriptor pbd(
+        readback->pixels, length,
+        static_cast<filament::backend::PixelDataFormat>(format),
+        static_cast<filament::backend::PixelDataType>(type),
+        1, 0, 0, 0, // tightly packed rows, including odd-width RGB captures
+        readback,
+        [](void*, size_t, void *user) {
+            auto *readback = static_cast<PixelReadback*>(user);
+            // The consumer now owns pixels; the handler releases only its context.
+            readback->onComplete(readback->pixels);
+        }, readback);
+    if (target) {
+        renderer->readPixels(target, x, y, width, height, std::move(pbd));
     } else {
-        renderer->readPixels(xOffset, yOffset, width, height, std::move(pbd));
+        renderer->readPixels(x, y, width, height, std::move(pbd));
     }
-
 }
-
 
 #ifdef __cplusplus
-    }
-}
+} // namespace thermion
 #endif

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -1,3 +1,4 @@
+#include "ReadPixels.hpp"
 #include <atomic>
 #include <math/mat4.h>
 #include <functional>
@@ -835,16 +836,16 @@ extern "C"
       TRenderTarget *tRenderTarget,
       TPixelDataFormat tPixelBufferFormat,
       TPixelDataType tPixelDataType,
-      uint8_t *out,
       size_t outLength,
-      uint32_t requestId, VoidCallback onComplete)
+      void (*onComplete)(uint8_t*))
   {
     auto *rt = RT(tRenderer);
     std::packaged_task<void()> lambda(
         [=]() mutable
         {
-          Renderer_readPixels(tRenderer, width, height, xOffset, yOffset, tRenderTarget, tPixelBufferFormat, tPixelDataType, out, outLength);
-          PROXY(onComplete(requestId));
+          Renderer_readPixelsOwned(tRenderer, width, height, xOffset, yOffset,
+              tRenderTarget, tPixelBufferFormat, tPixelDataType, outLength,
+              [rt, onComplete](uint8_t *pixels) { PROXY(onComplete(pixels)); });
         });
     auto fut = rt->addTask(lambda);
   }

--- a/thermion_dart/test/capture_buffer_lifetime_test.dart
+++ b/thermion_dart/test/capture_buffer_lifetime_test.dart
@@ -1,0 +1,69 @@
+import 'package:test/test.dart';
+import 'package:thermion_dart/thermion_dart.dart';
+import 'helpers.dart';
+
+void main() async {
+  final helper = TestHelper('capture_buffer_lifetime');
+  await helper.setup();
+
+  for (final (format, type) in [
+    (TextureFormat.RGBA8, PixelDataType.UBYTE),
+    (TextureFormat.RGBA8, PixelDataType.FLOAT),
+    (TextureFormat.RGBA32F, PixelDataType.FLOAT),
+  ]) {
+    test('capture returns completed independent $format / $type pixels', () async {
+      final (viewer, swapChain) = await helper.createViewer(
+        bg: kRed,
+        createRenderTarget: format == TextureFormat.RGBA32F,
+      );
+      // Use an attachment so browser presentation cannot clear the framebuffer
+      // between queued calls. Match the attachment's supported readback type.
+      final target = format == TextureFormat.RGBA8 ? await FilamentApp.instance!.createRenderTarget(512, 512) : null;
+      final color = await target?.getColorTexture();
+      final depth = await target?.getDepthTexture();
+      if (target != null) await viewer.view.setRenderTarget(target);
+      try {
+        await helper.capture(
+          viewer.view,
+          null,
+          swapChain: swapChain,
+          pixelDataType: type,
+        ); // Warm up backend shader compilation.
+        final first = (await helper.capture(
+          viewer.view,
+          null,
+          swapChain: swapChain,
+          pixelDataType: type,
+        ))[viewer.view]!;
+        final viewport = await viewer.view.getViewport();
+        expect(first.length, viewport.width * viewport.height * 4 * (type == PixelDataType.FLOAT ? 4 : 1));
+        if (type == PixelDataType.UBYTE) {
+          expect(first.take(4), [255, 0, 0, 255]);
+        } else {
+          final floats = Float32List.view(first.buffer, first.offsetInBytes, first.length ~/ 4);
+          expect(floats[0], closeTo(1, 0.01));
+          expect(floats[1], closeTo(0, 0.01));
+          expect(floats[2], closeTo(0, 0.01));
+          expect(floats[3], closeTo(1, 0.01));
+        }
+        // The returned result is managed storage; another capture cannot reuse it.
+        first.fillRange(0, first.length, 0x5a);
+        final second = (await helper.capture(
+          viewer.view,
+          null,
+          swapChain: swapChain,
+          pixelDataType: type,
+        ))[viewer.view]!;
+        expect(second, isNot(everyElement(0x5a)));
+        expect(first, everyElement(0x5a));
+      } finally {
+        await viewer.dispose();
+        if (target != null) await target.destroy();
+        await color?.destroy();
+        await depth?.destroy();
+        await helper.disposeColorGradings();
+        await FilamentApp.instance!.destroySwapChain(swapChain);
+      }
+    });
+  }
+}


### PR DESCRIPTION
Capture gave Filament a pointer into Dart output storage and completed its queued callback when the read was submitted. The GPU could still be writing after that callback and after the FFI borrow had ended. Waiting a fixed amount of time did not establish that the pixels were ready.

Allocate the readback buffer in C++ and deliver its pointer through the callback only when Filament finishes writing. Dart then uses one synchronous native call to copy into its final result and release the native buffer. There is no Dart staging buffer for the asynchronous read.

Capture submits the read, ends and flushes the frame, then awaits completion. WebGL also submits the frame needed to poll its fence. Browser output copying and float conversion finish within the same synchronous callback, so temporary WASM stack storage does not span an `await`.

The internal C readback signatures change, and native/web bindings are regenerated from those headers. The headers document ownership, release, and the need to submit/flush before waiting. Public Dart capture signatures stay the same.

Validation: all three dedicated capture tests pass on macOS/Metal and Chrome/WebGL against independently built native/WASM libraries. They use explicit render targets and cover RGBA8 byte output, RGBA8 float conversion, RGBA32F output, and independence of successive results. `flutter analyze` reports the same 47 existing diagnostics.

Based on `develop`; can merge independently of #332.
