### PR TITLE
refactor: separate native and web render workers

### DIFF
--- a/thermion_dart/native/include/rendering/NativeRenderThread.hpp
+++ b/thermion_dart/native/include/rendering/NativeRenderThread.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+namespace thermion {
+
+// A blocking FIFO worker. Sleeps until work arrives; destruction drains and
+// joins before returning. Drawing is scheduled separately on native platforms.
+class NativeRenderThread {
+public:
+    NativeRenderThread();
+    ~NativeRenderThread();
+
+    // Matches the shared creation API; the canvas selector is unused on native.
+    static std::unique_ptr<NativeRenderThread> create(const char* = nullptr);
+    // Consumes ownership. Previously accepted work finishes before this returns.
+    static void destroy(std::unique_ptr<NativeRenderThread> thread);
+
+    template <class Rt>
+    auto addTask(std::packaged_task<Rt()>& task) -> std::future<Rt> {
+        auto result = task.get_future();
+        addDetachedTask([task = std::make_shared<std::packaged_task<Rt()>>(std::move(task))] {
+            (*task)();
+        });
+        return result;
+    }
+
+    template <class Fn>
+    void addDetachedTask(Fn&& fn) {
+        enqueue(std::function<void()>(std::forward<Fn>(fn)));
+    }
+
+    bool isStopping() const { return _stopping.load(std::memory_order_acquire); }
+
+private:
+    void enqueue(std::function<void()> task);
+    void run();
+
+    std::mutex _taskMutex;
+    std::condition_variable _cv;
+    std::deque<std::function<void()>> _tasks;
+    std::atomic<bool> _stopping{false};
+    std::thread _thread;
+};
+
+} // namespace thermion

--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -1,102 +1,11 @@
 #pragma once
 
-#include <atomic>
-#include <condition_variable>
-#include <deque>
-#include <functional>
-#include <future>
-#include <memory>
-#include <mutex>
-#include <string>
-#include <thread>
-#include <utility>
-
+// Select one concrete implementation at compile time. The C API uses the same
+// name without virtual dispatch or a separately allocated implementation object.
 #ifdef __EMSCRIPTEN__
-#include <emscripten/threading.h>
-#include <emscripten/proxying.h>
-#include <emscripten/eventloop.h>
-#endif
-
-namespace thermion {
-
-class RenderManager;
-
-// One ordered command queue per engine. Native workers sleep until work arrives;
-// web workers service bounded batches from event notifications independently of
-// their drawing loop. Filament calls always execute on the owning worker.
-// FIFO applies to commands, not transactions: drawing may run between batches.
-class RenderThread {
-public:
-    explicit RenderThread(const char* canvasSelector = "#thermion_canvas");
-    ~RenderThread();
-
-    const char* canvasSelector() const { return _canvasSelector.c_str(); }
-    bool creationFailed() const { return _creationFailed; }
-    bool isStopping() const { return _stopping.load(std::memory_order_acquire); }
-
-    // Drain accepted work. Native destruction joins the worker. On web this
-    // transfers ownership to the worker, which deletes this object after its
-    // queue and frame loop stop. Call only once on a heap-allocated web worker;
-    // the caller must release its owner before calling and never use it again.
-    void shutdown();
-
-    template <class Rt>
-    auto addTask(std::packaged_task<Rt()>& task) -> std::future<Rt>;
-
-    template <class Fn>
-    void addDetachedTask(Fn&& fn) { enqueue(std::function<void()>(std::forward<Fn>(fn))); }
-
-    static std::atomic<int32_t> mLiveWorkerCount;
-
-#ifdef __EMSCRIPTEN__
-    // Completion delivery uses a module-lifetime queue, so accepted callbacks
-    // remain deliverable after the originating engine/worker has shut down.
-    void dispatchCallback(std::function<void()> callback) const;
-    static void executeCallbacks();
-    void setRenderManager(RenderManager* manager); // worker-only
+#include "rendering/WebRenderThread.hpp"
+namespace thermion { using RenderThread = WebRenderThread; }
 #else
-    void dispatchCallback(std::function<void()> callback) const { callback(); }
+#include "rendering/NativeRenderThread.hpp"
+namespace thermion { using RenderThread = NativeRenderThread; }
 #endif
-
-private:
-    void enqueue(std::function<void()> task);
-    bool isWorkerThread() const;
-
-    std::mutex _taskMutex;
-    std::condition_variable _cv;
-    std::deque<std::function<void()>> _tasks;
-    std::atomic<bool> _stopping{false};
-    // Dart frees its UTF8 buffer immediately after worker creation.
-    std::string _canvasSelector;
-    bool _creationFailed = false;
-
-#ifdef __EMSCRIPTEN__
-    void startWebWorker();
-    static void* startHelper(void* arg);
-    static void frameCallback(void* arg);
-    static void pumpCallback(void* arg);
-    static void finishShutdown(void* arg);
-    void scheduleWakeLocked();
-    void pumpTasks();
-
-    pthread_t _thread{};
-    pthread_t _caller{};
-    bool _wakePending = false; // protected by _taskMutex
-    bool _workerFinished = false;
-    RenderManager* _renderManager = nullptr; // worker-only
-#else
-    void runNativeLoop();
-    std::thread _thread;
-#endif
-};
-
-template <class Rt>
-auto RenderThread::addTask(std::packaged_task<Rt()>& task) -> std::future<Rt> {
-    auto result = task.get_future();
-    addDetachedTask([task = std::make_shared<std::packaged_task<Rt()>>(std::move(task))] {
-        (*task)();
-    });
-    return result;
-}
-
-} // namespace thermion

