### PR TITLE
fix: set keepIsolateAlive to false when native void callbacks finish executing to ensure Dart isolates exit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- Let Dart isolates exit after their native void callbacks finish, without
+  closing the shared callback listener while requests are still pending.
 - Upgrade Filament from 1.75.0 to 1.76.0 and expose the bundled release through
   the public Dart `filamentVersion` constant (#327).
 - Include WebGPU-capable `matc` and `resgen` tools in the standard Linux archives

--- a/thermion_dart/lib/src/bindings/src/void_callback_registry.dart
+++ b/thermion_dart/lib/src/bindings/src/void_callback_registry.dart
@@ -7,13 +7,17 @@ import 'dart:ffi';
 /// request ID. A single trampoline is retained for the registry lifetime so
 /// concurrent native requests cannot call metadata from a collected
 /// [NativeCallable].
+/// The listener keeps the isolate alive while requests are pending, but lets
+/// it exit after successful completion. Stop native workers before killing
+/// their isolate or closing this registry.
 class VoidCallbackRegistry {
   int _nextRequestId = 0;
   final _requests = <int, Completer<void>>{};
+  bool _dispatchFailed = false;
 
   late final NativeCallable<Void Function(Int32)> _nativeCallable = NativeCallable<Void Function(Int32)>.listener(
     _complete,
-  );
+  )..keepIsolateAlive = false;
 
   int get pendingRequestCount => _requests.length;
 
@@ -32,16 +36,23 @@ class VoidCallbackRegistry {
     _requests[requestId] = completer;
 
     try {
+      _nativeCallable.keepIsolateAlive = true;
       dispatch.call(requestId, _nativeCallable.nativeFunction.cast());
+      await completer.future;
     } catch (_) {
-      _requests.remove(requestId);
+      // Dispatch may have submitted native work before throwing. Without a
+      // completion guarantee, preserve the listener's previous keep-alive
+      // behavior until the caller stops its workers and closes the registry.
+      _dispatchFailed = true;
       rethrow;
+    } finally {
+      _requests.remove(requestId);
+      _nativeCallable.keepIsolateAlive = _requests.isNotEmpty || _dispatchFailed;
     }
-
-    await completer.future;
   }
 
   void close() {
+    if (_requests.isNotEmpty) throw StateError('Cannot close a registry with pending callbacks');
     _nativeCallable.close();
   }
 }

