### PR TITLE
Fix the cubemap test's creation depth

### DIFF
--- a/thermion_dart/test/texture_tests.dart
+++ b/thermion_dart/test/texture_tests.dart
@@ -46,10 +46,10 @@ void main() async {
 
   test('set cubemap texture from pixel buffer', () async {
     await ViewerBuilder(testHelper).setBackgroundColor(kRed).execute((result) async {
+      // A single cubemap uses depth 1 (the default); its six faces are implicit.
       final texture = await FilamentApp.instance!.createTexture(
         1,
         1,
-        depth: 6,
         textureSamplerType: TextureSamplerType.SAMPLER_CUBEMAP,
         textureFormat: TextureFormat.RGBA32F,
       );


### PR DESCRIPTION
The cubemap upload test passes `depth: 6` when creating a single cubemap. This causes Metal to abort during texture creation. Remove the argument to use the existing default of one. The six faces are still present, and the test still uploads them using `zOffset: 0..5`. This PR changes only the test and adds a comment explaining the default.

Why this also applies to other backends:

- **Metal:** Filament forwards builder depth into the descriptor's array length. A single Metal cubemap requires an array length of one; its six faces are implicit. See [Filament's descriptor construction](https://github.com/google/filament/blob/v1.75.0/filament/backend/src/metal/MetalHandles.mm#L722-L734) and [Apple's array-length requirements](https://developer.apple.com/documentation/metal/mtltexturedescriptor/arraylength?language=objc).
- **Vulkan (used by Thermion on Windows, and optionally Linux):** Filament creates a 2D image and sets its array-layer count to six separately. It also forwards builder depth into the image extent. Vulkan requires a 2D image's extent depth to be one, so the original `depth: 6` produces invalid creation parameters according to the source and specification. This is a source-level finding, not a reproduced Windows failure. See [Filament's image construction](https://github.com/google/filament/blob/v1.75.0/filament/backend/src/vulkan/VulkanTexture.cpp#L404-L428) and [Vulkan requirement VUID-VkImageCreateInfo-imageType-00957](https://docs.vulkan.org/refpages/latest/refpages/source/VkImageCreateInfo.html#VUID-VkImageCreateInfo-imageType-00957). Uploads [select array layers using `zOffset`](https://github.com/google/filament/blob/v1.75.0/filament/backend/src/vulkan/VulkanTexture.cpp#L625-L634), independently of creation depth.
- **OpenGL / OpenGL ES (used on Android and Linux) and WebGL:** Filament's ordinary cubemap allocation uses width and height and ignores builder depth. Face uploads select the cube face using `zOffset`. Removing the argument therefore preserves allocation and face selection on this path. See [allocation](https://github.com/google/filament/blob/v1.75.0/filament/backend/src/opengl/OpenGLDriver.cpp#L995-L1026) and [uploads](https://github.com/google/filament/blob/v1.75.0/filament/backend/src/opengl/OpenGLDriver.cpp#L3586-L3606).

There is an upstream documentation inconsistency: [Filament documents `Builder::depth()` as having no effect for an ordinary cubemap](https://github.com/google/filament/blob/v1.75.0/filament/include/filament/Texture.h#L147-L156), but Metal and Vulkan still use the supplied value. This test correction uses the documented default; changing Filament to ignore the argument consistently would be a separate upstream fix. The relevant allocation and face-upload behavior was also checked in v1.76.0.

