### PR TITLE
fix(web): release temporary KTX input buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changes
 
+- Release temporary web KTX input buffers after bundle creation so repeated
+  skybox and IBL loading does not retain a WASM copy of every input file.
+
 - Let Dart isolates exit after their native void callbacks finish, without
   closing the shared callback listener while requests are still pending.
 - Upgrade Filament from 1.75.0 to 1.76.0 and expose the bundled release through

--- a/thermion_dart/lib/src/bindings/src/ffi.dart
+++ b/thermion_dart/lib/src/bindings/src/ffi.dart
@@ -68,6 +68,9 @@ Pointer<T> allocate<T extends NativeType>(int byteCount) {
   return calloc.allocate<T>(byteCount);
 }
 
+// The leaf FFI call borrows Dart storage only for this synchronous call.
+Pointer<TKtx1Bundle> createKtx1BundleFromData(Uint8List data) => Ktx1Bundle_create(data.address, data.length);
+
 void free(Pointer ptr) {
   calloc.free(ptr);
 }

--- a/thermion_dart/lib/src/bindings/src/js_interop.dart
+++ b/thermion_dart/lib/src/bindings/src/js_interop.dart
@@ -14,6 +14,22 @@ const FILAMENT_SINGLE_THREADED = true;
 const FILAMENT_WASM = true;
 const IS_WINDOWS = false;
 