--- a/thermion_dart/native/include/rendering/WebRenderThread.hpp
+++ b/thermion_dart/native/include/rendering/WebRenderThread.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <emscripten/threading.h>
+
+namespace thermion {
+
+class RenderManager;
+
+// An event-driven worker: commands run in yielding FIFO batches independently
+// of animation-frame drawing. Drawing can happen between batches, so a group
+// of commands is not an atomic transaction. Use create()/destroy() for ownership.
+class WebRenderThread {
+public:
+    explicit WebRenderThread(const char* canvasSelector);
+    ~WebRenderThread();
+
+    // Returns null if the pthread cannot start. Owns a copy of the selector.
+    static std::unique_ptr<WebRenderThread> create(const char* canvasSelector = nullptr);
+    // Consumes ownership and returns without blocking the browser. The worker
+    // drains, cancels its frame loop, then deletes itself. Never use it afterward.
+    static void destroy(std::unique_ptr<WebRenderThread> thread);
+
+    template <class Rt>
+    auto addTask(std::packaged_task<Rt()>& task) -> std::future<Rt> {
+        auto result = task.get_future();
+        addDetachedTask([task = std::make_shared<std::packaged_task<Rt()>>(std::move(task))] {
+            (*task)();
+        });
+        return result;
+    }
+
+    template <class Fn>
+    void addDetachedTask(Fn&& fn) {
+        enqueue(std::function<void()>(std::forward<Fn>(fn)));
+    }
+
+    bool isStopping() const { return _stopping.load(std::memory_order_acquire); }
+
+    const char* canvasSelector() const { return _canvasSelector.c_str(); }
+
+    // Posted callbacks outlive their worker and are serviced by browser events.
+    void dispatchCallback(std::function<void()> callback) const;
+    static void executeCallbacks();
+    void setRenderManager(RenderManager* manager); // worker-only
+    static std::atomic<int32_t> mLiveWorkerCount;
+
+private:
+    void startWorker();
+    void requestShutdown();
+    void enqueue(std::function<void()> task);
+    void scheduleWakeLocked();
+    void pumpTasks();
+    static void* startHelper(void* arg);
+    static void frameCallback(void* arg);
+    static void pumpCallback(void* arg);
+    static void finishShutdown(void* arg);
+
+    std::mutex _taskMutex;
+    std::deque<std::function<void()>> _tasks;
+    std::atomic<bool> _stopping{false};
+    // Dart frees its UTF8 buffer immediately after worker creation.
+    std::string _canvasSelector;
+    bool _creationFailed = false;
+    pthread_t _thread{};
+    pthread_t _caller{};
+    bool _wakePending = false; // protected by _taskMutex
+    bool _workerFinished = false;
+    RenderManager* _renderManager = nullptr; // worker-only
+};
+
+} // namespace thermion

--- a/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
+++ b/thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp
@@ -179,18 +179,12 @@ extern "C"
   // on the right canvas.
   EMSCRIPTEN_KEEPALIVE const char *RenderThread_getActiveCanvasSelector()
   {
+#ifdef __EMSCRIPTEN__
     RenderThread *rt = g_activeThread != nullptr ? g_activeThread : _renderThread.get();
     return rt != nullptr ? rt->canvasSelector() : "#thermion_canvas";
-  }
-
-  // The registry owns live workers. On web, transfer ownership at shutdown:
-  // only the worker can drain its queue and cancel its frame loop safely.
-  static void disposeThread(std::unique_ptr<RenderThread> thread)
-  {
-#ifdef __EMSCRIPTEN__
-    thread.release()->shutdown();
+#else
+    return "#thermion_canvas";
 #endif
-    // Native destruction drains and joins synchronously.
   }
 
   EMSCRIPTEN_KEEPALIVE void* RenderThread_create()
