### PR TITLE
fix: (web) prevent render controls from deadlocking with upload callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Changes
 
-- Prevent web frame requests and pause controls from deadlocking with upload
-  callbacks on the browser main thread.
+- Remove the unused native `RenderManager_requestRender` API and make web pause
+  controls nonblocking to prevent deadlocks with main-thread upload callbacks.
 - Let Dart isolates exit after their native void callbacks finish, without
   closing the shared callback listener while requests are still pending.
 - Upgrade Filament from 1.75.0 to 1.76.0 and expose the bundled release through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- Prevent web frame requests and pause controls from deadlocking with upload
+  callbacks on the browser main thread.
 - Let Dart isolates exit after their native void callbacks finish, without
   closing the shared callback listener while requests are still pending.
 - Upgrade Filament from 1.75.0 to 1.76.0 and expose the bundled release through

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_ffi.g.dart
@@ -2626,9 +2626,6 @@ external void RenderManager_renderRenderThread(
   VoidCallback onComplete,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>)>(isLeaf: true)
-external void RenderManager_requestRender(ffi.Pointer<TRenderManager> tRenderer);
-
 @ffi.Native<ffi.Void Function(ffi.Pointer<TRenderManager>, ffi.Bool)>(isLeaf: true)
 external void RenderManager_setPaused(ffi.Pointer<TRenderManager> tRenderer, bool paused);
 

--- a/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
+++ b/thermion_dart/lib/src/bindings/src/thermion_dart_js_interop.g.dart
@@ -1316,7 +1316,6 @@ extension type GeneratedBindings(NativeLibrary _) implements JSObject {
     int requestId,
     VoidCallback onComplete,
   );
