### PR TITLE
refactor: reorganize RenderThread ahead of frame-independent command processing

### DIFF
--- a/thermion_dart/native/include/rendering/RenderThread.hpp
+++ b/thermion_dart/native/include/rendering/RenderThread.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <functional>
 #include <future>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -22,10 +22,20 @@ namespace thermion {
 class RenderManager;
 
 /**
- * @brief A render loop implementation that manages rendering on a separate thread.
- * 
- * This class handles frame rendering requests, viewer creation, and maintains
- * a task queue for rendering operations.
+ * @brief A render loop that executes Filament work on a dedicated worker
+ *        thread, one ordered command queue per engine.
+ *
+ * Dart-facing API calls are packaged as commands and appended to the queue;
+ * the worker normally executes them in FIFO order. On web, each animation
+ * frame drains the queue without yielding, then draws. Drawing does not
+ * interleave with commands within that drain.
+ *
+ * Native workers sleep on a condition variable until work arrives and are
+ * drained and joined during destruction. Web workers are browser pthreads:
+ * they service the queue on each animation frame (iter()). Web destruction
+ * still runs remaining queued commands on the caller's thread and detaches
+ * the worker. Worker affinity during web teardown is therefore not guaranteed;
+ * fixing that lifecycle is separate from this rearrangement.
  */
 class RenderThread {
 public:
@@ -36,10 +46,14 @@ public:
      *        transferred to this thread's worker (default "#thermion_canvas").
      *        Each engine-per-viewer thread owns its own canvas.
      */
-    explicit RenderThread(const char *canvasSelector = "#thermion_canvas");
+    explicit RenderThread(const char* canvasSelector = "#thermion_canvas");
 
     /**
      * @brief Destroys the RenderThread and stops the render thread.
+     *
+     * Signals the worker to exit. Native destruction joins after the worker
+     * drains its queue. Web destruction drains remaining commands on the
+     * caller's thread and detaches, without waiting for the worker to exit.
      */
     ~RenderThread();
 
@@ -48,7 +62,7 @@ public:
      *        worker (web only). Used by Engine_create to create the WebGL
      *        context on the right canvas.
      */
-    const char *canvasSelector() const { return _canvasSelector.c_str(); }
+    const char* canvasSelector() const { return _canvasSelector.c_str(); }
 
     /**
      * @brief True when the worker pthread failed to start (web). The C API
@@ -58,13 +72,26 @@ public:
     bool creationFailed() const { return _creationFailed; }
 
     /**
+     * @brief True once shutdown has been requested (see shutdown()).
+     */
+    bool isStopping() const { return _stop->value.load(std::memory_order_acquire); }
+
+    /**
+     * @brief Signals the worker to exit. Called by destruction; native workers
+     *        wake and drain their queue. Web workers stop at their next
+     *        animation-frame iteration, before draining; the web destructor
+     *        handles remaining commands on the caller's thread.
+     */
+    void shutdown();
+
+    /**
      * @brief Adds a task to the render thread's task queue.
-     * 
-     * @param pt The packaged task to be executed
+     *
+     * @param task The packaged task to be executed
      * @return std::future<Rt> Future for the task result
      */
     template <class Rt>
-    auto addTask(std::packaged_task<Rt()>& pt) -> std::future<Rt>;
+    auto addTask(std::packaged_task<Rt()>& task) -> std::future<Rt>;
 
     /**
      * @brief Adds a fire-and-forget task without allocating a packaged-task
@@ -74,14 +101,23 @@ public:
      * mechanism (for example, the Dart request-id callback).
      */
     template <class Fn>
-    void addDetachedTask(Fn&& fn);
-
+    void addDetachedTask(Fn&& fn) {
+        enqueue(std::function<void()>(std::forward<Fn>(fn)));
+    }
 
     #ifdef __EMSCRIPTEN__
     /**
      * @brief Main iteration of the browser-driven render loop.
      */
     void iter();
+
+    emscripten::ProxyingQueue queue;
+    pthread_t outer;
+
+    // Web-only: iter() invokes _renderManager->tick() on each rAF so rendering
+    // is driven by the browser's frame cadence rather than a Dart-queued task.
+    void setRenderManager(RenderManager* rm) { _renderManager = rm; }
+    RenderManager* _renderManager = nullptr;
     #endif
 
     /**
@@ -91,10 +127,10 @@ public:
      *
      * The flag must outlive `this`: on web pthread_detach lets the destructor
      * return and `*this` be freed before the worker observes the signal, so a
-     * plain member would be UAF. The worker only dereferences the RenderThread
-     * after observing the flag is false, which keeps the window closed (the
-     * destructor sets the flag before draining and detaching, so the worker
-     * never touches `this` after shutdown begins).
+     * plain member would be UAF. The flag keeps the stop check alive, but
+     * does not protect `this` if shutdown starts after the worker has checked
+     * the flag. Coordinating web object destruction with the worker remains
+     * a separate lifecycle fix.
      *
      * Per-instance, not static: with one engine per thread, destroying one
      * engine's RenderThread must not signal another engine's worker (a shared
@@ -114,70 +150,42 @@ public:
      */
     static std::atomic<int32_t> mLiveWorkerCount;
 
-    #ifdef __EMSCRIPTEN__
-    emscripten::ProxyingQueue queue;
-    pthread_t outer;
-
-    // Web-only: iter() invokes mRenderManager->tick() on each rAF so rendering
-    // is driven by the browser's frame cadence rather than a Dart-queued task.
-    void setRenderManager(RenderManager* rm) { mRenderManager = rm; }
-    RenderManager* mRenderManager = nullptr;
-    #endif
-
 private:
     #ifndef __EMSCRIPTEN__
     void runNativeLoop();
+    #else
+    void startWebWorker(const char* canvasSelector);
+    void pumpTasks();
     #endif
+
+    // Appends one command to the queue. Native workers are woken immediately;
+    // web workers service the queue on their next animation-frame iteration.
+    void enqueue(std::function<void()> task);
 
     std::mutex _taskMutex;
     std::condition_variable _cv;
     std::deque<std::function<void()>> _tasks;
-    std::chrono::high_resolution_clock::time_point _lastFrameTime;
-    int _frameCount = 0;
-    float _accumulatedTime = 0.0f;
-    float _fps = 0.0f;
     // Owned copy: the Dart side frees its UTF8 buffer right after
     // RenderThread_createForCanvas returns, and Engine_create reads the
     // selector later (during the same serialized engine creation).
     std::string _canvasSelector = "#thermion_canvas";
     bool _creationFailed = false;
 
-    
+
 #ifdef __EMSCRIPTEN__
-    pthread_t t;
+    pthread_t _thread{};
 #else
-    std::thread* t = nullptr;
+    std::thread* _thread = nullptr;
 #endif
 };
 
 // Template implementation
 template <class Rt>