@@ -201,15 +195,15 @@ extern "C"
     {
       Log("WARNING - you are attempting to create a RenderThread when the previous one has not been disposed.");
     }
-    auto thread = std::make_unique<RenderThread>();
-    if (thread->creationFailed())
+    auto thread = RenderThread::create();
+    if (!thread)
     {
       // pthread_create failed on web (e.g. worker pool exhausted); a null
       // handle lets Dart fail loudly instead of hanging on never-run tasks.
       Log("RenderThread worker failed to start; returning null handle");
       return nullptr;
     }
-    if (_renderThread) disposeThread(std::move(_renderThread));
+    if (_renderThread) RenderThread::destroy(std::move(_renderThread));
     _renderThread = std::move(thread);
     // Native destruction joins; the web worker retains ownership while it
     // drains. In both cases stopping workers cannot register new owners.
@@ -225,8 +219,8 @@ extern "C"
   EMSCRIPTEN_KEEPALIVE void* RenderThread_createForCanvas(const char *canvasSelector)
   {
     TRACE("RenderThread_createForCanvas %s", canvasSelector);
-    auto thread = std::make_unique<RenderThread>(canvasSelector);
-    if (thread->creationFailed())
+    auto thread = RenderThread::create(canvasSelector);
+    if (!thread)
     {
       Log("RenderThread worker failed to start for canvas %s; returning null handle", canvasSelector);
       return nullptr;
@@ -247,14 +241,14 @@ extern "C"
     }
     if (renderThread == _renderThread.get())
     {
-      disposeThread(std::move(_renderThread));
+      RenderThread::destroy(std::move(_renderThread));
     }
     else
     {
       auto it = _renderThreads.find(renderThread);
       if (it != _renderThreads.end())
       {
-        disposeThread(std::move(it->second));
+        RenderThread::destroy(std::move(it->second));
         _renderThreads.erase(it);
       }
     }

--- a/thermion_dart/native/src/rendering/NativeRenderThread.cpp
+++ b/thermion_dart/native/src/rendering/NativeRenderThread.cpp
@@ -1,0 +1,55 @@
+#include "rendering/NativeRenderThread.hpp"
+#include "Log.hpp"
+#include <cstdlib>
+
+namespace thermion {
+
+std::unique_ptr<NativeRenderThread> NativeRenderThread::create(const char*) {
+    return std::make_unique<NativeRenderThread>();
+}
+
+void NativeRenderThread::destroy(std::unique_ptr<NativeRenderThread> thread) {
+    thread.reset();
+}
+
+NativeRenderThread::NativeRenderThread()
+    : _thread([this] { run(); }) {}
+
+NativeRenderThread::~NativeRenderThread() {
+    {
+        std::lock_guard<std::mutex> lock(_taskMutex);
+        _stopping.store(true, std::memory_order_release);
+    }
+    _cv.notify_one();
+    _thread.join();
+}
+
+void NativeRenderThread::enqueue(std::function<void()> work) {
+    {
+        std::unique_lock<std::mutex> lock(_taskMutex);
+        // Accepted work can enqueue its own completion while draining.
+        if (isStopping() && std::this_thread::get_id() != _thread.get_id()) {
+            lock.unlock();
+            Log("Cannot submit work after RenderThread shutdown");
+            std::abort();
+        }
+        _tasks.push_back(std::move(work));
+    }
+    _cv.notify_one();
+}
+
+void NativeRenderThread::run() {
+    std::unique_lock<std::mutex> lock(_taskMutex);
+    while (true) {
+        _cv.wait(lock, [this] { return !_tasks.empty() || isStopping(); });
+        if (_tasks.empty() && isStopping()) return;
+        auto task = std::move(_tasks.front());
+        _tasks.pop_front();
+        lock.unlock();
+        task();
+        task = {};
+        lock.lock();
+    }
+}
+
+} // namespace thermion

--- a/thermion_dart/native/test/rendering/CMakeLists.txt
+++ b/thermion_dart/native/test/rendering/CMakeLists.txt
@@ -30,7 +30,7 @@ set_tests_properties(scheduling PROPERTIES TIMEOUT 30)
 
 add_executable(worker_queue_test
     worker_queue_test.cpp
-    ../../src/rendering/RenderThread.cpp)
+    ../../src/rendering/NativeRenderThread.cpp)
 target_compile_features(worker_queue_test PRIVATE cxx_std_17)
 target_include_directories(worker_queue_test PRIVATE ../../include)
 target_link_libraries(worker_queue_test PRIVATE Threads::Threads)

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -69,6 +69,15 @@ Thermion and obtains Filament.
 
 ## Web command processing and shutdown
 
