### PR TITLE
fix: decouple render command processing and teardown from animation frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changes
 
+- Let web commands and upload callbacks progress without animation frames, and
+  await render-manager destruction on its worker before tearing down the engine (#301).
+
 - Let Dart isolates exit after their native void callbacks finish, without
   closing the shared callback listener while requests are still pending.
 - Upgrade Filament from 1.75.0 to 1.76.0 and expose the bundled release through

--- a/thermion_dart/lib/src/bindings/src/js_interop.dart
+++ b/thermion_dart/lib/src/bindings/src/js_interop.dart
@@ -14,12 +14,6 @@ const FILAMENT_SINGLE_THREADED = true;
 const FILAMENT_WASM = true;
 const IS_WINDOWS = false;
 
-extension type _NativeLibrary(NativeLibrary _) implements JSObject {
-  static _NativeLibrary get instance => NativeLibrary.instance as _NativeLibrary;
-
-  external void _execute_queue();
-}
-
 typedef IntPtrList = Int32List;
 typedef Utf8 = Char;
 typedef Float = Float32;
@@ -87,10 +81,6 @@ Future<void> withVoidCallback(Function(int, Pointer<NativeFunction<Void Function
     _completers.remove(requestId);
     rethrow;
   }
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
   await completer.future;
 }
 
@@ -106,11 +96,6 @@ Future<Pointer<T>> withPointerCallback<T extends NativeType>(
   final onComplete_interopFnPtr = callback.addFunction();
 
   func.call(onComplete_interopFnPtr.cast());
-
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
 
   var ptr = await completer.future;
   onComplete_interopFnPtr.dispose();
@@ -129,11 +114,6 @@ Future<bool> withBoolCallback(Function(Pointer<NativeFunction<Void Function(Bool
 
   func.call(onComplete_interopFnPtr.cast());
 
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
-
   return completer.future;
 }
 
@@ -145,10 +125,6 @@ Future<double> withFloatCallback(void Function(Pointer<NativeFunction<void Funct
   };
   var ptr = callback.addFunction();
   func.call(ptr);
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
   return completer.future;
 }
 
@@ -160,10 +136,6 @@ Future<int> withIntCallback(Function(Pointer<NativeFunction<void Function(int)>>
   };
   var ptr = callback.addFunction();
   func.call(ptr);
-  while (!completer.isCompleted) {
-    _NativeLibrary.instance._execute_queue();
-    await Future.delayed(Duration(milliseconds: 1));
-  }
   return completer.future;
 }
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -2583,6 +2583,13 @@ external ffi.Pointer<TRenderManager> RenderManager_create(
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
 external void RenderManager_destroy(ffi.Pointer<TRenderManager> tRenderer);
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Uint32, VoidCallback)>(isLeaf: true)
+external void RenderManager_destroyRenderThread(
+  ffi.Pointer<TRenderManager> manager,
+  int requestId,
+  VoidCallback onComplete,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
 external void RenderManager_detachFromRenderThread(ffi.Pointer<TRenderManager> tRenderManager);
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1291,6 +1291,11 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
   external void _RenderManager_attachToRenderThread(Pointer<TRenderManager> tRenderer);
   external Pointer<TRenderManager> _RenderManager_create(Pointer<TEngine> tEngine, Pointer<TRenderer> tRenderer);
   external void _RenderManager_destroy(Pointer<TRenderManager> tRenderer);
+  external void _RenderManager_destroyRenderThread(
+    Pointer<TRenderManager> manager,
+    int requestId,
+    VoidCallback onComplete,
+  );
   external void _RenderManager_detachFromRenderThread(Pointer<TRenderManager> tRenderManager);
   external void _RenderManager_removeAnimationManager(
     Pointer<TRenderManager> tRenderer,
@@ -5955,6 +5960,15 @@ Pointer<TRenderManager> RenderManager_create(Pointer<TEngine> tEngine, Pointer<T
 
 void RenderManager_destroy(Pointer<TRenderManager> tRenderer) {
   final result = GeneratedBindings.instance._RenderManager_destroy(tRenderer.cast());
+  return result;
+}
+
+void RenderManager_destroyRenderThread(Pointer<TRenderManager> manager, int requestId, DartVoidCallback onComplete) {
+  final result = GeneratedBindings.instance._RenderManager_destroyRenderThread(
+    manager.cast(),
+    requestId,
+    onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
+  );
   return result;
 }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart
@@ -407,15 +407,9 @@ class FFIFilamentApp extends FilamentApp<Pointer> {
     }
 
     FilamentApp.instance = null;
-    // Detach the RenderManager from the worker pthread BEFORE deleting it.
-    // The worker's mainLoop/iter() reads `mRenderManager` to drive ticks; once
-    // we delete the RenderManager that pointer dangles, and the next iter()
-    // crashes inside tick() — which is silent in release builds and leaves
-    // the worker pthread effectively dead but with its mimalloc arena still
-    // owned, so every subsequent FilamentApp.create() spawns a fresh worker
-    // on top of the leaked one.
-    RenderManager_detachFromRenderThread(renderManager.getNativeHandle());
-    renderManager.destroy();
+    // Detachment and destruction run together on the worker, ordered after
+    // earlier commands and before engine resource teardown.
+    await renderManager.destroy();
 
     // Filament's contract is: tear down everything created on top of the
     // Engine before destroying the Engine itself. Order matters — the

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
@@ -209,18 +209,17 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
     });
   }
 
-  void destroy() {
+  Future<void> destroy() => _serialize(() async {
+    await withVoidCallback((requestId, callback) {
+      RenderManager_destroyRenderThread(pointer, requestId, callback);
+    });
     _attachmentState.clear();
-    RenderManager_destroy(pointer);
-  }
+  });
 
   Future render({int? frameTimeInNanos}) async {
     if (FILAMENT_SINGLE_THREADED) {
-      // Web: fire-and-forget. The render completes across the next N rAF
-      // cycles (N = number of swapchains) driven by RenderThread::iter()
-      // calling RenderManager::tick(). We cannot await completion without
-      // deadlocking the worker's main loop from the main browser thread,
-      // and pre-refactor web was already fire-and-forget via requestFrame.
+      // Web drawing belongs to RenderManager::tick() on
+      // the worker. This future acknowledges the request, not a drawn frame.
       RenderManager_requestRender(pointer);
     } else {
       // Frame timestamps share one clock: the native steady clock that the

--- a/thermion_dart/lib/src/filament/src/interface/render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/render_manager.dart
@@ -28,5 +28,11 @@ abstract class RenderManager<T> extends NativeHandle<T> {
   /// waiting for completion. [frameTimeInNanos] is ignored on that path.
   Future render({int? frameTimeInNanos});
 
-  void destroy();
+  /// Detaches this manager from the render worker and destroys it after earlier
+  /// queued work. Await this before destroying its animation managers, renderer,
+  /// or engine. Stop submitting work to this manager before calling destroy.
+  ///
+  /// Completion means the manager has been deleted; it does not shut down the
+  /// worker. Engine and worker teardown are owned by the Filament app.
+  Future<void> destroy();
 }

--- a/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
+++ b/thermion_dart/native/include/c_api/ThermionDartRenderThreadApi.h
@@ -25,6 +25,9 @@ namespace thermion
         // Creates a RenderThread that transfers the given canvas element
         // (CSS selector) to its worker — one thread per viewer on web.
         EMSCRIPTEN_KEEPALIVE void* RenderThread_createForCanvas(const char *canvasSelector);
+        // Stop accepting external work and drain accepted commands. Native
+        // destruction joins the thread; web returns before the worker exits.
+        // Destroy engine resources first and do not use the handle afterward.
         EMSCRIPTEN_KEEPALIVE void RenderThread_destroy(void *renderThread);
         
         EMSCRIPTEN_KEEPALIVE void RenderThread_addTask(void (*task)());
@@ -34,6 +37,11 @@ namespace thermion
         // Copies all 16 column-major doubles before returning. The caller may
         // immediately reuse/free matrix16 while the queued task is pending.
         EMSCRIPTEN_KEEPALIVE void TransformManager_setTransformFromBufferRenderThread(TTransformManager *manager, EntityId entity, const double *matrix16, uint32_t requestId, VoidCallback onComplete);
+        // Queue worker detachment and manager deletion as one ordered command.
+        // Stop submitting work to manager before calling. onComplete means it
+        // is deleted; only then may the renderer/engine be destroyed. This does
+        // not stop or wait for the worker itself.
+        EMSCRIPTEN_KEEPALIVE void RenderManager_destroyRenderThread(TRenderManager *manager, uint32_t requestId, VoidCallback onComplete);
         EMSCRIPTEN_KEEPALIVE void RenderManager_setRenderableRenderThread(TRenderManager *tRenderer, TSwapChain *tSwapChain, TView **tViews, uint8_t numViews, uint32_t requestId, VoidCallback onComplete);
 
         EMSCRIPTEN_KEEPALIVE void RenderManager_renderRenderThread(TRenderManager *tRenderManager, uint64_t frameTimeInNanos, uint32_t requestId, VoidCallback onComplete);

--- a/thermion_dart/native/include/rendering/RenderManager.hpp
+++ b/thermion_dart/native/include/rendering/RenderManager.hpp
@@ -52,7 +52,7 @@ namespace thermion
             uint64_t frameTimeInNanos);
 
         /// Flip the "render wanted" flag. Used on web — the actual work is
-        /// driven from RenderThread::iter() on each rAF via tick().
+        /// driven from RenderThread's frame callback via tick().
         void requestRender();
 
         /// Web: pause/resume rendering. When paused, tick() skips animation
@@ -61,12 +61,15 @@ namespace thermion
         /// queued before pause complete cleanly and don't burst on resume.
         void setPaused(bool paused);
 
-        /// Web path: called once per rAF from RenderThread::iter().
+        /// Web path: called once per rAF from RenderThread's frame callback.
         /// Renders all attached swapchains synchronously (in practice there
         /// is only one on web — see ARCHITECTURE.md), then calls
         /// mEngine->execute() to drain the Filament WebGL backend command
         /// buffer. Returns true if any swapchain produced a visible frame.
         bool tick(uint64_t frameTimeInNanos);
+
+        /// Drain commands after a web task batch, including when rAF is suspended.
+        void executePendingCommands();
 
         /// @brief
         /// @param swapChain
@@ -107,17 +110,15 @@ namespace thermion
         std::vector<ViewAttachment> mViewAttachments;
         std::chrono::high_resolution_clock::time_point mLastRender;
 
-        // Web: tick() checks this flag and renders if set, then clears it.
-        // Set by Dart via RenderManager_requestRender() on each main-thread
-        // rAF. Rejection retries (beginFrame failing) keep the flag set so
-        // RenderThread's 12ms iter-loop can retry in the same rAF.
+        // Legacy request marker. The worker's frame clock admits frames;
+        // requests from Dart do not gate rendering.
         bool mRenderRequested = false;
 
         // Web: when true, tick() short-circuits animations + swapchain render.
         // mEngine->execute() still runs so the backend command buffer keeps
         // draining (matches native "scheduler keeps ticking" pause semantics).
         // Note: this gates *rendering only* — task queue drain in
-        // RenderThread::iter() is outside this flag, so FFI state changes
+        // RenderThread's event-driven pump is outside this flag, so FFI state changes
         // (setTransform, addEntity, etc.) continue to apply while paused.
         bool mRenderPaused = false;
     };

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -21,170 +21,81 @@ namespace thermion {
 
 class RenderManager;
 
-/**
- * @brief A render loop that executes Filament work on a dedicated worker
- *        thread, one ordered command queue per engine.
- *
- * Dart-facing API calls are packaged as commands and appended to the queue;
- * the worker normally executes them in FIFO order. On web, each animation
- * frame drains the queue without yielding, then draws. Drawing does not
- * interleave with commands within that drain.
- *
- * Native workers sleep on a condition variable until work arrives and are
- * drained and joined during destruction. Web workers are browser pthreads:
- * they service the queue on each animation frame (iter()). Web destruction
- * still runs remaining queued commands on the caller's thread and detaches
- * the worker. Worker affinity during web teardown is therefore not guaranteed;
- * fixing that lifecycle is separate from this rearrangement.
- */
+// One ordered command queue per engine. Native workers sleep until work arrives;
+// web workers service bounded batches from event notifications independently of
+// their drawing loop. Filament calls always execute on the owning worker.
+// FIFO applies to commands, not transactions: drawing may run between batches.
 class RenderThread {
 public:
-    /**
-     * @brief Constructs a new RenderThread and starts the render thread.
-     *
-     * @param canvasSelector Web-only: the CSS selector of the canvas element
-     *        transferred to this thread's worker (default "#thermion_canvas").
-     *        Each engine-per-viewer thread owns its own canvas.
-     */
     explicit RenderThread(const char* canvasSelector = "#thermion_canvas");
-
-    /**
-     * @brief Destroys the RenderThread and stops the render thread.
-     *
-     * Signals the worker to exit. Native destruction joins after the worker
-     * drains its queue. Web destruction drains remaining commands on the
-     * caller's thread and detaches, without waiting for the worker to exit.
-     */
     ~RenderThread();
 
-    /**
-     * @brief The CSS selector of the canvas transferred to this thread's
-     *        worker (web only). Used by Engine_create to create the WebGL
-     *        context on the right canvas.
-     */
     const char* canvasSelector() const { return _canvasSelector.c_str(); }
-
-    /**
-     * @brief True when the worker pthread failed to start (web). The C API
-     *        returns a null handle in that case so Dart can fail loudly
-     *        instead of hanging on tasks that will never run.
-     */
     bool creationFailed() const { return _creationFailed; }
+    bool isStopping() const { return _stopping.load(std::memory_order_acquire); }
 
-    /**
-     * @brief True once shutdown has been requested (see shutdown()).
-     */
-    bool isStopping() const { return _stop->value.load(std::memory_order_acquire); }
-
-    /**
-     * @brief Signals the worker to exit. Called by destruction; native workers
-     *        wake and drain their queue. Web workers stop at their next
-     *        animation-frame iteration, before draining; the web destructor
-     *        handles remaining commands on the caller's thread.
-     */
+    // Drain accepted work. Native destruction joins the worker. On web this
+    // transfers ownership to the worker, which deletes this object after its
+    // queue and frame loop stop. Call only once on a heap-allocated web worker;
+    // the caller must release its owner before calling and never use it again.
     void shutdown();
 
-    /**
-     * @brief Adds a task to the render thread's task queue.
-     *
-     * @param task The packaged task to be executed
-     * @return std::future<Rt> Future for the task result
-     */
     template <class Rt>
     auto addTask(std::packaged_task<Rt()>& task) -> std::future<Rt>;
 
-    /**
-     * @brief Adds a fire-and-forget task without allocating a packaged-task
-     * shared state or future.
-     *
-     * Use this for callbacks whose completion is communicated by another
-     * mechanism (for example, the Dart request-id callback).
-     */
     template <class Fn>
-    void addDetachedTask(Fn&& fn) {
-        enqueue(std::function<void()>(std::forward<Fn>(fn)));
-    }
+    void addDetachedTask(Fn&& fn) { enqueue(std::function<void()>(std::forward<Fn>(fn))); }
 
-    #ifdef __EMSCRIPTEN__
-    /**
-     * @brief Main iteration of the browser-driven render loop.
-     */
-    void iter();
-
-    emscripten::ProxyingQueue queue;
-    pthread_t outer;
-
-    // Web-only: iter() invokes _renderManager->tick() on each rAF so rendering
-    // is driven by the browser's frame cadence rather than a Dart-queued task.
-    void setRenderManager(RenderManager* rm) { _renderManager = rm; }
-    RenderManager* _renderManager = nullptr;
-    #endif
-
-    /**
-     * Per-instance worker shutdown signal, heap-allocated and shared with the
-     * worker via a std::shared_ptr copy. Native workers exit after draining
-     * queued tasks; web workers exit on their next browser-loop iteration.
-     *
-     * The flag must outlive `this`: on web pthread_detach lets the destructor
-     * return and `*this` be freed before the worker observes the signal, so a
-     * plain member would be UAF. The flag keeps the stop check alive, but
-     * does not protect `this` if shutdown starts after the worker has checked
-     * the flag. Coordinating web object destruction with the worker remains
-     * a separate lifecycle fix.
-     *
-     * Per-instance, not static: with one engine per thread, destroying one
-     * engine's RenderThread must not signal another engine's worker (a shared
-     * static flag would stop every worker in the module).
-     */
-    struct StopFlag {
-        std::atomic<bool> value{false};
-    };
-    std::shared_ptr<StopFlag> stopFlag() const { return _stop; }
-    std::shared_ptr<StopFlag> _stop = std::make_shared<StopFlag>();
-
-    /**
-     * Live worker count. Incremented on worker entry, decremented just before
-     * the worker exits. Polled from the main thread before constructing a
-     * replacement RenderThread on web, since pthread_detach lets the destructor
-     * return before the worker has actually exited.
-     */
     static std::atomic<int32_t> mLiveWorkerCount;
 
-private:
-    #ifndef __EMSCRIPTEN__
-    void runNativeLoop();
-    #else
-    void startWebWorker(const char* canvasSelector);
-    void pumpTasks();
-    #endif
+#ifdef __EMSCRIPTEN__
+    // Completion delivery uses a module-lifetime queue, so accepted callbacks
+    // remain deliverable after the originating engine/worker has shut down.
+    void dispatchCallback(std::function<void()> callback) const;
+    static void executeCallbacks();
+    void setRenderManager(RenderManager* manager); // worker-only
+#else
+    void dispatchCallback(std::function<void()> callback) const { callback(); }
+#endif
 
-    // Appends one command to the queue. Native workers are woken immediately;
-    // web workers service the queue on their next animation-frame iteration.
+private:
     void enqueue(std::function<void()> task);
+    bool isWorkerThread() const;
 
     std::mutex _taskMutex;
     std::condition_variable _cv;
     std::deque<std::function<void()>> _tasks;
-    // Owned copy: the Dart side frees its UTF8 buffer right after
-    // RenderThread_createForCanvas returns, and Engine_create reads the
-    // selector later (during the same serialized engine creation).
-    std::string _canvasSelector = "#thermion_canvas";
+    std::atomic<bool> _stopping{false};
+    // Dart frees its UTF8 buffer immediately after worker creation.
+    std::string _canvasSelector;
     bool _creationFailed = false;
 
-
 #ifdef __EMSCRIPTEN__
+    void startWebWorker();
+    static void* startHelper(void* arg);
+    static void frameCallback(void* arg);
+    static void pumpCallback(void* arg);
+    static void finishShutdown(void* arg);
+    void scheduleWakeLocked();
+    void pumpTasks();
+
     pthread_t _thread{};
+    pthread_t _caller{};
+    bool _wakePending = false; // protected by _taskMutex
+    bool _workerFinished = false;
+    RenderManager* _renderManager = nullptr; // worker-only
 #else
-    std::thread* _thread = nullptr;
+    void runNativeLoop();
+    std::thread _thread;
 #endif
 };
 
-// Template implementation
 template <class Rt>
 auto RenderThread::addTask(std::packaged_task<Rt()>& task) -> std::future<Rt> {
     auto result = task.get_future();
-    addDetachedTask([task = std::make_shared<std::packaged_task<Rt()>>(
-                         std::move(task))] { (*task)(); });
+    addDetachedTask([task = std::make_shared<std::packaged_task<Rt()>>(std::move(task))] {
+        (*task)();
+    });
     return result;
 }
 

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <functional>
 #include <future>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -22,10 +22,20 @@ namespace thermion {
 class RenderManager;
 
 /**
- * @brief A render loop implementation that manages rendering on a separate thread.
- * 
- * This class handles frame rendering requests, viewer creation, and maintains
- * a task queue for rendering operations.
+ * @brief A render loop that executes Filament work on a dedicated worker
+ *        thread, one ordered command queue per engine.
+ *
+ * Dart-facing API calls are packaged as commands and appended to the queue;
+ * the worker normally executes them in FIFO order. On web, each animation
+ * frame drains the queue without yielding, then draws. Drawing does not
+ * interleave with commands within that drain.
+ *
+ * Native workers sleep on a condition variable until work arrives and are
+ * drained and joined during destruction. Web workers are browser pthreads:
+ * they service the queue on each animation frame (iter()). Web destruction
+ * still runs remaining queued commands on the caller's thread and detaches
+ * the worker. Worker affinity during web teardown is therefore not guaranteed;
+ * fixing that lifecycle is separate from this rearrangement.
  */
 class RenderThread {
 public:
@@ -36,10 +46,14 @@ public:
      *        transferred to this thread's worker (default "#thermion_canvas").
      *        Each engine-per-viewer thread owns its own canvas.
      */
-    explicit RenderThread(const char *canvasSelector = "#thermion_canvas");
+    explicit RenderThread(const char* canvasSelector = "#thermion_canvas");
 
     /**
      * @brief Destroys the RenderThread and stops the render thread.
+     *
+     * Signals the worker to exit. Native destruction joins after the worker
+     * drains its queue. Web destruction drains remaining commands on the
+     * caller's thread and detaches, without waiting for the worker to exit.
      */
     ~RenderThread();
 
@@ -48,7 +62,7 @@ public:
      *        worker (web only). Used by Engine_create to create the WebGL
      *        context on the right canvas.
      */
-    const char *canvasSelector() const { return _canvasSelector.c_str(); }
+    const char* canvasSelector() const { return _canvasSelector.c_str(); }
 
     /**
      * @brief True when the worker pthread failed to start (web). The C API
@@ -58,13 +72,26 @@ public:
     bool creationFailed() const { return _creationFailed; }
 
     /**
+     * @brief True once shutdown has been requested (see shutdown()).
+     */
+    bool isStopping() const { return _stop->value.load(std::memory_order_acquire); }
+
+    /**
+     * @brief Signals the worker to exit. Called by destruction; native workers
+     *        wake and drain their queue. Web workers stop at their next
+     *        animation-frame iteration, before draining; the web destructor
+     *        handles remaining commands on the caller's thread.
+     */
+    void shutdown();
+
+    /**
      * @brief Adds a task to the render thread's task queue.
-     * 
-     * @param pt The packaged task to be executed
+     *
+     * @param task The packaged task to be executed
      * @return std::future<Rt> Future for the task result
      */
     template <class Rt>
-    auto addTask(std::packaged_task<Rt()>& pt) -> std::future<Rt>;
+    auto addTask(std::packaged_task<Rt()>& task) -> std::future<Rt>;
 
     /**
      * @brief Adds a fire-and-forget task without allocating a packaged-task
@@ -74,14 +101,23 @@ public:
      * mechanism (for example, the Dart request-id callback).
      */
     template <class Fn>
-    void addDetachedTask(Fn&& fn);
-
+    void addDetachedTask(Fn&& fn) {
+        enqueue(std::function<void()>(std::forward<Fn>(fn)));
+    }
 
     #ifdef __EMSCRIPTEN__
     /**
      * @brief Main iteration of the browser-driven render loop.
      */
     void iter();
+
+    emscripten::ProxyingQueue queue;
+    pthread_t outer;
+
+    // Web-only: iter() invokes _renderManager->tick() on each rAF so rendering
+    // is driven by the browser's frame cadence rather than a Dart-queued task.
+    void setRenderManager(RenderManager* rm) { _renderManager = rm; }
+    RenderManager* _renderManager = nullptr;
     #endif
 
     /**
@@ -91,10 +127,10 @@ public:
      *
      * The flag must outlive `this`: on web pthread_detach lets the destructor
      * return and `*this` be freed before the worker observes the signal, so a
-     * plain member would be UAF. The worker only dereferences the RenderThread
-     * after observing the flag is false, which keeps the window closed (the
-     * destructor sets the flag before draining and detaching, so the worker
-     * never touches `this` after shutdown begins).
+     * plain member would be UAF. The flag keeps the stop check alive, but
+     * does not protect `this` if shutdown starts after the worker has checked
+     * the flag. Coordinating web object destruction with the worker remains
+     * a separate lifecycle fix.
      *
      * Per-instance, not static: with one engine per thread, destroying one
      * engine's RenderThread must not signal another engine's worker (a shared
@@ -114,70 +150,42 @@ public:
      */
     static std::atomic<int32_t> mLiveWorkerCount;
 
-    #ifdef __EMSCRIPTEN__
-    emscripten::ProxyingQueue queue;
-    pthread_t outer;
-
-    // Web-only: iter() invokes mRenderManager->tick() on each rAF so rendering
-    // is driven by the browser's frame cadence rather than a Dart-queued task.
-    void setRenderManager(RenderManager* rm) { mRenderManager = rm; }
-    RenderManager* mRenderManager = nullptr;
-    #endif
-
 private:
     #ifndef __EMSCRIPTEN__
     void runNativeLoop();
+    #else
+    void startWebWorker(const char* canvasSelector);
+    void pumpTasks();
     #endif
+
+    // Appends one command to the queue. Native workers are woken immediately;
+    // web workers service the queue on their next animation-frame iteration.
+    void enqueue(std::function<void()> task);
 
     std::mutex _taskMutex;
     std::condition_variable _cv;
     std::deque<std::function<void()>> _tasks;
-    std::chrono::high_resolution_clock::time_point _lastFrameTime;
-    int _frameCount = 0;
-    float _accumulatedTime = 0.0f;
-    float _fps = 0.0f;
     // Owned copy: the Dart side frees its UTF8 buffer right after
     // RenderThread_createForCanvas returns, and Engine_create reads the
     // selector later (during the same serialized engine creation).
     std::string _canvasSelector = "#thermion_canvas";
     bool _creationFailed = false;
 
-    
+
 #ifdef __EMSCRIPTEN__
-    pthread_t t;
+    pthread_t _thread{};
 #else
-    std::thread* t = nullptr;
+    std::thread* _thread = nullptr;
 #endif
 };
 
 // Template implementation
 template <class Rt>
-auto RenderThread::addTask(std::packaged_task<Rt()>& pt) -> std::future<Rt> {
-    auto ret = pt.get_future();
-    {
-        std::lock_guard<std::mutex> lock(_taskMutex);
-        _tasks.push_back([pt = std::make_shared<std::packaged_task<Rt()>>(
-                             std::move(pt))]
-                        { (*pt)(); });
-    }
-    #ifndef __EMSCRIPTEN__
-    _cv.notify_one();
-    #endif
-    return ret;
-}
-
-template <class Fn>
-void RenderThread::addDetachedTask(Fn&& fn) {
-    // Construct outside the critical section since std::function may need to
-    // allocate for a large capture.
-    std::function<void()> task(std::forward<Fn>(fn));
-    {
-        std::lock_guard<std::mutex> lock(_taskMutex);
-        _tasks.push_back(std::move(task));
-    }
-    #ifndef __EMSCRIPTEN__
-    _cv.notify_one();
-    #endif
+auto RenderThread::addTask(std::packaged_task<Rt()>& task) -> std::future<Rt> {
+    auto result = task.get_future();
+    addDetachedTask([task = std::make_shared<std::packaged_task<Rt()>>(
+                         std::move(task))] { (*task)(); });
+    return result;
 }
 
 } // namespace thermion

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -54,11 +54,8 @@ using namespace std::chrono_literals;
 #include <time.h>
 #include <cinttypes>
 
-#if defined __EMSCRIPTEN__
-#define PROXY(call)                                           \
-  auto startTime = std::chrono::high_resolution_clock::now(); \
-  TRACE("PROXYING");                                          \
-  rt->queue.proxySync(rt->outer, [=]() { call; });
+#ifdef __EMSCRIPTEN__
+#define PROXY(call) rt->dispatchCallback([=]() { call; })
 #else
 #define PROXY(call) call
 #endif
@@ -125,13 +122,11 @@ extern "C"
       return;
     }
     std::lock_guard<std::shared_mutex> lock(g_ownerMutex);
-    g_threadByOwner[owner] = rt;
+    if (!rt->isStopping()) g_threadByOwner[owner] = rt;
   }
 
-  // Remove every owner registration that maps to `rt`. Call AFTER the thread's
-  // worker has been joined (otherwise an in-flight creation task on that worker
-  // could re-add an entry pointing at the about-to-be-freed RenderThread, and a
-  // recycled handle address would later resolve to freed memory via RT()).
+  // Remove mappings after requesting shutdown. setOwner() refuses to register
+  // new handles on a stopping worker, including during asynchronous web drain.
   static void unregisterOwnersOf(void *rt)
   {
     if (rt == nullptr)
@@ -188,6 +183,16 @@ extern "C"
     return rt != nullptr ? rt->canvasSelector() : "#thermion_canvas";
   }
 
+  // The registry owns live workers. On web, transfer ownership at shutdown:
+  // only the worker can drain its queue and cancel its frame loop safely.
+  static void disposeThread(std::unique_ptr<RenderThread> thread)
+  {
+#ifdef __EMSCRIPTEN__
+    thread.release()->shutdown();
+#endif
+    // Native destruction drains and joins synchronously.
+  }
+
   EMSCRIPTEN_KEEPALIVE void* RenderThread_create()
   {
     TRACE("RenderThread_create");
@@ -204,11 +209,10 @@ extern "C"
       Log("RenderThread worker failed to start; returning null handle");
       return nullptr;
     }
+    if (_renderThread) disposeThread(std::move(_renderThread));
     _renderThread = std::move(thread);
-    // The move-assignment above destroyed the previous RenderThread (and joined
-    // its worker). Sweep stale owner registrations AFTER the join — the dying
-    // worker's last creation task can't then re-add an entry pointing at freed
-    // memory, and a recycled handle address can't resolve to it via RT().
+    // Native destruction joins; the web worker retains ownership while it
+    // drains. In both cases stopping workers cannot register new owners.
     if (stale != nullptr)
     {
       unregisterOwnersOf(stale);
@@ -243,13 +247,14 @@ extern "C"
     }
     if (renderThread == _renderThread.get())
     {
-      _renderThread = nullptr;
+      disposeThread(std::move(_renderThread));
     }
     else
     {
       auto it = _renderThreads.find(renderThread);
       if (it != _renderThreads.end())
       {
+        disposeThread(std::move(it->second));
         _renderThreads.erase(it);
       }
     }
@@ -257,9 +262,7 @@ extern "C"
     {
       g_activeThread = nullptr;
     }
-    // _renderThread = nullptr / _renderThreads.erase above already destroyed
-    // the RenderThread (and joined its worker), so it's safe to drop any owner
-    // registrations that still point at it.
+    // The worker is stopping and cannot re-add owner registrations.
     unregisterOwnersOf(renderThread);
   }
 
@@ -289,21 +292,20 @@ extern "C"
     auto *rm = reinterpret_cast<RenderManager *>(tRenderManager);
     auto *rt = RT(tRenderManager);
     setOwner(tRenderManager, rt);
-    rt->setRenderManager(rm);
+    rt->addDetachedTask([rt, rm] { rt->setRenderManager(rm); });
 #else
     (void)tRenderManager; // no-op on native
 #endif
   }
 
-  // Inverse of RenderManager_attachToRenderThread. Call before deleting a
-  // RenderManager so the worker's iter() doesn't dereference a freed pointer
-  // on its next tick.
+  // Queues detachment. Callers must await a queue barrier before freeing the
+  // manager; RenderManager_destroyRenderThread combines both operations safely.
   EMSCRIPTEN_KEEPALIVE void RenderManager_detachFromRenderThread(TRenderManager *tRenderManager)
   {
 #ifdef __EMSCRIPTEN__
     auto *rt = RT(tRenderManager);
     if (rt) {
-      rt->setRenderManager(nullptr);
+      rt->addDetachedTask([rt] { rt->setRenderManager(nullptr); });
     }
     {
       std::lock_guard<std::shared_mutex> lock(g_ownerMutex);
@@ -312,6 +314,23 @@ extern "C"
 #else
     (void)tRenderManager; // no-op on native
 #endif
+  }
+
+  EMSCRIPTEN_KEEPALIVE void RenderManager_destroyRenderThread(
+      TRenderManager* manager, uint32_t requestId, VoidCallback onComplete)
+  {
+    auto* rt = RT(manager);
+    rt->addDetachedTask([=] {
+#ifdef __EMSCRIPTEN__
+      rt->setRenderManager(nullptr);
+#endif
+      RenderManager_destroy(manager);
+      {
+        std::lock_guard<std::shared_mutex> lock(g_ownerMutex);
+        g_threadByOwner.erase(manager);
+      }
+      PROXY(onComplete(requestId));
+    });
   }
 
   EMSCRIPTEN_KEEPALIVE void RenderManager_setRenderableRenderThread(
@@ -708,9 +727,8 @@ extern "C"
 
   EMSCRIPTEN_KEEPALIVE void execute_queue()
   {
-    auto *rt = RT(nullptr);
 #ifdef __EMSCRIPTEN__
-    rt->queue.execute();
+    RenderThread::executeCallbacks();
 #endif
   }
 
@@ -1416,7 +1434,15 @@ extern "C"
         [=]
         {
           auto name = View_getName(tView);
+#ifdef __EMSCRIPTEN__
+          // A subsequent rename/destroy can run before the browser receives
+          // this completion. Own the string through callback delivery.
+          rt->dispatchCallback([onComplete, name = std::string(name ? name : "")] {
+            onComplete(name.c_str());
+          });
+#else
           PROXY(onComplete(name));
+#endif
         });
     auto fut = rt->addTask(lambda);
   }

--- a/thermion_dart/native/src/rendering/RenderManager.cpp
+++ b/thermion_dart/native/src/rendering/RenderManager.cpp
@@ -249,16 +249,21 @@ namespace thermion
     mRenderPaused = paused;
   }
 
