### PR TITLE
Restore the skinning test's reviewed golden filename

### DIFF
--- a/thermion_dart/test/renderable_manager_tests.dart
+++ b/thermion_dart/test/renderable_manager_tests.dart
@@ -444,7 +444,10 @@ void main() async {
           await camera.lookAt(Vector3(0, 0, 2), focus: Vector3.zero(), up: Vector3(0, 1, 0));
 
           // Initial pose: both bones identity.
-          final initial = await testHelper.capture(result.viewer.view, "skinned_initial_pose_$inputType");
+          final initial = await testHelper.capture(
+            result.viewer.view,
+            inputType == 'matrices' ? "skinned_initial_pose" : null,
+          );
           int foregroundPixelCount(Uint8List buffer) {
             final pixels = buffer.buffer.asFloat32List(buffer.offsetInBytes, buffer.lengthInBytes ~/ 4);
             var count = 0;


### PR DESCRIPTION
#340 parameterized the skinning test and renamed its initial-pose capture, so golden comparison reports one missing file and three extra files. Keep the original filename for the matrix case; the additional cases still check pixels but do not write extra golden images.

Checked the captured CI artifacts with this filename correction against the reviewed baselines: all 257 Linux, 197 Windows and 71 macOS images match pixel-for-pixel. No baseline images or comparison settings change.