-auto RenderThread::addTask(std::packaged_task<Rt()>& pt) -> std::future<Rt> {
-    auto ret = pt.get_future();
-    {
-        std::lock_guard<std::mutex> lock(_taskMutex);
-        _tasks.push_back([pt = std::make_shared<std::packaged_task<Rt()>>(
-                             std::move(pt))]
-                        { (*pt)(); });
-    }
-    #ifndef __EMSCRIPTEN__
-    _cv.notify_one();
-    #endif
-    return ret;
-}
-
-template <class Fn>
-void RenderThread::addDetachedTask(Fn&& fn) {
-    // Construct outside the critical section since std::function may need to
-    // allocate for a large capture.
-    std::function<void()> task(std::forward<Fn>(fn));
-    {
-        std::lock_guard<std::mutex> lock(_taskMutex);
-        _tasks.push_back(std::move(task));
-    }
-    #ifndef __EMSCRIPTEN__
-    _cv.notify_one();
-    #endif
+auto RenderThread::addTask(std::packaged_task<Rt()>& task) -> std::future<Rt> {
+    auto result = task.get_future();
+    addDetachedTask([task = std::make_shared<std::packaged_task<Rt()>>(
+                         std::move(task))] { (*task)(); });
+    return result;
 }
 
 } // namespace thermion

--- a/thermion_dart/native/src/rendering/RenderThread.cpp
+++ b/thermion_dart/native/src/rendering/RenderThread.cpp
@@ -1,5 +1,10 @@
 #include "rendering/RenderThread.hpp"