+  void RenderManager::executePendingCommands()
+  {
+#ifdef __EMSCRIPTEN__
+    std::lock_guard<std::mutex> lock(mMutex);
+    mEngine->execute();
+    mEngine->pumpMessageQueues();
+#endif
+  }
+
   bool RenderManager::tick(uint64_t frameTimeInNanos)
   {
     std::lock_guard<std::mutex> lock(mMutex);
 
-    // Render unconditionally on every worker rAF. The mRenderRequested flag
-    // is kept in the API for symmetry with the native path but is not
-    // gating on web: Dart's main-thread _tick and this worker's mainLoop
-    // are independent 60Hz rAFs that aren't phase-locked. Gating on the flag
-    // drops ~5-10 fps whenever the worker rAF fires before Dart has had a
-    // chance to set it.
+    // Dart's independent hook loop cannot reliably set a request flag before
+    // every worker tick, so that flag does not gate drawing.
     (void)mRenderRequested;
 
     // Match pre-refactor RenderTicker semantics: render all swapchains

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -1,242 +1,213 @@
 #include "rendering/RenderThread.hpp"
-// Web only: iter() calls into RenderManager. The native worker never touches
-// the manager, so the standalone queue test can compile this file without
-// Filament headers.
 #ifdef __EMSCRIPTEN__
 #include "rendering/RenderManager.hpp"
 #endif
+#include "Log.hpp"
 
-#include <functional>
-#include <stdlib.h>
-#include <time.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
 #include <chrono>
 
-#include "Log.hpp"
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#include <mimalloc.h>
+#endif
 
 namespace thermion {
 
 std::atomic<int32_t> RenderThread::mLiveWorkerCount{0};
 
 #ifdef __EMSCRIPTEN__
-#define GL_GLEXT_PROTOTYPES
-#include <GL/gl.h>
-#include <GL/glext.h>
-#include <emscripten/html5.h>
-#include <emscripten/threading.h>
-#include <emscripten/proxying.h>
-#include <emscripten/eventloop.h>
-#include <mimalloc.h>
-#include "ThermionWebApi.h"
-
-std::chrono::high_resolution_clock::time_point loopStart;
-std::chrono::high_resolution_clock::time_point loopExitTime;
-bool loopExitTimeValid = false;
-
-// Heap arg for the worker: owns a shared_ptr copy of the stop flag so the
-// flag outlives the RenderThread (web detach lets the destructor return
-// before the worker's next iteration). The worker frees this struct itself
-// on exit — the destructor never touches it.
-struct WorkerArg {
-    RenderThread *rt;
-    std::shared_ptr<RenderThread::StopFlag> stop;
-};
-
-static void mainLoop(void* arg) {
-    // Check the stop flag BEFORE touching `rt` — the destructor may have
-    // returned (via pthread_detach) and `*this` may already be freed. The
-    // flag is heap-shared, so the read is safe; the worker never dereferences
-    // the RenderThread after observing stop.
-    auto *workerArg = static_cast<WorkerArg *>(arg);
-    if (workerArg->stop->value.load()) {
-        emscripten_cancel_main_loop();
-        loopExitTime = std::chrono::high_resolution_clock::now();
-        loopExitTimeValid = true;
-        // mimalloc reserves a per-thread arena (~32 MiB initial on wasm32)
-        // that survives pthread_exit unless we explicitly release it.
-        mi_thread_done();
-        RenderThread::mLiveWorkerCount.fetch_sub(1, std::memory_order_relaxed);
-        // emscripten_set_main_loop_arg(..., simulate_infinite_loop=true) threw
-        // to unwind startHelper, so the pthread function never returned. The
-        // JS-side worker would otherwise stay alive in the event loop after
-        // emscripten_cancel_main_loop; explicit pthread_exit terminates it.
-        delete workerArg;
-        pthread_exit(nullptr);
-    }
-
-    auto *rt = workerArg->rt;
-    rt->iter();
-    loopExitTime = std::chrono::high_resolution_clock::now();
-    loopExitTimeValid = true;
+// The queues live until the WASM module is unloaded. A completion posted to the
+// browser must survive destruction of its originating RenderThread. Wakeups
+// share the same lifetime so executing proxy closures never own a dying queue.
+static emscripten::ProxyingQueue& callbacks() {
+    static auto* queue = new emscripten::ProxyingQueue();
+    return *queue;
 }
-
-static void *startHelper(void * parm) {
-    loopStart = std::chrono::high_resolution_clock::now();
-    RenderThread::mLiveWorkerCount.fetch_add(1, std::memory_order_relaxed);
-    emscripten_set_main_loop_arg(&mainLoop, parm, 0, true);
-    return nullptr;
+static emscripten::ProxyingQueue& wakeups() {
+    static auto* queue = new emscripten::ProxyingQueue();
+    return *queue;
 }
 
 #endif
 
 RenderThread::RenderThread(const char* canvasSelector)
-    : _canvasSelector(canvasSelector != nullptr ? canvasSelector : "#thermion_canvas")
-{
-    srand(time(NULL));
-    #ifdef __EMSCRIPTEN__
-    Log("Starting RenderThread")
-    outer = pthread_self();
-    startWebWorker(canvasSelector);
-    #else
-    _thread = new std::thread([this]() { runNativeLoop(); });
-    #endif
+    : _canvasSelector(canvasSelector ? canvasSelector : "#thermion_canvas") {
+#ifdef __EMSCRIPTEN__
+    _caller = pthread_self();
+    startWebWorker();
+#else
+    _thread = std::thread([this] { runNativeLoop(); });
+#endif
+}
+
+RenderThread::~RenderThread() {
+#ifdef __EMSCRIPTEN__
+    assert(_creationFailed || _workerFinished);
+#else
+    shutdown();
+    _thread.join();
+#endif
+}
+
+bool RenderThread::isWorkerThread() const {
+#ifdef __EMSCRIPTEN__
+    return pthread_equal(pthread_self(), _thread);
+#else
+    return std::this_thread::get_id() == _thread.get_id();
+#endif
+}
+
+void RenderThread::shutdown() {
+    {
+        std::lock_guard<std::mutex> lock(_taskMutex);
+        _stopping.store(true, std::memory_order_release);
+#ifdef __EMSCRIPTEN__
+        if (!_creationFailed) scheduleWakeLocked();
+#endif
+    }
+#ifndef __EMSCRIPTEN__
+    _cv.notify_one();
+#endif
+}
+
+void RenderThread::enqueue(std::function<void()> work) {
+    {
+        std::unique_lock<std::mutex> lock(_taskMutex);
+        // Accepted tasks can enqueue their own completion work while draining.
+        if (isStopping() && !isWorkerThread()) {
+            lock.unlock();
+            Log("Cannot submit work after RenderThread shutdown");
+            std::abort();
+        }
+        _tasks.push_back(std::move(work));
+#ifdef __EMSCRIPTEN__
+        scheduleWakeLocked();
+#endif
+    }
+#ifndef __EMSCRIPTEN__
+    _cv.notify_one();
+#endif
 }
 
 #ifdef __EMSCRIPTEN__
-// Start the worker pthread and transfer the canvas to it. On failure,
-// _creationFailed lets the C API return a null handle instead of a worker
-// that would hang every queued task forever.
-void RenderThread::startWebWorker(const char* canvasSelector) {
+void RenderThread::startWebWorker() {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    emscripten_pthread_attr_settransferredcanvases(&attr, canvasSelector);
-    auto *workerArg = new WorkerArg{this, _stop};
-    int rc = pthread_create(&_thread, &attr, startHelper, workerArg);
-    if (rc != 0) {
-      Log("SEVERE - pthread_create failed with code %d; worker did not start "
-          "(canvas selector %s, pool exhausted?)",
-          rc, canvasSelector);
-      _creationFailed = true;
-      delete workerArg;
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    emscripten_pthread_attr_settransferredcanvases(&attr, _canvasSelector.c_str());
+    // Include workers that have been requested but not entered startHelper yet.
+    mLiveWorkerCount.fetch_add(1, std::memory_order_relaxed);
+    const int result = pthread_create(&_thread, &attr, startHelper, this);
+    pthread_attr_destroy(&attr);
+    if (result != 0) {
+        _creationFailed = true;
+        mLiveWorkerCount.fetch_sub(1, std::memory_order_relaxed);
+        Log("RenderThread pthread_create failed: %d", result);
     }
 }
-#endif
 
-RenderThread::~RenderThread()
-{
-    size_t pendingTaskCount;
-    {
-        std::lock_guard<std::mutex> lock(_taskMutex);
-        pendingTaskCount = _tasks.size();
-    }
-    TRACE("Destroying RenderThread (%zu tasks remaining)", pendingTaskCount);
-    shutdown();
-
-    #ifdef __EMSCRIPTEN__
-    // The web worker cannot be synchronously joined from the browser main
-    // thread. Preserve the existing synchronous drain behavior, but claim
-    // each task under the queue mutex so the worker and destructor cannot
-    // concurrently mutate the deque.
-    while (true) {
-        std::function<void()> task;
-        {
-            std::lock_guard<std::mutex> lock(_taskMutex);
-            if (_tasks.empty()) {
-                break;
-            }
-            task = std::move(_tasks.front());
-            _tasks.pop_front();
-        }
-        task();
-    }
-
-    // pthread_join from the browser main thread is fundamentally restricted in
-    // Emscripten: it would have to call Atomics.wait, which the Web platform
-    // disallows on the main thread (would freeze the event loop). With
-    // ALLOW_BLOCKING_ON_MAIN_THREAD=1 emscripten downgrades it to a busy-spin
-    // warning, but in practice it hangs the page indefinitely.
-    //
-    // Detach instead. The worker has been signalled via mStop; on its next
-    // iteration mainLoop will call emscripten_cancel_main_loop +
-    // mi_thread_done + pthread_exit, terminating the pthread cleanly. Detach
-    // hands the OS responsibility for reaping it so the destructor can return
-    // without blocking. Callers that need to wait for the worker to actually
-    // finish exiting (e.g. before constructing a replacement RenderThread)
-    // should poll mLiveWorkerCount from Dart.
-    pthread_detach(_thread);
-    #else
-    TRACE("Joining RenderThread thread..");
-    _thread->join();
-    delete _thread;
-    #endif
-
-    TRACE("RenderThread destructor complete");
+void* RenderThread::startHelper(void* arg) {
+    // simulateInfiniteLoop keeps this pthread's event loop alive for wakeups.
+    emscripten_set_main_loop_arg(frameCallback, arg, 0, true);
+    return nullptr;
 }
 
-void RenderThread::shutdown()
-{
-    _stop->value.store(true, std::memory_order_release);
-    #ifndef __EMSCRIPTEN__
-    _cv.notify_all();
-    #endif
-}
-
-void RenderThread::enqueue(std::function<void()> task) {
-    {
-        std::lock_guard<std::mutex> lock(_taskMutex);
-        _tasks.push_back(std::move(task));
+void RenderThread::frameCallback(void* arg) {
+    auto* self = static_cast<RenderThread*>(arg);
+    if (self->isStopping()) return;
+    if (self->_renderManager) {
+        const auto now = std::chrono::steady_clock::now();
+        self->_renderManager->tick(std::chrono::duration_cast<std::chrono::nanoseconds>(
+            now.time_since_epoch()).count());
     }
-    #ifndef __EMSCRIPTEN__
-    _cv.notify_one();
-    #endif
 }
 
-#ifdef __EMSCRIPTEN__
-// Drain every queued task without yielding to the browser. Called from
-// iter() on the worker, so Filament calls keep their thread affinity; the
-// queue mutex is released while each task executes so tasks may queue
-// further work.
+void RenderThread::scheduleWakeLocked() {
+    if (_wakePending) return;
+    _wakePending = true;
+    // Coalesce notifications. Shutdown deletes this object only after the
+    // pump and its continuations have finished on this worker.
+    if (!wakeups().proxyAsync(_thread, [this] { pumpTasks(); })) {
+        _wakePending = false;
+        Log("Failed to wake render worker");
+        std::abort();
+    }
+}
+
+void RenderThread::pumpCallback(void* arg) {
+    auto* self = static_cast<RenderThread*>(arg);
+    self->pumpTasks();
+}
+
 void RenderThread::pumpTasks() {
-    std::unique_lock<std::mutex> taskLock(_taskMutex);
-
-    while (!_tasks.empty())
-    {
+    // Check between tasks: one expensive task or backend execution can exceed
+    // this budget. It is a yielding policy, not a hard two-millisecond deadline.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(2);
+    std::unique_lock<std::mutex> lock(_taskMutex);
+    while (!_tasks.empty()) {
         auto task = std::move(_tasks.front());
         _tasks.pop_front();
-        taskLock.unlock();
+        lock.unlock();
         task();
-        taskLock.lock();
+        task = {};
+        lock.lock();
+        if (std::chrono::steady_clock::now() >= deadline) break;
     }
-    taskLock.unlock();
+    // Browser backgrounding can suspend rAF entirely. Commands from uploads
+    // and other API calls still need to reach Filament's single-thread backend.
+    lock.unlock();
+    if (_renderManager) _renderManager->executePendingCommands();
+    lock.lock();
+    if (!_tasks.empty()) {
+        // A timer continuation yields the worker event loop; re-proxying onto
+        // the currently executing queue could otherwise drain without yielding.
+        emscripten_set_timeout(pumpCallback, 0, this);
+    } else if (isStopping()) {
+        // Exit outside the proxy callback so its closure is freed first.
+        emscripten_set_timeout(finishShutdown, 0, this);
+    } else {
+        _wakePending = false;
+    }
 }
 
-void RenderThread::iter() {
-    // FPS measurement
-    auto now = std::chrono::high_resolution_clock::now();
+void RenderThread::finishShutdown(void* arg) {
+    auto* self = static_cast<RenderThread*>(arg);
+    emscripten_cancel_main_loop();
+    self->_workerFinished = true;
+    delete self; // ownership transferred by shutdown(), after registry release
+    mi_thread_done();
+    mLiveWorkerCount.fetch_sub(1, std::memory_order_relaxed);
+    pthread_exit(nullptr);
+}
 
-    pumpTasks();
-
-    // Render at most one swapchain per rAF so Filament's WebGL backend can
-    // commit the frame between iterations. When no render has been requested,
-    // tick() is a cheap flag-check and returns immediately.
-    if (_renderManager) {
-        auto frameTimeInNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                    now.time_since_epoch()).count();
-        _renderManager->tick(frameTimeInNanos);
+void RenderThread::dispatchCallback(std::function<void()> callback) const {
+    if (!callbacks().proxyAsync(_caller, std::move(callback))) {
+        Log("Failed to post render completion");
+        std::abort();
     }
+}
+
+void RenderThread::executeCallbacks() { callbacks().execute(); }
+
+void RenderThread::setRenderManager(RenderManager* manager) {
+    assert(isWorkerThread());
+    _renderManager = manager;
 }
 #else
 void RenderThread::runNativeLoop() {
-    std::unique_lock<std::mutex> taskLock(_taskMutex);
-
+    std::unique_lock<std::mutex> lock(_taskMutex);
     while (true) {
-        _cv.wait(taskLock, [this] {
-            return !_tasks.empty() || isStopping();
-        });
-
-        if (_tasks.empty()) {
-            // A stop request only terminates the worker after it has executed
-            // every task that was already queued.
-            if (isStopping()) {
-                break;
-            }
-            continue;
-        }
-
+        _cv.wait(lock, [this] { return !_tasks.empty() || isStopping(); });
+        if (_tasks.empty() && isStopping()) return;
         auto task = std::move(_tasks.front());
         _tasks.pop_front();
-        taskLock.unlock();
+        lock.unlock();
         task();
-        taskLock.lock();
+        task = {};
+        lock.lock();
     }
 }
 #endif

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -1,5 +1,10 @@
 #include "rendering/RenderThread.hpp"
+// Web only: iter() calls into RenderManager. The native worker never touches
+// the manager, so the standalone queue test can compile this file without
+// Filament headers.
+#ifdef __EMSCRIPTEN__
 #include "rendering/RenderManager.hpp"
+#endif
 
 #include <functional>
 #include <stdlib.h>
@@ -73,35 +78,38 @@ static void *startHelper(void * parm) {
 
 #endif
 
-RenderThread::RenderThread(const char *canvasSelector)
+RenderThread::RenderThread(const char* canvasSelector)
     : _canvasSelector(canvasSelector != nullptr ? canvasSelector : "#thermion_canvas")
 {
     srand(time(NULL));
-    _lastFrameTime = std::chrono::high_resolution_clock::now();
     #ifdef __EMSCRIPTEN__
     Log("Starting RenderThread")
     outer = pthread_self();
+    startWebWorker(canvasSelector);
+    #else
+    _thread = new std::thread([this]() { runNativeLoop(); });
+    #endif
+}
+
+#ifdef __EMSCRIPTEN__
+// Start the worker pthread and transfer the canvas to it. On failure,
+// _creationFailed lets the C API return a null handle instead of a worker
+// that would hang every queued task forever.
+void RenderThread::startWebWorker(const char* canvasSelector) {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     emscripten_pthread_attr_settransferredcanvases(&attr, canvasSelector);
     auto *workerArg = new WorkerArg{this, _stop};
-    int rc = pthread_create(&t, &attr, startHelper, workerArg);
+    int rc = pthread_create(&_thread, &attr, startHelper, workerArg);
     if (rc != 0) {
-      // The worker never started, so tasks queued for this thread will never
-      // run — every caller would hang forever. Surface it: the C API returns
-      // a null handle and Dart throws "Failed to create render thread".
       Log("SEVERE - pthread_create failed with code %d; worker did not start "
           "(canvas selector %s, pool exhausted?)",
           rc, canvasSelector);
       _creationFailed = true;
       delete workerArg;
     }
-    #else
-    t = new std::thread([this]() { runNativeLoop(); });
-    #endif
 }
-
-
+#endif
 
 RenderThread::~RenderThread()
 {
@@ -111,7 +119,7 @@ RenderThread::~RenderThread()
         pendingTaskCount = _tasks.size();
     }
     TRACE("Destroying RenderThread (%zu tasks remaining)", pendingTaskCount);
-    _stop->value.store(true, std::memory_order_release);
+    shutdown();
 
     #ifdef __EMSCRIPTEN__
     // The web worker cannot be synchronously joined from the browser main
@@ -144,27 +152,42 @@ RenderThread::~RenderThread()
     // without blocking. Callers that need to wait for the worker to actually
     // finish exiting (e.g. before constructing a replacement RenderThread)
     // should poll mLiveWorkerCount from Dart.
-    pthread_detach(t);
+    pthread_detach(_thread);
     #else
-    // The worker owns and drains the queue. This preserves render-thread
-    // affinity and avoids racing the destructor against a concurrent pop.
-    _cv.notify_all();
     TRACE("Joining RenderThread thread..");
-    t->join();
-    delete t;
+    _thread->join();
+    delete _thread;
     #endif
 
     TRACE("RenderThread destructor complete");
 }
 
-#ifdef __EMSCRIPTEN__
-void RenderThread::iter() {
-    // FPS measurement
-    auto now = std::chrono::high_resolution_clock::now();
+void RenderThread::shutdown()
+{
+    _stop->value.store(true, std::memory_order_release);
+    #ifndef __EMSCRIPTEN__
+    _cv.notify_all();
+    #endif
+}
 
+void RenderThread::enqueue(std::function<void()> task) {
+    {
+        std::lock_guard<std::mutex> lock(_taskMutex);
+        _tasks.push_back(std::move(task));
+    }
+    #ifndef __EMSCRIPTEN__
+    _cv.notify_one();
+    #endif
+}
+
+#ifdef __EMSCRIPTEN__
+// Drain every queued task without yielding to the browser. Called from
+// iter() on the worker, so Filament calls keep their thread affinity; the
+// queue mutex is released while each task executes so tasks may queue
+// further work.
+void RenderThread::pumpTasks() {
     std::unique_lock<std::mutex> taskLock(_taskMutex);
 
-    // On Emscripten, drain all queued tasks then yield to browser.
     while (!_tasks.empty())
     {
         auto task = std::move(_tasks.front());
@@ -174,14 +197,21 @@ void RenderThread::iter() {
         taskLock.lock();
     }
     taskLock.unlock();
+}
+
+void RenderThread::iter() {
+    // FPS measurement
+    auto now = std::chrono::high_resolution_clock::now();
+
+    pumpTasks();
 
     // Render at most one swapchain per rAF so Filament's WebGL backend can
     // commit the frame between iterations. When no render has been requested,
     // tick() is a cheap flag-check and returns immediately.
-    if (mRenderManager) {
+    if (_renderManager) {
         auto frameTimeInNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
                                     now.time_since_epoch()).count();
-        mRenderManager->tick(frameTimeInNanos);
+        _renderManager->tick(frameTimeInNanos);
     }
 }
 #else
@@ -190,14 +220,13 @@ void RenderThread::runNativeLoop() {
 
     while (true) {
         _cv.wait(taskLock, [this] {
-            return !_tasks.empty() ||
-                   _stop->value.load(std::memory_order_acquire);
+            return !_tasks.empty() || isStopping();
         });
 
         if (_tasks.empty()) {
             // A stop request only terminates the worker after it has executed
             // every task that was already queued.
-            if (_stop->value.load(std::memory_order_acquire)) {
+            if (isStopping()) {
                 break;
             }
             continue;

--- a/thermion_dart/native/test/rendering/CMakeLists.txt
+++ b/thermion_dart/native/test/rendering/CMakeLists.txt
@@ -27,3 +27,12 @@ endif()
 enable_testing()
 add_test(NAME scheduling COMMAND scheduling_test)
 set_tests_properties(scheduling PROPERTIES TIMEOUT 30)
+
+add_executable(worker_queue_test
+    worker_queue_test.cpp
+    ../../src/rendering/RenderThread.cpp)
+target_compile_features(worker_queue_test PRIVATE cxx_std_17)
+target_include_directories(worker_queue_test PRIVATE ../../include)
+target_link_libraries(worker_queue_test PRIVATE Threads::Threads)
+add_test(NAME worker_queue COMMAND worker_queue_test)
+set_tests_properties(worker_queue PROPERTIES TIMEOUT 30)

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -37,10 +37,6 @@ Native Android callbacks remain registered at display frequency even when the
 gate rejects rendering work. Device validation should check the cadence and
 wakeup cost at low target rates and during display refresh changes.
 
-The gate extraction is reused by the web worker in #301. Forwarding scheduler
-timestamps through Flutter into rendering is in #319. Normalizing native scheduler output alone does not replace the existing
-Dart wall-clock render timestamp. Browser dispatch/lifetime fixtures land in #301.
-
 ## KTX upload lifetime tests
 
 The caller owns the KTX bundle. `destroy()` immediately deletes it and its data;
@@ -70,3 +66,96 @@ backend (Metal on macOS). They gate the worker to verify release is still pendin
 exercise cubemap/mipmapped/2D uploads followed by explicit bundle destruction,
 and check public skybox/IBL failure delivery. Dart's native build hook builds
 Thermion and obtains Filament.
+
+## Web command processing and shutdown
+
+Web drawing still runs on animation-frame callbacks. Commands wake the render
+worker independently, so an upload does not have to wait for another frame.
+The worker checks a two-millisecond budget between commands and yields between
+batches. Commands remain FIFO, but drawing may happen between batches: several
+commands are not an atomic transaction. A long command or backend operation can
+exceed that budget. Browsers can still throttle or suspend a whole page/worker;
+this removes the dependency on animation frames, not browser scheduling limits.
+
+Render-manager attachment, detachment, and destruction run on the worker.
+Await `RenderManager.destroy()` before destroying its animation managers,
+renderer, or engine. The app handles this ordering during `destroy()`.
+Manager destruction means deletion has finished, not that the worker has exited.
+After engine cleanup, `RenderThread_destroy` releases the registry's ownership
+and asks the web worker to drain and delete itself. Native destruction joins
+synchronously. Do not use the worker handle after requesting destruction.
+
+Web completions are posted asynchronously through a module-lifetime proxy queue.
+They remain deliverable after their worker exits, without Dart polling. A view
+name is copied for callback delivery because a later queued rename/destruction
+may otherwise invalidate its storage. These changes do not introduce an error
+transport, change buffer ownership, or change the no-exceptions build settings.
+
+The native `worker_queue` test above checks packaged results, FIFO ordering,
+worker affinity, nested completion work, and 25 drain/join cycles.
+
+### Commands with animation frames disabled
+
+The standalone fixture uses the production worker queue and a stub RenderManager.
+It checks 25 shutdown cycles, FIFO ordering, yielding, and callbacks delivered
+after worker exit. It deliberately keeps the browser busy during shutdown to
+check that the worker can finish without synchronous browser callbacks.
+Use an activated Emscripten SDK and the web Filament headers installed by `make wasm`:
+
+```sh
+mkdir -p /tmp/thermion-web-dispatch
+em++ -O1 -g -std=c++17 -pthread -fno-exceptions \
+  -sASSERTIONS=2 -sPTHREAD_POOL_SIZE=2 -sMALLOC=mimalloc \
+  -sINITIAL_MEMORY=134217728 -sOFFSCREENCANVAS_SUPPORT=1 \
+  -sALLOW_BLOCKING_ON_MAIN_THREAD=0 \
+  --pre-js thermion_dart/native/test/rendering/disable_worker_frames.js \
+  -I thermion_dart/native/include -I thermion_dart/native/web/lib/release/include \
+  thermion_dart/native/test/rendering/web_dispatch_test.cpp \
+  thermion_dart/native/src/rendering/RenderThread.cpp \
+  -o /tmp/thermion-web-dispatch/test.js
+dart run thermion_dart/native/test/rendering/run_web_dispatch_test.dart /tmp/thermion-web-dispatch
+```
+
+The runner serves COOP/COEP headers and launches headless Chrome. An optional
+second argument selects the Chrome executable; the default is its macOS path.
+
+The full-module fixture checks generated Dart bindings, pointer/void/string
+callbacks, KTX upload and buffer release with animation frames disabled, public
+skybox/IBL loading, and four engine lifecycles. Missing resources fail through
+Dart's resource loader; it does not test recovery from a native panic.
+
+```sh
+emcmake cmake -S thermion_dart/native/web -B /tmp/thermion-web-api \
+  -DCMAKE_BUILD_TYPE=Release \
+  "-DCMAKE_EXE_LINKER_FLAGS=--pre-js $PWD/thermion_dart/native/test/rendering/disable_worker_frames.js"
+cmake --build /tmp/thermion-web-api -j 4
+cp thermion_dart/native/test/rendering/web_api_test.html /tmp/thermion-web-api/build/out/index.html
+cp examples/assets/materials_studio_ibl.ktx /tmp/thermion-web-api/build/out/texture.ktx
+cp examples/assets/default_env_skybox.ktx /tmp/thermion-web-api/build/out/skybox.ktx
+cd thermion_dart
+dart compile js native/test/rendering/web_api_test.dart -o /tmp/thermion-web-api/build/out/test.js
+dart run native/test/rendering/run_web_dispatch_test.dart /tmp/thermion-web-api/build/out
+```
+
+### Teardown while drawing
+
+The drawing-enabled fixture creates two real engines and 32×32 views. It checks
+that both draw, one can pause/resume independently, and destroying one leaves the
+other drawing. It waits for both workers to exit. Frame histories establish
+progress, not physical presentation intervals or a particular FPS limit.
+Its native helpers are opt-in test sources, excluded from normal builds.
+Run from the repository root, using a separate build directory:
+
+```sh
+emcmake cmake -S thermion_dart/native/web -B /tmp/thermion-web-frames \
+  -DCMAKE_BUILD_TYPE=Release \
+  "-DEXTERNAL_PROJECTS=$PWD/thermion_dart/native/test/rendering/web_frame_fixture.cmake"
+cmake --build /tmp/thermion-web-frames -j 4
+cp thermion_dart/native/test/rendering/web_frame_test.html /tmp/thermion-web-frames/build/out/index.html
+cd thermion_dart
+dart compile js native/test/rendering/web_frame_test.dart -o /tmp/thermion-web-frames/build/out/test.js
+dart run native/test/rendering/run_web_dispatch_test.dart /tmp/thermion-web-frames/build/out
+```
+
+These manual tests cover headless Chrome. They do not establish behavior under
+full browser suspension, mobile browser policies, or other browser engines.

--- a/thermion_dart/native/test/rendering/disable_worker_frames.js
+++ b/thermion_dart/native/test/rendering/disable_worker_frames.js
@@ -1,0 +1,5 @@
+// Model a background tab: worker rendering callbacks never fire. Commands and
+// shutdown must still complete using event notifications, without Dart polling.
+if (typeof window === 'undefined') {
+  globalThis.requestAnimationFrame = () => 0;
+}

--- a/thermion_dart/native/test/rendering/run_web_dispatch_test.dart
+++ b/thermion_dart/native/test/rendering/run_web_dispatch_test.dart
@@ -1,0 +1,116 @@
+// Runs the standalone Emscripten fixture in headless Chrome with COOP/COEP.
+// Usage: dart run run_web_dispatch_test.dart BUILD_DIR [CHROME_EXECUTABLE]
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty) throw ArgumentError('Expected directory containing test.js');
+  final root = Directory(args.first).absolute;
+  final chrome = args.length > 1 ? args[1] : '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+  final profile = await Directory.systemTemp.createTemp('thermion-worker-test-');
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((request) async {
+    final response = request.response;
+    response.headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+    response.headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+    final name = request.uri.pathSegments.lastOrNull ?? '';
+    if (name.isEmpty) {
+      response.headers.contentType = ContentType.html;
+      final host = File('${root.path}/index.html');
+      response.write(
+        await host.exists()
+            ? await host.readAsString()
+            : '<!doctype html><script>globalThis.testResult="pending";</script><script src="test.js"></script>',
+      );
+    } else if (RegExp(r'^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*\.(js|wasm|ktx)$').hasMatch(name)) {
+      final file = File('${root.path}/$name');
+      if (await file.exists()) {
+        response.headers.contentType = ContentType.parse(
+          name.endsWith('.wasm')
+              ? 'application/wasm'
+              : name.endsWith('.ktx')
+              ? 'application/octet-stream'
+              : 'text/javascript',
+        );
+        await response.addStream(file.openRead());
+      } else {
+        response.statusCode = HttpStatus.notFound;
+      }
+    } else {
+      response.statusCode = HttpStatus.notFound;
+    }
+    await response.close();
+  });
+  Process? process;
+  WebSocket? socket;
+  final client = HttpClient();
+  try {
+    process = await Process.start(chrome, [
+      '--headless=new',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--remote-debugging-port=0',
+      '--user-data-dir=${profile.path}',
+      'http://127.0.0.1:${server.port}/',
+    ]);
+    unawaited(process.stdout.drain<void>());
+    unawaited(process.stderr.drain<void>());
+    final deadline = DateTime.now().add(const Duration(seconds: 30));
+    final portFile = File('${profile.path}/DevToolsActivePort');
+    while (!await portFile.exists()) {
+      if (DateTime.now().isAfter(deadline)) throw TimeoutException('Chrome did not start');
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    final port = (await portFile.readAsLines()).first;
+    final request = await client.getUrl(Uri.parse('http://127.0.0.1:$port/json/list'));
+    final targets = jsonDecode(await utf8.decoder.bind(await request.close()).join()) as List;
+    final page = targets.firstWhere((target) => target['type'] == 'page');
+    socket = await WebSocket.connect(page['webSocketDebuggerUrl'] as String);
+    final pending = <int, Completer<Map<String, dynamic>>>{};
+    Object? browserException;
+    socket.listen((data) {
+      final message = jsonDecode(data as String) as Map<String, dynamic>;
+      pending.remove(message['id'])?.complete(message);
+      if (message['method'] == 'Runtime.exceptionThrown') {
+        browserException = message['params']?['exceptionDetails'];
+      }
+    });
+    socket.add(jsonEncode({'id': 0, 'method': 'Runtime.enable'}));
+    var id = 0;
+    Object? progress;
+    while (DateTime.now().isBefore(deadline)) {
+      final result = Completer<Map<String, dynamic>>();
+      pending[++id] = result;
+      socket.add(
+        jsonEncode({
+          'id': id,
+          'method': 'Runtime.evaluate',
+          'params': {
+            'expression': '({result: globalThis.testResult, progress: globalThis.testProgress})',
+            'returnByValue': true,
+          },
+        }),
+      );
+      final response = await result.future.timeout(const Duration(seconds: 5));
+      if (browserException != null) throw StateError('Unhandled browser exception: $browserException');
+      final state = response['result']?['result']?['value'];
+      final value = state is Map ? state['result'] : null;
+      progress = state is Map ? state['progress'] : null;
+      if (value is String && value.startsWith('FAIL')) throw StateError(value);
+      if (value is String && value.startsWith('PASS')) {
+        stdout.writeln(value);
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    throw TimeoutException('Browser fixture did not finish (last progress: $progress)');
+  } finally {
+    await socket?.close();
+    process?.kill();
+    if (process != null) await process.exitCode;
+    client.close(force: true);
+    await server.close(force: true);
+    await profile.delete(recursive: true);
+  }
+}

--- a/thermion_dart/native/test/rendering/web_api_test.dart
+++ b/thermion_dart/native/test/rendering/web_api_test.dart
@@ -1,0 +1,124 @@
+// Full-module browser smoke test. See README.md for compile/run commands.
+import 'dart:async';
+import 'package:http/http.dart' as http;
+import 'package:thermion_dart/src/bindings/src/js_interop.dart';
+import 'package:thermion_dart/thermion_dart.dart' show Backend, FilamentApp, ThermionViewerFFI, Vector3;
+import 'package:thermion_dart/src/filament/src/implementation/ffi_filament_app.dart';
+
+void progress(String message) => globalContext['testProgress'] = message.toJS;
+
+// Copy a borrowed string during callback delivery, before native storage expires.
+Future<String> readName(Pointer<TView> view) async {
+  final result = Completer<String>();
+  void callback(Pointer<Char> name) => result.complete(name.cast<Utf8>().toDartString());
+  final pointer = callback.addFunction();
+  View_getNameRenderThread(view, pointer.cast());
+  final name = await result.future;
+  pointer.dispose();
+  return name;
+}
+
+Future<void> main() async {
+  try {
+    progress('module initialization');
+    await (globalContext['__thermionReady'] as JSPromise).toDart;
+    NativeLibrary.initBindings('thermion_dart');
+    for (var round = 0; round < 3; round++) {
+      progress('engine $round creation');
+      final selector = '#test_canvas_$round'.toNativeUtf8().cast<Char>();
+      final worker = RenderThread_createForCanvas(selector);
+      free(selector);
+      if (worker == nullptr) throw StateError('Worker creation failed');
+      final engine = await withPointerCallback<TEngine>((cb) {
+        Engine_createRenderThread(1, nullptr, nullptr, 1, false, cb);
+      });
+      if (engine == nullptr) throw StateError('Engine creation failed');
+      final renderer = await withPointerCallback<TRenderer>((cb) => Engine_createRendererRenderThread(engine, cb));
+      final manager = RenderManager_create(engine, renderer);
+      RenderManager_attachToRenderThread(manager);
+      RenderManager_setPaused(manager, true);
+      final view = await withPointerCallback<TView>((cb) => Engine_createViewRenderThread(engine, cb));
+      final name = 'worker-$round'.toNativeUtf8().cast<Char>();
+      await withVoidCallback((id, cb) => View_setNameRenderThread(view, name, id, cb));
+      free(name);
+      // Queue a rename before awaiting the name callback. Its old native
+      // storage may be replaced before the browser receives that callback.
+      final pendingName = readName(view);
+      final replacement = 'renamed-worker-$round'.toNativeUtf8().cast<Char>();
+      await withVoidCallback((id, cb) => View_setNameRenderThread(view, replacement, id, cb));
+      free(replacement);
+      final returnedName = await pendingName;
+      if (returnedName != 'worker-$round') throw StateError('Invalid string callback: $returnedName');
+      // Successful KTX creation and buffer release must also finish while
+      // worker animation-frame callbacks are disabled.
+      progress('engine $round KTX upload');
+      final bytes = (await http.get(Uri.base.resolve('texture.ktx'))).bodyBytes;
+      final bundle = Ktx1Bundle_create(bytes.address, bytes.length);
+      late Future<Pointer<TTexture>> created;
+      final released = withVoidCallback((id, releasedCallback) {
+        created = withPointerCallback<TTexture>((createdCallback) {
+          Ktx1Reader_createTextureRenderThread(engine, bundle, id, releasedCallback, createdCallback);
+        });
+      });
+      final texture = await created;
+      await released.timeout(const Duration(seconds: 5));
+      Ktx1Bundle_destroy(bundle);
+      bytes.free();
+      if (texture == nullptr) throw StateError('KTX creation failed');
+      await withVoidCallback((id, cb) => Engine_destroyTextureRenderThread(engine, texture, id, cb));
+      progress('engine $round command burst');
+      await Future.wait(
+        List.generate(
+          200,
+          (_) => withVoidCallback((id, cb) {
+            Engine_executeRenderThread(engine, id, cb);
+          }),
+        ),
+      );
+      await withVoidCallback((id, cb) => Engine_destroyViewRenderThread(engine, view, id, cb));
+      await withVoidCallback((id, cb) => RenderManager_destroyRenderThread(manager, id, cb));
+      await withVoidCallback((id, cb) => Engine_destroyRendererRenderThread(engine, renderer, id, cb));
+      await withVoidCallback((id, cb) => Engine_destroyRenderThread(engine, id, cb));
+      RenderThread_destroy(worker);
+    }
+    progress('viewer creation');
+    await FFIFilamentApp.create(
+      canvasSelector: '#test_canvas_3',
+      config: FFIFilamentConfig(
+        backend: Backend.OPENGL,
+        loadResource: (path) async {
+          final response = await http.get(Uri.base.resolve(path));
+          if (response.statusCode != 200) throw StateError('Resource load failed');
+          return response.bodyBytes;
+        },
+      ),
+    );
+    final app = FilamentApp.instance! as FFIFilamentApp;
+    final viewer = ThermionViewerFFI(app: app);
+    await viewer.initialized;
+    final camera = await viewer.getActiveCamera();
+    await camera.lookAt(Vector3(2, 3, 4));
+    final position = await camera.getPosition();
+    if ((position - Vector3(2, 3, 4)).length > 1e-6) {
+      throw StateError('Camera model matrix update failed');
+    }
+    var failed = false;
+    try {
+      await viewer.loadSkybox('missing.ktx');
+    } on StateError {
+      failed = true;
+    }
+    if (!failed) throw StateError('Missing skybox did not fail');
+    progress('viewer skybox');
+    await viewer.loadSkybox('skybox.ktx');
+    progress('viewer IBL');
+    await viewer.loadIbl('texture.ktx');
+    progress('viewer disposal');
+    await viewer.dispose();
+    await app.destroy();
+    globalContext['testResult'] =
+        'PASS: full WASM module, callbacks, camera, uploads, viewer skybox/IBL, 4 engine lifecycles'.toJS;
+  } catch (error, stack) {
+    globalContext['testResult'] = 'FAIL: $error\n$stack'.toJS;
+  }
+}

--- a/thermion_dart/native/test/rendering/web_api_test.html
+++ b/thermion_dart/native/test/rendering/web_api_test.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<canvas id="test_canvas_0" width="32" height="32"></canvas>
+<canvas id="test_canvas_1" width="32" height="32"></canvas>
+<canvas id="test_canvas_2" width="32" height="32"></canvas>
+<canvas id="test_canvas_3" width="32" height="32"></canvas>
+<script src="thermion_dart.js"></script>
+<script>
+  globalThis.testResult = 'pending';
+  globalThis.__thermionReady = thermion_dart().then(module => {
+    globalThis.thermion_dart = module;
+  }).catch(error => { globalThis.testResult = 'FAIL: ' + error; throw error; });
+</script>
+<script defer src="test.js"></script>

--- a/thermion_dart/native/test/rendering/web_dispatch_test.cpp
+++ b/thermion_dart/native/test/rendering/web_dispatch_test.cpp
@@ -1,0 +1,79 @@
+#include "rendering/RenderThread.hpp"
+#include "rendering/RenderManager.hpp"
+#include <emscripten.h>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+
+using namespace thermion;
+// Exercise the production queue without creating a Filament engine.
+namespace thermion { bool RenderManager::tick(uint64_t) { return false; } }
+namespace thermion { void RenderManager::executePendingCommands() {} }
+
+static std::atomic<int> executed{0};
+static bool completed = false; // browser-only
+static int roundNumber = 0;
+static int polls = 0;
+static bool yielded = false; // worker-only; reset before starting a new worker
+
+static void check(bool condition, const char* message) {
+    if (!condition) {
+        EM_ASM({ globalThis.testResult = 'FAIL: ' + UTF8ToString($0); }, message);
+        std::abort();
+    }
+}
+
+static void startRound(void*);
+static void poll(void*) {
+    if (completed && RenderThread::mLiveWorkerCount == 0) {
+        check(executed == 200, "shutdown lost tasks");
+        if (++roundNumber == 25) {
+            EM_ASM({ globalThis.testResult = 'PASS: 25 worker shutdown cycles, FIFO, yielding, callbacks after worker exit, rAF disabled'; });
+            return;
+        }
+        emscripten_set_timeout(startRound, 0, nullptr);
+        return;
+    }
+    check(++polls < 1000, "worker or completion failed to finish");
+    emscripten_set_timeout(poll, 5, nullptr);
+}
+
+static void startRound(void*) {
+    completed = false;
+    polls = 0;
+    executed = 0;
+    yielded = false;
+    auto* raw = new RenderThread("");
+    check(!raw->creationFailed(), "worker failed to start");
+    for (int i = 0; i < 200; ++i) {
+        raw->addDetachedTask([i] {
+            check(!emscripten_is_main_browser_thread(), "task ran on the browser thread");
+            check(executed.fetch_add(1) == i, "queue violated FIFO");
+            if (i == 0) emscripten_set_timeout([](void*) { yielded = true; }, 0, nullptr);
+            const auto end = std::chrono::steady_clock::now() + std::chrono::microseconds(50);
+            while (std::chrono::steady_clock::now() < end) {}
+        });
+    }
+    raw->addDetachedTask([raw] {
+        check(yielded, "task batches did not yield to the worker event loop");
+        // Already accepted work can still queue its completion while draining.
+        raw->addDetachedTask([raw] {
+            raw->dispatchCallback([] {
+                check(emscripten_is_main_browser_thread(), "completion ran on worker");
+                completed = true;
+            });
+        });
+    });
+    raw->shutdown(); // transfers ownership; do not access raw again
+    // Keep the browser busy until the worker exits. Completion delivery must
+    // still work afterward, without manually executing a proxy queue.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (RenderThread::mLiveWorkerCount != 0 && std::chrono::steady_clock::now() < deadline) {}
+    check(RenderThread::mLiveWorkerCount == 0, "worker shutdown needed browser callback servicing");
+    emscripten_set_timeout(poll, 0, nullptr);
+}
+
+int main() {
+    emscripten_set_timeout(startRound, 0, nullptr);
+    emscripten_exit_with_live_runtime();
+}

--- a/thermion_dart/native/test/rendering/web_frame_fixture.cmake
+++ b/thermion_dart/native/test/rendering/web_frame_fixture.cmake
@@ -1,0 +1,2 @@
+# Opt-in browser-test helpers; never compiled into normal web builds.
+list(APPEND SOURCES "${CMAKE_CURRENT_LIST_DIR}/web_frame_fixture.cpp")

--- a/thermion_dart/native/test/rendering/web_frame_fixture.cpp
+++ b/thermion_dart/native/test/rendering/web_frame_fixture.cpp
@@ -1,0 +1,76 @@
+// Browser integration helpers for the real RenderManager / Filament pipeline.
+// Compiled only when web_frame_fixture.cmake is explicitly supplied to CMake.
+#include "rendering/RenderThread.hpp"
+#include "rendering/RenderManager.hpp"
+#include <filament/Engine.h>
+#include <filament/Renderer.h>
+#include <filament/Scene.h>
+#include <filament/View.h>
+#include <utils/EntityManager.h>
+#include <algorithm>
+#include <emscripten.h>
+
+using namespace thermion;
+// The production dispatcher resolves each engine to its owning worker.
+extern "C" RenderThread* RT(void* owner);
+
+struct TestScene {
+    filament::SwapChain* swapChain = nullptr;
+    filament::View* view = nullptr;
+    filament::Scene* scene = nullptr;
+    utils::Entity camera;
+};
+// Each slot is accessed only on its owning worker.
+static TestScene scenes[2];
+
+extern "C" {
+EMSCRIPTEN_KEEPALIVE void WebTest_attachScene(filament::Engine* engine,
+        RenderManager* manager, int slot, uint32_t id, void (*done)(uint32_t)) {
+    auto* rt = RT(engine);
+    rt->addDetachedTask([=] {
+        auto& s = scenes[slot];
+        s.swapChain = engine->createSwapChain(nullptr);
+        s.scene = engine->createScene();
+        s.view = engine->createView();
+        s.camera = utils::EntityManager::get().create();
+        s.view->setCamera(engine->createCamera(s.camera));
+        s.view->setScene(s.scene);
+        s.view->setViewport({0, 0, 32, 32});
+        s.view->setPostProcessingEnabled(false);
+        manager->setRenderable(s.swapChain, &s.view, 1);
+        rt->dispatchCallback([=] { done(id); });
+    });
+}
+
+EMSCRIPTEN_KEEPALIVE void WebTest_frameId(filament::Engine* engine,
+        filament::Renderer* renderer, void (*done)(uint32_t)) {
+    auto* rt = RT(engine);
+    rt->addDetachedTask([=] {
+        uint32_t latest = 0;
+        for (const auto& frame : renderer->getFrameInfoHistory()) {
+            latest = std::max(latest, frame.frameId);
+        }
+        rt->dispatchCallback([=] { done(latest); });
+    });
+}
+
+// Called only after the public RenderManager_destroyRenderThread completes.
+EMSCRIPTEN_KEEPALIVE void WebTest_destroyScene(filament::Engine* engine,
+        int slot, uint32_t id, void (*done)(uint32_t)) {
+    auto* rt = RT(engine);
+    rt->addDetachedTask([=] {
+        auto& s = scenes[slot];
+        engine->destroy(s.view);
+        engine->destroy(s.scene);
+        engine->destroyCameraComponent(s.camera);
+        utils::EntityManager::get().destroy(s.camera);
+        engine->destroy(s.swapChain);
+        s = {};
+        rt->dispatchCallback([=] { done(id); });
+    });
+}
+
+EMSCRIPTEN_KEEPALIVE int WebTest_liveWorkers() {
+    return RenderThread::mLiveWorkerCount.load();
+}
+}

--- a/thermion_dart/native/test/rendering/web_frame_test.dart
+++ b/thermion_dart/native/test/rendering/web_frame_test.dart
@@ -1,0 +1,93 @@
+// Real worker rAF + Filament integration. See README.md for build instructions.
+import 'dart:async';
+import 'package:thermion_dart/src/bindings/src/js_interop.dart';
+
+@JS('thermion_dart._WebTest_attachScene')
+external void _attachScene(int engine, int manager, int slot, int id, int callback);
+@JS('thermion_dart._WebTest_frameId')
+external void _frameId(int engine, int renderer, int callback);
+@JS('thermion_dart._WebTest_destroyScene')
+external void _destroyScene(int engine, int slot, int id, int callback);
+@JS('thermion_dart._WebTest_liveWorkers')
+external int _liveWorkers();
+
+void check(bool condition, String message) {
+  if (!condition) throw StateError(message);
+}
+
+class _Engine {
+  _Engine(this.slot, this.worker, this.engine, this.renderer, this.manager);
+  final int slot;
+  final Pointer<Void> worker;
+  final Pointer<TEngine> engine;
+  final Pointer<TRenderer> renderer;
+  final Pointer<TRenderManager> manager;
+
+  static Future<_Engine> create(int slot) async {
+    final selector = '#frame_canvas_$slot'.toNativeUtf8().cast<Char>();
+    final worker = RenderThread_createForCanvas(selector);
+    free(selector);
+    check(worker != nullptr, 'Worker creation failed');
+    final engine = await withPointerCallback<TEngine>(
+      (cb) => Engine_createRenderThread(1, nullptr, nullptr, 1, false, cb),
+    );
+    final renderer = await withPointerCallback<TRenderer>((cb) => Engine_createRendererRenderThread(engine, cb));
+    final manager = RenderManager_create(engine, renderer);
+    RenderManager_attachToRenderThread(manager);
+    await withVoidCallback((id, cb) => _attachScene(engine.address, manager.address, slot, id, cb.address));
+    return _Engine(slot, worker, engine, renderer, manager);
+  }
+
+  Future<int> frameId() => withUInt32Callback((cb) => _frameId(engine.address, renderer.address, cb.address));
+
+  Future<void> destroy() async {
+    // Intentionally destroy while rAF is active: queued detachment must finish
+    // before freeing the view/swapchain/renderer that tick() used to access.
+    await withVoidCallback((id, cb) => RenderManager_destroyRenderThread(manager, id, cb));
+    await withVoidCallback((id, cb) => _destroyScene(engine.address, slot, id, cb.address));
+    await withVoidCallback((id, cb) => Engine_destroyRendererRenderThread(engine, renderer, id, cb));
+    await withVoidCallback((id, cb) => Engine_destroyRenderThread(engine, id, cb));
+    RenderThread_destroy(worker);
+  }
+}
+
+Future<List<int>> sample(_Engine first, _Engine second) async {
+  final before = await Future.wait([first.frameId(), second.frameId()]);
+  await Future<void>.delayed(const Duration(seconds: 1));
+  final after = await Future.wait([first.frameId(), second.frameId()]);
+  return [after[0] - before[0], after[1] - before[1]];
+}
+
+Future<void> main() async {
+  try {
+    await (globalContext['__thermionReady'] as JSPromise).toDart;
+    NativeLibrary.initBindings('thermion_dart');
+    final first = await _Engine.create(0);
+    final second = await _Engine.create(1);
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    final initial = await sample(first, second);
+    check(initial[0] > 0 && initial[1] > 0, 'Both engines must draw: $initial');
+
+    RenderManager_setPaused(first.manager, true);
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    final paused = await sample(first, second);
+    check(paused[0] == 0 && paused[1] >= 5, 'Pause affected the wrong engine: $paused');
+    RenderManager_setPaused(first.manager, false);
+    final resumed = await sample(first, second);
+    check(resumed[0] >= 5, 'Paused engine failed to resume: $resumed');
+
+    await first.destroy();
+    final before = await second.frameId();
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    check(await second.frameId() > before, 'Destroying one engine stopped the other');
+    await second.destroy();
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (_liveWorkers() != 0 && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    check(_liveWorkers() == 0, 'Workers remained alive after teardown');
+    globalContext['testResult'] = 'PASS: two engines drawing, pause/resume, independent teardown and worker exit'.toJS;
+  } catch (error, stack) {
+    globalContext['testResult'] = 'FAIL: $error\n$stack'.toJS;
+  }
+}

--- a/thermion_dart/native/test/rendering/web_frame_test.html
+++ b/thermion_dart/native/test/rendering/web_frame_test.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<canvas id="frame_canvas_0" width="32" height="32"></canvas>
+<canvas id="frame_canvas_1" width="32" height="32"></canvas>
+<script src="thermion_dart.js"></script>
+<script>
+  globalThis.testResult = 'pending';
+  globalThis.__thermionReady = thermion_dart().then(module => {
+    globalThis.thermion_dart = module;
+  }).catch(error => { globalThis.testResult = 'FAIL: ' + error; throw error; });
+</script>
+<script defer src="test.js"></script>

--- a/thermion_dart/native/test/rendering/worker_queue_test.cpp
+++ b/thermion_dart/native/test/rendering/worker_queue_test.cpp
@@ -1,0 +1,40 @@
+#include "rendering/RenderThread.hpp"
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace thermion;
+using namespace std::chrono_literals;
+
+static void check(bool condition) {
+    if (!condition) std::abort();
+}
+
+int main() {
+    for (int round = 0; round < 25; ++round) {
+        int executed = 0;
+        const auto caller = std::this_thread::get_id();
+        {
+            RenderThread worker;
+            std::packaged_task<int()> query([caller] {
+                check(std::this_thread::get_id() != caller);
+                return 42;
+            });
+            auto result = worker.addTask(query);
+            check(result.wait_for(2s) == std::future_status::ready);
+            check(result.get() == 42);
+            for (int i = 0; i < 200; ++i) {
+                worker.addDetachedTask([&, i] {
+                    check(std::this_thread::get_id() != caller);
+                    check(executed++ == i);
+                });
+            }
+            worker.addDetachedTask([&] {
+                worker.addDetachedTask([&] { check(executed++ == 200); });
+            });
+            // Destruction must drain on the worker and join before returning.
+        }
+        check(executed == 201);
+    }
+    std::puts("PASS: native FIFO, packaged result, nested completion and 25 shutdown cycles");
+}


### PR DESCRIPTION
Web rendering uses a worker thread, but that worker currently runs queued commands when an animation-frame callback arrives. If those callbacks stop, an upload or another awaited operation can remain waiting even though it does not need to draw anything. Destruction also has a threading problem: the caller can detach or delete the render manager while the worker is drawing, and worker destruction can run remaining commands on the caller's thread.

This PR separates command processing from drawing and makes teardown follow the same queue as normal operations. This lets uploads and cleanup progress without another animation frame, and makes repeated viewer creation and destruction safer.

### How it works

**Stacked on #349**, a preparation PR that rearranges and documents `RenderThread` with no behavior change (and adds the native `worker_queue_test`). This PR therefore contains only the behavior change.

This keeps the existing single shared `RenderThread` implementation (platform branches behind `#ifdef __EMSCRIPTEN__`); splitting it into separate `NativeRenderThread`/`WebRenderThread` implementations is deliberately extracted into #348 so this diff stays reviewable as a behavior change only.

- Adding a command wakes the worker. Commands run in FIFO order, with a two-millisecond budget checked between commands. The worker yields between batches so other events can run. A long command can exceed that budget, and drawing can happen between batches.
- Animation frames still drive drawing. After a command batch, the worker also processes Filament backend commands and release callbacks. Pausing drawing or disabling animation frames therefore does not stop uploads from completing.
- Render-manager attachment, detachment, and deletion run on the worker. `FilamentApp.destroy()` awaits manager deletion before destroying its animation manager, renderer, and engine. `RenderManager.destroy()` now returns a Future that callers must await.
- Worker destruction consumes the registry's existing unique owner. After engine cleanup, web worker destruction transfers ownership to the worker. The worker drains its queue, cancels its frame loop, and deletes itself. This avoids blocking the browser and does not add shared ownership. Native worker destruction still drains and joins synchronously.
- Web completion callbacks use a queue that lives for the WASM module's lifetime. A posted callback remains deliverable after its worker exits, and Dart can await it without polling. View names are copied for delivery because a later queued rename or deletion can invalidate the original string.

Manager destruction completes when the manager has been deleted. Web worker destruction returns before the worker exits; its handle must not be used again. Browsers may still throttle or suspend an entire page or worker—this change removes the dependency on animation frames, not browser scheduling limits.

### Scope

Based on #349, which starts from `develop` with Filament 1.76.0 and the merged callback and buffer-lifetime fixes. There is no dependency on the closed #318, and C++ exceptions remain disabled.

The platform split is #348, and per-engine FPS limiting is #346 on top of #348. Review and merge order: **#349 → #347 → #348 → #346**. This PR does not change FPS policy, KTX validation, KTX ownership, or the KTX upload loop.

### Validation

Previously tested locally on macOS with the no-exceptions build. The stack refresh preserves this PR's exact file tree, so those results still apply:

- Both standalone native tests pass, including FIFO, worker affinity, packaged results, nested completion work, and 25 shutdown cycles.
- The standalone Chrome fixture passes 25 cycles with animation frames disabled, checking yielding and callback delivery after worker exit without browser-side queue polling.
- The full Filament Chrome fixture passes KTX upload/release, queued view renaming, public skybox/IBL loading, and four engine lifecycles with animation frames disabled.
- The drawing-enabled Chrome fixture passes with two real engines: independent pause/resume, destruction while the other keeps drawing, and eventual worker exit.
- All 23 selected native Dart callback, KTX-lifetime, and skybox tests pass. All 41 Flutter tests pass; one Linux-only test is skipped.
- Bindings regenerated with `make bindings`; only the generated API additions are included. Targeted Dart analysis is clean. Flutter analysis reports seven existing informational notices.

Reproduction commands and lifecycle details are in the [manual test guide](https://github.com/nmfisher/thermion/blob/fix/web-render-worker-teardown/thermion_dart/native/test/rendering/README.md). Browser validation covers headless Chrome/WebGL, not other browsers or physical presentation timing.