+Pointer<TKtx1Bundle> createKtx1BundleFromData(Uint8List data) {
+  final marker = stackSave();
+  // .address borrows heap-backed views, but copies ordinary Dart bytes into
+  // WASM. The KTX constructor copies its input synchronously; release only
+  // the temporary copy, never the caller's existing WASM allocation.
+  final borrowed = identical(data.toJS.buffer, NativeLibrary.instance.HEAPU8.buffer);
+  Pointer<Uint8>? pointer;
+  try {
+    pointer = data.address;
+    return Ktx1Bundle_create(pointer, data.length);
+  } finally {
+    if (!borrowed) pointer?.free();
+    stackRestore(marker);
+  }
+}
+
 extension type _NativeLibrary(NativeLibrary _) implements JSObject {
   static _NativeLibrary get instance => NativeLibrary.instance as _NativeLibrary;
 

--- a/thermion_dart/lib/src/filament/src/implementation/ffi_ktx1_bundle.dart
+++ b/thermion_dart/lib/src/filament/src/implementation/ffi_ktx1_bundle.dart
@@ -44,7 +44,7 @@ class FFIKtx1Bundle extends Ktx1Bundle {
   ///
   ///
   static Future<Ktx1Bundle> create(FFIFilamentApp app, Uint8List data) async {
-    var bundle = Ktx1Bundle_create(data.address, data.length);
+    var bundle = createKtx1BundleFromData(data);
 
     if (bundle == nullptr) {
       throw Exception("Failed to decode KTX texture");

--- a/thermion_dart/test/ktx_input_buffer_web_test.dart
+++ b/thermion_dart/test/ktx_input_buffer_web_test.dart
@@ -1,0 +1,89 @@
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:thermion_dart/src/bindings/src/js_interop.dart' as bindings;
+
+void main() {
+  late Uint8List heap;
+  late Set<int> allocations;
+  late int stackTop;
+  late int heapTop;
+  late int Function(int, int) construct;
+
+  setUp(() {
+    heap = Uint8List(1024 * 1024);
+    allocations = {};
+    stackTop = 1024;
+    heapTop = 128 * 1024;
+    construct = (_, __) => 123;
+    // Exercise the real web buffer adapter with a small instrumented native
+    // boundary. No renderer is needed to check allocation ownership.
+    final module = JSObject();
+    module.setProperty('HEAPU8'.toJS, heap.toJS);
+    module.setProperty(
+      '_malloc'.toJS,
+      ((int size) {
+        final pointer = heapTop;
+        heapTop += size;
+        allocations.add(pointer);
+        return pointer;
+      }).toJS,
+    );
+    module.setProperty(
+      '_free'.toJS,
+      ((int pointer) {
+        expect(allocations.remove(pointer), isTrue);
+      }).toJS,
+    );
+    module.setProperty('stackSave'.toJS, (() => stackTop).toJS);
+    module.setProperty('stackRestore'.toJS, ((int marker) => stackTop = marker).toJS);
+    module.setProperty(
+      'stackAlloc'.toJS,
+      ((int size) {
+        final pointer = stackTop;
+        stackTop += size;
+        return pointer;
+      }).toJS,
+    );
+    module.setProperty('_Ktx1Bundle_create'.toJS, ((int pointer, int size) => construct(pointer, size)).toJS);
+    bindings.NativeLibrary.instance = module as bindings.NativeLibrary;
+  });
+
+  for (final size in [64, 64 * 1024]) {
+    test('repeated $size-byte inputs release temporary storage', () {
+      final input = Uint8List(size)..fillRange(0, size, 42);
+      construct = (pointer, length) {
+        expect(heap.sublist(pointer, pointer + length), input);
+        return 123;
+      };
+      for (var i = 0; i < 5; i++) {
+        expect(bindings.createKtx1BundleFromData(input).address, 123);
+        expect(allocations, isEmpty);
+        expect(stackTop, 1024);
+      }
+    });
+  }
+
+  test('borrowed WASM storage remains owned by the caller', () {
+    // .address registers a heap allocation; derive a view from that pointer
+    // so freeing the borrowed pointer would be observable in this test.
+    final pointer = bindings.Uint8ListExtension(Uint8List(64 * 1024)).address;
+    final input = Uint8List.sublistView(heap, pointer.address, pointer.address + 64 * 1024);
+    bindings.createKtx1BundleFromData(input);
+    expect(allocations, {pointer.address});
+    pointer.free();
+    expect(allocations, isEmpty);
+  });
+
+  test('constructor failure still releases temporary storage', () {
+    construct = (_, __) => throw StateError('constructor failed');
+    expect(() => bindings.createKtx1BundleFromData(Uint8List(64 * 1024)), throwsA(anything));
+    expect(allocations, isEmpty);
+    expect(stackTop, 1024);
+  });
+}


### PR DESCRIPTION
Repeatedly creating web viewers leaks the temporary WASM copies of their skybox and IBL files. Eventually allocation aborts with `Aborted(OOM)` and viewer initialization stops. With #350 applied, six viewers rendered on a fresh page, but repeated replacement still reproduced this separate failure.

On web, `Uint8List.address` copies ordinary Dart bytes into WASM memory. The native KTX constructor then copies those bytes into its own bundle. Destroying the bundle frees its own storage, but the first copy was never released. Quickstart loads about 3.5 MiB of KTX input per viewer, so each replacement batch adds more retained data.

This PR scopes that temporary input to the synchronous constructor call. Large temporary copies are freed and small stack copies are reclaimed by restoring the stack marker. When the caller already supplies a WASM-backed view, its allocation remains owned by the caller. Native Dart still passes `data.address` directly to the existing leaf FFI call.

The bundle and texture-upload lifetime rules are unchanged. This is separate from the render-control deadlock in #350; both PRs target `develop` independently and both fixes were applied for the browser lifecycle check. Neither requires the pending RenderThread refactors.

Validation:

- Ten complete remove/add cycles with six mounted viewers in Chrome/WebGL on macOS, using the CI-produced #350 WASM module and this Dart change. Cubes and skyboxes rendered after replacement, with no OOM or lockup.
- Instrumented the actual KTX input pointers: 132 constructor calls, 132 corresponding frees, zero pending temporary inputs.
- All four browser tests pass and the changed Dart files pass analysis. Tests cover repeated small and large input buffers, preservation of caller-owned WASM storage, and cleanup when construction fails.

Run the focused tests from `thermion_dart` with `dart test -p chrome test/ktx_input_buffer_web_test.dart`. The repository browser configuration requires `dart run tool/coi_proxy.dart 8899` in another terminal.