+// Web only: iter() calls into RenderManager. The native worker never touches
+// the manager, so the standalone queue test can compile this file without
+// Filament headers.
+#ifdef __EMSCRIPTEN__
 #include "rendering/RenderManager.hpp"
+#endif
 
 #include <functional>
 #include <stdlib.h>
@@ -73,35 +78,38 @@ static void *startHelper(void * parm) {
 
 #endif
 
-RenderThread::RenderThread(const char *canvasSelector)
+RenderThread::RenderThread(const char* canvasSelector)
     : _canvasSelector(canvasSelector != nullptr ? canvasSelector : "#thermion_canvas")
 {
     srand(time(NULL));
-    _lastFrameTime = std::chrono::high_resolution_clock::now();
     #ifdef __EMSCRIPTEN__
     Log("Starting RenderThread")
     outer = pthread_self();
+    startWebWorker(canvasSelector);
+    #else
+    _thread = new std::thread([this]() { runNativeLoop(); });
+    #endif
+}
+
+#ifdef __EMSCRIPTEN__
+// Start the worker pthread and transfer the canvas to it. On failure,
+// _creationFailed lets the C API return a null handle instead of a worker
+// that would hang every queued task forever.
+void RenderThread::startWebWorker(const char* canvasSelector) {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     emscripten_pthread_attr_settransferredcanvases(&attr, canvasSelector);
     auto *workerArg = new WorkerArg{this, _stop};
-    int rc = pthread_create(&t, &attr, startHelper, workerArg);
+    int rc = pthread_create(&_thread, &attr, startHelper, workerArg);
     if (rc != 0) {
-      // The worker never started, so tasks queued for this thread will never
-      // run — every caller would hang forever. Surface it: the C API returns
-      // a null handle and Dart throws "Failed to create render thread".
       Log("SEVERE - pthread_create failed with code %d; worker did not start "
           "(canvas selector %s, pool exhausted?)",
           rc, canvasSelector);
       _creationFailed = true;
       delete workerArg;
     }
-    #else
-    t = new std::thread([this]() { runNativeLoop(); });
-    #endif
 }
-
-
+#endif
 
 RenderThread::~RenderThread()
 {
@@ -111,7 +119,7 @@ RenderThread::~RenderThread()
         pendingTaskCount = _tasks.size();
     }
     TRACE("Destroying RenderThread (%zu tasks remaining)", pendingTaskCount);
-    _stop->value.store(true, std::memory_order_release);
+    shutdown();
 
     #ifdef __EMSCRIPTEN__
     // The web worker cannot be synchronously joined from the browser main
@@ -144,27 +152,42 @@ RenderThread::~RenderThread()
     // without blocking. Callers that need to wait for the worker to actually
     // finish exiting (e.g. before constructing a replacement RenderThread)
     // should poll mLiveWorkerCount from Dart.
-    pthread_detach(t);
+    pthread_detach(_thread);
     #else
-    // The worker owns and drains the queue. This preserves render-thread
-    // affinity and avoids racing the destructor against a concurrent pop.
-    _cv.notify_all();
     TRACE("Joining RenderThread thread..");
-    t->join();
-    delete t;
+    _thread->join();
+    delete _thread;
     #endif
 
     TRACE("RenderThread destructor complete");
 }
 
