### PR TITLE
fix(web): apply FPS limits independently on each render worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- Apply the web target frame rate to actual worker drawing, independently for each engine.
+
 - Let web commands and upload callbacks progress without animation frames, and
   await render-manager destruction on its worker before tearing down the engine (#301).
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -2668,6 +2668,9 @@ external void RenderManager_setRenderableRenderThread(
   VoidCallback onComplete,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Int)>(isLeaf: true)
+external void RenderManager_setTargetFps(ffi.Pointer<TRenderManager> tRenderManager, int fps);
+
 @ffi.Native<ffi.Pointer<TRenderTarget> Function(ffi.Pointer<TEngine>, ffi.Pointer<TTexture>, ffi.Pointer<TTexture>)>(
   isLeaf: true,
 )

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1337,6 +1337,7 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
+  external void _RenderManager_setTargetFps(Pointer<TRenderManager> tRenderManager, int fps);
   external Pointer<TRenderTarget> _RenderTarget_create(
     Pointer<TEngine> tEngine,
     Pointer<TTexture> color,
@@ -6084,6 +6085,11 @@ void RenderManager_setRenderableRenderThread(
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
+  return result;
+}
+
+void RenderManager_setTargetFps(Pointer<TRenderManager> tRenderManager, int fps) {
+  final result = GeneratedBindings.instance._RenderManager_setTargetFps(tRenderManager.cast(), fps);
   return result;
 }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -871,19 +871,22 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
 
   int _targetFramerate = 0;
 
-  /// The process-wide render-loop cap requested through [setTargetFramerate].
-  /// A value of zero means unlimited. Used by the web rAF scheduler; native
-  /// platforms keep the authoritative value in FrameSchedulerApi.cpp.
+  /// The render-loop cap requested through [setTargetFramerate]. Zero means
+  /// unlimited. Native admission is process-wide; each web engine applies its
+  /// own limit on the worker as well as pacing Dart's request-frame hooks.
   int get targetFramerate => _targetFramerate;
 
   //
   @override
   void setTargetFramerate(int fps) {
     _targetFramerate = fps > 0 ? fps : 0;
-    // Native platforms pace both display-link dispatch and Linux's
-    // Flutter-synced request-render path. Web reads [targetFramerate] from its
-    // requestAnimationFrame loop.
-    bindings.FrameScheduler_setTargetFps(_targetFramerate);
+    // Web must limit actual worker drawing as well as Dart's hook loop.
+    // Native platforms pace display-link dispatch and Linux's Flutter ticks.
+    if (FILAMENT_SINGLE_THREADED) {
+      bindings.RenderManager_setTargetFps(renderManager.getNativeHandle(), _targetFramerate);
+    } else {
+      bindings.FrameScheduler_setTargetFps(_targetFramerate);
+    }
   }
 
   //

--- a/thermion_dart/native/include/c_api/TRenderManager.h
+++ b/thermion_dart/native/include/c_api/TRenderManager.h
@@ -21,6 +21,7 @@ extern "C"
 	// synchronous render (requestRender). Dart branches on FILAMENT_SINGLE_THREADED
 	// and only calls these on the web build.
 	EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer);
+	EMSCRIPTEN_KEEPALIVE void RenderManager_setTargetFps(TRenderManager *tRenderManager, int fps);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderer);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_detachFromRenderThread(TRenderManager *tRenderManager);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_setPaused(TRenderManager *tRenderer, bool paused);

--- a/thermion_dart/native/include/rendering/RenderManager.hpp
+++ b/thermion_dart/native/include/rendering/RenderManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <vector>
@@ -22,6 +23,7 @@
 
 #include "scene/AnimationManager.hpp"
 #include "PluginAPI.hpp"
+#include "rendering/FrameRateGate.hpp"
 
 namespace thermion
 {
@@ -61,6 +63,9 @@ namespace thermion
         /// queued before pause complete cleanly and don't burst on resume.
         void setPaused(bool paused);
 
+        /// Limit actual web drawing independently for each engine; zero is unlimited.
+        void setTargetFps(int fps);
+
         /// Web path: called once per rAF from RenderThread's frame callback.
         /// Renders all attached swapchains synchronously (in practice there
         /// is only one on web — see ARCHITECTURE.md), then calls
@@ -92,6 +97,8 @@ namespace thermion
         void removeAnimationManager(AnimationManager *animationManager);
 
     private:
+        std::atomic<int> mTargetFps{0};
+        FrameRateGate mFrameRateGate;
         struct ViewAttachment
         {
             SwapChain *swapChain = nullptr;

--- a/thermion_dart/native/src/c_api/TRenderManager.cpp
+++ b/thermion_dart/native/src/c_api/TRenderManager.cpp
@@ -50,6 +50,11 @@ EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer)
     renderManager->requestRender();
 }
 