-  external void _RenderManager_requestRender(Pointer<TRenderManager> tRenderer);
   external void _RenderManager_setPaused(Pointer<TRenderManager> tRenderer, bool paused);
   external void _RenderManager_setRenderable(
     Pointer<TRenderManager> tRenderer,
@@ -6026,11 +6025,6 @@ void RenderManager_renderRenderThread(
     requestId,
     onComplete as Pointer<NativeFunction<VoidCallbackFunction>>,
   );
-  return result;
-}
-
-void RenderManager_requestRender(Pointer<TRenderManager> tRenderer) {
-  final result = GeneratedBindings.instance._RenderManager_requestRender(tRenderer.cast());
   return result;
 }
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_render_manager.dart
@@ -216,12 +216,9 @@ class FFIRenderManager extends RenderManager<Pointer<TRenderManager>> {
 
   Future render({int? frameTimeInNanos}) async {
     if (FILAMENT_SINGLE_THREADED) {
-      // Web: fire-and-forget. The render completes across the next N rAF
-      // cycles (N = number of swapchains) driven by RenderThread::iter()
-      // calling RenderManager::tick(). We cannot await completion without
-      // deadlocking the worker's main loop from the main browser thread,
-      // and pre-refactor web was already fire-and-forget via requestFrame.
-      RenderManager_requestRender(pointer);
+      // Web renders independently on the worker's animation frames. There is
+      // no frame request to submit, and this Future does not await drawing.
+      return;
     } else {
       // Frame timestamps share one clock: the native steady clock that the
       // frame schedulers and Filament's beginFrame already use.

--- a/thermion_dart/lib/src/filament/src/interface/filament_app.dart
+++ b/thermion_dart/lib/src/filament/src/interface/filament_app.dart
@@ -294,8 +294,9 @@ abstract class FilamentApp<T> {
   /// When omitted, uses the current native steady-clock time. The returned
   /// [Future] completes when the render pipeline step has finished.
   ///
-  /// On web, queues rendering for browser animation frames and returns without
-  /// waiting for completion. [frameTimeInNanos] is ignored on that path.
+  /// On web, rendering runs independently on the worker's animation frames.
+  /// This method returns immediately without requesting or waiting for a frame;
+  /// [frameTimeInNanos] is ignored.
   Future render({int? frameTimeInNanos});
 
   /// Caps the continuous-render framerate to [fps].

--- a/thermion_dart/lib/src/filament/src/interface/render_manager.dart
+++ b/thermion_dart/lib/src/filament/src/interface/render_manager.dart
@@ -24,8 +24,9 @@ abstract class RenderManager<T> extends NativeHandle<T> {
   /// When omitted, uses the current native steady-clock time. The returned
   /// [Future] completes when the render pipeline step has finished.
   ///
-  /// On web, queues rendering for browser animation frames and returns without
-  /// waiting for completion. [frameTimeInNanos] is ignored on that path.
+  /// On web, rendering runs independently on the worker's animation frames.
+  /// This method returns immediately without requesting or waiting for a frame;
+  /// [frameTimeInNanos] is ignored.
   Future render({int? frameTimeInNanos});
 
   void destroy();

--- a/thermion_dart/native/include/c_api/TRenderManager.h
+++ b/thermion_dart/native/include/c_api/TRenderManager.h
@@ -17,10 +17,8 @@ extern "C"
 	EMSCRIPTEN_KEEPALIVE void RenderManager_setRenderable(TRenderManager *tRenderer, TSwapChain *swapChain, TView **views, uint8_t numViews);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_removeSwapChain(TRenderManager *tRenderer, TSwapChain *swapChain);
 
-	// Web path. On native these are either no-ops (attach) or equivalent to a
-	// synchronous render (requestRender). Dart branches on FILAMENT_SINGLE_THREADED
-	// and only calls these on the web build.
-	EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer);
+	// Web worker attachment and pause controls. Dart calls these only on web;
+	// drawing is driven by the worker's animation frames, without frame requests.
 	EMSCRIPTEN_KEEPALIVE void RenderManager_attachToRenderThread(TRenderManager *tRenderer);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_detachFromRenderThread(TRenderManager *tRenderManager);
 	EMSCRIPTEN_KEEPALIVE void RenderManager_setPaused(TRenderManager *tRenderer, bool paused);

--- a/thermion_dart/native/include/rendering/RenderManager.hpp
+++ b/thermion_dart/native/include/rendering/RenderManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <vector>
@@ -51,14 +52,16 @@ namespace thermion
         bool render(
             uint64_t frameTimeInNanos);
 
-        /// Flip the "render wanted" flag. Used on web — the actual work is
-        /// driven from RenderThread::iter() on each rAF via tick().
+        /// Compatibility no-op: web drawing is already driven by tick() on
+        /// every worker animation frame, without waiting for a request.
         void requestRender();
 
         /// Web: pause/resume rendering. When paused, tick() skips animation
         /// updates and swapchain rendering but still drains the Filament
         /// backend command buffer (mEngine->execute()) so any state changes
         /// queued before pause complete cleanly and don't burst on resume.
+        /// Takes effect on a subsequent tick; does not wait for an in-flight
+        /// frame or its callbacks to finish.
         void setPaused(bool paused);
 
         /// Web path: called once per rAF from RenderThread::iter().
@@ -107,19 +110,15 @@ namespace thermion
         std::vector<ViewAttachment> mViewAttachments;
         std::chrono::high_resolution_clock::time_point mLastRender;
 
-        // Web: tick() checks this flag and renders if set, then clears it.
-        // Set by Dart via RenderManager_requestRender() on each main-thread
-        // rAF. Rejection retries (beginFrame failing) keep the flag set so
-        // RenderThread's 12ms iter-loop can retry in the same rAF.
-        bool mRenderRequested = false;
-
         // Web: when true, tick() short-circuits animations + swapchain render.
         // mEngine->execute() still runs so the backend command buffer keeps
         // draining (matches native "scheduler keeps ticking" pause semantics).
         // Note: this gates *rendering only* — task queue drain in
         // RenderThread::iter() is outside this flag, so FFI state changes
         // (setTransform, addEntity, etc.) continue to apply while paused.
-        bool mRenderPaused = false;
+        // Main-thread controls must not take mMutex: tick() can hold it while
+        // a Filament upload callback waits for that same main thread.
+        std::atomic<bool> mRenderPaused{false};
     };
 
 }

--- a/thermion_dart/native/include/rendering/RenderManager.hpp
+++ b/thermion_dart/native/include/rendering/RenderManager.hpp
@@ -52,10 +52,6 @@ namespace thermion
         bool render(
             uint64_t frameTimeInNanos);
 
-        /// Compatibility no-op: web drawing is already driven by tick() on
-        /// every worker animation frame, without waiting for a request.
-        void requestRender();
-
         /// Web: pause/resume rendering. When paused, tick() skips animation
         /// updates and swapchain rendering but still drains the Filament
         /// backend command buffer (mEngine->execute()) so any state changes

--- a/thermion_dart/native/src/c_api/TRenderManager.cpp
+++ b/thermion_dart/native/src/c_api/TRenderManager.cpp
@@ -45,11 +45,6 @@ EMSCRIPTEN_KEEPALIVE void RenderManager_render(TRenderManager *tRenderer, uint64
     renderManager->render(frameTimeInNanos);
 }
 
-EMSCRIPTEN_KEEPALIVE void RenderManager_requestRender(TRenderManager *tRenderer) {
-    auto *renderManager = reinterpret_cast<RenderManager *>(tRenderer);
-    renderManager->requestRender();
-}
-
 EMSCRIPTEN_KEEPALIVE void RenderManager_setPaused(TRenderManager *tRenderer, bool paused) {
     auto *renderManager = reinterpret_cast<RenderManager *>(tRenderer);
     renderManager->setPaused(paused);

--- a/thermion_dart/native/src/rendering/RenderManager.cpp
+++ b/thermion_dart/native/src/rendering/RenderManager.cpp
@@ -237,13 +237,6 @@ namespace thermion
     return rendered;
   }
 
-  void RenderManager::requestRender()
-  {
-    // Retain the exported API for existing callers. Web tick() already draws
-    // unconditionally. Taking mMutex here could block the browser main thread
-    // while tick() waits for an upload callback to execute on that thread.
-  }
-
   void RenderManager::setPaused(bool paused)
   {
     // This flag publishes no other state. A frame already in progress may

--- a/thermion_dart/native/src/rendering/RenderManager.cpp
+++ b/thermion_dart/native/src/rendering/RenderManager.cpp
@@ -239,28 +239,27 @@ namespace thermion
 
   void RenderManager::requestRender()
   {
-    std::lock_guard lock(mMutex);
-    mRenderRequested = true;
+    // Retain the exported API for existing callers. Web tick() already draws
+    // unconditionally. Taking mMutex here could block the browser main thread
+    // while tick() waits for an upload callback to execute on that thread.
   }
 
   void RenderManager::setPaused(bool paused)
   {
-    std::lock_guard lock(mMutex);
-    mRenderPaused = paused;
+    // This flag publishes no other state. A frame already in progress may
+    // finish; subsequent ticks observe the requested pause state.
+    mRenderPaused.store(paused, std::memory_order_relaxed);
   }
 
   bool RenderManager::tick(uint64_t frameTimeInNanos)
   {
     std::lock_guard<std::mutex> lock(mMutex);
 
-    // Render unconditionally on every worker rAF. The mRenderRequested flag
-    // is kept in the API for symmetry with the native path but is not
-    // gating on web: Dart's main-thread _tick and this worker's mainLoop
-    // are independent 60Hz rAFs that aren't phase-locked. Gating on the flag
+    // Render unconditionally on every worker rAF. Dart's main-thread _tick
+    // and this worker's mainLoop are independent rAFs that aren't
+    // phase-locked. Gating on a main-thread request
     // drops ~5-10 fps whenever the worker rAF fires before Dart has had a
     // chance to set it.
-    (void)mRenderRequested;
-
     // Match pre-refactor RenderTicker semantics: render all swapchains
     // synchronously and ALWAYS call mEngine->execute() — even if every
     // beginFrame rejected or we're paused. Filament's WebGL backend queues
@@ -268,7 +267,7 @@ namespace thermion
     // independent of whether a visible frame was produced. Skipping
     // execute() stalls the backend and causes a burst on resume.
     bool anyRendered = false;
-    if (!mRenderPaused) {
+    if (!mRenderPaused.load(std::memory_order_relaxed)) {
       updateAnimationsAndPlugins(frameTimeInNanos);
 
       for (size_t i = 0; i < mViewAttachments.size(); i++)
@@ -283,10 +282,6 @@ namespace thermion
 #ifdef __EMSCRIPTEN__
     mEngine->execute();
 #endif
-
-    if (anyRendered) {
-      mRenderRequested = false;
-    }
 
     return anyRendered;
   }

--- a/thermion_dart/native/test/rendering/CMakeLists.txt
+++ b/thermion_dart/native/test/rendering/CMakeLists.txt
@@ -49,8 +49,7 @@ if(THERMION_TEST_LIBRARY AND FILAMENT_TEST_INCLUDE_DIR)
         ../../include "${FILAMENT_TEST_INCLUDE_DIR}")
     target_link_libraries(render_control_test PRIVATE
         Threads::Threads "${THERMION_TEST_LIBRARY}")
-    add_test(NAME render_request_nonblocking COMMAND render_control_test request)
-    add_test(NAME render_pause_nonblocking COMMAND render_control_test pause)
-    set_tests_properties(render_request_nonblocking render_pause_nonblocking
+    add_test(NAME render_pause_nonblocking COMMAND render_control_test)
+    set_tests_properties(render_pause_nonblocking
         PROPERTIES TIMEOUT 10)
 endif()

--- a/thermion_dart/native/test/rendering/CMakeLists.txt
+++ b/thermion_dart/native/test/rendering/CMakeLists.txt
@@ -36,3 +36,21 @@ target_include_directories(worker_queue_test PRIVATE ../../include)
 target_link_libraries(worker_queue_test PRIVATE Threads::Threads)
 add_test(NAME worker_queue COMMAND worker_queue_test)
 set_tests_properties(worker_queue PROPERTIES TIMEOUT 30)
+
+# Optional: the render-control regression uses Filament headers and symbols
+# from an existing native Thermion build, but does not create a GPU context.
+if(THERMION_TEST_LIBRARY AND FILAMENT_TEST_INCLUDE_DIR)
+    add_executable(render_control_test
+        render_control_test.cpp
+        ../../src/rendering/RenderManager.cpp
+        ../../src/PluginRegistry.cpp)
+    target_compile_features(render_control_test PRIVATE cxx_std_17)
+    target_include_directories(render_control_test PRIVATE
+        ../../include "${FILAMENT_TEST_INCLUDE_DIR}")
+    target_link_libraries(render_control_test PRIVATE
+        Threads::Threads "${THERMION_TEST_LIBRARY}")
+    add_test(NAME render_request_nonblocking COMMAND render_control_test request)
+    add_test(NAME render_pause_nonblocking COMMAND render_control_test pause)
+    set_tests_properties(render_request_nonblocking render_pause_nonblocking
+        PROPERTIES TIMEOUT 10)
+endif()

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -43,14 +43,14 @@ Dart wall-clock render timestamp. Browser dispatch/lifetime fixtures land in #30
 
 ## Nonblocking render controls
 
-The optional render-control tests hold a plugin update inside a frame until
-the caller issues `requestRender()` or `setPaused()`. Neither control may wait
-for the frame to finish: on web, a frame can itself be waiting for an upload
-callback on the browser main thread. Both tests fail against the old locking
-implementation; the pause test also checks subsequent pause/resume behavior.
+The optional render-control test holds a plugin update inside a frame until
+the caller issues `setPaused()`. Pausing must not wait for the frame to finish:
+on web, a frame can itself be waiting for an upload callback on the browser
+main thread. The test fails against the old locking implementation and also
+checks subsequent pause/resume behavior.
 
-These tests run natively without a GPU context. They compile the current
-`RenderManager` and use an existing native Thermion library for its Filament
+This test runs natively without a GPU context. It compiles the current
+`RenderManager` and uses an existing native Thermion library for its Filament
 and animation dependencies. Supply that library and matching Filament headers:
 
 ```sh

--- a/thermion_dart/native/test/rendering/README.md
+++ b/thermion_dart/native/test/rendering/README.md
@@ -41,6 +41,32 @@ The gate extraction is reused by the web worker in #301. Forwarding scheduler
 timestamps through Flutter into rendering is in #319. Normalizing native scheduler output alone does not replace the existing
 Dart wall-clock render timestamp. Browser dispatch/lifetime fixtures land in #301.
 
+## Nonblocking render controls
+
+The optional render-control tests hold a plugin update inside a frame until
+the caller issues `requestRender()` or `setPaused()`. Neither control may wait
+for the frame to finish: on web, a frame can itself be waiting for an upload
+callback on the browser main thread. Both tests fail against the old locking
+implementation; the pause test also checks subsequent pause/resume behavior.
+
+These tests run natively without a GPU context. They compile the current
+`RenderManager` and use an existing native Thermion library for its Filament
+and animation dependencies. Supply that library and matching Filament headers:
+
+```sh
+cmake -S thermion_dart/native/test/rendering -B /tmp/thermion-render-controls \
+  -DTHERMION_TEST_LIBRARY=/absolute/path/to/libthermion_dart.dylib \
+  -DFILAMENT_TEST_INCLUDE_DIR=/absolute/path/to/filament/include
+cmake --build /tmp/thermion-render-controls --config Release
+ctest --test-dir /tmp/thermion-render-controls -C Release --output-on-failure
+```
+
+For browser validation, run quickstart with its matching web module, set the
+batch size to four, then repeatedly add, remove, and replace the viewers with
+skybox/IBL loading enabled. Verify all four viewers finish loading, and test
+pause/resume while uploads are pending. The native tests isolate the mutex
+cycle; they do not test browser worker reuse or WASM memory capacity.
+
 ## KTX upload lifetime tests
 
 The caller owns the KTX bundle. `destroy()` immediately deletes it and its data;

--- a/thermion_dart/native/test/rendering/render_control_test.cpp
+++ b/thermion_dart/native/test/rendering/render_control_test.cpp
@@ -5,7 +5,6 @@
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <mutex>
 #include <thread>
 
@@ -33,9 +32,7 @@ public:
     int updates = 0;
 };
 
-int main(int argc, char** argv) {
-    if (argc != 2) return 2;
-    const bool pause = std::strcmp(argv[1], "pause") == 0;
+int main() {
     PendingCallback callback;
     thermion::plugin::RegisterPlugin(callback.getName(), &callback);
     // With no attachments, native tick() needs neither an Engine nor Renderer.
@@ -59,8 +56,7 @@ int main(int argc, char** argv) {
             callback.cv.notify_all();
         }
     });
-    if (pause) manager.setPaused(true);
-    else manager.requestRender();
+    manager.setPaused(true);
     {
         std::lock_guard lock(callback.mutex);
         callback.released = true;
@@ -69,15 +65,13 @@ int main(int argc, char** argv) {
     worker.join();
     watchdog.join();
     if (callback.timedOut) {
-        std::fprintf(stderr, "FAIL: %s waited for the in-flight callback\n", argv[1]);
+        std::fputs("FAIL: pause waited for the in-flight callback\n", stderr);
         return 1;
     }
-    if (pause) {
-        manager.tick(1);
-        if (callback.updates != 1) return 1;
-        manager.setPaused(false);
-        manager.tick(2);
-        if (callback.updates != 2) return 1;
-    }
-    std::printf("PASS: %s returns while a render callback is pending\n", argv[1]);
+    manager.tick(1);
+    if (callback.updates != 1) return 1;
+    manager.setPaused(false);
+    manager.tick(2);
+    if (callback.updates != 2) return 1;
+    std::puts("PASS: pause returns while a render callback is pending");
 }

--- a/thermion_dart/native/test/rendering/render_control_test.cpp
+++ b/thermion_dart/native/test/rendering/render_control_test.cpp
@@ -1,0 +1,83 @@
+#include "Plugin.hpp"
+#include "rendering/RenderManager.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+// Plugin updates run under the same render-manager mutex as Filament's upload
+// release callbacks. Hold an update until the caller has issued a control,
+// reproducing the worker -> main -> render mutex circular wait without a GPU.
+class PendingCallback final : public thermion::plugin::Plugin {
+public:
+    const char* getName() const override { return "render-control-test"; }
+    void update(uint64_t) override {
+        std::unique_lock lock(mutex);
+        ++updates;
+        entered = true;
+        cv.notify_all();
+        cv.wait(lock, [&] { return released; });
+    }
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool entered = false;
+    bool released = false;
+    bool timedOut = false;
+    int updates = 0;
+};
+
+int main(int argc, char** argv) {
+    if (argc != 2) return 2;
+    const bool pause = std::strcmp(argv[1], "pause") == 0;
+    PendingCallback callback;
+    thermion::plugin::RegisterPlugin(callback.getName(), &callback);
+    // With no attachments, native tick() needs neither an Engine nor Renderer.
+    // Its plugin update and control methods use the same code as web.
+    thermion::RenderManager manager(nullptr, nullptr);
+    std::thread worker([&] { manager.tick(0); });
+    {
+        std::unique_lock lock(callback.mutex);
+        if (!callback.cv.wait_for(lock, 3s, [&] { return callback.entered; })) {
+            std::fputs("FAIL: worker did not enter plugin update\n", stderr);
+            std::abort();
+        }
+    }
+    // Release a broken implementation after a timeout so the test reports a
+    // failure instead of hanging. A correct control returns before release.
+    std::thread watchdog([&] {
+        std::unique_lock lock(callback.mutex);
+        if (!callback.cv.wait_for(lock, 3s, [&] { return callback.released; })) {
+            callback.timedOut = true;
+            callback.released = true;
+            callback.cv.notify_all();
+        }
+    });
+    if (pause) manager.setPaused(true);
+    else manager.requestRender();
+    {
+        std::lock_guard lock(callback.mutex);
+        callback.released = true;
+        callback.cv.notify_all();
+    }
+    worker.join();
+    watchdog.join();
+    if (callback.timedOut) {
+        std::fprintf(stderr, "FAIL: %s waited for the in-flight callback\n", argv[1]);
+        return 1;
+    }
+    if (pause) {
+        manager.tick(1);
+        if (callback.updates != 1) return 1;
+        manager.setPaused(false);
+        manager.tick(2);
+        if (callback.updates != 2) return 1;
+    }
+    std::printf("PASS: %s returns while a render callback is pending\n", argv[1]);
+}

--- a/thermion_flutter/thermion_flutter/ARCHITECTURE.md
+++ b/thermion_flutter/thermion_flutter/ARCHITECTURE.md
@@ -268,7 +268,7 @@ The net effect is that Dart code can `await` a Filament call as if it were synch
 Unlike the native path, Dart on web does **not** await individual renders. `FFIFilamentApp.render()` branches on `FILAMENT_SINGLE_THREADED`:
 
 - **Native** queues a `RenderManager_renderRenderThread` task and awaits its completion. `RenderManager::render()` runs the whole pipeline (animations + plugins + all swapchains' beginFrame/render/endFrame + `mEngine->execute()`) as one synchronous task.
-- **Web** calls `RenderManager_requestRender(renderManager)` — fire-and-forget. This flips `mRenderRequested = true` but is effectively a no-op (see [Why `mRenderRequested` is bypassed on web](#why-mrenderrequested-is-bypassed-on-web) below).
+- **Web** returns immediately. Drawing runs independently on the worker, so there is no native frame-request call. Completing this Future does not mean a frame has been drawn.
 
 Rendering is driven entirely from the worker's mainLoop. Each worker rAF, `RenderThread::iter()` drains the task queue and calls `RenderManager::tick(now)`. `tick()`:
 
@@ -286,11 +286,11 @@ Two things about this loop are load-bearing and easy to break accidentally. Both
 
 2. **`beginFrame`, `endFrame`, and `execute` must all happen in the same `tick()` invocation.** Earlier attempts split these across ticks to fit a clean state machine ("tick N renders, tick N+1 executes"), to pipeline across frames (execute previous at top of tick, render next at bottom), or to schedule execute as a `setTimeout(0)` microtask. Every variation either hung, rejected every `beginFrame` after the first, or dropped rendering entirely. The pre-refactor shape — begin/render/end/execute inline under the RenderManager mutex — is the only arrangement empirically shown to work on this combination of emscripten pthreads + OffscreenCanvas + Filament WebGL backend. Don't try to pipeline or split these phases without first understanding why it broke before.
 
-### Why `mRenderRequested` is bypassed on web
+### Why web rendering does not wait for Dart frame requests
 
-The flag was originally intended to gate rendering so Dart could control when frames are produced. In practice, both Dart's main-thread `_tick` and the worker's `mainLoop` run at 60Hz but are **not phase-locked** — they're independent rAFs on different threads. When the worker rAF fires slightly before Dart's has set the flag, the worker finds it clear and skips, losing that frame. Over a second, phase drift costs ~5-10 fps (measured: ~50-55 fps instead of 60).
+Dart's main-thread `_tick` and the worker's `mainLoop` run on independent animation frames. Gating worker rendering on a flag set by Dart could skip a frame whenever the worker ran first. The worker therefore renders on its own animation frames, without a request flag or exported request function.
 
-The fix is to render unconditionally on every worker rAF and let Dart's flag-setting be a no-op. This matches pre-refactor semantics (the `RenderTicker` also ran every worker rAF once it was requested). The flag is kept in the API for symmetry with native but is not gating on the web path.
+The former request call also took the render-manager mutex on the browser main thread. A worker holding that mutex could be waiting for an upload callback on the main thread, creating a circular wait. Removing the unused call eliminates that path; pause uses an atomic flag so it does not wait for the worker either.
 
 ### Pause/resume on web
 
@@ -299,7 +299,7 @@ See [Pause/resume](#pauseresume) in the native lifecycle section — the invaria
 ### Key files
 
 - `thermion_dart/native/src/rendering/RenderThread.cpp` — pthread + emscripten mainLoop, task queue.
-- `thermion_dart/native/src/rendering/RenderManager.cpp` — `render()` (native), `requestRender()`/`tick()` (web).
+- `thermion_dart/native/src/rendering/RenderManager.cpp` — `render()` (native), `tick()` (web).
 - `thermion_dart/native/src/c_api/ThermionDartRenderThreadApi.cpp` — `*_RenderThread` C shims + proxy-back callbacks.
 - `thermion_dart/lib/src/filament/src/implementation/ffi_filament_app.dart` — `FFIFilamentApp.render()` branches on `FILAMENT_SINGLE_THREADED`.
 - `thermion_dart/hook/build.dart` — web artifact download + `THERMION_WEB_LOCAL` override.


### PR DESCRIPTION
Replacing a batch of web viewers can freeze the whole page while skybox or IBL uploads finish. I reproduced this with four viewers in quickstart: the browser main thread entered `RenderManager_requestRender()` and never returned.

The worker holds the render-manager mutex while rendering. Filament can deliver an upload-release callback during that work, and our existing web callback bridge waits for the callback to run on the browser main thread. Meanwhile, Dart's frame loop calls the request function on the main thread and waits for the same mutex. Each thread is waiting for the other. Pausing had the same problem.

Web drawing already runs independently on each worker animation frame, so the frame-request flag serves no purpose. This PR removes the unused C++ method, C export, generated Dart bindings, and their only Dart caller. Public Dart `render()` remains available and returns immediately on web; its documentation now explains that it neither requests nor waits for a frame. Native rendering is unchanged.

Pause becomes an atomic flag, so changing it does not wait for rendering or callback delivery. An in-flight frame may finish; the pause applies to subsequent ticks.