+`RenderThread.hpp` selects a concrete implementation at compile time:
+`NativeRenderThread` has a blocking queue and joins on destruction;
+`WebRenderThread` has browser wakeups, drawing callbacks, and asynchronous exit.
+There is no virtual interface or extra implementation allocation. Both expose
+`create()` and `destroy()`; destruction consumes the registry's existing unique
+owner. The web implementation handles the ownership transfer internally.
+The native build hook compiles `NativeRenderThread.cpp` from `native/src`;
+web CMake excludes it and selects `native/web/src/cpp/WebRenderThread.cpp`.
+
 Web drawing still runs on animation-frame callbacks. Commands wake the render
 worker independently, so an upload does not have to wait for another frame.
 The worker checks a two-millisecond budget between commands and yields between
@@ -111,7 +120,7 @@ em++ -O1 -g -std=c++17 -pthread -fno-exceptions \
   --pre-js thermion_dart/native/test/rendering/disable_worker_frames.js \
   -I thermion_dart/native/include -I thermion_dart/native/web/lib/release/include \
   thermion_dart/native/test/rendering/web_dispatch_test.cpp \
-  thermion_dart/native/src/rendering/RenderThread.cpp \
+  thermion_dart/native/web/src/cpp/WebRenderThread.cpp \
   -o /tmp/thermion-web-dispatch/test.js
 dart run thermion_dart/native/test/rendering/run_web_dispatch_test.dart /tmp/thermion-web-dispatch
 ```

--- a/thermion_dart/native/test/rendering/web_dispatch_test.cpp
+++ b/thermion_dart/native/test/rendering/web_dispatch_test.cpp
@@ -43,8 +43,9 @@ static void startRound(void*) {
     polls = 0;
     executed = 0;
     yielded = false;
-    auto* raw = new RenderThread("");
-    check(!raw->creationFailed(), "worker failed to start");
+    auto owner = RenderThread::create("");
+    check(owner != nullptr, "worker failed to start");
+    auto* raw = owner.get();
     for (int i = 0; i < 200; ++i) {
         raw->addDetachedTask([i] {
             check(!emscripten_is_main_browser_thread(), "task ran on the browser thread");
@@ -64,7 +65,7 @@ static void startRound(void*) {
             });
         });
     });
-    raw->shutdown(); // transfers ownership; do not access raw again
+    RenderThread::destroy(std::move(owner)); // do not access raw again
     // Keep the browser busy until the worker exits. Completion delivery must
     // still work afterward, without manually executing a proxy queue.
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);

--- a/thermion_dart/native/test/rendering/worker_queue_test.cpp
+++ b/thermion_dart/native/test/rendering/worker_queue_test.cpp
@@ -15,7 +15,8 @@ int main() {
         int executed = 0;
         const auto caller = std::this_thread::get_id();
         {
-            RenderThread worker;
+            auto owner = RenderThread::create();
+            auto& worker = *owner;
             std::packaged_task<int()> query([caller] {
                 check(std::this_thread::get_id() != caller);
                 return 42;
@@ -32,7 +33,10 @@ int main() {
             worker.addDetachedTask([&] {
                 worker.addDetachedTask([&] { check(executed++ == 200); });
             });
-            // Destruction must drain on the worker and join before returning.
+            // Both implementations consume ownership through the same API.
+            RenderThread::destroy(std::move(owner));
+            check(!owner);
+            check(executed == 201);
         }
         check(executed == 201);
     }

--- a/thermion_dart/native/web/CMakeLists.txt
+++ b/thermion_dart/native/web/CMakeLists.txt
@@ -126,8 +126,13 @@ file(GLOB SOURCES
   "${CMAKE_CURRENT_SOURCE_DIR}/../src/transform_pipeline/*.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/../include/resources/*.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/ThermionWebApi.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/WebRenderThread.cpp"
    # "${CMAKE_CURRENT_SOURCE_DIR}/../src/rendering/EmscriptenTest.cpp"
   )
+
+# The Dart native build hook compiles NativeRenderThread from native/src.
+# Web supplies its own implementation, outside that source tree.
+list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../src/rendering/NativeRenderThread.cpp")
 
 if(DEFINED EXTERNAL_PROJECTS)
 

--- a/thermion_dart/native/web/src/cpp/WebRenderThread.cpp
+++ b/thermion_dart/native/web/src/cpp/WebRenderThread.cpp
@@ -1,24 +1,18 @@
-#include "rendering/RenderThread.hpp"
-#ifdef __EMSCRIPTEN__
+#include "rendering/WebRenderThread.hpp"
 #include "rendering/RenderManager.hpp"
-#endif
 #include "Log.hpp"
-
 #include <cassert>
-#include <cstdlib>
-#include <cstring>
 #include <chrono>
-
-#ifdef __EMSCRIPTEN__
+#include <cstdlib>
 #include <emscripten/emscripten.h>
+#include <emscripten/proxying.h>
+#include <emscripten/eventloop.h>
 #include <mimalloc.h>
-#endif
 
 namespace thermion {
 
-std::atomic<int32_t> RenderThread::mLiveWorkerCount{0};
+std::atomic<int32_t> WebRenderThread::mLiveWorkerCount{0};
 
-#ifdef __EMSCRIPTEN__
 // The queues live until the WASM module is unloaded. A completion posted to the
 // browser must survive destruction of its originating RenderThread. Wakeups
 // share the same lifetime so executing proxy closures never own a dying queue.
@@ -31,69 +25,48 @@ static emscripten::ProxyingQueue& wakeups() {
     return *queue;
 }
 
-#endif
+std::unique_ptr<WebRenderThread> WebRenderThread::create(const char* canvasSelector) {
+    auto thread = std::make_unique<WebRenderThread>(canvasSelector);
+    if (thread->_creationFailed) return nullptr;
+    return thread;
+}
 
-RenderThread::RenderThread(const char* canvasSelector)
+void WebRenderThread::destroy(std::unique_ptr<WebRenderThread> thread) {
+    // Release the caller's owner before the worker can finish and delete itself.
+    if (thread) thread.release()->requestShutdown();
+}
+
+WebRenderThread::WebRenderThread(const char* canvasSelector)
     : _canvasSelector(canvasSelector ? canvasSelector : "#thermion_canvas") {
-#ifdef __EMSCRIPTEN__
     _caller = pthread_self();
-    startWebWorker();
-#else
-    _thread = std::thread([this] { runNativeLoop(); });
-#endif
+    startWorker();
 }
 
-RenderThread::~RenderThread() {
-#ifdef __EMSCRIPTEN__
+WebRenderThread::~WebRenderThread() {
     assert(_creationFailed || _workerFinished);
-#else
-    shutdown();
-    _thread.join();
-#endif
 }
 
-bool RenderThread::isWorkerThread() const {
-#ifdef __EMSCRIPTEN__
-    return pthread_equal(pthread_self(), _thread);
-#else
-    return std::this_thread::get_id() == _thread.get_id();
-#endif
+void WebRenderThread::requestShutdown() {
+    // Unlocking is the final access to this object: the worker may delete it
+    // as soon as it acquires the mutex and finishes draining.
+    std::lock_guard<std::mutex> lock(_taskMutex);
+    _stopping.store(true, std::memory_order_release);
+    scheduleWakeLocked();
 }
 
-void RenderThread::shutdown() {
-    {
-        std::lock_guard<std::mutex> lock(_taskMutex);
-        _stopping.store(true, std::memory_order_release);
-#ifdef __EMSCRIPTEN__
-        if (!_creationFailed) scheduleWakeLocked();
-#endif
+void WebRenderThread::enqueue(std::function<void()> work) {
+    std::unique_lock<std::mutex> lock(_taskMutex);
+    // Accepted work can enqueue its own completion while draining.
+    if (isStopping() && !pthread_equal(pthread_self(), _thread)) {
+        lock.unlock();
+        Log("Cannot submit work after RenderThread shutdown");
+        std::abort();
     }
-#ifndef __EMSCRIPTEN__
-    _cv.notify_one();
-#endif
+    _tasks.push_back(std::move(work));
+    scheduleWakeLocked();
 }
 
-void RenderThread::enqueue(std::function<void()> work) {
-    {
-        std::unique_lock<std::mutex> lock(_taskMutex);
-        // Accepted tasks can enqueue their own completion work while draining.
-        if (isStopping() && !isWorkerThread()) {
-            lock.unlock();
-            Log("Cannot submit work after RenderThread shutdown");
-            std::abort();
-        }
-        _tasks.push_back(std::move(work));
-#ifdef __EMSCRIPTEN__
-        scheduleWakeLocked();
-#endif
-    }
-#ifndef __EMSCRIPTEN__
-    _cv.notify_one();
-#endif
-}
-
-#ifdef __EMSCRIPTEN__
-void RenderThread::startWebWorker() {
+void WebRenderThread::startWorker() {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
@@ -109,14 +82,14 @@ void RenderThread::startWebWorker() {
     }
 }
 
-void* RenderThread::startHelper(void* arg) {
+void* WebRenderThread::startHelper(void* arg) {
     // simulateInfiniteLoop keeps this pthread's event loop alive for wakeups.
     emscripten_set_main_loop_arg(frameCallback, arg, 0, true);
     return nullptr;
 }
 
-void RenderThread::frameCallback(void* arg) {
-    auto* self = static_cast<RenderThread*>(arg);
+void WebRenderThread::frameCallback(void* arg) {
+    auto* self = static_cast<WebRenderThread*>(arg);
     if (self->isStopping()) return;
     if (self->_renderManager) {
         const auto now = std::chrono::steady_clock::now();
@@ -125,7 +98,7 @@ void RenderThread::frameCallback(void* arg) {
     }
 }
 
-void RenderThread::scheduleWakeLocked() {
+void WebRenderThread::scheduleWakeLocked() {
     if (_wakePending) return;
     _wakePending = true;
     // Coalesce notifications. Shutdown deletes this object only after the
@@ -137,12 +110,12 @@ void RenderThread::scheduleWakeLocked() {
     }
 }
 
-void RenderThread::pumpCallback(void* arg) {
-    auto* self = static_cast<RenderThread*>(arg);
+void WebRenderThread::pumpCallback(void* arg) {
+    auto* self = static_cast<WebRenderThread*>(arg);
     self->pumpTasks();
 }
 
-void RenderThread::pumpTasks() {
+void WebRenderThread::pumpTasks() {
     // Check between tasks: one expensive task or backend execution can exceed
     // this budget. It is a yielding policy, not a hard two-millisecond deadline.
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(2);
@@ -173,43 +146,28 @@ void RenderThread::pumpTasks() {
     }
 }
 
-void RenderThread::finishShutdown(void* arg) {
-    auto* self = static_cast<RenderThread*>(arg);
+void WebRenderThread::finishShutdown(void* arg) {
+    auto* self = static_cast<WebRenderThread*>(arg);
     emscripten_cancel_main_loop();
     self->_workerFinished = true;
-    delete self; // ownership transferred by shutdown(), after registry release
+    delete self; // ownership transferred by destroy(), after registry release
     mi_thread_done();
     mLiveWorkerCount.fetch_sub(1, std::memory_order_relaxed);
     pthread_exit(nullptr);
 }
 
-void RenderThread::dispatchCallback(std::function<void()> callback) const {
+void WebRenderThread::dispatchCallback(std::function<void()> callback) const {
     if (!callbacks().proxyAsync(_caller, std::move(callback))) {
         Log("Failed to post render completion");
         std::abort();
     }
 }
 
-void RenderThread::executeCallbacks() { callbacks().execute(); }
+void WebRenderThread::executeCallbacks() { callbacks().execute(); }
 
-void RenderThread::setRenderManager(RenderManager* manager) {
-    assert(isWorkerThread());
+void WebRenderThread::setRenderManager(RenderManager* manager) {
+    assert(pthread_equal(pthread_self(), _thread));
     _renderManager = manager;
 }
-#else
-void RenderThread::runNativeLoop() {
-    std::unique_lock<std::mutex> lock(_taskMutex);
-    while (true) {
-        _cv.wait(lock, [this] { return !_tasks.empty() || isStopping(); });
-        if (_tasks.empty() && isStopping()) return;
-        auto task = std::move(_tasks.front());
-        _tasks.pop_front();
-        lock.unlock();
-        task();
-        task = {};
-        lock.lock();
-    }
-}
-#endif
 
 } // namespace thermion

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -244,39 +244,52 @@ Web is fundamentally single-swapchain. `emscripten_pthread_attr_settransferredca
 
 ### Threading model
 