+EMSCRIPTEN_KEEPALIVE void RenderManager_setTargetFps(TRenderManager *tRenderer, int fps) {
+    auto *renderManager = reinterpret_cast<RenderManager *>(tRenderer);
+    renderManager->setTargetFps(fps);
+}
+
 EMSCRIPTEN_KEEPALIVE void RenderManager_setPaused(TRenderManager *tRenderer, bool paused) {
     auto *renderManager = reinterpret_cast<RenderManager *>(tRenderer);
     renderManager->setPaused(paused);

--- a/thermion_dart/native/src/rendering/RenderManager.cpp
+++ b/thermion_dart/native/src/rendering/RenderManager.cpp
@@ -246,7 +246,13 @@ namespace thermion
   void RenderManager::setPaused(bool paused)
   {
     std::lock_guard lock(mMutex);
+    if (mRenderPaused != paused) mFrameRateGate.reset();
     mRenderPaused = paused;
+  }
+
+  void RenderManager::setTargetFps(int fps)
+  {
+    mTargetFps.store(fps > 0 ? fps : 0, std::memory_order_relaxed);
   }
 
   void RenderManager::executePendingCommands()
@@ -273,7 +279,7 @@ namespace thermion
     // independent of whether a visible frame was produced. Skipping
     // execute() stalls the backend and causes a burst on resume.
     bool anyRendered = false;
-    if (!mRenderPaused) {
+    if (!mRenderPaused && mFrameRateGate.admit(frameTimeInNanos, mTargetFps.load(std::memory_order_relaxed))) {
       updateAnimationsAndPlugins(frameTimeInNanos);
 
       for (size_t i = 0; i < mViewAttachments.size(); i++)

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -151,7 +151,10 @@ dart run native/test/rendering/run_web_dispatch_test.dart /tmp/thermion-web-api/
 The drawing-enabled fixture creates two real engines and 32×32 views. It checks
 that both draw, one can pause/resume independently, and destroying one leaves the
 other drawing. It waits for both workers to exit. Frame histories establish
-progress, not physical presentation intervals or a particular FPS limit.
+progress. It also checks independent 30/10 FPS limits, swaps those limits, and
+allows timing variation while checking that worker drawing respects each cap.
+The browser must sustain more than 15 FPS for these checks. This does not measure
+physical presentation intervals.
 Its native helpers are opt-in test sources, excluded from normal builds.
 Run from the repository root, using a separate build directory:
 

--- a/thermion_dart/native/test/rendering/web_frame_test.dart
+++ b/thermion_dart/native/test/rendering/web_frame_test.dart
@@ -23,7 +23,7 @@ class _Engine {
   final Pointer<TRenderer> renderer;
   final Pointer<TRenderManager> manager;
 
-  static Future<_Engine> create(int slot) async {
+  static Future<_Engine> create(int slot, int fps) async {
     final selector = '#frame_canvas_$slot'.toNativeUtf8().cast<Char>();
     final worker = RenderThread_createForCanvas(selector);
     free(selector);
@@ -34,6 +34,7 @@ class _Engine {
     final renderer = await withPointerCallback<TRenderer>((cb) => Engine_createRendererRenderThread(engine, cb));
     final manager = RenderManager_create(engine, renderer);
     RenderManager_attachToRenderThread(manager);
+    RenderManager_setTargetFps(manager, fps);
     await withVoidCallback((id, cb) => _attachScene(engine.address, manager.address, slot, id, cb.address));
     return _Engine(slot, worker, engine, renderer, manager);
   }
@@ -62,11 +63,18 @@ Future<void> main() async {
   try {
     await (globalContext['__thermionReady'] as JSPromise).toDart;
     NativeLibrary.initBindings('thermion_dart');
-    final first = await _Engine.create(0);
-    final second = await _Engine.create(1);
+    final first = await _Engine.create(0, 30);
+    final second = await _Engine.create(1, 10);
     await Future<void>.delayed(const Duration(milliseconds: 300));
     final initial = await sample(first, second);
-    check(initial[0] > 0 && initial[1] > 0, 'Both engines must draw: $initial');
+    check(initial[0] > initial[1] * 1.5 && initial[1] >= 5, 'Independent 30/10 FPS limits failed: $initial');
+    check(initial[0] <= 34 && initial[1] <= 14, 'FPS limits exceeded: $initial');
+
+    RenderManager_setTargetFps(first.manager, 10);
+    RenderManager_setTargetFps(second.manager, 30);
+    final changed = await sample(first, second);
+    check(changed[1] > changed[0] * 1.5 && changed[0] >= 5, 'Changed 10/30 FPS limits failed: $changed');
+    check(changed[0] <= 14 && changed[1] <= 34, 'Changed FPS limits exceeded: $changed');
 
     RenderManager_setPaused(first.manager, true);
     await Future<void>.delayed(const Duration(milliseconds: 150));
@@ -86,7 +94,8 @@ Future<void> main() async {
       await Future<void>.delayed(const Duration(milliseconds: 10));
     }
     check(_liveWorkers() == 0, 'Workers remained alive after teardown');
-    globalContext['testResult'] = 'PASS: two engines drawing, pause/resume, independent teardown and worker exit'.toJS;
+    globalContext['testResult'] =
+        'PASS: real drawing, per-engine FPS $initial / $changed, pause/resume, independent teardown'.toJS;
   } catch (error, stack) {
     globalContext['testResult'] = 'FAIL: $error\n$stack'.toJS;
   }

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -303,7 +303,7 @@ Two things about this loop are load-bearing and easy to break accidentally. Both
 
 The flag was originally intended to gate rendering so Dart could control when frames are produced. In practice, both Dart's main-thread `_tick` and the worker's frame callback run at 60Hz but are **not phase-locked** — they're independent rAFs on different threads. When the worker rAF fires slightly before Dart's has set the flag, the worker finds it clear and skips, losing that frame. Over a second, phase drift costs ~5-10 fps (measured: ~50-55 fps instead of 60).
 
-The fix is to render unconditionally on every worker rAF and let Dart's flag-setting be a no-op. This matches pre-refactor semantics (the `RenderTicker` also ran every worker rAF once it was requested). The flag is kept in the API for symmetry with native but is not gating on the web path.
+The worker decides whether to draw on each animation frame, using its own target FPS gate. Dart's request flag does not gate drawing. Each web engine has an independent limit, and skipped frames do not stop the command pump or backend processing.
 
 ### Pause/resume on web
 


### PR DESCRIPTION
On web, `setTargetFramerate()` paces Dart's frame hooks, but the render worker has its own animation-frame loop. Limiting the hooks does not limit actual drawing: asking for 10 FPS can still leave the worker drawing at the browser's full frame rate.

This PR applies the requested limit where drawing happens. Each render manager uses the existing `FrameRateGate`, so two web engines can have different limits. Dart forwards a web app's requested rate to its render manager; native platforms continue using their existing scheduler.

The gate runs before animation updates and drawing. Commands and Filament backend processing continue when a frame is skipped, so a low FPS limit does not hold up uploads or other awaited operations. Zero means unlimited. Changing pause state resets the gate so rendering can resume promptly.

This is the FPS change split out of the closed #301. It is stacked on #348's separate native and web worker implementations and uses their browser test fixture. Review and merge order: **#349 → #347 → #348 → #346**. If a dependency is squash-merged, refresh the remaining stack onto the merged commit before continuing.

This PR contains one commit and changes 11 files: FPS limiting, its bindings, documentation, changelog, and test coverage.

Previously validated on macOS with Filament 1.76.0 and C++ exceptions disabled. The rebase changes ancestry only; its file tree is identical to the tested version:

- Rebuilt the full web module and ran the two-engine Chrome fixture. One-second samples were `[30, 10]`, then `[10, 30]` after swapping limits. Pause/resume, independent destruction, and worker exit also passed.
- The existing native scheduling suite passes and covers the shared gate's rate changes, unlimited mode, reset, stalls, and different source refresh rates.
- Bindings regenerated with `make bindings`; only the generated API additions are included. Targeted Dart analysis is clean. Flutter analysis reports seven existing informational notices.

The [manual test guide](https://github.com/nmfisher/thermion/blob/fix/web-worker-fps/thermion_dart/native/test/rendering/README.md#teardown-while-drawing) includes reproduction commands. The browser test counts Filament frames in headless Chrome/WebGL; it does not measure physical presentation timing or power savings.