-#ifdef __EMSCRIPTEN__
-void RenderThread::iter() {
-    // FPS measurement
-    auto now = std::chrono::high_resolution_clock::now();
+void RenderThread::shutdown()
+{
+    _stop->value.store(true, std::memory_order_release);
+    #ifndef __EMSCRIPTEN__
+    _cv.notify_all();
+    #endif
+}
 
+void RenderThread::enqueue(std::function<void()> task) {
+    {
+        std::lock_guard<std::mutex> lock(_taskMutex);
+        _tasks.push_back(std::move(task));
+    }
+    #ifndef __EMSCRIPTEN__
+    _cv.notify_one();
+    #endif
+}
+
+#ifdef __EMSCRIPTEN__
+// Drain every queued task without yielding to the browser. Called from
+// iter() on the worker, so Filament calls keep their thread affinity; the
+// queue mutex is released while each task executes so tasks may queue
+// further work.
+void RenderThread::pumpTasks() {
     std::unique_lock<std::mutex> taskLock(_taskMutex);
 
-    // On Emscripten, drain all queued tasks then yield to browser.
     while (!_tasks.empty())
     {
         auto task = std::move(_tasks.front());
@@ -174,14 +197,21 @@ void RenderThread::iter() {
         taskLock.lock();
     }
     taskLock.unlock();
+}
+
+void RenderThread::iter() {
+    // FPS measurement
+    auto now = std::chrono::high_resolution_clock::now();
+
+    pumpTasks();
 
     // Render at most one swapchain per rAF so Filament's WebGL backend can
     // commit the frame between iterations. When no render has been requested,
     // tick() is a cheap flag-check and returns immediately.
-    if (mRenderManager) {
+    if (_renderManager) {
         auto frameTimeInNanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
                                     now.time_since_epoch()).count();
-        mRenderManager->tick(frameTimeInNanos);
+        _renderManager->tick(frameTimeInNanos);
     }
 }
 #else
@@ -190,14 +220,13 @@ void RenderThread::runNativeLoop() {
 
     while (true) {
         _cv.wait(taskLock, [this] {
-            return !_tasks.empty() ||
-                   _stop->value.load(std::memory_order_acquire);
+            return !_tasks.empty() || isStopping();
         });
 
         if (_tasks.empty()) {
             // A stop request only terminates the worker after it has executed
             // every task that was already queued.
-            if (_stop->value.load(std::memory_order_acquire)) {
+            if (isStopping()) {
                 break;
             }
             continue;

--- a/thermion_dart/native/test/rendering/CMakeLists.txt
+++ b/thermion_dart/native/test/rendering/CMakeLists.txt
@@ -27,3 +27,12 @@ endif()
 enable_testing()
 add_test(NAME scheduling COMMAND scheduling_test)
 set_tests_properties(scheduling PROPERTIES TIMEOUT 30)
+
+add_executable(worker_queue_test
+    worker_queue_test.cpp
+    ../../src/rendering/RenderThread.cpp)
+target_compile_features(worker_queue_test PRIVATE cxx_std_17)
+target_include_directories(worker_queue_test PRIVATE ../../include)
+target_link_libraries(worker_queue_test PRIVATE Threads::Threads)
+add_test(NAME worker_queue COMMAND worker_queue_test)
+set_tests_properties(worker_queue PROPERTIES TIMEOUT 30)

--- a/thermion_dart/native/test/rendering/worker_queue_test.cpp
+++ b/thermion_dart/native/test/rendering/worker_queue_test.cpp
@@ -1,0 +1,40 @@
+#include "rendering/RenderThread.hpp"
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace thermion;
+using namespace std::chrono_literals;
+
+static void check(bool condition) {
+    if (!condition) std::abort();
+}
+
+int main() {
+    for (int round = 0; round < 25; ++round) {
+        int executed = 0;
+        const auto caller = std::this_thread::get_id();
+        {
+            RenderThread worker;
+            std::packaged_task<int()> query([caller] {
+                check(std::this_thread::get_id() != caller);
+                return 42;
+            });
+            auto result = worker.addTask(query);
+            check(result.wait_for(2s) == std::future_status::ready);
+            check(result.get() == 42);
+            for (int i = 0; i < 200; ++i) {
+                worker.addDetachedTask([&, i] {
+                    check(std::this_thread::get_id() != caller);
+                    check(executed++ == i);
+                });
+            }
+            worker.addDetachedTask([&] {
+                worker.addDetachedTask([&] { check(executed++ == 200); });
+            });
+            // Destruction must drain on the worker and join before returning.
+        }
+        check(executed == 201);
+    }
+    std::puts("PASS: native FIFO, packaged result, nested completion and 25 shutdown cycles");
+}


### PR DESCRIPTION
This PR cleans up/rearranges the existing render worker to show the command-processing and teardown fixes clearly. This just preparatory work for #347, behavior should not change. Native workers still wake when commands arrive, drain their queue, and join during destruction. Web workers still drain commands on each animation frame before drawing. The existing web destructor still runs remaining commands on the caller's thread and detaches the worker; #347 fixes that lifecycle and removes the dependency on animation frames.