-Two threads matter:
+`RenderThread.hpp` selects `NativeRenderThread` or `WebRenderThread` at compile
+time. The native implementation owns a blocking queue and joins during
+destruction. The web implementation owns the browser event loop and exits
+asynchronously. Both provide `create()` and `destroy()`; `destroy()` consumes
+the registry's unique owner, with platform-specific cleanup handled internally.
 
-- **Main browser thread**: where Dart executes (Flutter's engine runs on the main thread on web). All `FilamentApp` method calls originate here.
-- **Render worker**: a pthread spun up at startup by `RenderThread::RenderThread()` via `pthread_create` with `emscripten_pthread_attr_settransferredcanvases(&attr, "#thermion_canvas")`. This transfers ownership of the OffscreenCanvas to the worker, which then owns the WebGL context for the lifetime of the app. The worker's entry point installs `emscripten_set_main_loop_arg(&mainLoop, ...)` so that `RenderThread::iter()` is called on the worker's own `requestAnimationFrame` cadence.
+Two threads matter on web:
 
-Dart and the worker communicate via emscripten's proxying queue + a lock-protected task deque (`RenderThread::_tasks`). Dart never calls Filament directly from the main thread — every call crosses the thread boundary as a packaged task.
+- **Main browser thread**: where Dart executes and submits commands.
+- **Render worker**: a pthread started by `WebRenderThread::create()`. The selected canvas is transferred to this worker, which owns the WebGL context. Its animation-frame callback drives drawing; a separate event-driven pump handles commands.
 
 ### Dart → worker call pattern
 
-Every generated FFI binding that needs to touch Filament takes the `*_RenderThread` shape — e.g. `Renderer_beginFrameRenderThread(..., requestId, onComplete)`. The Dart side wraps these with `withVoidCallback` / `withPointerCallback` / etc., which:
+Operations that require the owning render worker use a `*_RenderThread` C API
+function. Dart registers a completion callback, submits the operation, then
+awaits its Future. Void callbacks use request IDs; typed callbacks return their
+result through a callback registered for that operation.
 
-1. Register a callback port keyed by a fresh `requestId`.
-2. Call the `*_RenderThread` FFI function. The C wrapper packages the target call + a capture of `(requestId, onComplete)` into a `std::packaged_task`, pushes it onto `RenderThread::_tasks`, and returns immediately.
-3. Dart awaits the completer associated with `requestId`.
+The C wrapper puts work into the worker's mutex-protected FIFO queue and wakes
+the worker. `WebRenderThread::pumpTasks()` processes a batch, checking a
+two-millisecond budget between tasks, and yields before continuing. Filament
+backend processing runs after the batch even when animation frames are disabled.
+Drawing can happen between batches; a group of commands is not a transaction.
 
-On the worker side, `RenderThread::iter()` (emscripten branch) drains every queued task synchronously, each of which runs its underlying Filament call and then fires `onComplete(requestId)`. The callback is proxied back to the main thread via `emscripten::ProxyingQueue::proxySync` (the `PROXY(...)` macro in `ThermionDartRenderThreadApi.cpp`), which resolves the Dart future.
-
-The net effect is that Dart code can `await` a Filament call as if it were synchronous, but the actual GL work happens on the worker where the canvas lives.
+Completions use `ProxyingQueue::proxyAsync` to reach the browser thread. That
+queue lives for the WASM module's lifetime, so a posted completion remains
+available after its worker exits. Dart awaits notifications without polling.
 
 ### Render loop
 
-Unlike the native path, Dart on web does **not** await individual renders. `FFIFilamentApp.render()` branches on `FILAMENT_SINGLE_THREADED`:
+Unlike the native path, Dart on web does **not** await individual renders:
 
-- **Native** queues a `RenderManager_renderRenderThread` task and awaits its completion. `RenderManager::render()` runs the whole pipeline (animations + plugins + all swapchains' beginFrame/render/endFrame + `mEngine->execute()`) as one synchronous task.
-- **Web** calls `RenderManager_requestRender(renderManager)` — fire-and-forget. This flips `mRenderRequested = true` but is effectively a no-op (see [Why `mRenderRequested` is bypassed on web](#why-mrenderrequested-is-bypassed-on-web) below).
+- **Native** queues a `RenderManager_renderRenderThread` task and awaits its completion. `RenderManager::render()` runs animations, plugins, and swapchain rendering on the native worker.
+- **Web** calls `RenderManager_requestRender(renderManager)`, acknowledging a request without waiting for a frame. Drawing is driven by `WebRenderThread::frameCallback()`, separately from the command queue.
 
-Rendering is driven entirely from the worker's mainLoop. Each worker rAF, `RenderThread::iter()` drains the task queue and calls `RenderManager::tick(now)`. `tick()`:
+Each worker animation frame calls `RenderManager::tick(now)`. Unless paused,
+it updates animations/plugins and renders the attached swapchains. It then
+calls `mEngine->execute()` even if drawing is paused or `beginFrame` rejects.
+The command pump also executes backend work after each batch, allowing uploads
+to progress without an animation frame.
 
-1. Runs `updateAnimationsAndPlugins(now)`.
-2. For each attached swapchain: `renderSwapChainAt(i)` (beginFrame → render each view → endFrame).
-3. **Always** calls `mEngine->execute()` — even if every `beginFrame` rejected.
-
-All three steps happen in a single `tick()` invocation, matching the pre-refactor `RenderTicker::render()` pattern exactly. One frame per worker rAF = ~60fps at display vsync.
+Render-manager detachment and deletion are queued together. The app awaits
+deletion before destroying its animation manager, renderer, and engine. Finally,
+`WebRenderThread::destroy()` transfers the registry's ownership to the worker;
+the worker drains, cancels drawing, and deletes itself. The browser is never
+blocked waiting for it to join. The worker handle must not be reused afterward.
 
 ### Render loop invariants 
 
@@ -288,7 +301,7 @@ Two things about this loop are load-bearing and easy to break accidentally. Both
 
 ### Why `mRenderRequested` is bypassed on web
 
-The flag was originally intended to gate rendering so Dart could control when frames are produced. In practice, both Dart's main-thread `_tick` and the worker's `mainLoop` run at 60Hz but are **not phase-locked** — they're independent rAFs on different threads. When the worker rAF fires slightly before Dart's has set the flag, the worker finds it clear and skips, losing that frame. Over a second, phase drift costs ~5-10 fps (measured: ~50-55 fps instead of 60).
+The flag was originally intended to gate rendering so Dart could control when frames are produced. In practice, both Dart's main-thread `_tick` and the worker's frame callback run at 60Hz but are **not phase-locked** — they're independent rAFs on different threads. When the worker rAF fires slightly before Dart's has set the flag, the worker finds it clear and skips, losing that frame. Over a second, phase drift costs ~5-10 fps (measured: ~50-55 fps instead of 60).
 
 The fix is to render unconditionally on every worker rAF and let Dart's flag-setting be a no-op. This matches pre-refactor semantics (the `RenderTicker` also ran every worker rAF once it was requested). The flag is kept in the API for symmetry with native but is not gating on the web path.
 
@@ -298,7 +311,9 @@ See [Pause/resume](#pauseresume) in the native lifecycle section — the invaria
 
 ### Key files
 
-- `thermion_dart/native/src/rendering/RenderThread.cpp` — pthread + emscripten mainLoop, task queue.
+- `thermion_dart/native/include/rendering/RenderThread.hpp` — compile-time platform selection.
+- `thermion_dart/native/src/rendering/NativeRenderThread.cpp` — blocking queue and drain/join.
+- `thermion_dart/native/web/src/cpp/WebRenderThread.cpp` — browser command pump, frame callbacks, and asynchronous exit.
 - `thermion_dart/native/src/rendering/RenderManager.cpp` — `render()` (native), `requestRender()`/`tick()` (web).
 - `thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp` — `*_RenderThread` C shims + proxy-back callbacks.
 - `thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart` — `FFIFilamentApp.render()` branches on `FILAMENT_SINGLE_THREADED`.


### PR DESCRIPTION
**Stacked on #347 — merge that first.** This is the refactor half of the closed #301, extracted so each PR shows one kind of change: #347 is the behavior fix on the shared `RenderThread`, this PR is the mechanical split with no behavior change of its own.

### What changes

Native workers can sleep while idle and join during destruction. Web workers must yield to browser events and finish shutdown asynchronously. These were already separate concrete behaviors behind `#ifdef __EMSCRIPTEN__` in the shared `RenderThread`; this PR splits them into separate implementations, `NativeRenderThread` and `WebRenderThread`, selected at compile time by `RenderThread.hpp`. Each owns its queue and lifecycle; browser-only state stays in the web implementation. This adds no virtual dispatch, shared ownership, or extra implementation allocation.

- `RenderThread.hpp` becomes a compile-time alias selecting the platform implementation. Each concrete header declares its own queue and lifecycle API, including `create()` and `destroy()`.
- The platform code moves into `NativeRenderThread.hpp/.cpp` and `WebRenderThread.hpp/.cpp`. Web scheduling and queue-draining behavior are retained, while worker creation and destruction move behind the platform API.
- The C API registry calls `RenderThread::create()/destroy()` instead of constructing workers directly and dispatching ownership in `disposeThread()`.
- Test targets and `ARCHITECTURE.md` use the new layout. The native `worker_queue_test` exercises `NativeRenderThread`; the browser `web_dispatch_test` exercises `WebRenderThread`. Both use the platform's ownership API.

### Scope

No behavior change relative to #347. No dependency on #318 or #346; C++ exceptions remain disabled.

### Validation

The same suite as #347 was previously rerun on the split implementation on macOS with exceptions disabled. This stack refresh preserves that exact file tree:

- Generated builds select only their platform's worker source.
- Both standalone native tests pass (FIFO, worker affinity, packaged results, nested completion work, 25 shutdown cycles).
- The standalone Chrome fixture passes 25 cycles with animation frames disabled; the full Filament and drawing-enabled Chrome fixtures pass as described in #347.
- All 23 selected native Dart tests and 41 Flutter tests pass. Bindings unchanged from #347; targeted Dart analysis is clean.

Review and merge order: **#349 → #347 → #348 → #346**.