--- a/thermion_dart/test/ffi_void_callback_test.dart
+++ b/thermion_dart/test/ffi_void_callback_test.dart
@@ -1,9 +1,68 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:ffi';
+import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:thermion_dart/src/bindings/src/void_callback_registry.dart';
 
 void main() {
+  for (final mode in ['completed', 'pending', 'dispatch-failure']) {
+    test('callback listener permits process exit: $mode', () async {
+      final process = await Process.start(Platform.resolvedExecutable, ['test/fixtures/void_callback_exit.dart', mode]);
+      final output = process.stdout.transform(utf8.decoder).join();
+      final errors = process.stderr.transform(utf8.decoder).join();
+      try {
+        final code = await process.exitCode.timeout(const Duration(seconds: 10));
+        expect(code, 0, reason: await errors);
+        expect(await output, switch (mode) {
+          'pending' => allOf(contains('completed 50'), contains('completed 200')),
+          'dispatch-failure' => contains('dispatch failed'),
+          _ => contains('completed'),
+        });
+      } finally {
+        process.kill();
+        await process.exitCode;
+        await Future.wait([output, errors]);
+      }
+    });
+  }
+
+  test('dispatch failure preserves keep-alive even after a later successful request', () async {
+    final process = await Process.start(Platform.resolvedExecutable, [
+      'test/fixtures/void_callback_exit.dart',
+      'failed-retained',
+    ]);
+    final ready = Completer<void>();
+    final output = process.stdout.transform(utf8.decoder).transform(const LineSplitter()).forEach((line) {
+      if (line == 'completed after failure') ready.complete();
+    });
+    final errors = process.stderr.transform(utf8.decoder).join();
+    try {
+      await ready.future.timeout(const Duration(seconds: 10));
+      // A dispatch error cannot prove native completion, even if another
+      // request succeeds later. Retain the previous keep-alive behavior.
+      await expectLater(process.exitCode.timeout(const Duration(milliseconds: 200)), throwsA(isA<TimeoutException>()));
+    } finally {
+      process.kill();
+      await process.exitCode;
+      await output;
+      await errors;
+    }
+  });
+
+  test('cannot close while callbacks are pending', () async {
+    final registry = VoidCallbackRegistry();
+    late void Function() complete;
+    final pending = registry.invoke((id, callback) {
+      complete = () => callback.asFunction<void Function(int)>()(id);
+    });
+    expect(registry.close, throwsStateError);
+    complete();
+    await pending;
+    registry.close();
+  });
+
   test('completed void callbacks are removed from the request registry', () async {
     final registry = VoidCallbackRegistry();
     late int completedRequestId;

--- a/thermion_dart/test/fixtures/void_callback_exit.dart
+++ b/thermion_dart/test/fixtures/void_callback_exit.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:isolate';
+
+// A relative import lets this subprocess exercise only Dart FFI, without
+// running Thermion's native build hook or creating a rendering engine.
+import '../../lib/src/bindings/src/void_callback_registry.dart';
+
+final registry = VoidCallbackRegistry();
+
+Future<void> completeFromWorker(List<int> request) async {
+  await Future<void>.delayed(Duration(milliseconds: request[2]));
+  final callback = Pointer<NativeFunction<Void Function(Int32)>>.fromAddress(request[0]);
+  callback.asFunction<void Function(int)>()(request[1]);
+}
+
+Future<void> main(List<String> args) async {
+  if (args.single == 'dispatch-failure' || args.single == 'failed-retained') {
+    try {
+      await registry.invoke((_, __) => throw StateError('failed before submission'));
+    } on StateError {
+      print('dispatch failed');
+    }
+    if (args.single == 'failed-retained') {
+      await registry.invoke((id, callback) {
+        callback.asFunction<void Function(int)>()(id);
+      });
+      print('completed after failure');
+    } else {
+      // The registry cannot know whether a failed dispatch submitted native
+      // work. This fixture submitted none, so explicit close is safe.
+      registry.close();
+    }
+  } else if (args.single == 'pending') {
+    // The worker isolates keep the process alive, but must not be what keeps
+    // this isolate alive. No receive port or timer is retained in this isolate.
+    // If the listener is unreferenced while requests are pending, a worker will
+    // call a dead isolate. The parent test confines that failure to this process.
+    for (final delay in [50, 200]) {
+      unawaited(
+        registry
+            .invoke((id, callback) {
+              unawaited(Isolate.spawn(completeFromWorker, [callback.address, id, delay]));
+            })
+            .then((_) => print('completed $delay')),
+      );
+    }
+  } else {
+    await registry.invoke((id, callback) {
+      callback.asFunction<void Function(int)>()(id);
+    });
+    print('completed');
+  }
+  // Successful cases deliberately do not close the process-wide registry:
+  // production retains it after the final engine stops.
+}


### PR DESCRIPTION
After a native void callback finishes, Thermion's shared `NativeCallable.listener` still keeps its Dart isolate alive. This means a command-line program can finish its work but never exit. This PR keeps the isolate alive while requests are pending and releases that keep-alive after successful completion. It also rejects closing the registry while callbacks are pending.

If Dart dispatch throws, we cannot tell whether it already queued native work. The registry therefore preserves its previous keep-alive behavior until its owner stops the workers and closes it, even if a later request succeeds. This does not add generic dispatch-error recovery or claim that a Dart error permits freeing borrowed buffers or callbacks. Workers must be stopped before their isolate is explicitly killed.

